### PR TITLE
fix(select): fix select opening on clear

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Select/AutoCompleteSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/AutoCompleteSelect.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import {
-    ActionButtonsContainer,
     Container,
     DropdownContainer,
     LabelsWrapper,
@@ -14,11 +13,11 @@ import {
     SelectBase,
     SelectLabel,
     SelectLabelContainer,
-    StyledClearButton,
     StyledIcon,
 } from '@components/components/Select/components';
 import DropdownSearchBar from '@components/components/Select/private/DropdownSearchBar';
-import { ActionButtonsProps, SelectProps } from '@components/components/Select/types';
+import SelectActionButtons from '@components/components/Select/private/SelectActionButtons';
+import { SelectProps } from '@components/components/Select/types';
 
 const NoSuggestions = styled.div`
     padding: 8px;
@@ -194,7 +193,7 @@ export default function AutoCompleteSelect<T>({
                         </LabelsWrapper>
                     </SelectLabelContainer>
                     <SelectActionButtons
-                        selectedValues={selectedValue ? [selectedValue.value] : []}
+                        hasSelectedValues={!!selectedValue}
                         isOpen={isOpen}
                         isDisabled={!!isDisabled}
                         isReadOnly={!!isReadOnly}
@@ -205,27 +204,5 @@ export default function AutoCompleteSelect<T>({
                 <input type="hidden" name={name} value={selectedValue?.value || ''} readOnly />
             </Dropdown>
         </Container>
-    );
-}
-
-function SelectActionButtons({
-    selectedValues,
-    isOpen,
-    isDisabled,
-    isReadOnly,
-    showClear,
-    handleClearSelection,
-}: ActionButtonsProps) {
-    return (
-        <ActionButtonsContainer>
-            {showClear && selectedValues.length > 0 && !isDisabled && !isReadOnly && (
-                <StyledClearButton
-                    icon={{ icon: 'Close', source: 'material', size: 'lg' }}
-                    isCircle
-                    onClick={handleClearSelection}
-                />
-            )}
-            <StyledIcon icon="CaretDown" source="phosphor" rotate={isOpen ? '180' : '0'} size="md" color="gray" />
-        </ActionButtonsContainer>
     );
 }

--- a/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
@@ -14,37 +14,15 @@ import {
     SelectLabel,
     SelectLabelContainer,
     StyledCheckbox,
-    StyledClearButton,
     StyledIcon,
 } from '@components/components/Select/components';
 import DropdownFooterActions from '@components/components/Select/private/DropdownFooterActions';
 import DropdownSearchBar from '@components/components/Select/private/DropdownSearchBar';
 import DropdownSelectAllOption from '@components/components/Select/private/DropdownSelectAllOption';
+import SelectActionButtons from '@components/components/Select/private/SelectActionButtons';
 import SelectLabelRenderer from '@components/components/Select/private/SelectLabelRenderer/SelectLabelRenderer';
-import { ActionButtonsProps, SelectOption, SelectProps } from '@components/components/Select/types';
+import { SelectOption, SelectProps } from '@components/components/Select/types';
 import { getFooterButtonSize } from '@components/components/Select/utils';
-
-const SelectActionButtons = ({
-    selectedValues,
-    isOpen,
-    isDisabled,
-    isReadOnly,
-    showClear,
-    handleClearSelection,
-}: ActionButtonsProps) => {
-    return (
-        <ActionButtonsContainer>
-            {showClear && selectedValues.length > 0 && !isDisabled && !isReadOnly && (
-                <StyledClearButton
-                    icon={{ icon: 'Close', source: 'material', size: 'lg' }}
-                    isCircle
-                    onClick={handleClearSelection}
-                />
-            )}
-            <StyledIcon icon="CaretDown" source="phosphor" rotate={isOpen ? '180' : '0'} size="md" color="gray" />
-        </ActionButtonsContainer>
-    );
-};
 
 // Updated main component
 export const selectDefaults: SelectProps = {
@@ -299,7 +277,7 @@ export const BasicSelect = <OptionType extends SelectOption = SelectOption>({
                         />
                     </SelectLabelContainer>
                     <SelectActionButtons
-                        selectedValues={selectedValues}
+                        hasSelectedValues={selectedValues.length > 0}
                         isOpen={isOpen}
                         isDisabled={!!isDisabled}
                         isReadOnly={!!isReadOnly}

--- a/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
@@ -14,35 +14,13 @@ import {
     SelectLabel,
     SelectLabelContainer,
     StyledCheckbox,
-    StyledClearButton,
     StyledIcon,
 } from '@components/components/Select/components';
 import DropdownSearchBar from '@components/components/Select/private/DropdownSearchBar';
 import DropdownSelectAllOption from '@components/components/Select/private/DropdownSelectAllOption';
+import SelectActionButtons from '@components/components/Select/private/SelectActionButtons';
 import SelectLabelRenderer from '@components/components/Select/private/SelectLabelRenderer/SelectLabelRenderer';
-import { ActionButtonsProps, SelectOption, SelectProps } from '@components/components/Select/types';
-
-const SelectActionButtons = ({
-    selectedValues,
-    isOpen,
-    isDisabled,
-    isReadOnly,
-    showClear,
-    handleClearSelection,
-}: ActionButtonsProps) => {
-    return (
-        <ActionButtonsContainer>
-            {showClear && selectedValues.length > 0 && !isDisabled && !isReadOnly && (
-                <StyledClearButton
-                    icon={{ icon: 'Close', source: 'material', size: 'lg' }}
-                    isCircle
-                    onClick={handleClearSelection}
-                />
-            )}
-            <StyledIcon icon="CaretDown" source="phosphor" rotate={isOpen ? '180' : '0'} size="md" color="gray" />
-        </ActionButtonsContainer>
-    );
-};
+import { SelectOption, SelectProps } from '@components/components/Select/types';
 
 export const selectDefaults: SelectProps = {
     options: [],
@@ -305,7 +283,7 @@ export const SimpleSelect = ({
                         />
                     </SelectLabelContainer>
                     <SelectActionButtons
-                        selectedValues={selectedValues}
+                        hasSelectedValues={selectedValues.length > 0}
                         isOpen={isOpen}
                         isDisabled={!!isDisabled}
                         isReadOnly={!!isReadOnly}

--- a/datahub-web-react/src/alchemy-components/components/Select/private/SelectActionButtons.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/SelectActionButtons.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from 'react';
+import styled from 'styled-components';
+
+import { Button } from '@components/components/Button';
+import { ActionButtonsContainer, StyledIcon } from '@components/components/Select/components';
+import { ActionButtonsProps } from '@components/components/Select/types';
+
+import { colors, shadows } from '@src/alchemy-components/theme';
+
+export const StyledClearButton = styled(Button).attrs({
+    variant: 'text',
+})({
+    color: colors.gray[1800],
+    padding: '0px',
+
+    '&:hover': {
+        border: 'none',
+        backgroundColor: colors.transparent,
+        borderColor: colors.transparent,
+        boxShadow: shadows.none,
+    },
+
+    '&:focus': {
+        border: 'none',
+        backgroundColor: colors.transparent,
+        boxShadow: `0 0 0 2px ${colors.white}, 0 0 0 4px ${colors.violet[50]}`,
+    },
+});
+
+export default function SelectActionButtons({
+    hasSelectedValues,
+    isOpen,
+    isDisabled,
+    isReadOnly,
+    showClear,
+    handleClearSelection,
+}: ActionButtonsProps) {
+    const onClearClickHandler = useCallback(
+        (event: React.MouseEvent<HTMLButtonElement>) => {
+            handleClearSelection?.();
+            event.stopPropagation();
+        },
+        [handleClearSelection],
+    );
+
+    return (
+        <ActionButtonsContainer>
+            {showClear && hasSelectedValues && !isDisabled && !isReadOnly && (
+                <StyledClearButton
+                    icon={{ icon: 'Close', source: 'material', size: 'lg' }}
+                    isCircle
+                    onClick={onClearClickHandler}
+                />
+            )}
+            <StyledIcon icon="CaretDown" source="phosphor" rotate={isOpen ? '180' : '0'} size="md" color="gray" />
+        </ActionButtonsContainer>
+    );
+}

--- a/datahub-web-react/src/alchemy-components/components/Select/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/types.ts
@@ -66,7 +66,7 @@ export interface SelectStyleProps {
 }
 
 export interface ActionButtonsProps {
-    selectedValues: string[];
+    hasSelectedValues: boolean;
     isOpen: boolean;
     isDisabled: boolean;
     isReadOnly: boolean;


### PR DESCRIPTION
- Fixed opening of select's dropdown on clicking on the clear button
- Extracted common `SelectActionButtons` component for selects

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
