### PR TITLE
fix(ui) Sanitize V1 UI sidebar description section

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/AboutSection/DescriptionSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/AboutSection/DescriptionSection.tsx
@@ -2,6 +2,7 @@ import { Typography } from 'antd';
 import React, { useState } from 'react';
 import styled from 'styled-components/macro';
 import { useHistory } from 'react-router';
+import DOMPurify from 'dompurify';
 import CompactContext from '../../../../../../shared/CompactContext';
 import MarkdownViewer, { MarkdownView } from '../../../../components/legacy/MarkdownViewer';
 import NoMarkdownViewer, { removeMarkdown } from '../../../../components/styled/StripMarkdownText';
@@ -68,12 +69,15 @@ export default function DescriptionSection({ description, baDescription, isExpan
         }
     }
 
+    const sanitizedDescription = DOMPurify.sanitize(description);
+    const sanitizedBADescription = DOMPurify.sanitize(baDescription || '');
+
     return (
         <>
             <ContentWrapper>
                 {isExpanded && (
                     <>
-                        <MarkdownViewer source={description} ignoreLimit />
+                        <MarkdownViewer source={sanitizedDescription} ignoreLimit />
                         {isOverLimit && (
                             <Typography.Link onClick={() => setIsExpanded(false)}>Read Less</Typography.Link>
                         )}
@@ -89,14 +93,14 @@ export default function DescriptionSection({ description, baDescription, isExpan
                         }
                         shouldWrap
                     >
-                        {description}
+                        {sanitizedDescription}
                     </NoMarkdownViewer>
                 )}
             </ContentWrapper>
             <BaContentWrapper>
                 {isBaExpanded && (
                     <>
-                        <MarkdownViewer source={baDescription || ''} ignoreLimit />
+                        <MarkdownViewer source={sanitizedBADescription || ''} ignoreLimit />
                         {isBaOverLimit && (
                             <Typography.Link onClick={() => setIsBaExpanded(false)}>Read Less</Typography.Link>
                         )}
@@ -112,7 +116,7 @@ export default function DescriptionSection({ description, baDescription, isExpan
                         }
                         shouldWrap
                     >
-                        {baDescription}
+                        {sanitizedBADescription}
                     </NoMarkdownViewer>
                 )}
             </BaContentWrapper>


### PR DESCRIPTION
We're properly sanitizing input in the documentation tab in V1 UI and both the tab and the sidebar in the V2 UI, but the description sidebar section was not properly sanitizing user input before rendering making it susceptible to XSS attacks.

This was only possible if the user issues an API call directly as we are sanitizing user input on the way in when saving descriptions from the UI.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
