### PR TITLE
fix(ingest/mlflow): pin mlflow-skinny version

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -465,7 +465,7 @@ plugins: Dict[str, Set[str]] = {
     "lookml": looker_common,
     "metabase": {"requests"} | sqlglot_lib,
     "mlflow": {
-        "mlflow-skinny>=2.10.0,<2.20.0",
+        "mlflow-skinny>=2.3.0,<2.21.0",
         # It's technically wrong for packages to depend on setuptools. However, it seems mlflow does it anyways.
         "setuptools",
     },

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -465,7 +465,7 @@ plugins: Dict[str, Set[str]] = {
     "lookml": looker_common,
     "metabase": {"requests"} | sqlglot_lib,
     "mlflow": {
-        "mlflow-skinny>=2.3.0",
+        "mlflow-skinny>=2.10.0,<2.20.0",
         # It's technically wrong for packages to depend on setuptools. However, it seems mlflow does it anyways.
         "setuptools",
     },

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -466,6 +466,10 @@ plugins: Dict[str, Set[str]] = {
     "metabase": {"requests"} | sqlglot_lib,
     "mlflow": {
         "mlflow-skinny>=2.3.0,<2.21.0",
+        # Pinned to avoid the breaking change introduced in MLflow 2.21.0 where search_registered_models injects an implicit filter
+        # https://github.com/mlflow/mlflow/pull/14795
+        # Upper bound can be removed once the upstream issue is resolved,
+        # or we have a reliable and backward-compatible way to handle prompt filtering.
         # It's technically wrong for packages to depend on setuptools. However, it seems mlflow does it anyways.
         "setuptools",
     },


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


* avoids the breaking change with the [MLflow 2.21.0 release](https://www.mlflow.org/releases/2.21.0) when calling `search_registered_models` in our connector 
  * related bug report : https://github.com/mlflow/mlflow/pull/14795
* confirmed that the ingestion using `2.20.4` client is compatible with `2.21.3` (latest) server 
