### PR TITLE
fix(gms) Generate schema field urns consistently (#5583)

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/ChangeEventGeneratorUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/ChangeEventGeneratorUtils.java
@@ -9,38 +9,12 @@ import com.linkedin.metadata.timeline.data.dataset.schema.SchemaFieldGlossaryTer
 import com.linkedin.metadata.timeline.data.dataset.schema.SchemaFieldTagChangeEvent;
 import com.linkedin.metadata.timeline.data.entity.GlossaryTermChangeEvent;
 import com.linkedin.metadata.timeline.data.entity.TagChangeEvent;
-import com.linkedin.schema.SchemaField;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 public class ChangeEventGeneratorUtils {
-
-  public static Urn getSchemaFieldUrn(
-      @Nonnull String datasetUrnStr, @Nonnull String schemaFieldPath) {
-    return UrnUtils.getUrn(
-        String.format("urn:li:schemaField:(%s,%s)", datasetUrnStr, schemaFieldPath));
-  }
-
-  public static Urn getSchemaFieldUrn(@Nonnull Urn datasetUrn, @Nonnull String schemaFieldPath) {
-    return UrnUtils.getUrn(
-        String.format("urn:li:schemaField:(%s,%s)", datasetUrn.toString(), schemaFieldPath));
-  }
-
-  public static Urn getSchemaFieldUrn(@Nonnull Urn datasetUrn, @Nonnull SchemaField schemaField) {
-    return UrnUtils.getUrn(
-        String.format("urn:li:schemaField:(%s,%s)", datasetUrn, getFieldPathV1(schemaField)));
-  }
-
-  public static String getFieldPathV1(@Nonnull SchemaField field) {
-    String[] v1PathTokens =
-        Arrays.stream(field.getFieldPath().split("\\."))
-            .filter(x -> !(x.startsWith("[") || x.endsWith("]")))
-            .toArray(String[]::new);
-    return String.join(".", v1PathTokens);
-  }
 
   public static List<ChangeEvent> convertEntityTagChangeEvents(
       @Nonnull String fieldPath,

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.timeline.eventgenerator;
 
 import static com.linkedin.metadata.Constants.*;
 import static com.linkedin.metadata.timeline.eventgenerator.ChangeEventGeneratorUtils.*;
+import static com.linkedin.metadata.utils.SchemaFieldUtils.generateSchemaFieldUrn;
 
 import com.datahub.util.RecordUtils;
 import com.google.common.collect.ImmutableMap;
@@ -354,7 +355,7 @@ public class EditableSchemaMetadataChangeEventGenerator
       final EditableSchemaFieldInfo latest,
       String entityUrn) {
     return previous != null
-        ? getSchemaFieldUrn(UrnUtils.getUrn(entityUrn), previous.getFieldPath())
-        : getSchemaFieldUrn(UrnUtils.getUrn(entityUrn), latest.getFieldPath());
+        ? generateSchemaFieldUrn(UrnUtils.getUrn(entityUrn), previous.getFieldPath())
+        : generateSchemaFieldUrn(UrnUtils.getUrn(entityUrn), latest.getFieldPath());
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
@@ -1,6 +1,8 @@
 package com.linkedin.metadata.timeline.eventgenerator;
 
 import static com.linkedin.metadata.timeline.eventgenerator.ChangeEventGeneratorUtils.*;
+import static com.linkedin.metadata.utils.SchemaFieldUtils.downgradeFieldPath;
+import static com.linkedin.metadata.utils.SchemaFieldUtils.generateSchemaFieldUrn;
 
 import com.datahub.util.RecordUtils;
 import com.google.common.collect.ImmutableMap;
@@ -179,9 +181,9 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
     List<ChangeEvent> propChangeEvents = new ArrayList<>();
     String datasetFieldUrn;
     if (targetField != null) {
-      datasetFieldUrn = getSchemaFieldUrn(datasetUrn, targetField).toString();
+      datasetFieldUrn = generateSchemaFieldUrn(datasetUrn, targetField).toString();
     } else {
-      datasetFieldUrn = getSchemaFieldUrn(datasetUrn, baseField).toString();
+      datasetFieldUrn = generateSchemaFieldUrn(datasetUrn, baseField).toString();
     }
 
     // Description Change.
@@ -395,7 +397,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
     if (changeCategories != null && changeCategories.contains(ChangeCategory.TECHNICAL_SCHEMA)) {
       changeEvents.add(
           DatasetSchemaFieldChangeEvent.schemaFieldChangeEventBuilder()
-              .modifier(getSchemaFieldUrn(datasetUrn, baseField).toString())
+              .modifier(generateSchemaFieldUrn(datasetUrn, baseField).toString())
               .entityUrn(datasetUrn.toString())
               .category(ChangeCategory.TECHNICAL_SCHEMA)
               .operation(ChangeOperation.REMOVE)
@@ -403,10 +405,10 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
               .description(
                   BACKWARDS_INCOMPATIBLE_DESC
                       + " removal of field: '"
-                      + getFieldPathV1(baseField)
+                      + downgradeFieldPath(baseField)
                       + "'.")
               .fieldPath(baseField.getFieldPath())
-              .fieldUrn(getSchemaFieldUrn(datasetUrn, baseField))
+              .fieldUrn(generateSchemaFieldUrn(datasetUrn, baseField))
               .nullable(baseField.isNullable())
               .modificationCategory(SchemaFieldModificationCategory.OTHER)
               .auditStamp(auditStamp)
@@ -426,7 +428,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
     if (changeCategories != null && changeCategories.contains(ChangeCategory.TECHNICAL_SCHEMA)) {
       changeEvents.add(
           DatasetSchemaFieldChangeEvent.schemaFieldChangeEventBuilder()
-              .modifier(getSchemaFieldUrn(datasetUrn, targetField).toString())
+              .modifier(generateSchemaFieldUrn(datasetUrn, targetField).toString())
               .entityUrn(datasetUrn.toString())
               .category(ChangeCategory.TECHNICAL_SCHEMA)
               .operation(ChangeOperation.ADD)
@@ -434,10 +436,10 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
               .description(
                   BACK_AND_FORWARD_COMPATIBLE_DESC
                       + "the newly added field '"
-                      + getFieldPathV1(targetField)
+                      + downgradeFieldPath(targetField)
                       + "'.")
               .fieldPath(targetField.getFieldPath())
-              .fieldUrn(getSchemaFieldUrn(datasetUrn, targetField))
+              .fieldUrn(generateSchemaFieldUrn(datasetUrn, targetField))
               .nullable(targetField.isNullable())
               .auditStamp(auditStamp)
               .modificationCategory(SchemaFieldModificationCategory.OTHER)
@@ -460,7 +462,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       changeEvents.add(
           DatasetSchemaFieldChangeEvent.schemaFieldChangeEventBuilder()
               .category(ChangeCategory.TECHNICAL_SCHEMA)
-              .modifier(getSchemaFieldUrn(datasetUrn, curBaseField).toString())
+              .modifier(generateSchemaFieldUrn(datasetUrn, curBaseField).toString())
               .entityUrn(datasetUrn.toString())
               .operation(ChangeOperation.MODIFY)
               .semVerChange(SemanticChangeType.MAJOR)
@@ -468,11 +470,11 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
                   String.format(
                       "%s native datatype of the field '%s' changed from '%s' to '%s'.",
                       BACKWARDS_INCOMPATIBLE_DESC,
-                      getFieldPathV1(curTargetField),
+                      downgradeFieldPath(curTargetField),
                       curBaseField.getNativeDataType(),
                       curTargetField.getNativeDataType()))
               .fieldPath(curBaseField.getFieldPath())
-              .fieldUrn(getSchemaFieldUrn(datasetUrn, curBaseField))
+              .fieldUrn(generateSchemaFieldUrn(datasetUrn, curBaseField))
               .nullable(curBaseField.isNullable())
               .modificationCategory(SchemaFieldModificationCategory.TYPE_CHANGE)
               .auditStamp(auditStamp)
@@ -484,19 +486,19 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       Urn datasetUrn, SchemaField curBaseField, SchemaField curTargetField, AuditStamp auditStamp) {
     return DatasetSchemaFieldChangeEvent.schemaFieldChangeEventBuilder()
         .category(ChangeCategory.TECHNICAL_SCHEMA)
-        .modifier(getSchemaFieldUrn(datasetUrn, curBaseField).toString())
+        .modifier(generateSchemaFieldUrn(datasetUrn, curBaseField).toString())
         .entityUrn(datasetUrn.toString())
         .operation(ChangeOperation.MODIFY)
         .semVerChange(SemanticChangeType.MINOR)
         .description(
             BACK_AND_FORWARD_COMPATIBLE_DESC
                 + "renaming of the field '"
-                + getFieldPathV1(curBaseField)
+                + downgradeFieldPath(curBaseField)
                 + " to "
-                + getFieldPathV1(curTargetField)
+                + downgradeFieldPath(curTargetField)
                 + "'.")
         .fieldPath(curBaseField.getFieldPath())
-        .fieldUrn(getSchemaFieldUrn(datasetUrn, curBaseField))
+        .fieldUrn(generateSchemaFieldUrn(datasetUrn, curBaseField))
         .nullable(curBaseField.isNullable())
         .modificationCategory(SchemaFieldModificationCategory.RENAME)
         .auditStamp(auditStamp)
@@ -538,7 +540,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
               .filter(key -> !targetPrimaryKeys.contains(key))
               .collect(Collectors.toSet());
       for (String removedBaseKeyField : removedBaseKeys) {
-        Urn schemaFieldUrn = getSchemaFieldUrn(datasetUrn.toString(), removedBaseKeyField);
+        Urn schemaFieldUrn = generateSchemaFieldUrn(datasetUrn, removedBaseKeyField);
         primaryKeyChangeEvents.add(
             DatasetSchemaFieldChangeEvent.schemaFieldChangeEventBuilder()
                 .category(ChangeCategory.TECHNICAL_SCHEMA)
@@ -563,11 +565,11 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
               .filter(key -> !basePrimaryKeys.contains(key))
               .collect(Collectors.toSet());
       for (String addedTargetKeyField : addedTargetKeys) {
-        Urn schemaFieldUrn = getSchemaFieldUrn(datasetUrn.toString(), addedTargetKeyField);
+        Urn schemaFieldUrn = generateSchemaFieldUrn(datasetUrn, addedTargetKeyField);
         primaryKeyChangeEvents.add(
             DatasetSchemaFieldChangeEvent.schemaFieldChangeEventBuilder()
                 .category(ChangeCategory.TECHNICAL_SCHEMA)
-                .modifier(getSchemaFieldUrn(datasetUrn, addedTargetKeyField).toString())
+                .modifier(generateSchemaFieldUrn(datasetUrn, addedTargetKeyField).toString())
                 .fieldUrn(schemaFieldUrn)
                 .fieldPath(addedTargetKeyField)
                 .entityUrn(datasetUrn.toString())

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
@@ -1,7 +1,7 @@
 package com.linkedin.metadata.kafka.hook.event;
 
 import static com.linkedin.metadata.Constants.*;
-import static com.linkedin.metadata.timeline.eventgenerator.ChangeEventGeneratorUtils.getSchemaFieldUrn;
+import static com.linkedin.metadata.utils.SchemaFieldUtils.generateSchemaFieldUrn;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -955,7 +955,7 @@ public class EntityChangeEventGeneratorHookTest {
         _mockClient,
         createChangeEvent(
             SCHEMA_FIELD_ENTITY_NAME,
-            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c1"),
+            generateSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c1"),
             ChangeCategory.DOCUMENTATION,
             ChangeOperation.ADD,
             null,
@@ -967,7 +967,7 @@ public class EntityChangeEventGeneratorHookTest {
         _mockClient,
         createChangeEvent(
             SCHEMA_FIELD_ENTITY_NAME,
-            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c2"),
+            generateSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c2"),
             ChangeCategory.DOCUMENTATION,
             ChangeOperation.MODIFY,
             null,
@@ -979,7 +979,7 @@ public class EntityChangeEventGeneratorHookTest {
         _mockClient,
         createChangeEvent(
             SCHEMA_FIELD_ENTITY_NAME,
-            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c3"),
+            generateSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c3"),
             ChangeCategory.DOCUMENTATION,
             ChangeOperation.REMOVE,
             null,
@@ -1030,7 +1030,7 @@ public class EntityChangeEventGeneratorHookTest {
         _mockClient,
         createChangeEvent(
             SCHEMA_FIELD_ENTITY_NAME,
-            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c1"),
+            generateSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c1"),
             ChangeCategory.DOCUMENTATION,
             ChangeOperation.ADD,
             null,
@@ -1042,7 +1042,7 @@ public class EntityChangeEventGeneratorHookTest {
         _mockClient,
         createChangeEvent(
             SCHEMA_FIELD_ENTITY_NAME,
-            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c2"),
+            generateSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c2"),
             ChangeCategory.DOCUMENTATION,
             ChangeOperation.MODIFY,
             null,
@@ -1054,7 +1054,7 @@ public class EntityChangeEventGeneratorHookTest {
         _mockClient,
         createChangeEvent(
             SCHEMA_FIELD_ENTITY_NAME,
-            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c3"),
+            generateSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c3"),
             ChangeCategory.DOCUMENTATION,
             ChangeOperation.REMOVE,
             null,

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/SchemaFieldUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/SchemaFieldUtils.java
@@ -111,6 +111,11 @@ public class SchemaFieldUtils {
 
   // https://datahubproject.io/docs/advanced/field-path-spec-v2/#backward-compatibility
   @Nonnull
+  public static String downgradeFieldPath(@Nonnull SchemaField field) {
+    return downgradeFieldPath(field.getFieldPath());
+  }
+
+  @Nonnull
   private static String downgradeFieldPath(@Nonnull String fieldPath) {
     if (fieldPath.startsWith(FIELD_PATH_V2)) {
       return Arrays.stream(fieldPath.substring(FIELD_PATH_V2.length()).split("[.]"))

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/SchemaFieldUtilsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/SchemaFieldUtilsTest.java
@@ -30,6 +30,19 @@ public class SchemaFieldUtilsTest {
             "[version=2.0].[type=ABFooUnion].[type=union].[type=array].[type=array].[type=Foo].a.[type=long].f"),
         UrnUtils.getUrn(
             "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,cypress_project.jaffle_shop.customers,PROD),[version=2.0].[type=ABFooUnion].[type=union].[type=array].[type=array].[type=Foo].a.[type=long].f)"));
+
+    assertEquals(
+        SchemaFieldUtils.generateSchemaFieldUrn(
+            TEST_DATASET_URN,
+            "[version=2.0].[type=ABFooUnion].[type=union].[type=array].[type=array].[type=Foo].a.[type=long].f"),
+        UrnUtils.getUrn(
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,cypress_project.jaffle_shop.customers,PROD),[version=2.0].[type=ABFooUnion].[type=union].[type=array].[type=array].[type=Foo].a.[type=long].f)"));
+
+    assertEquals(
+        SchemaFieldUtils.generateSchemaFieldUrn(
+            TEST_DATASET_URN, "Split 1 - final (Investment Income Details"),
+        UrnUtils.getUrn(
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,cypress_project.jaffle_shop.customers,PROD),Split 1 - final %28Investment Income Details)"));
   }
 
   @Test


### PR DESCRIPTION
Use one method for downgrading field paths and encoding schema field urns to be consistent and make sure we are encoding properly.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
