### PR TITLE
fix(cli): use patch to update dataset properties

### DIFF
--- a/metadata-ingestion-modules/dagster-plugin/tests/unit/golden/golden_test_emit_metadata_mcps.json
+++ b/metadata-ingestion-modules/dagster-plugin/tests/unit/golden/golden_test_emit_metadata_mcps.json
@@ -110,7 +110,7 @@
       "json": {
         "customProperties": {
           "job_snapshot_id": "28d03bf7b3138bea153a21f70f29e7c3ffa6ab0a",
-          "execution_plan_snapshot_id": "0f504b218cd28750ffa8d90a40e9647acba72021",
+          "execution_plan_snapshot_id": "834efb7cde870e3a78a6a8249c14733e089b7470",
           "has_repository_load_data": "False",
           "tags": "{}",
           "steps_succeeded": "2",

--- a/metadata-ingestion/src/datahub/ingestion/api/source_helpers.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source_helpers.py
@@ -92,6 +92,7 @@ def create_dataset_props_patch_builder(
     patch_builder.set_last_modified(dataset_properties.lastModified)
     patch_builder.set_qualified_name(dataset_properties.qualifiedName)
     patch_builder.add_custom_properties(dataset_properties.customProperties)
+    patch_builder.set_external_url(dataset_properties.externalUrl)
 
     return patch_builder
 

--- a/metadata-ingestion/src/datahub/specific/dataset.py
+++ b/metadata-ingestion/src/datahub/specific/dataset.py
@@ -292,3 +292,15 @@ class DatasetPatchBuilder(
                 value=timestamp,
             )
         return self
+
+    def set_external_url(
+        self, external_url: Optional[str] = None
+    ) -> "DatasetPatchBuilder":
+        if external_url is not None:
+            self._add_patch(
+                DatasetProperties.ASPECT_NAME,
+                "add",
+                path=("externalUrl",),
+                value=external_url,
+            )
+        return self

--- a/metadata-ingestion/tests/integration/dynamodb/dynamodb_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dynamodb/dynamodb_platform_instance_mces_golden.json
@@ -57,17 +57,6 @@
                     },
                     "nativeDataType": "List",
                     "recursive": false,
-                    "glossaryTerms": {
-                        "terms": [
-                            {
-                                "urn": "urn:li:glossaryTerm:Phone_Number"
-                            }
-                        ],
-                        "auditStamp": {
-                            "time": 1693396800000,
-                            "actor": "urn:li:corpuser:datahub"
-                        }
-                    },
                     "isPartOfKey": false
                 },
                 {
@@ -222,22 +211,6 @@
     "aspect": {
         "json": {
             "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1693396800000,
-        "runId": "dynamodb-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "glossaryTerm",
-    "entityUrn": "urn:li:glossaryTerm:Phone_Number",
-    "changeType": "UPSERT",
-    "aspectName": "glossaryTermKey",
-    "aspect": {
-        "json": {
-            "name": "Phone_Number"
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/dynamodb/dynamodb_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dynamodb/dynamodb_platform_instance_mces_golden.json
@@ -57,6 +57,17 @@
                     },
                     "nativeDataType": "List",
                     "recursive": false,
+                    "glossaryTerms": {
+                        "terms": [
+                            {
+                                "urn": "urn:li:glossaryTerm:Phone_Number"
+                            }
+                        ],
+                        "auditStamp": {
+                            "time": 1693396800000,
+                            "actor": "urn:li:corpuser:datahub"
+                        }
+                    },
                     "isPartOfKey": false
                 },
                 {
@@ -211,6 +222,22 @@
     "aspect": {
         "json": {
             "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1693396800000,
+        "runId": "dynamodb-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "glossaryTerm",
+    "entityUrn": "urn:li:glossaryTerm:Phone_Number",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTermKey",
+    "aspect": {
+        "json": {
+            "name": "Phone_Number"
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_privatelink_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_privatelink_golden.json
@@ -180,12 +180,17 @@
                 "op": "add",
                 "path": "/customProperties/IS_HYBRID",
                 "value": "true"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_3/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -631,12 +636,17 @@
                 "op": "add",
                 "path": "/customProperties/IS_SECURE",
                 "value": "true"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_1/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ivthci",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -899,12 +909,17 @@
                 "op": "add",
                 "path": "/customProperties/IS_ICEBERG",
                 "value": "true"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_1/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1586,12 +1601,17 @@
                 "op": "add",
                 "path": "/customProperties/CLUSTERING_KEY",
                 "value": "LINEAR(COL_1)"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_10/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1847,12 +1867,17 @@
                 "op": "add",
                 "path": "/customProperties/CLUSTERING_KEY",
                 "value": "LINEAR(COL_1)"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_5/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1901,12 +1926,17 @@
                 "op": "add",
                 "path": "/customProperties/IS_DYNAMIC",
                 "value": "true"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_2/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2485,12 +2515,17 @@
                 "op": "add",
                 "path": "/customProperties/CLUSTERING_KEY",
                 "value": "LINEAR(COL_1)"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_6/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2827,12 +2862,17 @@
                 "op": "add",
                 "path": "/customProperties/CLUSTERING_KEY",
                 "value": "LINEAR(COL_1)"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_7/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2892,12 +2932,17 @@
                 "op": "add",
                 "path": "/customProperties/CLUSTERING_KEY",
                 "value": "LINEAR(COL_1)"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_4/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3412,12 +3457,17 @@
                 "op": "add",
                 "path": "/customProperties/CLUSTERING_KEY",
                 "value": "LINEAR(COL_1)"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_8/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3574,12 +3624,17 @@
                 "op": "add",
                 "path": "/customProperties/CLUSTERING_KEY",
                 "value": "LINEAR(COL_1)"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_9/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3896,12 +3951,17 @@
                 "op": "add",
                 "path": "/qualifiedName",
                 "value": "TEST_DB.TEST_SCHEMA.VIEW_2"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_2/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ad3hnf",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4459,12 +4519,17 @@
                 "op": "add",
                 "path": "/customProperties/STALE_AFTER",
                 "value": "2021-06-22T00:00:00+00:00"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://app.abc12345.ap-south-1.privatelink.snowflakecomputing.com/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/STREAM_1/"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00-ftc9zc",
+        "runId": "snowflake-2022_06_07-17_00_00-9hbbfo",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/unity/unity_catalog_mces_golden.json
+++ b/metadata-ingestion/tests/integration/unity/unity_catalog_mces_golden.json
@@ -292,13 +292,19 @@
                 "op": "add",
                 "path": "/customProperties/created_at",
                 "value": "2022-06-22 05:14:56"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://dummy.cloud.databricks.com/explore/data/hive_metastore/bronze_kambi/view1"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1638860400000,
         "runId": "unity-catalog-test",
-        "lastRunId": "no-run-id-provided"
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-test-pipeline"
     }
 },
 {
@@ -1389,13 +1395,19 @@
                 "op": "add",
                 "path": "/customProperties/created_at",
                 "value": "2022-06-22 05:14:56"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://dummy.cloud.databricks.com/explore/data/hive_metastore/bronze_kambi/bet"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1638860400000,
         "runId": "unity-catalog-test",
-        "lastRunId": "no-run-id-provided"
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-test-pipeline"
     }
 },
 {
@@ -1599,13 +1611,19 @@
                 "op": "add",
                 "path": "/customProperties/created_at",
                 "value": "2022-06-22 05:14:56"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://dummy.cloud.databricks.com/explore/data/hive_metastore/bronze_kambi/external_metastore"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1638860400000,
         "runId": "unity-catalog-test",
-        "lastRunId": "no-run-id-provided"
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-test-pipeline"
     }
 },
 {
@@ -1677,13 +1695,19 @@
                 "op": "add",
                 "path": "/customProperties/table_id",
                 "value": "hive_metastore.bronze_kambi.delta_error_table"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://dummy.cloud.databricks.com/explore/data/hive_metastore/bronze_kambi/delta_error_table"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1638860400000,
         "runId": "unity-catalog-test",
-        "lastRunId": "no-run-id-provided"
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-test-pipeline"
     }
 },
 {
@@ -2679,13 +2703,19 @@
                 "op": "add",
                 "path": "/customProperties/created_at",
                 "value": "2022-10-19 13:21:38.688000+00:00"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://dummy.cloud.databricks.com/explore/data/quickstart_catalog/quickstart_schema/quickstart_table_external"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1638860400000,
         "runId": "unity-catalog-test",
-        "lastRunId": "no-run-id-provided"
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-test-pipeline"
     }
 },
 {
@@ -2974,13 +3004,19 @@
                 "op": "add",
                 "path": "/customProperties/created_at",
                 "value": "2022-10-19 13:21:38.688000+00:00"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "https://dummy.cloud.databricks.com/explore/data/quickstart_catalog/quickstart_schema/quickstart_table"
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1638860400000,
         "runId": "unity-catalog-test",
-        "lastRunId": "no-run-id-provided"
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-test-pipeline"
     }
 },
 {

--- a/metadata-ingestion/tests/unit/cli/dataset/test_resources/dataset.yaml
+++ b/metadata-ingestion/tests/unit/cli/dataset/test_resources/dataset.yaml
@@ -22,6 +22,9 @@
   platform: hive
   urn: urn:li:dataset:(urn:li:dataPlatform:hive,user.clicksv3,PROD) # use urn instead of id and platform
   subtype: View
+  name: clicks v3
+  description: clicks v3 description
+  external_url: http://foo.bar
   schema:
     # file: examples/structured_properties/click_event.avsc
     fields:

--- a/metadata-ingestion/tests/unit/cli/dataset/test_resources/golden_test_dataset_sync_mpcs.json
+++ b/metadata-ingestion/tests/unit/cli/dataset/test_resources/golden_test_dataset_sync_mpcs.json
@@ -1,0 +1,213 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,user.clicksv2,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/customProperties",
+                "value": {
+                    "test_property": "test_value"
+                }
+            },
+            {
+                "op": "add",
+                "path": "/name",
+                "value": "user.clicksv2"
+            }
+        ]
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,user.clicksv2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "user.clicksv2",
+            "platform": "urn:li:dataPlatform:hive",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": "fields:\n- description: The IP address of the user\n  id: ip\n  structured_properties:\n    io.acryl.privacy.retentionTime:\n    - '30'\n    - '90'\n  type: string\n- description: The user ID of the user\n  id: user_id\n  type: string\n"
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "ip",
+                    "nullable": false,
+                    "description": "The IP address of the user",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "user_id",
+                    "nullable": false,
+                    "description": "The user ID of the user",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,user.clicksv2,PROD),ip)",
+    "changeType": "UPSERT",
+    "aspectName": "structuredProperties",
+    "aspect": {
+        "json": {
+            "properties": [
+                {
+                    "propertyUrn": "urn:li:structuredProperty:io.acryl.privacy.retentionTime",
+                    "values": [
+                        {
+                            "string": "30"
+                        },
+                        {
+                            "string": "90"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,user.clicksv2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,user.clicksv3,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/customProperties",
+                "value": {}
+            },
+            {
+                "op": "add",
+                "path": "/description",
+                "value": "clicks v3 description"
+            },
+            {
+                "op": "add",
+                "path": "/name",
+                "value": "clicks v3"
+            },
+            {
+                "op": "add",
+                "path": "/externalUrl",
+                "value": "http://foo.bar"
+            }
+        ]
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,user.clicksv3,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "clicks v3",
+            "platform": "urn:li:dataPlatform:hive",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": "fields:\n- description: The IP address of the user\n  id: ip\n  type: string\n- description: The user ID of the user\n  id: user_id\n  type: string\n"
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "ip",
+                    "nullable": false,
+                    "description": "The IP address of the user",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "user_id",
+                    "nullable": false,
+                    "description": "The user ID of the user",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,user.clicksv3,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "View"
+            ]
+        }
+    }
+}
+]


### PR DESCRIPTION
Since the datahub dataset sync CLI supports a subset of the full dataset model, an update using the subset supported by the CLI was causing any additional properties previously set to be wiped out. 

Using patch instead upsert for all aspects were a subset of fields (and not all fields) are handled by the cli sync option of the datahub dataset command.
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
