### PR TITLE
fix(events API): Add back the original fixes for events API

### DIFF
--- a/metadata-service/events-service/build.gradle
+++ b/metadata-service/events-service/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation externalDependency.kafkaClients
     implementation externalDependency.kafkaAvroSerde
 
+    testImplementation externalDependency.mockito
+    testImplementation externalDependency.testng
+
     compileOnly externalDependency.lombok
     compileOnly externalDependency.swaggerAnnotations
 

--- a/metadata-service/events-service/src/main/java/io/datahubproject/event/kafka/KafkaConsumerPool.java
+++ b/metadata-service/events-service/src/main/java/io/datahubproject/event/kafka/KafkaConsumerPool.java
@@ -10,7 +10,6 @@ public class KafkaConsumerPool {
 
   private final BlockingQueue<KafkaConsumer<String, GenericRecord>> consumerPool;
   private final ConsumerFactory<String, GenericRecord> consumerFactory;
-  private final int initialPoolSize;
   private final int maxPoolSize;
 
   public KafkaConsumerPool(
@@ -18,7 +17,6 @@ public class KafkaConsumerPool {
       final int initialPoolSize,
       final int maxPoolSize) {
     this.consumerFactory = consumerFactory;
-    this.initialPoolSize = initialPoolSize;
     this.maxPoolSize = maxPoolSize;
     this.consumerPool = new LinkedBlockingQueue<>();
 

--- a/metadata-service/events-service/src/main/java/io/datahubproject/event/models/v1/ExternalEvent.java
+++ b/metadata-service/events-service/src/main/java/io/datahubproject/event/models/v1/ExternalEvent.java
@@ -1,12 +1,16 @@
 package io.datahubproject.event.models.v1;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Data
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ExternalEvent {
   /** The encoding type of the event */
   private String contentType;

--- a/metadata-service/events-service/src/main/java/io/datahubproject/event/models/v1/ExternalEvents.java
+++ b/metadata-service/events-service/src/main/java/io/datahubproject/event/models/v1/ExternalEvents.java
@@ -1,13 +1,17 @@
 package io.datahubproject.event.models.v1;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Data
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class ExternalEvents {
   /** Offset id for the next batch */
   private String offsetId;

--- a/metadata-service/events-service/src/main/java/io/datahubproject/event/models/v1/ExternalEventsResponse.java
+++ b/metadata-service/events-service/src/main/java/io/datahubproject/event/models/v1/ExternalEventsResponse.java
@@ -19,4 +19,7 @@ public class ExternalEventsResponse {
 
   @Schema(description = "The raw events")
   private List<ExternalEvent> events;
+
+  @Schema(description = "The error message if the request failed")
+  private String errorMessage;
 }

--- a/metadata-service/events-service/src/test/java/io/datahubproject/event/ExternalEventsServiceTest.java
+++ b/metadata-service/events-service/src/test/java/io/datahubproject/event/ExternalEventsServiceTest.java
@@ -1,0 +1,115 @@
+package io.datahubproject.event;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.datahubproject.event.exception.UnsupportedTopicException;
+import io.datahubproject.event.kafka.KafkaConsumerPool;
+import io.datahubproject.event.models.v1.ExternalEvents;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ExternalEventsServiceTest {
+  @Mock private KafkaConsumerPool consumerPool;
+  @Mock private KafkaConsumer<String, GenericRecord> kafkaConsumer;
+  @Mock private ObjectMapper objectMapper;
+  private ExternalEventsService service;
+  private Map<String, String> topicNames = new HashMap<>();
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    when(consumerPool.borrowConsumer()).thenReturn(kafkaConsumer);
+    topicNames.put(ExternalEventsService.PLATFORM_EVENT_TOPIC_NAME, "CustomerSpecificTopicName");
+    service = new ExternalEventsService(consumerPool, objectMapper, topicNames, 10, 100);
+
+    // Setup to simulate fetching records from Kafka
+    String topicName = "CustomerSpecificTopicName";
+    int partition = 0;
+    TopicPartition topicPartition = new TopicPartition(topicName, partition);
+
+    String userSchemaJson =
+        "{"
+            + "\"type\": \"record\","
+            + "\"name\": \"User\","
+            + "\"fields\": ["
+            + "  {\"name\": \"id\", \"type\": \"int\"},"
+            + "  {\"name\": \"name\", \"type\": \"string\"},"
+            + "  {\"name\": \"email\", \"type\": \"string\"}"
+            + "]}";
+
+    Schema userSchema = new Schema.Parser().parse(userSchemaJson);
+
+    GenericRecord testEvent1 = new GenericData.Record(userSchema);
+    testEvent1.put("id", 1);
+    testEvent1.put("name", "John Doe");
+    testEvent1.put("email", "john.doe@example.com");
+
+    GenericRecord testEvent2 = new GenericData.Record(userSchema);
+    testEvent2.put("id", 2);
+    testEvent2.put("name", "Jane Doe");
+    testEvent2.put("email", "jane.doe@example.com");
+
+    // Create a list of ConsumerRecords to return
+    List<ConsumerRecord<String, GenericRecord>> recordsList =
+        Arrays.asList(
+            new ConsumerRecord<>(topicName, partition, 0, "key1", testEvent1),
+            new ConsumerRecord<>(topicName, partition, 1, "key2", testEvent2));
+
+    // Create a Map<TopicPartition, List<ConsumerRecord<String, GenericRecord>>> for the
+    // ConsumerRecords constructor
+    Map<TopicPartition, List<ConsumerRecord<String, GenericRecord>>> recordsMap = new HashMap<>();
+    recordsMap.put(topicPartition, recordsList);
+
+    // Create the ConsumerRecords instance
+    ConsumerRecords<String, GenericRecord> consumerRecords = new ConsumerRecords<>(recordsMap);
+
+    // When the consumer polls, return this ConsumerRecords instance
+    when(kafkaConsumer.poll(eq(Duration.ofMillis(1000)))).thenReturn(consumerRecords);
+  }
+
+  @Test
+  public void testPollValidTopic() throws Exception {
+    // Mocking Kafka and ObjectMapper behaviors
+    when(kafkaConsumer.partitionsFor(anyString())).thenReturn(Collections.emptyList());
+    when(objectMapper.writeValueAsString(any())).thenReturn("encodedString");
+
+    // Execute
+    ExternalEvents events =
+        service.poll(ExternalEventsService.PLATFORM_EVENT_TOPIC_NAME, null, 10, 5, null);
+
+    // Validate
+    assertNotNull(events);
+    verify(kafkaConsumer, atLeastOnce()).poll(any());
+  }
+
+  @Test(expectedExceptions = UnsupportedTopicException.class)
+  public void testPollInvalidTopic() throws Exception {
+    service.poll("InvalidTopic", null, 10, 5, null);
+  }
+
+  @Test
+  public void testShutdown() {
+    // Execute
+    service.shutdown();
+
+    // Validate
+    verify(consumerPool).shutdownPool();
+  }
+}

--- a/metadata-service/events-service/src/test/java/io/datahubproject/event/kafka/KafkaConsumerPoolTest.java
+++ b/metadata-service/events-service/src/test/java/io/datahubproject/event/kafka/KafkaConsumerPoolTest.java
@@ -1,0 +1,65 @@
+package io.datahubproject.event.kafka;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class KafkaConsumerPoolTest {
+
+  @Mock private ConsumerFactory<String, GenericRecord> consumerFactory;
+
+  @Mock private KafkaConsumer<String, GenericRecord> kafkaConsumer;
+
+  private KafkaConsumerPool kafkaConsumerPool;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.initMocks(this); // Initialize mocks
+    when(consumerFactory.createConsumer()).thenReturn(kafkaConsumer);
+
+    // Manually instantiate KafkaConsumerPool after mocks are initialized
+    kafkaConsumerPool = new KafkaConsumerPool(consumerFactory, 2, 5);
+  }
+
+  @Test
+  public void testPoolInitialization() {
+    // Verify the consumer is created the initial number of times
+    verify(consumerFactory, times(2)).createConsumer();
+  }
+
+  @Test
+  public void testBorrowConsumerWhenAvailable() throws InterruptedException {
+    // Setup initial state
+    KafkaConsumer<String, GenericRecord> consumer = kafkaConsumerPool.borrowConsumer();
+
+    // Assertions
+    assertNotNull(consumer, "Consumer should not be null when borrowed");
+    verify(consumerFactory, times(2)).createConsumer(); // Initial + this borrow
+  }
+
+  @Test
+  public void testReturnConsumerToPool() throws InterruptedException {
+    // Return the consumer and then borrow again to check if it's the same instance
+    kafkaConsumerPool.returnConsumer(kafkaConsumer);
+    KafkaConsumer<String, GenericRecord> borrowedAgain = kafkaConsumerPool.borrowConsumer();
+
+    // Assertions
+    assertSame(borrowedAgain, kafkaConsumer, "The same consumer should be returned from the pool");
+  }
+
+  @Test
+  public void testShutdownPool() {
+    // Call shutdown
+    kafkaConsumerPool.shutdownPool();
+
+    // Verify all consumers are closed
+    verify(kafkaConsumer, atLeastOnce()).close();
+  }
+}


### PR DESCRIPTION
## Summary

In this PR we add back validated fixes for the events API. This includes correctly parsing the offset from topic name and other small fixes. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
