### PR TITLE
feat(ingest/snowflake): show returned query row counts

### DIFF
--- a/metadata-ingestion/tests/integration/snowflake/common.py
+++ b/metadata-ingestion/tests/integration/snowflake/common.py
@@ -173,6 +173,28 @@ large_sql_query = """WITH object_access_history AS
                                                """
 
 
+class RowCountList(list):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def rowcount(self):
+        return len(self)
+
+
+def inject_rowcount(func):
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        if result is None or isinstance(result, RowCountList):
+            return result
+        assert isinstance(result, list)
+        result = RowCountList(result)
+        return result
+
+    return wrapper
+
+
+@inject_rowcount
 def default_query_results(  # noqa: C901
     query,
     num_tables=NUM_TABLES,

--- a/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
+++ b/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
@@ -11,10 +11,15 @@ from datahub.ingestion.run.pipeline_config import PipelineConfig, SourceConfig
 from datahub.ingestion.source.snowflake import snowflake_query
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
 from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
-from tests.integration.snowflake.common import FROZEN_TIME, default_query_results
+from tests.integration.snowflake.common import (
+    FROZEN_TIME,
+    default_query_results,
+    inject_rowcount,
+)
 
 
 def query_permission_error_override(fn, override_for_query, error_msg):
+    @inject_rowcount
     def my_function(query):
         if query in override_for_query:
             raise Exception(error_msg)
@@ -25,6 +30,7 @@ def query_permission_error_override(fn, override_for_query, error_msg):
 
 
 def query_permission_response_override(fn, override_for_query, response):
+    @inject_rowcount
     def my_function(query):
         if query in override_for_query:
             return response

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
@@ -39,6 +39,7 @@ from datahub.ingestion.source.snowflake.snowflake_utils import (
 from datahub.ingestion.source.snowflake.snowflake_v2 import SnowflakeV2Source
 from datahub.sql_parsing.sql_parsing_aggregator import TableRename, TableSwap
 from datahub.testing.doctest import assert_doctest
+from tests.integration.snowflake.common import inject_rowcount
 from tests.test_helpers import test_connection_helpers
 
 default_oauth_dict: Dict[str, Any] = {
@@ -335,6 +336,7 @@ class MissingQueryMock(Exception):
 
 
 def setup_mock_connect(mock_connect, extra_query_results=None):
+    @inject_rowcount
     def query_results(query):
         if extra_query_results is not None:
             try:


### PR DESCRIPTION
This should help with debugging situations where behavior seems to differ between our ingestion and snowsight.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
