### PR TITLE
fix(ui): fix a type error when a CorpGroup entity appears in the search result with theme V2

### DIFF
--- a/datahub-web-react/src/app/entityV2/group/GroupMembersSidebarSectionContent.tsx
+++ b/datahub-web-react/src/app/entityV2/group/GroupMembersSidebarSectionContent.tsx
@@ -23,7 +23,7 @@ export default function GroupMembersSidebarSectionContent({ groupMemberRelations
 
     const entityRegistry = useEntityRegistry();
     const relationshipsTotal = groupMemberRelationships?.total || 0;
-    const relationshipsAvailableCount = groupMemberRelationships.relationships?.length || 0;
+    const relationshipsAvailableCount = groupMemberRelationships?.relationships?.length || 0;
 
     const hasHiddenEntities = relationshipsTotal > relationshipsAvailableCount;
     const isShowingMaxEntities = entityCount >= relationshipsAvailableCount;
@@ -36,7 +36,7 @@ export default function GroupMembersSidebarSectionContent({ groupMemberRelations
                     <Typography.Paragraph type="secondary">No members yet.</Typography.Paragraph>
                 )}
                 {relationshipsTotal > 0 &&
-                    groupMemberRelationships.relationships.map((item, index) => {
+                    groupMemberRelationships?.relationships.map((item, index) => {
                         const user = item.entity as CorpUser;
                         return index < entityCount && <GroupMemberLink user={user} entityRegistry={entityRegistry} />;
                     })}


### PR DESCRIPTION
This PR fixes a type error when CorpGroup entities appear in the search result with the theme V2.

![grafik](https://github.com/user-attachments/assets/86ebf35a-98fe-40ad-a28d-5247d0a16d33)


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
