### PR TITLE
improvement(component-library): bring back component library changes

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
@@ -69,6 +69,7 @@ export const SimpleSelect = ({
     values,
     initialValues,
     onUpdate,
+    onClear,
     showSearch = selectDefaults.showSearch,
     isDisabled = selectDefaults.isDisabled,
     isReadOnly = selectDefaults.isReadOnly,
@@ -91,6 +92,7 @@ export const SimpleSelect = ({
     optionListStyle,
     optionSwitchable,
     selectLabelProps,
+    selectedOptionListStyle,
     position,
     applyHoverWidth,
     ignoreMaxHeight = selectDefaults.ignoreMaxHeight,
@@ -165,7 +167,10 @@ export const SimpleSelect = ({
         if (onUpdate) {
             onUpdate([]);
         }
-    }, [onUpdate]);
+        if (onClear) {
+            onClear();
+        }
+    }, [onUpdate, onClear]);
 
     const handleSelectAll = () => {
         if (areAllSelected) {
@@ -301,6 +306,7 @@ export const SimpleSelect = ({
                             disabledValues={disabledValues}
                             showDescriptions={showDescriptions}
                             renderCustomSelectedValue={renderCustomSelectedValue}
+                            selectedOptionListStyle={selectedOptionListStyle}
                             {...(selectLabelProps || {})}
                         />
                     </SelectLabelContainer>

--- a/datahub-web-react/src/alchemy-components/components/Select/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/components.ts
@@ -25,11 +25,12 @@ export const SelectBase = styled.div<SelectStyleProps>(
         transition: sharedTransition,
         justifyContent: 'space-between',
         alignSelf: position || 'end',
+        minHeight: '36px',
         alignItems: 'center',
         overflow: 'auto',
         textWrapMode: 'nowrap',
         backgroundColor: isDisabled ? colors.gray[1500] : colors.white,
-        width: width === 'full' ? '100%' : `max-content`,
+        width: width === 'full' ? '100%' : 'max-content',
     }),
 );
 

--- a/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectCustom.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectCustom.tsx
@@ -13,9 +13,10 @@ export default function MultiSelectCustom<OptionType extends SelectOption>({
     placeholder,
     isMultiSelect,
     renderCustomSelectedValue,
+    selectedOptionListStyle
 }: SelectLabelVariantProps<OptionType>) {
     return (
-        <LabelsWrapper shouldShowGap={selectedOptions.length > 1}>
+        <LabelsWrapper shouldShowGap={selectedOptions.length > 1} style={selectedOptionListStyle}>
             {!selectedValues.length && <Placeholder>{placeholder}</Placeholder>}
             {!!selectedOptions.length &&
                 isMultiSelect &&

--- a/datahub-web-react/src/alchemy-components/components/Select/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/types.ts
@@ -26,6 +26,7 @@ export interface SelectProps<OptionType extends SelectOption = SelectOption> {
     values?: string[];
     initialValues?: string[];
     onCancel?: () => void;
+    onClear?: () => void;
     onUpdate?: (selectedValues: string[]) => void;
     size?: SelectSizeOptions;
     icon?: IconNames;
@@ -47,6 +48,7 @@ export interface SelectProps<OptionType extends SelectOption = SelectOption> {
     onSearchChange?: (searchText: string) => void;
     combinedSelectedAndSearchOptions?: OptionType[];
     optionListStyle?: React.CSSProperties;
+    selectedOptionListStyle?: React.CSSProperties;
     optionListTestId?: string;
     optionSwitchable?: boolean;
     selectLabelProps?: SelectLabelProps;
@@ -86,6 +88,7 @@ export interface SelectLabelDisplayProps<OptionType extends SelectOption> {
     renderCustomSelectedValue?: (selectedOptions: OptionType) => void;
     variant?: SelectLabelVariants;
     label?: string;
+    selectedOptionListStyle?: React.CSSProperties;
 }
 
 export interface SelectLabelVariantProps<OptionType extends SelectOption>

--- a/datahub-web-react/src/alchemy-components/components/Table/Table.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Table/Table.tsx
@@ -189,7 +189,11 @@ export const Table = <T,>({
                                     key={key}
                                     canExpand={canExpand}
                                     onClick={() => {
-                                        setFocusedRowIndex(index);
+                                        if (focusedRowIndex === index) {
+                                            setFocusedRowIndex(null);
+                                        } else {
+                                            setFocusedRowIndex(index);
+                                        }
                                         if (canExpand) onExpand?.(row); // Handle row expansion
                                         onRowClick?.(row); // Handle row click
                                     }}


### PR DESCRIPTION
Bringing back changes in component library from these PRs:
https://github.com/acryldata/datahub-fork/pull/5516
https://github.com/acryldata/datahub-fork/pull/5411/files

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
