### PR TITLE
Show a spin loading icon until platformPrivileges are loaded to prevent showing a premature 404 message

### DIFF
--- a/datahub-web-react/src/app/SearchRoutes.tsx
+++ b/datahub-web-react/src/app/SearchRoutes.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
+import { Spin } from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
 
 import { AnalyticsPage } from '@app/analyticsDashboard/components/AnalyticsPage';
 import { BrowseResultsPage } from '@app/browse/BrowseResultsPage';
@@ -32,6 +34,7 @@ import {
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { useIsThemeV2 } from '@app/useIsThemeV2';
 import { PageRoutes } from '@conf/Global';
+import { ANTD_GRAY } from '@app/entity/shared/constants';
 
 /**
  * Container for all searchable page routes
@@ -57,6 +60,10 @@ export const SearchRoutes = (): JSX.Element => {
     const showTags =
         config?.featureFlags?.showManageTags &&
         (me.platformPrivileges?.manageTags || me.platformPrivileges?.viewManageTags);
+
+    if (me.platformPrivileges === undefined) {
+        return <Spin indicator={<LoadingOutlined style={{ color: ANTD_GRAY[7] }} />} />;
+    }
 
     return (
         <FinalSearchablePage>


### PR DESCRIPTION
## Background:
When platform privileges are still loading, we see a 404 page momentarily before routing to the actual path. This PR attempts to fix it by displaying a loading spin icon until platform privileges is available.

_Example:_
When navigating to /structured-propeties, we briefly see this:
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/7621a418-6252-41f4-9473-cc3fd28bf3de" />

Updated to show a spin icon:
<img width="1274" alt="Pasted Graphic 20" src="https://github.com/user-attachments/assets/26dc0604-09da-4edd-939d-9442379ac9d6" />

<img width="583" alt="image" src="https://github.com/user-attachments/assets/9ec36e61-b83b-4689-9376-79d80c847bc2" />


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
