### PR TITLE
fix(pytest) Fix broken pytest after recent schema field urn change

### DIFF
--- a/smoke-test/tests/openapi/v1/timeline.json
+++ b/smoke-test/tests/openapi/v1/timeline.json
@@ -347,10 +347,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -361,10 +361,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.type)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=string].type)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.type)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=string].type)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -375,10 +375,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -389,10 +389,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -403,10 +403,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.name)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.name)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -440,10 +440,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "MODIFY",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id)",
                 "nullable": true,
                 "modificationCategory": "RENAME"
               },
@@ -454,10 +454,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id3)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id3)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -468,10 +468,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "REMOVE",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.name)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.name)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -491,10 +491,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "MODIFY",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id2)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id2)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id2",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id2)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id2)",
                 "nullable": true,
                 "modificationCategory": "RENAME"
               },
@@ -505,10 +505,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "REMOVE",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id3)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.id3)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -519,10 +519,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.name)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),service.provider.name)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV1,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },

--- a/smoke-test/tests/openapi/v2/timeline.json
+++ b/smoke-test/tests/openapi/v2/timeline.json
@@ -347,10 +347,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -361,10 +361,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.type)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=string].type)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.type)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=string].type)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -375,10 +375,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -389,10 +389,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -403,10 +403,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.name)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.name)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -440,10 +440,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "MODIFY",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id)",
                 "nullable": true,
                 "modificationCategory": "RENAME"
               },
@@ -454,10 +454,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id3)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id3)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -468,10 +468,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "REMOVE",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.name)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.name)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -491,10 +491,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "MODIFY",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id2)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id2)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id2",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id2)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id2)",
                 "nullable": true,
                 "modificationCategory": "RENAME"
               },
@@ -505,10 +505,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "REMOVE",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id3)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.id3)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id3)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },
@@ -519,10 +519,10 @@
               "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD)",
               "category": "TECHNICAL_SCHEMA",
               "operation": "ADD",
-              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.name)",
+              "modifier": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
               "parameters": {
                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
-                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),service.provider.name)",
+                "fieldUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:test,datasetTimelineV2,PROD),[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name)",
                 "nullable": true,
                 "modificationCategory": "OTHER"
               },


### PR DESCRIPTION
We recently merged a change where we don't downgrade field paths for change events anymore so we are always consistent with how we generate schema field urns. This broke one of our pytests as the fixtures weren't updated. this updates them.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
