### PR TITLE
fix(cypress) Fix flakiness in dataset_ownership cypress test

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_ownership.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_ownership.js
@@ -4,7 +4,15 @@ const email = `example${test_id}@example.com`;
 const password = "Example password";
 const group_name = `Test group ${test_id}`;
 
-const addOwner = (owner, type, elementId) => {
+const loginAndGoToDataset = () => {
+  cy.loginWithCredentials();
+  cy.goToDataset(
+    "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
+    "SampleCypressHiveDataset",
+  );
+};
+
+const addOwner = (owner, type) => {
   cy.clickOptionWithTestId("add-owners-button");
   cy.contains("Search for users or groups...").click({ force: true });
   cy.focused().type(owner);
@@ -17,9 +25,17 @@ const addOwner = (owner, type, elementId) => {
   cy.clickOptionWithText("Done");
   cy.waitTextVisible("Owners Added");
   cy.waitTextVisible(type);
-  cy.waitTextVisible(owner).wait(3000);
+  cy.waitTextVisible(owner);
+};
+
+const verifyAssetInOwnedAssets = (owner) => {
+  // ensure elastic is consistent before checking
+  cy.wait(3000);
   cy.clickOptionWithText(owner);
   cy.waitTextVisible("SampleCypressHiveDataset");
+};
+
+const removeOwner = (owner, elementId) => {
   cy.goToDataset(
     "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
     "SampleCypressHiveDataset",
@@ -28,6 +44,13 @@ const addOwner = (owner, type, elementId) => {
   cy.clickOptionWithText("Yes");
   cy.waitTextVisible("Owner Removed");
   cy.ensureTextNotPresent(owner);
+};
+
+const addAndRemoveOwnerOnDataset = (owner, type, elementId) => {
+  loginAndGoToDataset();
+  addOwner(owner, type);
+  verifyAssetInOwnedAssets(owner);
+  removeOwner(owner, elementId);
 };
 
 describe("add, remove ownership for dataset", () => {
@@ -49,12 +72,7 @@ describe("add, remove ownership for dataset", () => {
   });
 
   it("open test dataset page, add and remove user ownership (Business Owner)", () => {
-    cy.loginWithCredentials();
-    cy.goToDataset(
-      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
-      "SampleCypressHiveDataset",
-    );
-    addOwner(
+    addAndRemoveOwnerOnDataset(
       username,
       "Business Owner",
       `[href="/user/urn:li:corpuser:example${test_id}@example.com/owner of"]`,
@@ -62,12 +80,7 @@ describe("add, remove ownership for dataset", () => {
   });
 
   it("open test dataset page, add and remove user ownership (Data Steward)", () => {
-    cy.loginWithCredentials();
-    cy.goToDataset(
-      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
-      "SampleCypressHiveDataset",
-    );
-    addOwner(
+    addAndRemoveOwnerOnDataset(
       username,
       "Data Steward",
       `[href="/user/urn:li:corpuser:example${test_id}@example.com/owner of"]`,
@@ -75,12 +88,7 @@ describe("add, remove ownership for dataset", () => {
   });
 
   it("open test dataset page, add and remove user ownership (None)", () => {
-    cy.loginWithCredentials();
-    cy.goToDataset(
-      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
-      "SampleCypressHiveDataset",
-    );
-    addOwner(
+    addAndRemoveOwnerOnDataset(
       username,
       "None",
       `[href="/user/urn:li:corpuser:example${test_id}@example.com/owner of"]`,
@@ -88,12 +96,7 @@ describe("add, remove ownership for dataset", () => {
   });
 
   it("open test dataset page, add and remove user ownership (Technical Owner)", () => {
-    cy.loginWithCredentials();
-    cy.goToDataset(
-      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
-      "SampleCypressHiveDataset",
-    );
-    addOwner(
+    addAndRemoveOwnerOnDataset(
       username,
       "Technical Owner",
       `[href="/user/urn:li:corpuser:example${test_id}@example.com/owner of"]`,
@@ -101,12 +104,7 @@ describe("add, remove ownership for dataset", () => {
   });
 
   it("open test dataset page, add and remove group ownership (Business Owner)", () => {
-    cy.loginWithCredentials();
-    cy.goToDataset(
-      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
-      "SampleCypressHiveDataset",
-    );
-    addOwner(
+    addAndRemoveOwnerOnDataset(
       group_name,
       "Business Owner",
       `[href="/group/urn:li:corpGroup:${test_id}/owner of"]`,
@@ -114,13 +112,7 @@ describe("add, remove ownership for dataset", () => {
   });
 
   it("open test dataset page, add and remove group ownership (Data Steward)", () => {
-    cy.loginWithCredentials();
-    cy.goToDataset(
-      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
-      "SampleCypressHiveDataset",
-    );
-    // data steward
-    addOwner(
+    addAndRemoveOwnerOnDataset(
       group_name,
       "Data Steward",
       `[href="/group/urn:li:corpGroup:${test_id}/owner of"]`,
@@ -128,12 +120,7 @@ describe("add, remove ownership for dataset", () => {
   });
 
   it("open test dataset page, add and remove group ownership (None)", () => {
-    cy.loginWithCredentials();
-    cy.goToDataset(
-      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
-      "SampleCypressHiveDataset",
-    );
-    addOwner(
+    addAndRemoveOwnerOnDataset(
       group_name,
       "None",
       `[href="/group/urn:li:corpGroup:${test_id}/owner of"]`,
@@ -141,12 +128,7 @@ describe("add, remove ownership for dataset", () => {
   });
 
   it("open test dataset page, add and remove group ownership (Technical Owner)", () => {
-    cy.loginWithCredentials();
-    cy.goToDataset(
-      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
-      "SampleCypressHiveDataset",
-    );
-    addOwner(
+    addAndRemoveOwnerOnDataset(
       group_name,
       "Technical Owner",
       `[href="/group/urn:li:corpGroup:${test_id}/owner of"]`,

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_ownership.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_ownership.js
@@ -28,11 +28,12 @@ const addOwner = (owner, type, elementId) => {
   cy.clickOptionWithText("Yes");
   cy.waitTextVisible("Owner Removed");
   cy.ensureTextNotPresent(owner);
-  cy.ensureTextNotPresent(type);
 };
 
 describe("add, remove ownership for dataset", () => {
   beforeEach(() => {
+    cy.setIsThemeV2Enabled(false);
+    cy.skipIntroducePage();
     cy.on("uncaught:exception", (err, runnable) => false);
   });
 
@@ -47,31 +48,51 @@ describe("add, remove ownership for dataset", () => {
     );
   });
 
-  it("open test dataset page, add and remove user ownership(test every type)", () => {
+  it("open test dataset page, add and remove user ownership (Business Owner)", () => {
     cy.loginWithCredentials();
     cy.goToDataset(
       "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
       "SampleCypressHiveDataset",
     );
-    // business owner
     addOwner(
       username,
       "Business Owner",
       `[href="/user/urn:li:corpuser:example${test_id}@example.com/owner of"]`,
     );
-    // data steward
+  });
+
+  it("open test dataset page, add and remove user ownership (Data Steward)", () => {
+    cy.loginWithCredentials();
+    cy.goToDataset(
+      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
+      "SampleCypressHiveDataset",
+    );
     addOwner(
       username,
       "Data Steward",
       `[href="/user/urn:li:corpuser:example${test_id}@example.com/owner of"]`,
     );
-    // none
+  });
+
+  it("open test dataset page, add and remove user ownership (None)", () => {
+    cy.loginWithCredentials();
+    cy.goToDataset(
+      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
+      "SampleCypressHiveDataset",
+    );
     addOwner(
       username,
       "None",
       `[href="/user/urn:li:corpuser:example${test_id}@example.com/owner of"]`,
     );
-    // technical owner
+  });
+
+  it("open test dataset page, add and remove user ownership (Technical Owner)", () => {
+    cy.loginWithCredentials();
+    cy.goToDataset(
+      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
+      "SampleCypressHiveDataset",
+    );
     addOwner(
       username,
       "Technical Owner",
@@ -79,17 +100,24 @@ describe("add, remove ownership for dataset", () => {
     );
   });
 
-  it("open test dataset page, add and remove group ownership(test every type)", () => {
+  it("open test dataset page, add and remove group ownership (Business Owner)", () => {
     cy.loginWithCredentials();
     cy.goToDataset(
       "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
       "SampleCypressHiveDataset",
     );
-    // business owner
     addOwner(
       group_name,
       "Business Owner",
       `[href="/group/urn:li:corpGroup:${test_id}/owner of"]`,
+    );
+  });
+
+  it("open test dataset page, add and remove group ownership (Data Steward)", () => {
+    cy.loginWithCredentials();
+    cy.goToDataset(
+      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
+      "SampleCypressHiveDataset",
     );
     // data steward
     addOwner(
@@ -97,13 +125,27 @@ describe("add, remove ownership for dataset", () => {
       "Data Steward",
       `[href="/group/urn:li:corpGroup:${test_id}/owner of"]`,
     );
-    // none
+  });
+
+  it("open test dataset page, add and remove group ownership (None)", () => {
+    cy.loginWithCredentials();
+    cy.goToDataset(
+      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
+      "SampleCypressHiveDataset",
+    );
     addOwner(
       group_name,
       "None",
       `[href="/group/urn:li:corpGroup:${test_id}/owner of"]`,
     );
-    // technical owner
+  });
+
+  it("open test dataset page, add and remove group ownership (Technical Owner)", () => {
+    cy.loginWithCredentials();
+    cy.goToDataset(
+      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
+      "SampleCypressHiveDataset",
+    );
     addOwner(
       group_name,
       "Technical Owner",


### PR DESCRIPTION
This one was very tough to reproduce locally because it kept crashing cypress from running out of memory every single time no matter what i did or closed on my machine.

Ultimately I decided to break this test up into smaller chunks as that is a much more sustainable and easy way of writing cypress tests. I think this may have played into the flakiness we were seeing as we were just doing too much in one test. Now this consistently passes locally for me so hoping that does the trick.

I have a few other things I'll try to get to the bottom of the errors i was seeing remotely, but will put this up first as this is an obvious improvement.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
