### PR TITLE
fix(cypress) Catch resizeObserverLoop globally and fix setThemeV2

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/auto_completeV2/v2_auto_complete.js
+++ b/smoke-test/tests/cypress/cypress/e2e/auto_completeV2/v2_auto_complete.js
@@ -4,7 +4,6 @@ describe("auto-complete", () => {
     cy.skipIntroducePage();
     cy.hideOnboardingTour();
     cy.login();
-    cy.ignoreResizeObserverLoop();
     // look for a dataset
     cy.visit("/");
     cy.wait(2000);

--- a/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
@@ -90,7 +90,6 @@ describe("Verify nested domains test functionalities", () => {
     cy.setIsThemeV2Enabled(false);
     cy.loginWithCredentials();
     cy.goToDomainList();
-    cy.ignoreResizeObserverLoop();
   });
 
   it("Verify Create a new domain", () => {

--- a/smoke-test/tests/cypress/cypress/e2e/manage_tags/manage_tags.js
+++ b/smoke-test/tests/cypress/cypress/e2e/manage_tags/manage_tags.js
@@ -1,8 +1,4 @@
 describe("manage tags", () => {
-  beforeEach(() => {
-    cy.ignoreResizeObserverLoop();
-  });
-
   it("Manage Tags Page - Verify search bar placeholder", () => {
     cy.login();
     cy.visit("/tags");

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
@@ -9,7 +9,6 @@ const ingestion_source_name = `ingestion source ${number}`;
 describe("managing secrets for ingestion creation", () => {
   it("create a secret, create ingestion source using a secret, remove a secret", () => {
     // Navigate to the manage ingestion page → secrets
-    cy.ignoreResizeObserverLoop();
     cy.loginWithCredentials();
     cy.goToIngestionPage();
     cy.clickOptionWithText("Secrets");

--- a/smoke-test/tests/cypress/cypress/support/commands.js
+++ b/smoke-test/tests/cypress/cypress/support/commands.js
@@ -531,17 +531,22 @@ Cypress.Commands.add("setIsThemeV2Enabled", (isEnabled) => {
         res.body.data.appConfig.featureFlags.themeV2Default = isEnabled;
         res.body.data.appConfig.featureFlags.showNavBarRedesign = isEnabled;
       });
+    } else if (hasOperationName(req, "getMe")) {
+      req.alias = "gqlgetMeQuery";
+      req.on("response", (res) => {
+        res.body.data.me.corpUser.settings.appearance.showThemeV2 = isEnabled;
+      });
     }
   });
 });
 
-Cypress.Commands.add("ignoreResizeObserverLoop", () => {
-  const resizeObserverLoopErrRe = "ResizeObserver loop limit exceeded";
-  cy.on("uncaught:exception", (err) => {
-    if (err.message.includes(resizeObserverLoopErrRe)) {
-      return false;
-    }
-  });
+Cypress.on("uncaught:exception", (err) => {
+  const resizeObserverLoopErrMessage = "ResizeObserver loop limit exceeded";
+
+  /* returning false here prevents Cypress from failing the test */
+  if (err.message.includes(resizeObserverLoopErrMessage)) {
+    return false;
+  }
 });
 
 //


### PR DESCRIPTION
Makes 2 small improvements to our cypress suite:

1. Globally catch the reseizeObserverLoop error that shouldn't cause cypress to fail. We were manually setting this on a few tests we could see locally but occasionally tests would fail in CI because of this. This is a safe error to skip and is heavily documented with this recommendation from the cypress team.
2. When developing locally, if your user has toggled v2 ui on or off, the `setIsThemeV2Enabled` override in cypress doesn't do anything. This makes developing on cypress a little easier locally. My team has run into this, I've run into this, I know others who has as well. No more!

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
