### PR TITLE
ci: increase runner size for smoke tests

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1231,7 +1231,7 @@ jobs:
       - id: set-runner
         run: |
           if [[ "${{ env.DOCKER_CACHE }}" == "DEPOT" && "${{ env.DEPOT_PROJECT_ID }}" != "" ]]; then
-            echo "runner_type=depot-ubuntu-24.04" >> "$GITHUB_OUTPUT"
+            echo "runner_type=depot-ubuntu-24.04-4" >> "$GITHUB_OUTPUT"
           else
             echo "runner_type=ubuntu-latest" >> "$GITHUB_OUTPUT"
           fi
@@ -1253,7 +1253,7 @@ jobs:
     if: ${{ always() && !failure() && !cancelled() && needs.smoke_test_matrix.outputs.matrix != '[]' }}
     steps:
       - name: Free up disk space
-        if: ${{ needs.determine_runner.outputs.runner_type != 'depot-ubuntu-24.04' }}
+        if: ${{ needs.determine_runner.outputs.runner_type == 'ubuntu-latest' }}
         run: |
           sudo apt-get remove 'dotnet-*' azure-cli || true
           sudo rm -rf /usr/local/lib/android/ || true


### PR DESCRIPTION
Some cypress tests seem to cause the GMS to crash and needed a larger runner. 
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
