### PR TITLE
fix(cypress) Fix flakiness in nested_domains and v2_nested_domains cypress tests

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EntitySearchResults.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EntitySearchResults.tsx
@@ -104,6 +104,7 @@ export const EntitySearchResults = ({
                                   )
                                 : isSelectMode && (
                                       <StyledCheckbox
+                                          data-testid={`checkbox-${entity.urn}`}
                                           checked={selectedEntityUrns.indexOf(entity.urn) >= 0}
                                           onChange={(e) =>
                                               onSelectEntity({ urn: entity.urn, type: entity.type }, e.target.checked)

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/EditOwnersModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/EditOwnersModal.tsx
@@ -392,6 +392,7 @@ export const EditOwnersModal = ({
                                 label: owner.label,
                             }))}
                             optionLabelProp="label"
+                            data-testid="users-group-search"
                         >
                             {ownerSearchOptions}
                         </SelectInput>

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/EntitySearchResults.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/EntitySearchResults.tsx
@@ -179,6 +179,7 @@ export const EntitySearchResults = ({
                                             !selectedEntityUrns.includes(entity.urn)
                                         }
                                         onChange={(e) => onSelectEntity(entity, e.target.checked)}
+                                        data-testid={`checkbox-${entity.urn}`}
                                     />
                                 )}
                                 {entityRegistry.renderSearchResult(entity.type, searchResult)}

--- a/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
@@ -1,4 +1,5 @@
 const domainName = "CypressNestedDomain";
+const chartUrn = "urn:li:chart:(looker,baz1)";
 
 const createDomain = () => {
   cy.get(".anticon-plus").first().click();
@@ -60,6 +61,7 @@ const verifyEditAndPerformAddAndRemoveActionForDomain = (
 ) => {
   cy.clickOptionWithText(entity);
   cy.clickOptionWithText(action);
+  cy.wait(500);
   cy.get('[data-testid="tag-term-modal-input"]').type(text);
   cy.get('[data-testid="tag-term-option"]').contains(text).click();
   cy.clickOptionWithText(body);
@@ -135,6 +137,9 @@ describe("Verify nested domains test functionalities", () => {
     cy.waitTextVisible("Test Label");
     cy.clickOptionWithTestId("add-owners-button");
     cy.waitTextVisible("Find a user or group");
+    cy.get('[data-testid="users-group-search"]').type(
+      Cypress.env("ADMIN_DISPLAYNAME"),
+    );
     cy.clickTextOptionWithClass(
       ".rc-virtual-list-holder-inner",
       Cypress.env("ADMIN_DISPLAYNAME"),
@@ -224,25 +229,26 @@ describe("Verify nested domains test functionalities", () => {
     cy.clickOptionWithText("Add assets");
     cy.waitTextVisible("Add assets to Domain");
     cy.enterTextInSpecificTestId("search-bar", 3, "Baz Chart 1");
-    cy.clickOptionWithSpecificClass(".ant-checkbox", 1);
+    cy.clickFirstOptionWithTestId(`checkbox-${chartUrn}`);
     cy.clickOptionWithId("#continueButton");
     cy.waitTextVisible("Added assets to Domain!");
     cy.openThreeDotMenu();
     cy.clickOptionWithText("Edit");
-    cy.clickOptionWithSpecificClass(".ant-checkbox", 1);
+    cy.clickFirstOptionWithTestId(`checkbox-${chartUrn}`);
     verifyEditAndPerformAddAndRemoveActionForDomain(
       "Tags",
       "Add tags",
       "Cypress",
       "Add Tags",
     );
+    cy.wait(3000); // give time for elastic to update before going to page
     cy.clickOptionWithText("Baz Chart 1");
     cy.waitTextVisible("Cypress");
     cy.waitTextVisible("Marketing");
     cy.go("back");
     cy.openThreeDotMenu();
     cy.clickOptionWithText("Edit");
-    cy.clickOptionWithSpecificClass(".ant-checkbox", 1);
+    cy.clickFirstOptionWithTestId(`checkbox-${chartUrn}`);
     verifyEditAndPerformAddAndRemoveActionForDomain(
       "Tags",
       "Remove tags",

--- a/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
@@ -1,5 +1,5 @@
 const domainName = "CypressNestedDomain";
-const chartUrn = "urn:li:chart:(looker,baz1)";
+const chartUrn = "urn:li:chart:(looker,cypress_baz1)";
 
 const createDomain = () => {
   cy.get(".anticon-plus").first().click();

--- a/smoke-test/tests/cypress/cypress/e2e/domainsV2/v2_nested_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/domainsV2/v2_nested_domains.js
@@ -1,4 +1,5 @@
 const domainName = "CypressNestedDomain";
+const chartUrn = "urn:li:chart:(looker,baz2)";
 
 const handledResizeLoopErrors = () => {
   const resizeObserverLoopLimitErrRe = "ResizeObserver loop limit exceeded";
@@ -282,7 +283,7 @@ describe("Verify nested domains test functionalities", () => {
     cy.waitTextVisible("Add assets to Domain");
     cy.get("[data-testid='search-input']").last().type("Baz Chart 2");
     cy.get('[data-testid="preview-urn:li:chart:(looker,cypress_baz2)"]');
-    cy.clickOptionWithSpecificClass(".ant-checkbox", 1);
+    cy.clickFirstOptionWithTestId(`checkbox-${chartUrn}`);
     cy.clickOptionWithId("#continueButton");
     cy.waitTextVisible("Added assets to Domain!");
     cy.get('[data-node-key="Assets"]').click();
@@ -293,13 +294,14 @@ describe("Verify nested domains test functionalities", () => {
     }).click();
     cy.waitTextVisible("0 selected");
     cy.get("[data-testid='search-input']").last().type("Baz Chart 2");
-    cy.clickOptionWithSpecificClass(".ant-checkbox", 1);
+    cy.clickFirstOptionWithTestId(`checkbox-${chartUrn}`);
     verifyEditAndPerformAddAndRemoveActionForDomain(
       "Tags",
       "Add tags",
       "Cypress",
       "Add Tags",
     );
+    cy.wait(3000); // give time for elastic to update before going to page
     cy.clickOptionWithText("Baz Chart 2");
     cy.waitTextVisible("Cypress");
     cy.waitTextVisible("Marketing");
@@ -307,7 +309,7 @@ describe("Verify nested domains test functionalities", () => {
     cy.get('[data-testid="search-results-edit-button"]', {
       timeout: 10000,
     }).click();
-    cy.clickOptionWithSpecificClass(".ant-checkbox", 1);
+    cy.clickFirstOptionWithTestId(`checkbox-${chartUrn}`);
     verifyEditAndPerformAddAndRemoveActionForDomain(
       "Tags",
       "Remove tags",

--- a/smoke-test/tests/cypress/cypress/e2e/domainsV2/v2_nested_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/domainsV2/v2_nested_domains.js
@@ -1,5 +1,5 @@
 const domainName = "CypressNestedDomain";
-const chartUrn = "urn:li:chart:(looker,baz2)";
+const chartUrn = "urn:li:chart:(looker,cypress_baz2)";
 
 const handledResizeLoopErrors = () => {
   const resizeObserverLoopLimitErrRe = "ResizeObserver loop limit exceeded";


### PR DESCRIPTION
These tests were breaking, especially the V1 test, pretty often. This was due to assumptions on the ordering of data which is inaccurate and due to not waiting for elastic to be updated before going to a profile page to check if a tag is on there. The way it was written would work a good amount of the time but definitely failed often. These changes should harden these tests.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
