### PR TITLE
chore(sdk): rename `_schema_classes` to mark it as internal-only

### DIFF
--- a/metadata-ingestion/scripts/avro_codegen.py
+++ b/metadata-ingestion/scripts/avro_codegen.py
@@ -842,9 +842,9 @@ def generate(
     )
 
     if enable_custom_loader:
-        # Move schema_classes.py -> _schema_classes.py
+        # Move schema_classes.py -> _internal_schema_classes.py
         # and add a custom loader.
-        (Path(outdir) / "_schema_classes.py").write_text(
+        (Path(outdir) / "_internal_schema_classes.py").write_text(
             (Path(outdir) / "schema_classes.py").read_text()
         )
         (Path(outdir) / "schema_classes.py").write_text(
@@ -861,16 +861,16 @@ from datahub.utilities._custom_package_loader import get_custom_models_package
 _custom_package_path = get_custom_models_package()
 
 if TYPE_CHECKING or not _custom_package_path:
-    from ._schema_classes import *
+    from ._internal_schema_classes import *
 
     # Required explicitly because __all__ doesn't include _ prefixed names.
-    from ._schema_classes import __SCHEMA_TYPES
+    from ._internal_schema_classes import __SCHEMA_TYPES
 
     if IS_SPHINX_BUILD:
         # Set __module__ to the current module so that Sphinx will document the
         # classes as belonging to this module instead of the custom package.
         for _cls in list(globals().values()):
-            if hasattr(_cls, "__module__") and "datahub.metadata._schema_classes" in _cls.__module__:
+            if hasattr(_cls, "__module__") and "datahub.metadata._internal_schema_classes" in _cls.__module__:
                 _cls.__module__ = __name__
 else:
     _custom_package = importlib.import_module(_custom_package_path)

--- a/metadata-ingestion/src/datahub/testing/check_imports.py
+++ b/metadata-ingestion/src/datahub/testing/check_imports.py
@@ -9,7 +9,7 @@ def ensure_no_indirect_model_imports(dirs: List[pathlib.Path]) -> None:
     # If our needs become more complex, we should move to a proper linter.
     denied_imports = {
         "src.": "datahub.*",
-        "datahub.metadata._schema_classes": "datahub.metadata.schema_classes",
+        "datahub.metadata._internal_schema_classes": "datahub.metadata.schema_classes",
         "datahub.metadata._urns": "datahub.metadata.urns",
     }
     ignored_files = {

--- a/smoke-test/tests/restli/test_restli_batch_ingestion.py
+++ b/smoke-test/tests/restli/test_restli_batch_ingestion.py
@@ -7,11 +7,11 @@ import datahub.metadata.schema_classes as models
 from datahub.emitter.mce_builder import make_dashboard_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.serialization_helper import pre_json_transform
-from datahub.metadata._schema_classes import MetadataChangeProposalClass
 from datahub.metadata.schema_classes import (
     AuditStampClass,
     ChangeAuditStampsClass,
     DashboardInfoClass,
+    MetadataChangeProposalClass,
 )
 from datahub.metadata.urns import MlModelUrn
 from tests.consistency_utils import wait_for_writes_to_sync


### PR DESCRIPTION
If you use `import datahub.metadata._schema_classes` instead of `import datahub.metadata.schema_classes`, you'll run into errors with the codegen having duplicate types and so isinstance checks won't work properly when `acryl-datahub-cloud` (or any alternative models package) is installed.

We already have a lint rule to avoid this in the metadata-ingestion directory, but people have been tripped up by this despite that. As such, I'm renaming `_schema_classes.py` -> `_internal_schema_classes.py` to make more clearly reflect its internal-only nature.

Any existing usages of `datahub.metadata._schema_classes ` should be replaced with `datahub.metadata.schema_classes`. Making that edit should not break anything.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
