### PR TITLE
fix(cypress) Fix flaky mutations/domains cypress test

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelect.tsx
@@ -1,5 +1,6 @@
 import { FilterOutlined } from '@ant-design/icons';
 import { Button, Typography, message } from 'antd';
+import { debounce } from 'lodash';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
@@ -11,6 +12,7 @@ import { EntityAndType } from '@app/entity/shared/types';
 import { isListSubset } from '@app/entity/shared/utils';
 import { SearchBar } from '@app/search/SearchBar';
 import { ENTITY_FILTER_NAME, UnionType } from '@app/search/utils/constants';
+import { DEBOUNCE_SEARCH_MS } from '@app/shared/constants';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { SearchCfg } from '@src/conf';
 
@@ -112,9 +114,9 @@ export const SearchSelect = ({
     const selectedEntityUrns = selectedEntities.map((entity) => entity.urn);
     const facets = searchAcrossEntities?.facets || [];
 
-    const onSearch = (q: string) => {
+    const onSearch = debounce((q: string) => {
         setQuery(q);
-    };
+    }, DEBOUNCE_SEARCH_MS);
 
     const onChangeFilters = (newFilters: Array<FacetFilterInput>) => {
         setPage(1);

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/SearchSelect.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/SearchSelect.tsx
@@ -1,5 +1,6 @@
 import { FilterOutlined } from '@ant-design/icons';
 import { Button, Typography, message } from 'antd';
+import { debounce } from 'lodash';
 import React, { useState } from 'react';
 import { useDebounce } from 'react-use';
 import styled from 'styled-components';
@@ -12,6 +13,7 @@ import { ANTD_GRAY } from '@app/entityV2/shared/constants';
 import { isListSubset } from '@app/entityV2/shared/utils';
 import { SearchBar } from '@app/search/SearchBar';
 import { ENTITY_FILTER_NAME, UnionType } from '@app/search/utils/constants';
+import { DEBOUNCE_SEARCH_MS } from '@app/shared/constants';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import SearchSortSelect from '@src/app/searchV2/sorting/SearchSortSelect';
 import useSortInput from '@src/app/searchV2/sorting/useSortInput';
@@ -119,9 +121,9 @@ export const SearchSelect = ({
     const selectedEntityUrns = selectedEntities.map((entity) => entity.urn);
     const facets = searchAcrossEntities?.facets || [];
 
-    const onSearch = (q: string) => {
+    const onSearch = debounce((q: string) => {
         setQuery(q);
-    };
+    }, DEBOUNCE_SEARCH_MS);
 
     const onChangeFilters = (newFilters: Array<FacetFilterInput>) => {
         setPage(1);

--- a/datahub-web-react/src/app/shared/constants.ts
+++ b/datahub-web-react/src/app/shared/constants.ts
@@ -10,3 +10,5 @@ export enum ErrorCodes {
     NotFound = 404,
     ServerError = 500,
 }
+
+export const DEBOUNCE_SEARCH_MS = 300;

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
@@ -43,8 +43,7 @@ describe("add remove domain", () => {
     cy.get(".ant-modal-content").within(() => {
       cy.get('[data-testid="search-input"]')
         .click()
-        .invoke("val", "cypress_project.jaffle_shop.")
-        .type("customer");
+        .type("cypress_project.jaffle_shop.customer");
       cy.contains("BigQuery", { timeout: 30000 });
       cy.get(".ant-checkbox-input").first().click();
       cy.get("#continueButton").click();


### PR DESCRIPTION
I've only seen this one flake a few times and it's hard to get to the bottom of exactly what's happening, but I think it's that the domain isn't applied to the expected asset in the second test and then fails in the third test because it wants to remove a domain from an asset that the domain isn't on. So i made the search to apply this domain to the assets we're looking for more specific, which I think was the intention of the `invoke` method here but wasn't actually working.

Since we type a longer message now it made it clear when running the test that we did not debounce this search select input, so I added debouncing here for v1 and v2 UIs.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
