### PR TITLE
fix(cypress) Improve flakiness of managing_secrets v1 and v2

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
@@ -1,13 +1,15 @@
-const number = crypto.getRandomValues(new Uint32Array(1))[0];
-const accound_id = `account${number}`;
-const warehouse_id = `warehouse${number}`;
-const username = `user${number}`;
-const password = `password${number}`;
-const role = `role${number}`;
-const ingestion_source_name = `ingestion source ${number}`;
-
 describe("managing secrets for ingestion creation", () => {
+  beforeEach(() => {
+    cy.setIsThemeV2Enabled(false);
+  });
   it("create a secret, create ingestion source using a secret, remove a secret", () => {
+    const number = crypto.getRandomValues(new Uint32Array(1))[0];
+    const accound_id = `account${number}`;
+    const warehouse_id = `warehouse${number}`;
+    const username = `user${number}`;
+    const role = `role${number}`;
+    const ingestion_source_name = `ingestion source ${number}`;
+
     // Navigate to the manage ingestion page → secrets
     cy.loginWithCredentials();
     cy.goToIngestionPage();
@@ -44,7 +46,7 @@ describe("managing secrets for ingestion creation", () => {
     cy.get("button").contains("Next").click();
     cy.waitTextVisible("Give this data source a name");
     cy.get('[data-testid="source-name-input"]').type(ingestion_source_name);
-    cy.get("button").contains("Save").click();
+    cy.clickOptionWithTestId("ingestion-source-save-button");
     cy.waitTextVisible("Successfully created ingestion source!").wait(5000);
     cy.waitTextVisible(ingestion_source_name);
     cy.get("button").contains("Pending...").should("be.visible");

--- a/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managing_secrets.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutationsV2/v2_managing_secrets.js
@@ -1,16 +1,15 @@
-const number = Math.floor(Math.random() * 100000);
-const accound_id = `account${number}`;
-const warehouse_id = `warehouse${number}`;
-const username = `user${number}`;
-const password = `password${number}`;
-const role = `role${number}`;
-const ingestion_source_name = `ingestion source ${number}`;
-
 describe("managing secrets for ingestion creation", () => {
   beforeEach(() => {
     cy.setIsThemeV2Enabled(true);
   });
   it("create a secret, create ingestion source using a secret, remove a secret", () => {
+    const number = Math.floor(Math.random() * 100000);
+    const accound_id = `account${number}`;
+    const warehouse_id = `warehouse${number}`;
+    const username = `user${number}`;
+    const role = `role${number}`;
+    const ingestion_source_name = `ingestion source ${number}`;
+
     // Navigate to the manage ingestion page → secrets
     cy.loginWithCredentials();
     cy.skipIntroducePage();
@@ -50,7 +49,7 @@ describe("managing secrets for ingestion creation", () => {
     cy.get("button").contains("Next").click();
     cy.get(".ant-collapse-item").should("be.visible");
     cy.get('[data-testid="source-name-input"]').type(ingestion_source_name);
-    cy.get("button").contains("Save").click();
+    cy.clickOptionWithTestId("ingestion-source-save-button");
     cy.waitTextVisible("Successfully created ingestion source!").wait(5000);
     cy.waitTextVisible(ingestion_source_name);
     cy.get("button").contains("Pending...").should("be.visible");


### PR DESCRIPTION
This test was occasionally flaky i believe because we were clicking the wrong "save" button that would run an ingestion source instead of just saving it which would cause issues later in the test. Now I use the data test id we already had on this button.

Additionally, an improvement we should strive for in all cypress tests is to make tests so that if they do flake, the retry is a fresh start and isn't in a bad state right away. Here, when we did flake (by clicking the wrong button) we would retry by creating the same secret name again which would result in an error because the secret already exists. Now I define variable names inside of the test itself so a retry will try to create a new secret.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
