### PR TITLE
fix(cypress) Fix occasional socket closed exception in cypress

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/browse/browseV2.js
+++ b/smoke-test/tests/cypress/cypress/e2e/browse/browseV2.js
@@ -10,7 +10,8 @@ describe("search", () => {
   const setBrowseFeatureFlag = (isOn) => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "appConfig")) {
-        req.reply((res) => {
+        req.alias = "gqlappConfigQuery";
+        req.on("response", (res) => {
           // Modify the response body directly
           res.body.data.appConfig.featureFlags.showBrowseV2 = isOn;
           // search and browse both need to be on for browse to show

--- a/smoke-test/tests/cypress/cypress/e2e/businessAttribute/attribute_mutations.js
+++ b/smoke-test/tests/cypress/cypress/e2e/businessAttribute/attribute_mutations.js
@@ -12,7 +12,8 @@ describe("attribute list adding tags and terms", () => {
   const setBusinessAttributeFeatureFlag = () => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "appConfig")) {
-        req.reply((res) => {
+        req.alias = "gqlappConfigQuery";
+        req.on("response", (res) => {
           businessAttributeEntityEnabled =
             res.body.data.appConfig.featureFlags.businessAttributeEntityEnabled;
           return res;

--- a/smoke-test/tests/cypress/cypress/e2e/businessAttribute/businessAttribute.js
+++ b/smoke-test/tests/cypress/cypress/e2e/businessAttribute/businessAttribute.js
@@ -12,7 +12,8 @@ describe("businessAttribute", () => {
   const setBusinessAttributeFeatureFlag = () => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "appConfig")) {
-        req.reply((res) => {
+        req.alias = "gqlappConfigQuery";
+        req.on("response", (res) => {
           businessAttributeEntityEnabled =
             res.body.data.appConfig.featureFlags.businessAttributeEntityEnabled;
           return res;

--- a/smoke-test/tests/cypress/cypress/e2e/home/home.js
+++ b/smoke-test/tests/cypress/cypress/e2e/home/home.js
@@ -12,7 +12,8 @@ describe("home", () => {
   const setBusinessAttributeFeatureFlag = () => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "appConfig")) {
-        req.reply((res) => {
+        req.alias = "gqlappConfigQuery";
+        req.on("response", (res) => {
           businessAttributeEntityEnabled =
             res.body.data.appConfig.featureFlags.businessAttributeEntityEnabled;
           return res;

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
@@ -14,7 +14,8 @@ describe("add remove domain", () => {
   const setDomainsFeatureFlag = (isOn) => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "appConfig")) {
-        req.reply((res) => {
+        req.alias = "gqlappConfigQuery";
+        req.on("response", (res) => {
           res.body.data.appConfig.featureFlags.nestedDomainsEnabled = isOn;
         });
       }

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/mutations.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/mutations.js
@@ -12,7 +12,8 @@ describe("mutations", () => {
   const setBusinessAttributeFeatureFlag = () => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "appConfig")) {
-        req.reply((res) => {
+        req.alias = "gqlappConfigQuery";
+        req.on("response", (res) => {
           businessAttributeEntityEnabled =
             res.body.data.appConfig.featureFlags.businessAttributeEntityEnabled;
           return res;

--- a/smoke-test/tests/cypress/cypress/e2e/search/searchFilters.js
+++ b/smoke-test/tests/cypress/cypress/e2e/search/searchFilters.js
@@ -10,7 +10,8 @@ describe("search", () => {
   const setSearchFiltersFeatureFlag = (isOn) => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "appConfig")) {
-        req.reply((res) => {
+        req.alias = "gqlappConfigQuery";
+        req.on("response", (res) => {
           // Modify the response body directly
           res.body.data.appConfig.featureFlags.showSearchFiltersV2 = isOn;
         });

--- a/smoke-test/tests/cypress/cypress/e2e/settings/manage_access_tokens.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settings/manage_access_tokens.js
@@ -12,7 +12,8 @@ describe("manage access tokens", () => {
   const setTokenAuthEnabledFlag = (isOn) => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "appConfig")) {
-        req.reply((res) => {
+        req.alias = "gqlappConfigQuery";
+        req.on("response", (res) => {
           res.body.data.appConfig.authConfig.tokenAuthEnabled = isOn;
         });
       }

--- a/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_access_tokens.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settingsV2/v2_manage_access_tokens.js
@@ -12,7 +12,8 @@ describe("manage access tokens", () => {
   const setTokenAuthEnabledFlag = (isOn) => {
     cy.intercept("POST", "/api/v2/graphql", (req) => {
       if (hasOperationName(req, "appConfig")) {
-        req.reply((res) => {
+        req.alias = "gqlappConfigQuery";
+        req.on("response", (res) => {
           res.body.data.appConfig.authConfig.tokenAuthEnabled = isOn;
           res.body.data.appConfig.featureFlags.themeV2Enabled = true;
           res.body.data.appConfig.featureFlags.themeV2Default = true;


### PR DESCRIPTION
We would occasionally see a cypress test fail when we try to intercept a graphql query and the socket closes before we can mock it. This is because we were using an old way to intercept and replace a graphql query - using the `req.reply` method which completely takes over the request/response cycle, requiring handling to properly complete the response. Using `req.on("response")` allows us to modify the response data without interrupting the request/response flow, preventing the premature socket closure.

Also added request aliasing for improved test clarity and debugging capabilities.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
