### PR TITLE
feat(searchBarAutocomplete): add description to matched fields to results of the search bar

### DIFF
--- a/datahub-web-react/src/app/searchV2/autoCompleteV2/components/matches/Matches.tsx
+++ b/datahub-web-react/src/app/searchV2/autoCompleteV2/components/matches/Matches.tsx
@@ -33,8 +33,8 @@ export default function Matches({ entity, query, displayName, matchedFields }: P
             shouldShowInMatchedFieldList(entity.type, field),
         );
 
-        return getMatchesPrioritized(entity.type, showableFields, 'fieldLabels');
-    }, [entity, matchedFields]);
+        return getMatchesPrioritized(entity.type, query ?? '', showableFields, 'fieldLabels');
+    }, [entity, matchedFields, query]);
 
     const items = useMemo(() => {
         return groupedMatchedFields.map((match) => ({

--- a/datahub-web-react/src/app/searchV2/matches/constants.ts
+++ b/datahub-web-react/src/app/searchV2/matches/constants.ts
@@ -21,6 +21,7 @@ export type MatchedFieldName =
 export type MatchedFieldConfig = {
     name: MatchedFieldName;
     groupInto?: MatchedFieldName;
+    priorityInGroup?: number;
     label: string;
     showInMatchedFieldList?: boolean;
 };
@@ -47,12 +48,15 @@ const DEFAULT_MATCHED_FIELD_CONFIG: Array<MatchedFieldConfig> = [
     {
         name: 'editedDescription',
         groupInto: 'description',
+        priorityInGroup: 1,
         label: 'description',
+        showInMatchedFieldList: true,
     },
     {
         name: 'description',
         groupInto: 'description',
         label: 'description',
+        showInMatchedFieldList: true,
     },
     {
         name: 'editedFieldDescriptions',

--- a/datahub-web-react/src/app/searchV2/matches/utils.ts
+++ b/datahub-web-react/src/app/searchV2/matches/utils.ts
@@ -82,6 +82,39 @@ function fromQueryGetBestMatch(
     return [...exactMatches, ...containedMatches, ...rest];
 }
 
+const orderMatchedFieldsByPriorityInGroup = (entityType: EntityType, matchedFields: MatchedField[]) => {
+    const configs = getFieldConfigsByEntityType(entityType);
+
+    return matchedFields
+        .map((matchedField) => {
+            const fieldConfig = configs.find((config) => config.name === matchedField.name);
+            return {
+                priority: fieldConfig?.priorityInGroup,
+                matchedField,
+            };
+        })
+        .sort((matchedFieldA, matchedFieldB) => {
+            // Both have a priority, order by priority
+            if (matchedFieldA.priority !== undefined && matchedFieldB.priority !== undefined) {
+                return matchedFieldA.priority - matchedFieldB.priority;
+            }
+
+            // Only 'matchedFieldA' has a priority, it comes first
+            if (matchedFieldA.priority !== undefined && matchedFieldB.priority === undefined) {
+                return -1;
+            }
+
+            // Only 'matchedFieldB' has a priority, it comes first
+            if (matchedFieldA.priority === undefined && matchedFieldB.priority !== undefined) {
+                return 1;
+            }
+
+            // Neither has a priority, maintain original order
+            return 0;
+        })
+        .map((matchedFieldWithPriority) => matchedFieldWithPriority.matchedField);
+};
+
 const getMatchesGroupedByFieldName = (
     entityType: EntityType,
     matchedFields: Array<MatchedField>,
@@ -100,11 +133,21 @@ const getMatchesGroupedByFieldName = (
     });
     return fieldNames.map((fieldName) => ({
         fieldName,
-        matchedFields: fieldNameToMatches.get(fieldName) ?? [],
+        matchedFields: orderMatchedFieldsByPriorityInGroup(entityType, fieldNameToMatches.get(fieldName) ?? []),
     }));
 };
 
 export const getMatchesPrioritized = (
+    entityType: EntityType,
+    query: string,
+    matchedFields: MatchedField[],
+    prioritizedField: string,
+): Array<MatchesGroupedByFieldName> => {
+    const matches = fromQueryGetBestMatch(matchedFields, query, prioritizedField);
+    return getMatchesGroupedByFieldName(entityType, matches);
+};
+
+export const getMatchesPrioritizedByQueryInQueryParams = (
     entityType: EntityType,
     matchedFields: MatchedField[],
     prioritizedField: string,
@@ -112,8 +155,7 @@ export const getMatchesPrioritized = (
     const { location } = window;
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
     const query: string = decodeURIComponent(params.query ? (params.query as string) : '');
-    const matches = fromQueryGetBestMatch(matchedFields, query, prioritizedField);
-    return getMatchesGroupedByFieldName(entityType, matches);
+    return getMatchesPrioritized(entityType, query, matchedFields, prioritizedField);
 };
 
 export const isHighlightableEntityField = (field: MatchedField) =>
@@ -125,7 +167,7 @@ const SURROUNDING_DESCRIPTION_CHARS = 10;
 const MAX_DESCRIPTION_CHARS = 50;
 
 export const getDescriptionSlice = (text: string, target: string) => {
-    const queryIndex = text.indexOf(target);
+    const queryIndex = text.toLowerCase().indexOf(target.toLowerCase());
     const start = Math.max(0, queryIndex - SURROUNDING_DESCRIPTION_CHARS);
     const end = Math.min(
         start + MAX_DESCRIPTION_CHARS,


### PR DESCRIPTION
This PR adds the description field to matched fields section in the redesigned search bar

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
