### PR TITLE
fix(graphql/stats): Support SAMPLE dataset profiles with sample size

### DIFF
--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -127,14 +127,25 @@ fragment nonSiblingDatasetFields on Dataset {
     }
     latestFullTableProfile: datasetProfiles(
         limit: 1
-        filter: { and: [{ field: "partitionSpec.partition", values: ["FULL_TABLE_SNAPSHOT", "SAMPLE"] }] }
+        filter: {
+            and: [
+                { field: "partitionSpec.partition", values: ["FULL_TABLE_SNAPSHOT", "SAMPLE"], condition: START_WITH }
+            ]
+        }
     ) {
         ...datasetProfileFields
     }
     latestPartitionProfile: datasetProfiles(
         limit: 1
         filter: {
-            and: [{ field: "partitionSpec.partition", values: ["SAMPLE", "FULL_TABLE_SNAPSHOT"], negated: true }]
+            and: [
+                {
+                    field: "partitionSpec.partition"
+                    values: ["SAMPLE", "FULL_TABLE_SNAPSHOT"]
+                    negated: true
+                    condition: START_WITH
+                }
+            ]
         }
     ) {
         ...datasetProfileFields


### PR DESCRIPTION
[datahub-project/datahub#10319 (files)](https://github.com/datahub-project/datahub/pull/10319/files#diff-9de2cda98116de6142352060b80dd7511474a05dbba8d46416bff68ea873f7aaR712) means we label our partitions `SAMPLE (sample rows n)`, this will pick those up

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
