### PR TITLE
fix(ui): Hide deleted assets on home page recommendations

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationCandidateSourceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationCandidateSourceTest.java
@@ -194,9 +194,9 @@ public class EntitySearchAggregationCandidateSourceTest {
     Urn testUrn1 = new TestEntityUrn("testUrn1", "testUrn1", "testUrn1");
     Urn testUrn2 = new TestEntityUrn("testUrn2", "testUrn2", "testUrn2");
     Urn testUrn3 = new TestEntityUrn("testUrn3", "testUrn3", "testUrn3");
-    Mockito.when(entityService.exists(any(), eq(testUrn1))).thenReturn(true);
-    Mockito.when(entityService.exists(any(), eq(testUrn2))).thenReturn(true);
-    Mockito.when(entityService.exists(any(), eq(testUrn3))).thenReturn(true);
+    Mockito.when(entityService.exists(any(), eq(testUrn1), eq(false))).thenReturn(true);
+    Mockito.when(entityService.exists(any(), eq(testUrn2), eq(false))).thenReturn(true);
+    Mockito.when(entityService.exists(any(), eq(testUrn3), eq(false))).thenReturn(true);
 
     Mockito.when(
             entitySearchService.aggregateByValue(

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/DomainsCandidateSourceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/DomainsCandidateSourceFactory.java
@@ -1,6 +1,7 @@
 package com.linkedin.gms.factory.recommendation.candidatesource;
 
 import com.linkedin.gms.factory.search.EntitySearchServiceFactory;
+import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.candidatesource.DomainsCandidateSource;
 import com.linkedin.metadata.search.EntitySearchService;
@@ -17,6 +18,10 @@ import org.springframework.context.annotation.Import;
 public class DomainsCandidateSourceFactory {
 
   @Autowired
+  @Qualifier("entityService")
+  private EntityService<?> entityService;
+
+  @Autowired
   @Qualifier("entitySearchService")
   private EntitySearchService entitySearchService;
 
@@ -24,6 +29,6 @@ public class DomainsCandidateSourceFactory {
   @Nonnull
   protected DomainsCandidateSource getInstance(
       final OperationContext opContext, final EntityRegistry entityRegistry) {
-    return new DomainsCandidateSource(entitySearchService, entityRegistry);
+    return new DomainsCandidateSource(entityService, entitySearchService, entityRegistry);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/TopTagsCandidateSourceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/TopTagsCandidateSourceFactory.java
@@ -1,6 +1,8 @@
 package com.linkedin.gms.factory.recommendation.candidatesource;
 
+import com.linkedin.gms.factory.entity.EntityServiceFactory;
 import com.linkedin.gms.factory.search.EntitySearchServiceFactory;
+import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.candidatesource.TopTagsSource;
 import com.linkedin.metadata.search.EntitySearchService;
@@ -12,8 +14,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import({EntitySearchServiceFactory.class})
+@Import({EntitySearchServiceFactory.class, EntityServiceFactory.class})
 public class TopTagsCandidateSourceFactory {
+
+  @Autowired
+  @Qualifier("entityService")
+  private EntityService<?> entityService;
 
   @Autowired
   @Qualifier("entitySearchService")
@@ -22,6 +28,6 @@ public class TopTagsCandidateSourceFactory {
   @Bean(name = "topTagsCandidateSource")
   @Nonnull
   protected TopTagsSource getInstance(final EntityRegistry entityRegistry) {
-    return new TopTagsSource(entitySearchService, entityRegistry);
+    return new TopTagsSource(entitySearchService, entityService, entityRegistry);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/TopTagsCandidateSourceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/TopTagsCandidateSourceFactory.java
@@ -18,16 +18,13 @@ import org.springframework.context.annotation.Import;
 public class TopTagsCandidateSourceFactory {
 
   @Autowired
-  @Qualifier("entityService")
-  private EntityService<?> entityService;
-
-  @Autowired
   @Qualifier("entitySearchService")
   private EntitySearchService entitySearchService;
 
   @Bean(name = "topTagsCandidateSource")
   @Nonnull
-  protected TopTagsSource getInstance(final EntityRegistry entityRegistry) {
+  protected TopTagsSource getInstance(
+      final EntityService<?> entityService, final EntityRegistry entityRegistry) {
     return new TopTagsSource(entitySearchService, entityService, entityRegistry);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/TopTermsCandidateSourceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/TopTermsCandidateSourceFactory.java
@@ -1,6 +1,8 @@
 package com.linkedin.gms.factory.recommendation.candidatesource;
 
+import com.linkedin.gms.factory.entity.EntityServiceFactory;
 import com.linkedin.gms.factory.search.EntitySearchServiceFactory;
+import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.candidatesource.TopTermsSource;
 import com.linkedin.metadata.search.EntitySearchService;
@@ -12,8 +14,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@Import({EntitySearchServiceFactory.class})
+@Import({EntitySearchServiceFactory.class, EntityServiceFactory.class})
 public class TopTermsCandidateSourceFactory {
+
+  @Autowired
+  @Qualifier("entityService")
+  private EntityService<?> entityService;
 
   @Autowired
   @Qualifier("entitySearchService")
@@ -22,6 +28,6 @@ public class TopTermsCandidateSourceFactory {
   @Bean(name = "topTermsCandidateSource")
   @Nonnull
   protected TopTermsSource getInstance(final EntityRegistry entityRegistry) {
-    return new TopTermsSource(entitySearchService, entityRegistry);
+    return new TopTermsSource(entitySearchService, entityService, entityRegistry);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/TopTermsCandidateSourceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/recommendation/candidatesource/TopTermsCandidateSourceFactory.java
@@ -16,18 +16,14 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import({EntitySearchServiceFactory.class, EntityServiceFactory.class})
 public class TopTermsCandidateSourceFactory {
-
-  @Autowired
-  @Qualifier("entityService")
-  private EntityService<?> entityService;
-
   @Autowired
   @Qualifier("entitySearchService")
   private EntitySearchService entitySearchService;
 
   @Bean(name = "topTermsCandidateSource")
   @Nonnull
-  protected TopTermsSource getInstance(final EntityRegistry entityRegistry) {
+  protected TopTermsSource getInstance(
+      final EntityService<?> entityService, final EntityRegistry entityRegistry) {
     return new TopTermsSource(entitySearchService, entityService, entityRegistry);
   }
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/DomainsCandidateSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/DomainsCandidateSource.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.recommendation.candidatesource;
 
+import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.RecommendationRenderType;
 import com.linkedin.metadata.recommendation.RecommendationRequestContext;
@@ -15,8 +16,10 @@ public class DomainsCandidateSource extends EntitySearchAggregationSource {
   private static final String DOMAINS = "domains";
 
   public DomainsCandidateSource(
-      EntitySearchService entitySearchService, EntityRegistry entityRegistry) {
-    super(entitySearchService, entityRegistry);
+      EntityService<?> entityService,
+      EntitySearchService entitySearchService,
+      EntityRegistry entityRegistry) {
+    super(entityService, entitySearchService, entityRegistry);
   }
 
   @Override

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
@@ -4,6 +4,7 @@ import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.filter.Condition;
@@ -42,6 +43,8 @@ import org.apache.commons.lang3.tuple.Pair;
 @Slf4j
 @RequiredArgsConstructor
 public abstract class EntitySearchAggregationSource implements RecommendationSource {
+
+  private final EntityService entityService;
   private final EntitySearchService entitySearchService;
   private final EntityRegistry entityRegistry;
 
@@ -56,7 +59,7 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
 
   /** Whether the urn candidate is valid */
   protected boolean isValidCandidateUrn(@Nonnull OperationContext opContext, Urn urn) {
-    return true;
+    return entityService.exists(opContext, urn, false);
   }
 
   /** Whether the string candidate is valid */
@@ -103,10 +106,10 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
             .map(
                 entry -> {
                   try {
-                    Urn tagUrn = Urn.createFromString(entry.getKey());
-                    return Optional.of(Pair.of(tagUrn, entry.getValue()));
+                    Urn entityUrn = Urn.createFromString(entry.getKey());
+                    return Optional.of(Pair.of(entityUrn, entry.getValue()));
                   } catch (URISyntaxException e) {
-                    log.error("Invalid tag urn {}", entry.getKey(), e);
+                    log.error("Invalid entity urn {}", entry.getKey(), e);
                     return Optional.<Pair<Urn, Long>>empty();
                   }
                 })

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
@@ -46,7 +46,7 @@ public class TopPlatformsSource extends EntitySearchAggregationSource {
       EntitySearchService entitySearchService,
       EntityService<?> entityService,
       EntityRegistry entityRegistry) {
-    super(entitySearchService, entityRegistry);
+    super(entityService, entitySearchService, entityRegistry);
     this.entityService = entityService;
   }
 

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopTagsSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopTagsSource.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.recommendation.candidatesource;
 
+import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.RecommendationRenderType;
 import com.linkedin.metadata.recommendation.RecommendationRequestContext;
@@ -14,8 +15,11 @@ public class TopTagsSource extends EntitySearchAggregationSource {
 
   private static final String TAGS = "tags";
 
-  public TopTagsSource(EntitySearchService entitySearchService, EntityRegistry entityRegistry) {
-    super(entitySearchService, entityRegistry);
+  public TopTagsSource(
+      EntitySearchService entitySearchService,
+      EntityService<?> entityService,
+      EntityRegistry entityRegistry) {
+    super(entityService, entitySearchService, entityRegistry);
   }
 
   @Override

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopTermsSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopTermsSource.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.recommendation.candidatesource;
 
+import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.RecommendationRenderType;
 import com.linkedin.metadata.recommendation.RecommendationRequestContext;
@@ -14,8 +15,11 @@ public class TopTermsSource extends EntitySearchAggregationSource {
 
   private static final String TERMS = "glossaryTerms";
 
-  public TopTermsSource(EntitySearchService entitySearchService, EntityRegistry entityRegistry) {
-    super(entitySearchService, entityRegistry);
+  public TopTermsSource(
+      EntitySearchService entitySearchService,
+      EntityService<?> entityService,
+      EntityRegistry entityRegistry) {
+    super(entityService, entitySearchService, entityRegistry);
   }
 
   @Override


### PR DESCRIPTION
## Summary

Home page recommendations currently show some assets that were soft deleted in the top tags, platforms, terms, domains, sources. This PR fixes that by requiring an existance check that excludes soft deleted assets for all home page recco modules.

Loom overview: https://www.loom.com/share/ba21d5ac54bd43ce88543bea7a2d57cb?sid=4a519b75-ab18-4650-8438-7dab4e6c439e

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
