### PR TITLE
fix(actions): h11 dependency

### DIFF
--- a/datahub-actions/pyproject.toml
+++ b/datahub-actions/pyproject.toml
@@ -2,11 +2,6 @@
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>65.5.1", "wheel>0.38.1", "pip>=21.0.0"]
 
-dependencies = [
-        "httpcore >= 1.0.9",
-        "h11 >= 0.16"
-]
-
 [tool.ruff]
 line-length = 88
 target-version = "py38"

--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -50,6 +50,8 @@ base_requirements = {
     "pydantic<2",
     "dictdiffer",
     "ratelimit",
+    "httpcore>=1.0.9",
+    "h11>=0.16"
 }
 
 framework_common = {


### PR DESCRIPTION
`dependencies` in `pyproject.toml` must be in `[project]` section

and `[project]` section requires `version` field which I don't know what to set there

instead, I'm moving dependencies to `setup.py`

related to PR #13364 