### PR TITLE
fix(policyEngine): policy evaluation incorrect without type 

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -9323,19 +9323,22 @@ The resources that a DataHub Access Policy applies to
 """
 type ResourceFilter {
   """
+  Deprecated, use filter instead
   The type of the resource the policy should apply to Not required because in the future we want to support filtering by type OR by domain
   """
-  type: String
+  type: String @deprecated
 
   """
+  Deprecated, use filter instead
   A list of specific resource urns to apply the filter to
   """
-  resources: [String!]
+  resources: [String!] @deprecated
 
   """
+  Deprecated, use filter instead
   Whether of not to apply the filter to all resources of the type
   """
-  allResources: Boolean
+  allResources: Boolean @deprecated
 
   """
   Whether of not to apply the filter to all resources of the type
@@ -9469,17 +9472,20 @@ Input required when creating or updating an Access Policies Determines which res
 """
 input ResourceFilterInput {
   """
+  Deprecated, use filter field instead
   The type of the resource the policy should apply to
   Not required because in the future we want to support filtering by type OR by domain
   """
-  type: String
+  type: String @deprecated
 
   """
+  Deprecated, use filter instead
   A list of specific resource urns to apply the filter to
   """
   resources: [String!]
 
   """
+  Deprecated, use empty filter instead
   Whether of not to apply the filter to all resources of the type
   """
   allResources: Boolean

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
@@ -232,9 +232,8 @@ public class PolicyEngine {
               .setValues(
                   new StringArray(Collections.singletonList(policyResourceFilter.getType()))));
     }
-    if (policyResourceFilter.hasType()
-        && policyResourceFilter.hasResources()
-        && !policyResourceFilter.isAllResources()) {
+
+    if (policyResourceFilter.hasResources() && !policyResourceFilter.isAllResources()) {
       criteria.add(
           new PolicyMatchCriterion()
               .setField(EntityFieldType.URN.name())

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/PolicyEngineTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/PolicyEngineTest.java
@@ -956,6 +956,45 @@ public class PolicyEngineTest {
   }
 
   @Test
+  public void testEvaluatePolicyResourceFilterSpecificResourceMatchLegacyWithNoType()
+      throws Exception {
+    final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();
+    dataHubPolicyInfo.setType(METADATA_POLICY_TYPE);
+    dataHubPolicyInfo.setState(ACTIVE_POLICY_STATE);
+    dataHubPolicyInfo.setPrivileges(new StringArray("EDIT_ENTITY_TAGS"));
+    dataHubPolicyInfo.setDisplayName("My Test Display");
+    dataHubPolicyInfo.setDescription("My test display!");
+    dataHubPolicyInfo.setEditable(true);
+
+    final DataHubActorFilter actorFilter = new DataHubActorFilter();
+    actorFilter.setResourceOwners(true);
+    actorFilter.setAllUsers(true);
+    actorFilter.setAllGroups(true);
+    dataHubPolicyInfo.setActors(actorFilter);
+
+    final DataHubResourceFilter resourceFilter = new DataHubResourceFilter();
+    resourceFilter.setAllResources(false);
+
+    StringArray resourceUrns = new StringArray();
+    resourceUrns.add(RESOURCE_URN); // Filter applies to specific resource.
+    resourceFilter.setResources(resourceUrns);
+    dataHubPolicyInfo.setResources(resourceFilter);
+
+    ResolvedEntitySpec resourceSpec = buildEntityResolvers("dataset", RESOURCE_URN);
+    PolicyEngine.PolicyEvaluationResult result =
+        _policyEngine.evaluatePolicy(
+            systemOperationContext,
+            dataHubPolicyInfo,
+            resolvedAuthorizedUserSpec,
+            "EDIT_ENTITY_TAGS",
+            Optional.of(resourceSpec));
+    assertTrue(result.isGranted());
+
+    // Verify no network calls
+    verify(_entityClient, times(0)).batchGetV2(any(), any(), any(), any());
+  }
+
+  @Test
   public void testEvaluatePolicyResourceFilterSpecificResourceMatch() throws Exception {
     final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();
     dataHubPolicyInfo.setType(METADATA_POLICY_TYPE);
@@ -1019,6 +1058,44 @@ public class PolicyEngineTest {
                 Collections.singletonList("dataset"),
                 EntityFieldType.URN,
                 Collections.singletonList(RESOURCE_URN))));
+    dataHubPolicyInfo.setResources(resourceFilter);
+
+    ResolvedEntitySpec resourceSpec =
+        buildEntityResolvers(
+            "dataset", "urn:li:dataset:random"); // A resource not covered by the policy.
+    PolicyEngine.PolicyEvaluationResult result =
+        _policyEngine.evaluatePolicy(
+            systemOperationContext,
+            dataHubPolicyInfo,
+            resolvedAuthorizedUserSpec,
+            "EDIT_ENTITY_TAGS",
+            Optional.of(resourceSpec));
+    assertFalse(result.isGranted());
+
+    // Verify no network calls
+    verify(_entityClient, times(0)).batchGetV2(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testEvaluatePolicyResourceFilterSpecificResourceNoMatchWithNoType() throws Exception {
+    final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();
+    dataHubPolicyInfo.setType(METADATA_POLICY_TYPE);
+    dataHubPolicyInfo.setState(ACTIVE_POLICY_STATE);
+    dataHubPolicyInfo.setPrivileges(new StringArray("EDIT_ENTITY_TAGS"));
+    dataHubPolicyInfo.setDisplayName("My Test Display");
+    dataHubPolicyInfo.setDescription("My test display!");
+    dataHubPolicyInfo.setEditable(true);
+
+    final DataHubActorFilter actorFilter = new DataHubActorFilter();
+    actorFilter.setResourceOwners(true);
+    actorFilter.setAllUsers(true);
+    actorFilter.setAllGroups(true);
+    dataHubPolicyInfo.setActors(actorFilter);
+
+    final DataHubResourceFilter resourceFilter = new DataHubResourceFilter();
+    resourceFilter.setFilter(
+        FilterUtils.newFilter(
+            ImmutableMap.of(EntityFieldType.URN, Collections.singletonList(RESOURCE_URN))));
     dataHubPolicyInfo.setResources(resourceFilter);
 
     ResolvedEntitySpec resourceSpec =


### PR DESCRIPTION
Some fields in [DataHubResourceFilter.pdl](https://github.com/datahub-project/datahub/blob/f09bd8ac316c91b9dbc8d00337bfb41a5a26afb3/metadata-models/src/main/pegasus/com/linkedin/policy/DataHubResourceFilter.pdl#L4) were deprecated but these fields were not marked deprecated in the graphql. 
Policies created from the UI no longer use these deprecated fields, but policies created via API could still use these fields. 

While the [type field is marked optional](https://docs.datahub.com/docs/graphql/inputObjects#resourcefilterinput), omitting it but specifying a resourceURN had a bug in that code path that resulted in policy engine evaluate to effectively grant acces to all resources  ignoring the resourceUrn

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
