### PR TITLE
feat(ingestion): automatically report allow/deny filtering

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -12,6 +12,7 @@ import pydantic
 from pydantic import BaseModel
 from typing_extensions import Literal, Protocol
 
+from datahub.configuration.common import AllowDenyFilterReport
 from datahub.ingestion.api.report_helpers import format_datetime_relative
 from datahub.utilities.lossy_collections import LossyList
 
@@ -108,7 +109,7 @@ class ReportAttribute(BaseModel):
         logger.log(level=self.logger_sev, msg=msg, stacklevel=3)
 
 
-class EntityFilterReport(ReportAttribute):
+class EntityFilterReport(ReportAttribute, AllowDenyFilterReport):
     type: str
 
     processed_entities: LossyList[str] = pydantic.Field(default_factory=LossyList)

--- a/metadata-ingestion/src/datahub/ingestion/source/hex/hex.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/hex/hex.py
@@ -20,6 +20,7 @@ from datahub.ingestion.api.decorators import (
     platform_name,
     support_status,
 )
+from datahub.ingestion.api.report import EntityFilterReport
 from datahub.ingestion.api.source import MetadataWorkUnitProcessor
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.hex.api import HexApi, HexApiReport
@@ -169,7 +170,8 @@ class HexReport(
     IngestionStageReport,
     HexQueryFetcherReport,
 ):
-    pass
+    projects_filter: EntityFilterReport = EntityFilterReport.field(type="project")
+    components_filter: EntityFilterReport = EntityFilterReport.field(type="component")
 
 
 @platform_name("Hex")
@@ -184,6 +186,11 @@ class HexSource(StatefulIngestionSourceBase):
         super().__init__(config, ctx)
         self.source_config = config
         self.report: HexReport = HexReport()
+        self.source_config.project_title_pattern.set_report(self.report.projects_filter)
+        self.source_config.component_title_pattern.set_report(
+            self.report.components_filter
+        )
+
         self.platform = HEX_PLATFORM_NAME
         self.hex_api = HexApi(
             report=self.report,

--- a/metadata-ingestion/tests/unit/glue/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source.py
@@ -325,7 +325,9 @@ def test_get_databases_filters_by_catalog():
         expected = [flights_database, test_database, empty_database]
         actual = all_catalogs_source.get_all_databases()
         assert format_databases(actual) == format_databases(expected)
-        assert all_catalogs_source.report.databases.dropped_entities.as_obj() == []
+        assert (
+            all_catalogs_source.report.databases_filter.dropped_entities.as_obj() == []
+        )
 
     catalog_id = "123412341234"
     single_catalog_source: GlueSource = GlueSource(
@@ -340,9 +342,10 @@ def test_get_databases_filters_by_catalog():
         expected = [flights_database, test_database]
         actual = single_catalog_source.get_all_databases()
         assert format_databases(actual) == format_databases(expected)
-        assert single_catalog_source.report.databases.dropped_entities.as_obj() == [
-            "empty-database"
-        ]
+        assert (
+            single_catalog_source.report.databases_filter.dropped_entities.as_obj()
+            == ["empty-database"]
+        )
 
 
 @freeze_time(FROZEN_TIME)


### PR DESCRIPTION
`EntityFilterReport` is designed to work alongside `AllowDenyPattern`, but it relies on developers to maintain consistency.

This update introduces a mechanism where, once linked, `AllowDenyPattern` will automatically report its activity.

Implemented for two ingestors: Glue and Hex. Seeking feedback before applying to other sources.