### PR TITLE
fix(ui) Fix bug with entity select modal with no entity types passed in

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Properties/Edit/EditStructuredPropertyModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Properties/Edit/EditStructuredPropertyModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, message } from 'antd';
+import { message } from 'antd';
 import React, { useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 
@@ -6,7 +6,7 @@ import { useEntityContext, useEntityData, useMutationUrn } from '@app/entity/sha
 import StructuredPropertyInput from '@app/entity/shared/components/styled/StructuredProperty/StructuredPropertyInput';
 import { useEditStructuredProperty } from '@app/entity/shared/components/styled/StructuredProperty/useEditStructuredProperty';
 import handleGraphQLError from '@app/shared/handleGraphQLError';
-import { Button } from '@src/alchemy-components';
+import { Button, Modal } from '@src/alchemy-components';
 import analytics, { EventType } from '@src/app/analytics';
 import { ModalButtonContainer } from '@src/app/shared/button/styledComponents';
 
@@ -112,6 +112,7 @@ export default function EditStructuredPropertyModal({
             title={`${isAddMode ? 'Add property' : 'Edit property'} ${structuredProperty?.definition?.displayName}`}
             onCancel={closeModal}
             open={isOpen}
+            buttons={[]}
             // Urn input is a special case that requires a wider modal since it employs a search select component
             width={isUrnInput ? SEARCH_SELECT_MODAL_WIDTH : DEFAULT_MODAL_WIDTH}
             footer={

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/SearchSelect.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/SearchSelect.tsx
@@ -62,7 +62,7 @@ type Props = {
  * when the selection is complete.
  */
 export const SearchSelect = ({
-    fixedEntityTypes,
+    fixedEntityTypes = [],
     placeholderText,
     selectedEntities,
     setSelectedEntities,
@@ -90,24 +90,27 @@ export const SearchSelect = ({
     const entityFilters: Array<EntityType> = filters
         .filter((filter) => filter.field === ENTITY_FILTER_NAME)
         .flatMap((filter) => filter.values?.map((value) => value.toUpperCase() as EntityType) || []);
-    const finalEntityTypes = (entityFilters.length > 0 && entityFilters) || fixedEntityTypes || [];
+    const finalEntityTypes = [...entityFilters, ...(fixedEntityTypes || [])];
 
-    const finalEntityFilter: FacetFilterInput = {
-        field: ENTITY_FILTER_NAME,
-        condition: FilterOperator.Equal,
-        values: finalEntityTypes,
-        negated: false,
-    };
+    const finalEntityFilter = finalEntityTypes.length
+        ? {
+              field: ENTITY_FILTER_NAME,
+              condition: FilterOperator.Equal,
+              values: finalEntityTypes,
+              negated: false,
+          }
+        : undefined;
+    const finalFilters = finalEntityFilter ? [...filtersWithoutEntities, finalEntityFilter] : filtersWithoutEntities;
 
     // Execute search
     const { data, loading, error, refetch } = useGetSearchResultsForMultipleQuery({
         variables: {
             input: {
-                types: finalEntityTypes,
+                types: finalEntityTypes.length ? finalEntityTypes : undefined,
                 query: searchQuery,
                 start: (page - 1) * numResultsPerPage,
                 count: numResultsPerPage,
-                filters: [...filtersWithoutEntities, finalEntityFilter],
+                filters: finalFilters,
                 sortInput,
             },
         },

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/SearchSelectUrnInput.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/SearchSelectUrnInput.tsx
@@ -79,7 +79,7 @@ const INITIAL_SELECTED_ENTITIES = [] as EntityAndType[];
 
 // New interface for the generic component
 interface SearchSelectUrnInputProps {
-    allowedEntityTypes: EntityType[];
+    allowedEntityTypes?: EntityType[];
     isMultiple: boolean;
     selectedValues: string[];
     updateSelectedValues: (values: string[] | number[]) => void;

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlySearchedSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlySearchedSource.java
@@ -100,7 +100,7 @@ public class RecentlySearchedSource implements RecommendationSource {
                 .limit(MAX_CONTENT)
                 .collect(Collectors.toList());
           } catch (Exception e) {
-            log.error("Search query to get most recently viewed entities failed", e);
+            log.error("Search query to get most recently searched queries failed", e);
             throw new ESQueryException("Search query failed:", e);
           }
         },
@@ -112,7 +112,7 @@ public class RecentlySearchedSource implements RecommendationSource {
     SearchRequest request = new SearchRequest();
     SearchSourceBuilder source = new SearchSourceBuilder();
     BoolQueryBuilder query = QueryBuilders.boolQuery();
-    // Filter for the entity view events of the user requesting recommendation
+    // Filter for the search results view event of the user requesting recommendation
     query.must(
         QueryBuilders.termQuery(
             DataHubUsageEventConstants.ACTOR_URN + ".keyword", userUrn.toString()));


### PR DESCRIPTION
There was a bug with the entity select modal where if you passed in an empty list for entity types (as can happen for structured property with entity values that have no restrictions) then the modal shows no results and you can't search for anything.

To fix this I update the logic so that if there are no entity types, then we should treat that as no filter on entity types and search all types as it works elsewhere in the app.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
