### PR TITLE
feat(azure): include azure-identity-extensions for Microsoft Entra Workload Identity connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,8 @@ project.ext.externalDependency = [
     'awsSecretsManagerJdbc': 'com.amazonaws.secretsmanager:aws-secretsmanager-jdbc:1.0.15',
     'awsPostgresIamAuth': 'software.amazon.jdbc:aws-advanced-jdbc-wrapper:2.5.4',
     'awsRds':"software.amazon.awssdk:rds:$awsSdk2Version",
+    'azureIdentityExtensions': 'com.azure:azure-identity-extensions:1.2.2',
+    'azureIdentity': 'com.azure:azure-identity:1.15.4',
     'cacheApi': 'javax.cache:cache-api:1.1.0',
     'commonsCli': 'commons-cli:commons-cli:1.5.0',
     'commonsIo': 'commons-io:commons-io:2.17.0',

--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -55,6 +55,8 @@ base_requirements = {
     "ratelimit",
     # Lower bounds on httpcore and h11 due to CVE-2025-43859.
     "httpcore>=1.0.9",
+    "azure-identity==1.21.0",
+    "aws-msk-iam-sasl-signer-python==1.0.2",
     "h11>=0.16",
 }
 

--- a/datahub-frontend/play.gradle
+++ b/datahub-frontend/play.gradle
@@ -81,6 +81,8 @@ dependencies {
   implementation externalDependency.playFilters
   implementation externalDependency.kafkaClients
   implementation externalDependency.awsMskIamAuth
+  implementation externalDependency.azureIdentityExtensions
+  implementation externalDependency.azureIdentity
 
   testImplementation 'org.seleniumhq.selenium:htmlunit-driver:2.67.0'
   testImplementation externalDependency.mockito

--- a/datahub-upgrade/build.gradle
+++ b/datahub-upgrade/build.gradle
@@ -81,6 +81,8 @@ dependencies {
   runtimeOnly externalDependency.postgresql
 
   implementation externalDependency.awsMskIamAuth
+  implementation externalDependency.azureIdentityExtensions
+  implementation externalDependency.azureIdentity
 
   annotationProcessor externalDependency.lombok
   annotationProcessor externalDependency.picocli

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -254,7 +254,9 @@ pyhive_common = {
     # Instead, we put the fix in our PyHive fork, so no thrift pin is needed.
 }
 
-microsoft_common = {"msal>=1.24.0"}
+microsoft_common = {
+    "msal>=1.31.1",
+}
 
 iceberg_common = {
     # Iceberg Python SDK
@@ -295,8 +297,8 @@ threading_timeout_common = {
 }
 
 abs_base = {
-    "azure-core==1.29.4",
-    "azure-identity>=1.17.1",
+    "azure-core>=1.31.0",
+    "azure-identity>=1.21.0",
     "azure-storage-blob>=12.19.0",
     "azure-storage-file-datalake>=12.14.0",
     "more-itertools>=8.12.0",

--- a/metadata-jobs/mae-consumer/build.gradle
+++ b/metadata-jobs/mae-consumer/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 
     testImplementation externalDependency.mockito
     implementation externalDependency.awsMskIamAuth
+    implementation externalDependency.azureIdentityExtensions
+    implementation externalDependency.azureIdentity
 
     testImplementation externalDependency.testng
     testImplementation externalDependency.springBootTest

--- a/metadata-jobs/mce-consumer/build.gradle
+++ b/metadata-jobs/mce-consumer/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     annotationProcessor externalDependency.lombok
 
     implementation externalDependency.awsMskIamAuth
+    implementation externalDependency.azureIdentityExtensions
+    implementation externalDependency.azureIdentity
 
     testImplementation externalDependency.testng
     testImplementation externalDependency.mockito

--- a/metadata-service/war/build.gradle
+++ b/metadata-service/war/build.gradle
@@ -62,6 +62,8 @@ dependencies {
   runtimeOnly externalDependency.log4j2Api
   runtimeOnly externalDependency.logbackClassic
   implementation externalDependency.awsMskIamAuth
+  implementation externalDependency.azureIdentityExtensions
+  implementation externalDependency.azureIdentity
   testRuntimeOnly externalDependency.logbackClassic
   implementation externalDependency.charle
 


### PR DESCRIPTION
Include Java and Python modules required to support Microsoft Entra Workload Identities connections.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
