### PR TITLE
feat(dbt/ingestion): add support for nested meta properties mapping

### DIFF
--- a/metadata-ingestion/docs/sources/dbt/dbt.md
+++ b/metadata-ingestion/docs/sources/dbt/dbt.md
@@ -55,6 +55,11 @@ column_meta_mapping:
     operation: "add_tag"
     config:
       tag: "sensitive"
+  gdpr.pii:
+    match: true
+    operation: "add_tag"
+    config:
+      tag: "pii"
 ```
 
 We support the following operations:
@@ -117,6 +122,29 @@ meta_mapping:
      config:
        tag: "case_{{ $match }}"
 ```
+
+#### Nested meta properties
+
+If your meta section has nested properties and looks like this:
+
+```yaml
+meta:
+  data_governance:
+    team_owner: "Finance"
+```
+
+and you want attach term Finance_test in case of data_governance.team_owner is set to Finance, you can use the following meta_mapping section:
+
+```yaml
+meta:
+  data_governance.team_owner:
+    match: "Finance"
+    operation: "add_term"
+    config:
+      term: "Finance_test"
+```
+
+Note: nested meta properties mapping is supported also for column_meta_mapping
 
 #### Stripping out leading @ sign
 

--- a/metadata-ingestion/docs/sources/dbt/dbt.md
+++ b/metadata-ingestion/docs/sources/dbt/dbt.md
@@ -136,7 +136,7 @@ meta:
 and you want attach term Finance_test in case of data_governance.team_owner is set to Finance, you can use the following meta_mapping section:
 
 ```yaml
-meta:
+meta_mapping:
   data_governance.team_owner:
     match: "Finance"
     operation: "add_term"

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -1315,6 +1315,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             self.config.tag_prefix,
             "SOURCE_CONTROL",
             self.config.strip_user_ids_from_email,
+            match_nested_props=True,
         )
 
         action_processor_tag = OperationProcessor(
@@ -1686,6 +1687,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             self.config.tag_prefix,
             "SOURCE_CONTROL",
             self.config.strip_user_ids_from_email,
+            match_nested_props=True,
         )
 
         canonical_schema: List[SchemaField] = []

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_column_meta_mapping_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_column_meta_mapping_golden.json
@@ -921,6 +921,8 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
+                            "data_governance_nested": "{'team_owner': 'Finance'}",
+                            "data_governance.team_owner": "Finance",
                             "node_type": "model",
                             "materialization": "table",
                             "dbt_file_path": "models/transform/payments_by_customer_by_month.sql",
@@ -942,6 +944,22 @@
                 {
                     "com.linkedin.pegasus2avro.common.Status": {
                         "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.GlossaryTerms": {
+                        "terms": [
+                            {
+                                "urn": "urn:li:glossaryTerm:Finance_test"
+                            },
+                            {
+                                "urn": "urn:li:glossaryTerm:Finance_test_nested"
+                            }
+                        ],
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:datahub"
+                        }
                     }
                 },
                 {
@@ -1019,6 +1037,9 @@
                                         },
                                         {
                                             "urn": "urn:li:glossaryTerm:pii"
+                                        },
+                                        {
+                                            "urn": "urn:li:glossaryTerm:pii_category_organization"
                                         }
                                     ],
                                     "auditStamp": {
@@ -1567,11 +1588,8 @@
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
-                                "owner": "urn:li:corpuser:alice",
-                                "type": "DATAOWNER",
-                                "source": {
-                                    "type": "SOURCE_CONTROL"
-                                }
+                                "owner": "urn:li:corpuser:@alice",
+                                "type": "DATAOWNER"
                             }
                         ],
                         "ownerTypes": {},
@@ -2477,11 +2495,8 @@
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
-                                "owner": "urn:li:corpuser:bob",
-                                "type": "DATAOWNER",
-                                "source": {
-                                    "type": "SOURCE_CONTROL"
-                                }
+                                "owner": "urn:li:corpuser:@bob",
+                                "type": "DATAOWNER"
                             }
                         ],
                         "ownerTypes": {},
@@ -3272,11 +3287,8 @@
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
-                                "owner": "urn:li:corpuser:charles",
-                                "type": "DATAOWNER",
-                                "source": {
-                                    "type": "SOURCE_CONTROL"
-                                }
+                                "owner": "urn:li:corpuser:@charles",
+                                "type": "DATAOWNER"
                             }
                         ],
                         "ownerTypes": {},
@@ -4771,6 +4783,38 @@
 },
 {
     "entityType": "glossaryTerm",
+    "entityUrn": "urn:li:glossaryTerm:Finance_test",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTermKey",
+    "aspect": {
+        "json": {
+            "name": "Finance_test"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-column-meta-mapping",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "glossaryTerm",
+    "entityUrn": "urn:li:glossaryTerm:Finance_test_nested",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTermKey",
+    "aspect": {
+        "json": {
+            "name": "Finance_test_nested"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-column-meta-mapping",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "glossaryTerm",
     "entityUrn": "urn:li:glossaryTerm:customer_id",
     "changeType": "UPSERT",
     "aspectName": "glossaryTermKey",
@@ -4809,6 +4853,22 @@
     "aspect": {
         "json": {
             "name": "pii"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-column-meta-mapping",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "glossaryTerm",
+    "entityUrn": "urn:li:glossaryTerm:pii_category_organization",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTermKey",
+    "aspect": {
+        "json": {
+            "name": "pii_category_organization"
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_column_meta_mapping_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_column_meta_mapping_golden.json
@@ -1588,8 +1588,11 @@
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
-                                "owner": "urn:li:corpuser:@alice",
-                                "type": "DATAOWNER"
+                                "owner": "urn:li:corpuser:alice",
+                                "type": "DATAOWNER",
+                                "source": {
+                                    "type": "SOURCE_CONTROL"
+                                }
                             }
                         ],
                         "ownerTypes": {},
@@ -2495,8 +2498,11 @@
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
-                                "owner": "urn:li:corpuser:@bob",
-                                "type": "DATAOWNER"
+                                "owner": "urn:li:corpuser:bob",
+                                "type": "DATAOWNER",
+                                "source": {
+                                    "type": "SOURCE_CONTROL"
+                                }
                             }
                         ],
                         "ownerTypes": {},
@@ -3287,8 +3293,11 @@
                     "com.linkedin.pegasus2avro.common.Ownership": {
                         "owners": [
                             {
-                                "owner": "urn:li:corpuser:@charles",
-                                "type": "DATAOWNER"
+                                "owner": "urn:li:corpuser:charles",
+                                "type": "DATAOWNER",
+                                "source": {
+                                    "type": "SOURCE_CONTROL"
+                                }
                             }
                         ],
                         "ownerTypes": {},

--- a/metadata-ingestion/tests/integration/dbt/sample_dbt_manifest_1.json
+++ b/metadata-ingestion/tests/integration/dbt/sample_dbt_manifest_1.json
@@ -7883,7 +7883,10 @@
           "meta": {
             "is_sensitive": true,
             "maturity": "beta",
-            "terms": "pii, customer_id"
+            "terms": "pii, customer_id",
+            "governance": {
+              "pii_category": "organization"
+            }
           },
           "name": "customer_id",
           "quote": null,
@@ -7908,7 +7911,12 @@
         "grants": {},
         "incremental_strategy": null,
         "materialized": "table",
-        "meta": {},
+        "meta": {
+          "data_governance_nested": {
+            "team_owner": "Finance"
+          },
+          "data_governance.team_owner": "Finance"
+        },
         "on_schema_change": "ignore",
         "packages": [],
         "persist_docs": {},

--- a/metadata-ingestion/tests/integration/dbt/test_dbt.py
+++ b/metadata-ingestion/tests/integration/dbt/test_dbt.py
@@ -183,6 +183,31 @@ class DbtTestConfig:
                         "operation": "add_term",
                         "config": {"term": "Finance_test_nested"},
                     },
+                    "owner": {
+                        "match": "^@(.*)",
+                        "operation": "add_owner",
+                        "config": {"owner_type": "user"},
+                    },
+                    "business_owner": {
+                        "match": ".*",
+                        "operation": "add_owner",
+                        "config": {"owner_type": "user"},
+                    },
+                    "has_pii": {
+                        "match": True,
+                        "operation": "add_tag",
+                        "config": {"tag": "has_pii_test"},
+                    },
+                    "int_property": {
+                        "match": 1,
+                        "operation": "add_tag",
+                        "config": {"tag": "int_meta_property"},
+                    },
+                    "double_property": {
+                        "match": 2.5,
+                        "operation": "add_term",
+                        "config": {"term": "double_meta_property"},
+                    },
                     "data_governance.team_owner": {
                         "match": "Finance",
                         "operation": "add_term",

--- a/metadata-ingestion/tests/integration/dbt/test_dbt.py
+++ b/metadata-ingestion/tests/integration/dbt/test_dbt.py
@@ -169,7 +169,7 @@ class DbtTestConfig:
             },
         ),
         DbtTestConfig(
-            "dbt-column-meta-mapping",  # this also tests snapshot support
+            "dbt-column-meta-mapping",  # this also tests snapshot support and meta nested mapping
             "dbt_test_column_meta_mapping.json",
             "dbt_test_column_meta_mapping_golden.json",
             catalog_file="sample_dbt_catalog_1.json",
@@ -177,6 +177,18 @@ class DbtTestConfig:
             sources_file="sample_dbt_sources_1.json",
             source_config_modifiers={
                 "enable_meta_mapping": True,
+                "meta_mapping": {
+                    "data_governance_nested.team_owner": {
+                        "match": "Finance",
+                        "operation": "add_term",
+                        "config": {"term": "Finance_test_nested"},
+                    },
+                    "data_governance.team_owner": {
+                        "match": "Finance",
+                        "operation": "add_term",
+                        "config": {"term": "Finance_test"},
+                    },
+                },
                 "column_meta_mapping": {
                     "terms": {
                         "match": ".*",
@@ -192,6 +204,11 @@ class DbtTestConfig:
                         "match": ".*",
                         "operation": "add_term",
                         "config": {"term": "maturity_{{ $match }}"},
+                    },
+                    "governance.pii_category": {
+                        "match": ".*",
+                        "operation": "add_term",
+                        "config": {"term": "pii_category_{{ $match }}"},
                     },
                 },
                 "entities_enabled": {


### PR DESCRIPTION
add support for nested dbt meta field mapping (meta_mapping, column_meta_mapping)

dbt define [meta](https://docs.getdbt.com/reference/resource-configs/meta) field as dictionary

if meta section looks like this
```yaml
meta:
  data_governance:
     team_owner: "Finance"
```

this meta mapping start to work:
```yaml
meta_mapping:
  data_governance.team_owner:
    match: "Finance"
    operation: "add_term"
    config:
      term: "Finance_test"
```

## Checklist
---
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
