### PR TITLE
feat(ingest): associate queries with operations

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -1753,8 +1753,9 @@ class SqlParsingAggregator(Closeable):
             operationType=operation_type,
             lastUpdatedTimestamp=make_ts_millis(query.latest_timestamp),
             actor=query.actor.urn() if query.actor else None,
-            customProperties=(
-                {"query_urn": self._query_urn(query_id)}
+            sourceType=models.OperationSourceTypeClass.DATA_PLATFORM,
+            queries=(
+                [self._query_urn(query_id)]
                 if self.can_generate_query(query_id)
                 else None
             ),

--- a/metadata-ingestion/tests/integration/bigquery_v2/bigquery_lineage_usage_golden.json
+++ b/metadata-ingestion/tests/integration/bigquery_v2/bigquery_lineage_usage_golden.json
@@ -25,44 +25,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1643846400000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 1,
-            "totalSqlQueries": 4,
-            "topSqlQueries": [
-                "create view `bigquery-dataset-1`.`view-1` as select * from `bigquery-dataset-1`.`table-1`",
-                "select * from `bigquery-dataset-1`.`table-1`"
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:foo",
-                    "count": 4
-                }
-            ],
-            "fieldCounts": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -91,23 +54,46 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD)",
+    "entityType": "query",
+    "entityUrn": "urn:li:query:176428c30cc3197730c20f6d0161efe869a0a041876d23c044aa2cd60d4c7a12",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "querySubjects",
     "aspect": {
         "json": {
-            "removed": false
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)"
+                }
+            ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:176428c30cc3197730c20f6d0161efe869a0a041876d23c044aa2cd60d4c7a12",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -139,23 +125,44 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "query",
-    "entityUrn": "urn:li:query:176428c30cc3197730c20f6d0161efe869a0a041876d23c044aa2cd60d4c7a12",
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
+    "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
+            "timestampMillis": 1643846400000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 4,
+            "topSqlQueries": [
+                "select * from `bigquery-dataset-1`.`table-1`",
+                "create view `bigquery-dataset-1`.`view-1` as select * from `bigquery-dataset-1`.`table-1`"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:foo",
+                    "count": 4
+                }
+            ],
+            "fieldCounts": []
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -191,30 +198,34 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "query",
-    "entityUrn": "urn:li:query:176428c30cc3197730c20f6d0161efe869a0a041876d23c044aa2cd60d4c7a12",
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "querySubjects",
+    "aspectName": "operation",
     "aspect": {
         "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)"
-                }
+            "timestampMillis": 1643871600000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:foo",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1643871600000,
+            "queries": [
+                "urn:li:query:176428c30cc3197730c20f6d0161efe869a0a041876d23c044aa2cd60d4c7a12"
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -243,23 +254,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:176428c30cc3197730c20f6d0161efe869a0a041876d23c044aa2cd60d4c7a12",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -279,7 +274,23 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:23f1935934face229de381fad193e390153180bf1e7afaa6db58e91fc28d0021",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -311,7 +322,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -340,23 +351,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00-y4a2wl",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:23f1935934face229de381fad193e390153180bf1e7afaa6db58e91fc28d0021",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -376,7 +371,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -392,7 +387,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -424,33 +419,23 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "operation",
+    "aspectName": "status",
     "aspect": {
         "json": {
-            "timestampMillis": 1643871600000,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:foo",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:176428c30cc3197730c20f6d0161efe869a0a041876d23c044aa2cd60d4c7a12"
-            },
-            "lastUpdatedTimestamp": 1643871600000
+            "removed": false
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -466,7 +451,23 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:176428c30cc3197730c20f6d0161efe869a0a041876d23c044aa2cd60d4c7a12",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -482,7 +483,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -498,7 +499,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -520,7 +521,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-6mhnuz",
         "lastRunId": "no-run-id-provided"
     }
 }

--- a/metadata-ingestion/tests/integration/bigquery_v2/bigquery_queries_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/bigquery_v2/bigquery_queries_mcps_golden.json
@@ -25,7 +25,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -36,102 +36,25 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_3.derived_table` as (select * from `gcp-staging-2.smoke_test_db_3.base_table_2`);\n        ",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1721549585813,
+                "time": 1724322481569,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1721549585813,
+                "time": 1724322481569,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178195,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1724050800000,
-                        "actor": "urn:li:corpuser:_ingestion"
-                    },
-                    "created": {
-                        "time": 1724322460257,
-                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
-                    "type": "TRANSFORMED",
-                    "query": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:88c4674d369ef49e881a5ea67ed3485e48f09b9a4924d5282c3ae25004737f95",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178196,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:88c4674d369ef49e881a5ea67ed3485e48f09b9a4924d5282c3ae25004737f95",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -153,88 +76,30 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178196,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d",
+    "entityUrn": "urn:li:query:88c4674d369ef49e881a5ea67ed3485e48f09b9a4924d5282c3ae25004737f95",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498949,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1724050800000,
-                        "actor": "urn:li:corpuser:_ingestion"
-                    },
-                    "created": {
-                        "time": 1724322457731,
-                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
-                    "type": "TRANSFORMED",
-                    "query": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d"
-                }
-            ]
+            "platform": "urn:li:dataPlatform:bigquery"
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "create or replace table _smoke_test_db_tmp_tables.tmp_table as (select * from smoke_test_db.base_table);\n\ncreate or replace table smoke_test_db.lineage_from_tmp_table as (select * from _smoke_test_db_tmp_tables.tmp_table)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549567376,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549567376,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997222,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6e250c6966754a5e6532fbb444172dacf5813b0b7afceefbf7772a29878f48f8",
+    "entityUrn": "urn:li:query:88c4674d369ef49e881a5ea67ed3485e48f09b9a4924d5282c3ae25004737f95",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -260,35 +125,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6e250c6966754a5e6532fbb444172dacf5813b0b7afceefbf7772a29878f48f8",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_external_table` as (select * from `gcp-staging-2.smoke_test_db_4.external_table_us_states`);\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549602653,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549602653,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178198,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -318,7 +155,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -326,15 +163,28 @@
     "entityType": "query",
     "entityUrn": "urn:li:query:6e250c6966754a5e6532fbb444172dacf5813b0b7afceefbf7772a29878f48f8",
     "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
+    "aspectName": "queryProperties",
     "aspect": {
         "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_external_table` as (select * from `gcp-staging-2.smoke_test_db_4.external_table_us_states`);\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322505477,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322505477,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178200,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -356,14 +206,62 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178199,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6e250c6966754a5e6532fbb444172dacf5813b0b7afceefbf7772a29878f48f8",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6e250c6966754a5e6532fbb444172dacf5813b0b7afceefbf7772a29878f48f8",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
@@ -375,19 +273,87 @@
                         "actor": "urn:li:corpuser:_ingestion"
                     },
                     "created": {
-                        "time": 1724322508214,
+                        "time": 1724322500148,
                         "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
                     "type": "TRANSFORMED",
-                    "query": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab"
+                    "query": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table` as (select * from `gcp-staging-2.smoke_test_db_4.sharded_table1_20230101`);\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322500148,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322500148,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -419,13 +385,72 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1724050800000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 1724322508214,
+                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+                    "type": "TRANSFORMED",
+                    "query": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d",
+    "entityUrn": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table` as (\n                    SELECT *\n                    FROM `gcp-staging.smoke_test_db.base_table`\n                    FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)\n            );\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322508214,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322508214,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
@@ -435,80 +460,20 @@
                     "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
                 },
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997223,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1724050800000,
-                        "actor": "urn:li:corpuser:_ingestion"
-                    },
-                    "created": {
-                        "time": 1724322475572,
-                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
-                    "type": "TRANSFORMED",
-                    "query": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table,PROD)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1724050800000,
-                        "actor": "urn:li:corpuser:_ingestion"
-                    },
-                    "created": {
-                        "time": 1724322500148,
-                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
-                    "type": "TRANSFORMED",
-                    "query": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d",
+    "entityUrn": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -517,8 +482,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064997223,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -550,85 +515,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace view smoke_test_db.view_from_view_on_table\n            as (select * from smoke_test_db.view_from_table)\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549572202,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549572202,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498921,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table` as (select * from `gcp-staging-2.smoke_test_db_4.sharded_table1_20230101`);\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549598252,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549598252,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178202,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498922,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.destination_table_of_select_query,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
@@ -640,70 +533,87 @@
                         "actor": "urn:li:corpuser:_ingestion"
                     },
                     "created": {
-                        "time": 1724322510656,
+                        "time": 1724322502689,
                         "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
                     "type": "TRANSFORMED",
-                    "query": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4"
+                    "query": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
+    "entityUrn": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "CREATE TABLE `gcp-staging-2.smoke_test_db_4.destination_table_of_select_query` AS\n                (\n                    SELECT * FROM `gcp-staging.smoke_test_db.base_table`\n                )",
+                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table` as (select * from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`);\n        ",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322510656,
+                "time": 1724322502689,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1724322510656,
+                "time": 1724322502689,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
+    "entityUrn": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
         "json": {
             "subjects": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
                 },
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.destination_table_of_select_query,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table,PROD)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -735,139 +645,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178203,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178203,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498922,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498952,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.destination_table_of_select_query,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
@@ -879,137 +663,93 @@
                         "actor": "urn:li:corpuser:_ingestion"
                     },
                     "created": {
-                        "time": 1724322465459,
+                        "time": 1724322510656,
                         "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
                     "type": "TRANSFORMED",
-                    "query": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d"
+                    "query": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1",
+    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "\n            create or replace table smoke_test_db_2.table_from_other_db\n            as (select * from smoke_test_db.base_table)\n        ",
+                "value": "CREATE TABLE `gcp-staging-2.smoke_test_db_4.destination_table_of_select_query` AS\n                (\n                    SELECT * FROM `gcp-staging.smoke_test_db.base_table`\n                )",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1721549574990,
+                "time": 1724322510656,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1721549574990,
+                "time": 1724322510656,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498946,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab",
+    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
     "changeType": "UPSERT",
-    "aspectName": "queryProperties",
+    "aspectName": "querySubjects",
     "aspect": {
         "json": {
-            "statement": {
-                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table` as (\n                    SELECT *\n                    FROM `gcp-staging.smoke_test_db.base_table`\n                    FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)\n            );\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549605511,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549605511,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.destination_table_of_select_query,PROD)"
+                }
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178206,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991",
+    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
     "changeType": "UPSERT",
-    "aspectName": "queryProperties",
+    "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "statement": {
-                "value": "\n            create or replace view smoke_test_db.view_from_multiple_tables\n            as \n            (\n                select a.date_utc, a.revenue, b.revenue as revenue2, c.revenue as revenue3 \n                from \n                    smoke_test_db.base_table a\n                left join \n                    smoke_test_db.lineage_from_base b \n                    on a.date_utc = b.date_utc \n                left join \n                    smoke_test_db_2.table_from_other_db c \n                    on b.date_utc = c.date_utc \n            );\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549588112,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549588112,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
+            "platform": "urn:li:dataPlatform:bigquery"
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498924,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.sharded_table1_20230201` OPTIONS(description=\"Description of sharded table ending with _yyyyMMdd\") as (select * from `gcp-staging.smoke_test_db_2.table_from_other_db`);\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549591093,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549591093,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178217,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d",
+    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -1035,23 +775,37 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab",
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
+    "aspectName": "upstreamLineage",
     "aspect": {
         "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1724050800000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 1724322485618,
+                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
+                    "type": "TRANSFORMED",
+                    "query": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d"
+                }
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178207,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1059,15 +813,28 @@
     "entityType": "query",
     "entityUrn": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d",
     "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
+    "aspectName": "queryProperties",
     "aspect": {
         "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.sharded_table1_20230201` OPTIONS(description=\"Description of sharded table ending with _yyyyMMdd\") as (select * from `gcp-staging.smoke_test_db_2.table_from_other_db`);\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322488551,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322488551,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178218,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1089,8 +856,154 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178217,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1724050800000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 1724322460257,
+                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+                    "type": "TRANSFORMED",
+                    "query": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "create or replace table smoke_test_db.lineage_from_base as (select * from smoke_test_db.base_table)",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322460257,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322460257,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1122,13 +1035,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
@@ -1140,25 +1053,54 @@
                         "actor": "urn:li:corpuser:_ingestion"
                     },
                     "created": {
-                        "time": 1724322485618,
+                        "time": 1724322457731,
                         "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
                     "type": "TRANSFORMED",
-                    "query": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d"
+                    "query": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab",
+    "entityUrn": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "create or replace table _smoke_test_db_tmp_tables.tmp_table as (select * from smoke_test_db.base_table);\n\ncreate or replace table smoke_test_db.lineage_from_tmp_table as (select * from _smoke_test_db_tmp_tables.tmp_table)",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322457731,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322457731,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
@@ -1168,48 +1110,95 @@
                     "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
                 },
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)"
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178207,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930",
+    "entityUrn": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1724050800000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 1724322475572,
+                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+                    "type": "TRANSFORMED",
+                    "query": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table` as (select * from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`);\n        ",
+                "value": "create MATERIALIZED VIEW smoke_test_db.materialized_view_from_table as (select * from smoke_test_db.base_table where revenue>100)",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1721549600590,
+                "time": 1724322476091,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1721549600590,
+                "time": 1724322476091,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178211,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991",
+    "entityUrn": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
@@ -1219,50 +1208,20 @@
                     "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),date_utc)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),date_utc)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue2)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue3)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)"
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498924,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930",
+    "entityUrn": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -1271,75 +1230,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178212,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace table `gcp-staging.smoke_test_db.table_from_another_project` as (select * from `gcp-staging-2.smoke_test_db_3.base_table_2`);\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549583501,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549583501,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178230,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178211,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178231,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1371,7 +1263,105 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1724050800000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 1724322478955,
+                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
+                    "type": "TRANSFORMED",
+                    "query": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table `gcp-staging.smoke_test_db.table_from_another_project` as (select * from `gcp-staging-2.smoke_test_db_3.base_table_2`);\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322478955,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322478955,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1403,52 +1393,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178231,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498946,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
@@ -1460,25 +1411,77 @@
                         "actor": "urn:li:corpuser:_ingestion"
                     },
                     "created": {
-                        "time": 1724322502689,
+                        "time": 1724322465459,
                         "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
                     },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
                     "type": "TRANSFORMED",
-                    "query": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930"
+                    "query": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991",
+    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table smoke_test_db.table_from_view\n            as (select * from smoke_test_db.view_from_table)\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322465459,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322465459,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -1487,8 +1490,40 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498924,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1557,13 +1592,42 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1",
+    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table smoke_test_db.table_from_view_and_table\n            as (select b.date_utc, v.revenue from smoke_test_db.base_table b, smoke_test_db.view_from_table v)\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322472836,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322472836,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
@@ -1573,14 +1637,77 @@
                     "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
                 },
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD),revenue)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498946,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1686,368 +1813,105 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9",
+    "entityUrn": "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "\n            insert into smoke_test_db.usage_test values\n              (\"2022-05-01\", \"seven\", 7),\n              (\"2022-05-02\", \"ten\", 10),\n              (\"2022-06-01\", \"four\", 4)\n        ",
+                "value": "\n            create or replace view smoke_test_db.view_from_multiple_tables\n            as \n            (\n                select a.date_utc, a.revenue, b.revenue as revenue2, c.revenue as revenue3 \n                from \n                    smoke_test_db.base_table a\n                left join \n                    smoke_test_db.lineage_from_base b \n                    on a.date_utc = b.date_utc \n                left join \n                    smoke_test_db_2.table_from_other_db c \n                    on b.date_utc = c.date_utc \n            );\n        ",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1721549557813,
+                "time": 1724322484293,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1721549557813,
+                "time": 1724322484293,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498926,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9",
+    "entityUrn": "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
         "json": {
             "subjects": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498927,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1724050800000,
-                        "actor": "urn:li:corpuser:_ingestion"
-                    },
-                    "created": {
-                        "time": 1724322471500,
-                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.snapshot_from_table,PROD)",
-                    "type": "TRANSFORMED",
-                    "query": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498953,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1724050800000,
-                        "actor": "urn:li:corpuser:_ingestion"
-                    },
-                    "created": {
-                        "time": 1724322478955,
-                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
-                    "type": "TRANSFORMED",
-                    "query": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498927,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace view smoke_test_db.view_from_snapshot_on_table\n            as (select * from smoke_test_db.snapshot_from_table)\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549577574,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549577574,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498924,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1724050800000,
-                        "actor": "urn:li:corpuser:_ingestion"
-                    },
-                    "created": {
-                        "time": 1724322462741,
-                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
-                    "type": "TRANSFORMED",
-                    "query": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1724050800000,
-                        "actor": "urn:li:corpuser:_ingestion"
-                    },
-                    "created": {
-                        "time": 1724322464098,
-                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
-                    "type": "TRANSFORMED",
-                    "query": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498925,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.snapshot_from_table,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
                 },
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD),revenue)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD),revenue)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue2)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue3)"
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498925,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
+    "entityUrn": "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991",
     "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
+    "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
+            "platform": "urn:li:dataPlatform:bigquery"
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-        "json": {
-            "upstreams": [
-                {
-                    "auditStamp": {
-                        "time": 1724050800000,
-                        "actor": "urn:li:corpuser:_ingestion"
-                    },
-                    "created": {
-                        "time": 1724322467835,
-                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-                    },
-                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
-                    "type": "TRANSFORMED",
-                    "query": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2079,372 +1943,105 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.snapshot_from_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
+    "aspectName": "upstreamLineage",
     "aspect": {
         "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 1,
-            "totalSqlQueries": 1,
-            "topSqlQueries": [
-                "\n            create or replace view smoke_test_db.view_from_snapshot_on_table\n            as (select * from smoke_test_db.snapshot_from_table)\n        "
-            ],
-            "userCounts": [
+            "upstreams": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997260,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace view smoke_test_db.view_from_table\n            as (select * from smoke_test_db.base_table)\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549571609,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549571609,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498930,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 2,
-            "totalSqlQueries": 3,
-            "topSqlQueries": [
-                "select revenue, date_utc from gcp-staging.smoke_test_db.lineage_from_base",
-                "select revenue from gcp-staging.smoke_test_db.lineage_from_base",
-                "\n            create or replace view smoke_test_db.view_from_multiple_tables\n            as \n            (\n                select a.date_utc, a.revenue, b.revenue as revenue2, c.revenue as revenue3 \n                from \n                    smoke_test_db.base_table a\n                left join \n                    smoke_test_db.lineage_from_base b \n                    on a.date_utc = b.date_utc \n                left join \n                    smoke_test_db_2.table_from_other_db c \n                    on b.date_utc = c.date_utc \n            );\n        "
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 2
-                },
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "revenue",
-                    "count": 3
-                },
-                {
-                    "fieldPath": "date_utc",
-                    "count": 1
+                    "auditStamp": {
+                        "time": 1724050800000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 1724322471500,
+                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.snapshot_from_table,PROD)",
+                    "type": "TRANSFORMED",
+                    "query": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e"
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178262,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b",
+    "entityUrn": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace view smoke_test_db.view_from_snapshot_on_table\n            as (select * from smoke_test_db.snapshot_from_table)\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322471500,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322471500,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
         "json": {
             "subjects": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.snapshot_from_table,PROD)"
                 },
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498930,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 2,
-            "totalSqlQueries": 13,
-            "topSqlQueries": [
-                "create or replace table smoke_test_db.lineage_from_base as (select * from smoke_test_db.base_table)",
-                "\n            create or replace table smoke_test_db_2.table_from_other_db\n            as (select * from smoke_test_db.base_table)\n        ",
-                "\n            create or replace table smoke_test_db.table_from_view_and_table\n            as (select b.date_utc, v.revenue from smoke_test_db.base_table b, smoke_test_db.view_from_table v)\n        ",
-                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table` as (\n                    SELECT *\n                    FROM `gcp-staging.smoke_test_db.base_table`\n                    FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)\n            );\n        ",
-                "select revenue, date_utc from gcp-staging.smoke_test_db.base_table",
-                "\n            create or replace view smoke_test_db.view_from_table\n            as (select * from smoke_test_db.base_table)\n        ",
-                "create or replace table _smoke_test_db_tmp_tables.tmp_table as (select * from smoke_test_db.base_table)",
-                "select revenue from gcp-staging.smoke_test_db.base_table FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)",
-                "select revenue from gcp-staging.smoke_test_db.base_table",
-                "\n            create or replace view smoke_test_db.view_from_multiple_tables\n            as \n            (\n                select a.date_utc, a.revenue, b.revenue as revenue2, c.revenue as revenue3 \n                from \n                    smoke_test_db.base_table a\n                left join \n                    smoke_test_db.lineage_from_base b \n                    on a.date_utc = b.date_utc \n                left join \n                    smoke_test_db_2.table_from_other_db c \n                    on b.date_utc = c.date_utc \n            );\n        ",
-                "create MATERIALIZED VIEW smoke_test_db.materialized_view_from_table as (select * from smoke_test_db.base_table where revenue>100)",
-                "CREATE TABLE `gcp-staging-2.smoke_test_db_4.destination_table_of_select_query` AS\n                (\n                    SELECT * FROM `gcp-staging.smoke_test_db.base_table`\n                )",
-                "select revenue, date_utc from gcp-staging.smoke_test_db.base_table FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)"
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 11
-                },
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 2
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "revenue",
-                    "count": 5
-                },
-                {
-                    "fieldPath": "date_utc",
-                    "count": 4
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b",
+    "entityUrn": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e",
     "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
+    "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
+            "platform": "urn:li:dataPlatform:bigquery"
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 2,
-            "totalSqlQueries": 5,
-            "topSqlQueries": [
-                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.sharded_table1_20230101` OPTIONS(description=\"Description of sharded table ending with _yyyyMMdd\") as (select * from `gcp-staging.smoke_test_db_2.table_from_other_db`) ;\n        ",
-                "select revenue from gcp-staging.smoke_test_db_2.table_from_other_db",
-                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.sharded_table1_20230201` OPTIONS(description=\"Description of sharded table ending with _yyyyMMdd\") as (select * from `gcp-staging.smoke_test_db_2.table_from_other_db`);\n        ",
-                "\n            create or replace view smoke_test_db.view_from_multiple_tables\n            as \n            (\n                select a.date_utc, a.revenue, b.revenue as revenue2, c.revenue as revenue3 \n                from \n                    smoke_test_db.base_table a\n                left join \n                    smoke_test_db.lineage_from_base b \n                    on a.date_utc = b.date_utc \n                left join \n                    smoke_test_db_2.table_from_other_db c \n                    on b.date_utc = c.date_utc \n            );\n        ",
-                "select revenue, date_utc from gcp-staging.smoke_test_db_2.table_from_other_db"
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 4
-                },
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "revenue",
-                    "count": 3
-                },
-                {
-                    "fieldPath": "date_utc",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178265,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 2,
-            "totalSqlQueries": 5,
-            "topSqlQueries": [
-                "select revenue from gcp-staging.smoke_test_db.view_from_table",
-                "\n            create or replace table smoke_test_db.table_from_view_and_table\n            as (select b.date_utc, v.revenue from smoke_test_db.base_table b, smoke_test_db.view_from_table v)\n        ",
-                "\n            create or replace table smoke_test_db.table_from_view\n            as (select * from smoke_test_db.view_from_table)\n        ",
-                "\n            create or replace view smoke_test_db.view_from_view_on_table\n            as (select * from smoke_test_db.view_from_table)\n        ",
-                "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_table"
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 4
-                },
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "revenue",
-                    "count": 3
-                },
-                {
-                    "fieldPath": "date_utc",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178260,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "insert into smoke_test_db.partition_test values (\"2022-05-24\", 20), (\"2022-06-24\", 30)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549560560,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549560560,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498928,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2476,7 +2073,89 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1724050800000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 1724322462741,
+                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+                    "type": "TRANSFORMED",
+                    "query": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace view smoke_test_db.view_from_table\n            as (select * from smoke_test_db.base_table)\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322462741,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322462741,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2491,34 +2170,128 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498930,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
+    "entityUrn": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1724050800000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 1724322464098,
+                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
+                    "type": "TRANSFORMED",
+                    "query": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace view smoke_test_db.view_from_view_on_table\n            as (select * from smoke_test_db.view_from_table)\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322464098,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322464098,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
         "json": {
             "subjects": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)"
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498928,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
+    "entityUrn": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2527,193 +2300,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498929,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "create or replace table smoke_test_db.usage_test (date_utc date, key STRING, value INTEGER)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549557257,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549557257,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498927,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),date_utc)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),key)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),value)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498927,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498953,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498928,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997269,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "INSERT",
-            "customProperties": {
-                "query_urn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491"
-            },
-            "lastUpdatedTimestamp": 1721549563403
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997270,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "create MATERIALIZED VIEW smoke_test_db.materialized_view_from_table as (select * from smoke_test_db.base_table where revenue>100)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549581208,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549581208,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498938,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498938,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997268,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e"
-            },
-            "lastUpdatedTimestamp": 1721549577574
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997270,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2745,33 +2333,105 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "operation",
+    "aspectName": "upstreamLineage",
     "aspect": {
         "json": {
-            "timestampMillis": 1724064997271,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c"
-            },
-            "lastUpdatedTimestamp": 1721549562792
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1724050800000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 1724322467835,
+                        "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+                    "type": "TRANSFORMED",
+                    "query": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1"
+                }
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064997273,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table smoke_test_db_2.table_from_other_db\n            as (select * from smoke_test_db.base_table)\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322467835,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322467835,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2803,111 +2463,18 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997267,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0"
-            },
-            "lastUpdatedTimestamp": 1721549578210
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997269,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498938,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498948,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace table smoke_test_db.partition_test (date_utc date, revenue INTEGER) \n            PARTITION BY date_utc\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549559855,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549559855,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498929,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "timestampMillis": 1721520000000,
+            "timestampMillis": 1724284800000,
             "eventGranularity": {
                 "unit": "DAY",
                 "multiple": 1
@@ -2917,18 +2484,170 @@
                 "type": "FULL_TABLE"
             },
             "uniqueUserCount": 2,
-            "totalSqlQueries": 2,
+            "totalSqlQueries": 13,
             "topSqlQueries": [
-                "select revenue from gcp-staging.smoke_test_db.lineage_from_tmp_table",
-                "select revenue, date_utc from gcp-staging.smoke_test_db.lineage_from_tmp_table"
+                "create or replace table _smoke_test_db_tmp_tables.tmp_table as (select * from smoke_test_db.base_table)",
+                "create or replace table smoke_test_db.lineage_from_base as (select * from smoke_test_db.base_table)",
+                "\n            create or replace view smoke_test_db.view_from_table\n            as (select * from smoke_test_db.base_table)\n        ",
+                "\n            create or replace table smoke_test_db_2.table_from_other_db\n            as (select * from smoke_test_db.base_table)\n        ",
+                "\n            create or replace table smoke_test_db.table_from_view_and_table\n            as (select b.date_utc, v.revenue from smoke_test_db.base_table b, smoke_test_db.view_from_table v)\n        ",
+                "create MATERIALIZED VIEW smoke_test_db.materialized_view_from_table as (select * from smoke_test_db.base_table where revenue>100)",
+                "\n            create or replace view smoke_test_db.view_from_multiple_tables\n            as \n            (\n                select a.date_utc, a.revenue, b.revenue as revenue2, c.revenue as revenue3 \n                from \n                    smoke_test_db.base_table a\n                left join \n                    smoke_test_db.lineage_from_base b \n                    on a.date_utc = b.date_utc \n                left join \n                    smoke_test_db_2.table_from_other_db c \n                    on b.date_utc = c.date_utc \n            );\n        ",
+                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table` as (\n                    SELECT *\n                    FROM `gcp-staging.smoke_test_db.base_table`\n                    FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)\n            );\n        ",
+                "CREATE TABLE `gcp-staging-2.smoke_test_db_4.destination_table_of_select_query` AS\n                (\n                    SELECT * FROM `gcp-staging.smoke_test_db.base_table`\n                )",
+                "select revenue, date_utc from gcp-staging.smoke_test_db.base_table",
+                "select revenue, date_utc from gcp-staging.smoke_test_db.base_table FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)",
+                "select revenue from gcp-staging.smoke_test_db.base_table",
+                "select revenue from gcp-staging.smoke_test_db.base_table FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)"
             ],
             "userCounts": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 11
                 },
                 {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 2
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "revenue",
+                    "count": 5
+                },
+                {
+                    "fieldPath": "date_utc",
+                    "count": 4
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 2,
+            "totalSqlQueries": 5,
+            "topSqlQueries": [
+                "\n            create or replace view smoke_test_db.view_from_view_on_table\n            as (select * from smoke_test_db.view_from_table)\n        ",
+                "\n            create or replace table smoke_test_db.table_from_view\n            as (select * from smoke_test_db.view_from_table)\n        ",
+                "\n            create or replace table smoke_test_db.table_from_view_and_table\n            as (select b.date_utc, v.revenue from smoke_test_db.base_table b, smoke_test_db.view_from_table v)\n        ",
+                "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_table",
+                "select revenue from gcp-staging.smoke_test_db.view_from_table"
+            ],
+            "userCounts": [
+                {
                     "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 4
+                },
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "revenue",
+                    "count": 3
+                },
+                {
+                    "fieldPath": "date_utc",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.snapshot_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 1,
+            "topSqlQueries": [
+                "\n            create or replace view smoke_test_db.view_from_snapshot_on_table\n            as (select * from smoke_test_db.snapshot_from_table)\n        "
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 2,
+            "totalSqlQueries": 4,
+            "topSqlQueries": [
+                "\n            create or replace table `gcp-staging.smoke_test_db.table_from_another_project` as (select * from `gcp-staging-2.smoke_test_db_3.base_table_2`);\n        ",
+                "\n            create or replace table `gcp-staging-2.smoke_test_db_3.derived_table` as (select * from `gcp-staging-2.smoke_test_db_3.base_table_2`);\n        ",
+                "select revenue, date_utc from gcp-staging-2.smoke_test_db_3.base_table_2",
+                "select revenue from gcp-staging-2.smoke_test_db_3.base_table_2"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 3
+                },
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
                     "count": 1
                 }
             ],
@@ -2945,24 +2664,214 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178256,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
+    "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 2,
+            "totalSqlQueries": 3,
+            "topSqlQueries": [
+                "\n            create or replace view smoke_test_db.view_from_multiple_tables\n            as \n            (\n                select a.date_utc, a.revenue, b.revenue as revenue2, c.revenue as revenue3 \n                from \n                    smoke_test_db.base_table a\n                left join \n                    smoke_test_db.lineage_from_base b \n                    on a.date_utc = b.date_utc \n                left join \n                    smoke_test_db_2.table_from_other_db c \n                    on b.date_utc = c.date_utc \n            );\n        ",
+                "select revenue, date_utc from gcp-staging.smoke_test_db.lineage_from_base",
+                "select revenue from gcp-staging.smoke_test_db.lineage_from_base"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 2
+                },
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "revenue",
+                    "count": 3
+                },
+                {
+                    "fieldPath": "date_utc",
+                    "count": 1
+                }
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498930,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 2,
+            "totalSqlQueries": 5,
+            "topSqlQueries": [
+                "\n            create or replace view smoke_test_db.view_from_multiple_tables\n            as \n            (\n                select a.date_utc, a.revenue, b.revenue as revenue2, c.revenue as revenue3 \n                from \n                    smoke_test_db.base_table a\n                left join \n                    smoke_test_db.lineage_from_base b \n                    on a.date_utc = b.date_utc \n                left join \n                    smoke_test_db_2.table_from_other_db c \n                    on b.date_utc = c.date_utc \n            );\n        ",
+                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.sharded_table1_20230101` OPTIONS(description=\"Description of sharded table ending with _yyyyMMdd\") as (select * from `gcp-staging.smoke_test_db_2.table_from_other_db`) ;\n        ",
+                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.sharded_table1_20230201` OPTIONS(description=\"Description of sharded table ending with _yyyyMMdd\") as (select * from `gcp-staging.smoke_test_db_2.table_from_other_db`);\n        ",
+                "select revenue, date_utc from gcp-staging.smoke_test_db_2.table_from_other_db",
+                "select revenue from gcp-staging.smoke_test_db_2.table_from_other_db"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 4
+                },
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "revenue",
+                    "count": 3
+                },
+                {
+                    "fieldPath": "date_utc",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 2,
+            "totalSqlQueries": 8,
+            "topSqlQueries": [
+                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table` as (select * from `gcp-staging-2.smoke_test_db_4.sharded_table1_20230101`);\n        ",
+                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table` as (select * from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`);\n        ",
+                "select revenue, date_utc from gcp-staging-2.smoke_test_db_4.sharded_table1_20230101",
+                "select revenue, date_utc from gcp-staging-2.smoke_test_db_4.sharded_table1_20230201",
+                "select revenue, date_utc from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`",
+                "select revenue from gcp-staging-2.smoke_test_db_4.sharded_table1_20230101",
+                "select revenue from gcp-staging-2.smoke_test_db_4.sharded_table1_20230201",
+                "select revenue from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 5
+                },
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 3
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "revenue",
+                    "count": 6
+                },
+                {
+                    "fieldPath": "date_utc",
+                    "count": 3
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 2,
+            "topSqlQueries": [
+                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_external_table` as (select * from `gcp-staging-2.smoke_test_db_4.external_table_us_states`);\n        ",
+                "\n    select name, post_abbr from `gcp-staging-2.smoke_test_db_4.external_table_us_states`\n"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 2
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "name",
+                    "count": 1
+                },
+                {
+                    "fieldPath": "post_abbr",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3015,85 +2924,107 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "querySubjects",
+    "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "subjects": [
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 2,
+            "totalSqlQueries": 2,
+            "topSqlQueries": [
+                "select revenue, date_utc from gcp-staging.smoke_test_db.lineage_from_tmp_table",
+                "select revenue from gcp-staging.smoke_test_db.lineage_from_tmp_table"
+            ],
+            "userCounts": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),date_utc)"
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "revenue",
+                    "count": 2
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
+                    "fieldPath": "date_utc",
+                    "count": 1
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498929,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "operation",
+    "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "timestampMillis": 1724064997280,
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1"
-            },
-            "lastUpdatedTimestamp": 1721549574990
+            "uniqueUserCount": 2,
+            "totalSqlQueries": 2,
+            "topSqlQueries": [
+                "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_view_on_table",
+                "select revenue from gcp-staging.smoke_test_db.view_from_view_on_table"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                },
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "revenue",
+                    "count": 2
+                },
+                {
+                    "fieldPath": "date_utc",
+                    "count": 1
+                }
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064997281,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997278,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991"
-            },
-            "lastUpdatedTimestamp": 1721549588112
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997280,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3104,7 +3035,7 @@
     "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "timestampMillis": 1721520000000,
+            "timestampMillis": 1724284800000,
             "eventGranularity": {
                 "unit": "DAY",
                 "multiple": 1
@@ -3142,8 +3073,58 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178259,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 2,
+            "totalSqlQueries": 2,
+            "topSqlQueries": [
+                "select revenue, date_utc from gcp-staging.smoke_test_db.table_from_view_and_table",
+                "select revenue from gcp-staging.smoke_test_db.table_from_view_and_table"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                },
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "revenue",
+                    "count": 2
+                },
+                {
+                    "fieldPath": "date_utc",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3154,7 +3135,7 @@
     "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "timestampMillis": 1721520000000,
+            "timestampMillis": 1724284800000,
             "eventGranularity": {
                 "unit": "DAY",
                 "multiple": 1
@@ -3166,16 +3147,16 @@
             "uniqueUserCount": 2,
             "totalSqlQueries": 2,
             "topSqlQueries": [
-                "select revenue from gcp-staging.smoke_test_db.materialized_view_from_table",
-                "select revenue, date_utc from gcp-staging.smoke_test_db.materialized_view_from_table"
+                "select revenue, date_utc from gcp-staging.smoke_test_db.materialized_view_from_table",
+                "select revenue from gcp-staging.smoke_test_db.materialized_view_from_table"
             ],
             "userCounts": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
                     "count": 1
                 },
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
                     "count": 1
                 }
             ],
@@ -3192,296 +3173,19 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178271,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 1,
-            "totalSqlQueries": 1,
-            "topSqlQueries": [
-                "\n    SELECT\n        customer_id,\n        date1\n    FROM\n        `gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition`\n    WHERE\n        customer_id=1\n"
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "customer_id",
-                    "count": 1
-                },
-                {
-                    "fieldPath": "date1",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178264,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "create or replace table smoke_test_db.lineage_from_tmp_table as (select * from _smoke_test_db_tmp_tables.tmp_table)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549567376,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549567376,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498932,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997276,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b"
-            },
-            "lastUpdatedTimestamp": 1721549571609
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997278,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging._smoke_test_db_tmp_tables.tmp_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498933,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498933,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 1,
-            "totalSqlQueries": 1,
-            "topSqlQueries": [
-                "\n    select \n        transaction_id \n    from \n        `gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition` \n    where \n        _PARTITIONDATE = CURRENT_DATE()\n"
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "transaction_id",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178275,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997286,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1"
-            },
-            "lastUpdatedTimestamp": 1721549569547
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997288,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 1,
-            "totalSqlQueries": 2,
-            "topSqlQueries": [
-                "\n    select name, post_abbr from `gcp-staging-2.smoke_test_db_4.external_table_us_states`\n",
-                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_external_table` as (select * from `gcp-staging-2.smoke_test_db_4.external_table_us_states`);\n        "
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 2
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "name",
-                    "count": 1
-                },
-                {
-                    "fieldPath": "post_abbr",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178259,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997288,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c"
-            },
-            "lastUpdatedTimestamp": 1721549559855
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997290,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1721520000000,
+            "timestampMillis": 1724284800000,
             "eventGranularity": {
                 "unit": "DAY",
                 "multiple": 1
@@ -3491,42 +3195,36 @@
                 "type": "FULL_TABLE"
             },
             "uniqueUserCount": 2,
-            "totalSqlQueries": 8,
+            "totalSqlQueries": 2,
             "topSqlQueries": [
-                "select revenue from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`",
-                "select revenue, date_utc from gcp-staging-2.smoke_test_db_4.sharded_table1_20230101",
-                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table` as (select * from `gcp-staging-2.smoke_test_db_4.sharded_table1_20230101`);\n        ",
-                "\n            create or replace table `gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table` as (select * from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`);\n        ",
-                "select revenue, date_utc from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`",
-                "select revenue from gcp-staging-2.smoke_test_db_4.sharded_table1_20230101",
-                "select revenue, date_utc from gcp-staging-2.smoke_test_db_4.sharded_table1_20230201",
-                "select revenue from gcp-staging-2.smoke_test_db_4.sharded_table1_20230201"
+                "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_multiple_tables",
+                "select revenue from gcp-staging.smoke_test_db.view_from_multiple_tables"
             ],
             "userCounts": [
                 {
                     "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 5
+                    "count": 1
                 },
                 {
                     "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 3
+                    "count": 1
                 }
             ],
             "fieldCounts": [
                 {
                     "fieldPath": "revenue",
-                    "count": 6
+                    "count": 2
                 },
                 {
                     "fieldPath": "date_utc",
-                    "count": 3
+                    "count": 1
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178267,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3537,7 +3235,7 @@
     "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "timestampMillis": 1721520000000,
+            "timestampMillis": 1724284800000,
             "eventGranularity": {
                 "unit": "DAY",
                 "multiple": 1
@@ -3575,309 +3273,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178269,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997291,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "INSERT",
-            "customProperties": {
-                "query_urn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e"
-            },
-            "lastUpdatedTimestamp": 1721549560560
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997293,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 2,
-            "totalSqlQueries": 4,
-            "topSqlQueries": [
-                "select revenue from gcp-staging-2.smoke_test_db_3.base_table_2",
-                "\n            create or replace table `gcp-staging.smoke_test_db.table_from_another_project` as (select * from `gcp-staging-2.smoke_test_db_3.base_table_2`);\n        ",
-                "select revenue, date_utc from gcp-staging-2.smoke_test_db_3.base_table_2",
-                "\n            create or replace table `gcp-staging-2.smoke_test_db_3.derived_table` as (select * from `gcp-staging-2.smoke_test_db_3.base_table_2`);\n        "
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 3
-                },
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "revenue",
-                    "count": 2
-                },
-                {
-                    "fieldPath": "date_utc",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178263,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2d4a0fdd933c8f9009a21f00b3b0213b025d97ff5e6a39cd031e9d5e5c31f832",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.destination_table_of_select_query,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724050800000,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4"
-            },
-            "lastUpdatedTimestamp": 1724322510656
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 1,
-            "totalSqlQueries": 1,
-            "topSqlQueries": [
-                "\n    SELECT\n        first_name,\n        last_name,\n        dob,\n        addresses[offset(0)].address,\n        addresses[offset(0)].city\n    FROM        \n    gcp-staging-2.smoke_test_db_4.table_with_nested_fields\n"
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "addresses",
-                    "count": 1
-                },
-                {
-                    "fieldPath": "dob",
-                    "count": 1
-                },
-                {
-                    "fieldPath": "first_name",
-                    "count": 1
-                },
-                {
-                    "fieldPath": "last_name",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178276,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "create or replace table smoke_test_db.base_table (date_utc timestamp, revenue INTEGER)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549562792,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549562792,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498936,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),date_utc)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498936,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997294,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1"
-            },
-            "lastUpdatedTimestamp": 1721549557257
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997295,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3933,43 +3330,15 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace table smoke_test_db.table_from_view\n            as (select * from smoke_test_db.view_from_table)\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549572814,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549572814,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498942,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
+    "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
             "timestampMillis": 1724284800000,
@@ -3981,11 +3350,32 @@
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
-            "queryCount": 1,
             "uniqueUserCount": 1,
+            "totalSqlQueries": 1,
+            "topSqlQueries": [
+                "\n    SELECT\n        first_name,\n        last_name,\n        dob,\n        addresses[offset(0)].address,\n        addresses[offset(0)].city\n    FROM        \n    gcp-staging-2.smoke_test_db_4.table_with_nested_fields\n"
+            ],
             "userCounts": [
                 {
                     "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "addresses",
+                    "count": 1
+                },
+                {
+                    "fieldPath": "dob",
+                    "count": 1
+                },
+                {
+                    "fieldPath": "first_name",
+                    "count": 1
+                },
+                {
+                    "fieldPath": "last_name",
                     "count": 1
                 }
             ]
@@ -3993,38 +3383,15 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498942,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
+    "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
             "timestampMillis": 1724284800000,
@@ -4036,11 +3403,20 @@
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
-            "queryCount": 1,
             "uniqueUserCount": 1,
+            "totalSqlQueries": 1,
+            "topSqlQueries": [
+                "\n    select \n        transaction_id \n    from \n        `gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition` \n    where \n        _PARTITIONDATE = CURRENT_DATE()\n"
+            ],
             "userCounts": [
                 {
                     "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "transaction_id",
                     "count": 1
                 }
             ]
@@ -4048,60 +3424,18 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997296,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "INSERT",
-            "customProperties": {
-                "query_urn": "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9"
-            },
-            "lastUpdatedTimestamp": 1721549557813
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997298,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498937,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
         "json": {
-            "timestampMillis": 1721520000000,
+            "timestampMillis": 1724284800000,
             "eventGranularity": {
                 "unit": "DAY",
                 "multiple": 1
@@ -4110,17 +3444,12 @@
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
-            "uniqueUserCount": 2,
-            "totalSqlQueries": 2,
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 1,
             "topSqlQueries": [
-                "select revenue from gcp-staging.smoke_test_db.view_from_view_on_table",
-                "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_view_on_table"
+                "\n    SELECT\n        customer_id,\n        date1\n    FROM\n        `gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition`\n    WHERE\n        customer_id=1\n"
             ],
             "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                },
                 {
                     "user": "urn:li:corpuser:dh-bigquery-smoke-test",
                     "count": 1
@@ -4128,181 +3457,19 @@
             ],
             "fieldCounts": [
                 {
-                    "fieldPath": "revenue",
-                    "count": 2
+                    "fieldPath": "customer_id",
+                    "count": 1
                 },
                 {
-                    "fieldPath": "date_utc",
+                    "fieldPath": "date1",
                     "count": 1
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178272,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498942,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498953,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498953,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "insert into smoke_test_db.base_table values (CURRENT_TIMESTAMP(), 100), (TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR), 110)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549563403,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549563403,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498935,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498936,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 2,
-            "totalSqlQueries": 2,
-            "topSqlQueries": [
-                "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_multiple_tables",
-                "select revenue from gcp-staging.smoke_test_db.view_from_multiple_tables"
-            ],
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                },
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "revenue",
-                    "count": 2
-                },
-                {
-                    "fieldPath": "date_utc",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178268,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498935,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4347,83 +3514,98 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498951,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
         "json": {
-            "timestampMillis": 1724064997307,
+            "timestampMillis": 1724050800000,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
             "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2"
-            },
-            "lastUpdatedTimestamp": 1721549567376
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322443887,
+            "queries": [
+                "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1"
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064997309,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
+    "entityUrn": "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "\n            create or replace table smoke_test_db.table_from_view_and_table\n            as (select b.date_utc, v.revenue from smoke_test_db.base_table b, smoke_test_db.view_from_table v)\n        ",
+                "value": "create or replace table smoke_test_db.usage_test (date_utc date, key STRING, value INTEGER)",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1721549578210,
+                "time": 1724322443887,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1721549578210,
+                "time": 1724322443887,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498947,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
+    "entityUrn": "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),key)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),value)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -4432,8 +3614,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498947,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4465,161 +3647,99 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
         "json": {
-            "timestampMillis": 1724064997309,
+            "timestampMillis": 1724050800000,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "UNKNOWN",
-            "customProperties": {
-                "query_urn": "urn:li:query:a5b8ca0f0b97816db6ca440bdd7c6b11acc823fa70250396b902eb1d46835fbc"
-            },
-            "lastUpdatedTimestamp": 1721549580688
+            "operationType": "INSERT",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322445357,
+            "queries": [
+                "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9"
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064997311,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)",
+    "entityType": "query",
+    "entityUrn": "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9",
     "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
+    "aspectName": "queryProperties",
     "aspect": {
         "json": {
-            "timestampMillis": 1721520000000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
+            "customProperties": {},
+            "statement": {
+                "value": "\n            insert into smoke_test_db.usage_test values\n              (\"2022-05-01\", \"seven\", 7),\n              (\"2022-05-02\", \"ten\", 10),\n              (\"2022-06-01\", \"four\", 4)\n        ",
+                "language": "SQL"
             },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322445357,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
-            "uniqueUserCount": 2,
-            "totalSqlQueries": 2,
-            "topSqlQueries": [
-                "select revenue from gcp-staging.smoke_test_db.table_from_view_and_table",
-                "select revenue, date_utc from gcp-staging.smoke_test_db.table_from_view_and_table"
-            ],
-            "userCounts": [
+            "lastModified": {
+                "time": 1724322445357,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                },
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ],
-            "fieldCounts": [
-                {
-                    "fieldPath": "revenue",
-                    "count": 2
-                },
-                {
-                    "fieldPath": "date_utc",
-                    "count": 1
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178273,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
+    "entityType": "query",
+    "entityUrn": "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9",
     "changeType": "UPSERT",
-    "aspectName": "operation",
+    "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "timestampMillis": 1724064997306,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d"
-            },
-            "lastUpdatedTimestamp": 1721549572202
+            "platform": "urn:li:dataPlatform:bigquery"
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064997308,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997312,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d"
-            },
-            "lastUpdatedTimestamp": 1721549581208
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997314,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724064997305,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d"
-            },
-            "lastUpdatedTimestamp": 1721549572814
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997307,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4651,13 +3771,323 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322447620,
+            "queries": [
+                "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
+    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table smoke_test_db.partition_test (date_utc date, revenue INTEGER) \n            PARTITION BY date_utc\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322447620,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322447620,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "INSERT",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322448864,
+            "queries": [
+                "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "insert into smoke_test_db.partition_test values (\"2022-05-24\", 20), (\"2022-06-24\", 30)",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322448864,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322448864,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322451326,
+            "queries": [
+                "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "create or replace table smoke_test_db.base_table (date_utc timestamp, revenue INTEGER)",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322451326,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322451326,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
@@ -4670,42 +4100,186 @@
                     "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),date_utc)"
                 },
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),date_utc)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),revenue)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498947,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "operation",
     "aspect": {
         "json": {
-            "removed": false
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "INSERT",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322452660,
+            "queries": [
+                "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491"
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064997316,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "insert into smoke_test_db.base_table values (CURRENT_TIMESTAMP(), 100), (TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR), 110)",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322452660,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322452660,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4713,177 +4287,342 @@
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "operation",
     "aspect": {
         "json": {
-            "removed": false
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322457731,
+            "queries": [
+                "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2"
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064997315,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1",
+    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "queryProperties",
     "aspect": {
         "json": {
-            "removed": false
+            "customProperties": {},
+            "statement": {
+                "value": "create or replace table smoke_test_db.lineage_from_tmp_table as (select * from _smoke_test_db_tmp_tables.tmp_table)",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322457731,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322457731,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498950,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724065178292,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35"
-            },
-            "lastUpdatedTimestamp": 1721549588804
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178293,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_external_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724065178287,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:6e250c6966754a5e6532fbb444172dacf5813b0b7afceefbf7772a29878f48f8"
-            },
-            "lastUpdatedTimestamp": 1721549602653
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178288,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724065178288,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f"
-            },
-            "lastUpdatedTimestamp": 1721549582803
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178289,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9",
+    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "querySubjects",
     "aspect": {
         "json": {
-            "removed": false
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging._smoke_test_db_tmp_tables.tmp_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)"
+                }
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498947,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
         "json": {
-            "timestampMillis": 1724065178299,
+            "timestampMillis": 1724050800000,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
             "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539"
-            },
-            "lastUpdatedTimestamp": 1721549596824
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322460257,
+            "queries": [
+                "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1"
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178300,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
         "json": {
-            "timestampMillis": 1724065178293,
+            "timestampMillis": 1724050800000,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "INSERT",
-            "customProperties": {
-                "query_urn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178"
-            },
-            "lastUpdatedTimestamp": 1721549593090
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322462741,
+            "queries": [
+                "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b"
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178295,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322464098,
+            "queries": [
+                "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322465459,
+            "queries": [
+                "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322467835,
+            "queries": [
+                "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322471500,
+            "queries": [
+                "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322472836,
+            "queries": [
+                "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "UNKNOWN",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322475572,
+            "queries": [
+                "urn:li:query:a5b8ca0f0b97816db6ca440bdd7c6b11acc823fa70250396b902eb1d46835fbc"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4894,24 +4633,25 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "drop MATERIALIZED VIEW if exists smoke_test_db.materialized_view_from_table",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1721549580688,
+                "time": 1724322475572,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1721549580688,
+                "time": 1724322475572,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498939,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4930,8 +4670,213 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498939,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a5b8ca0f0b97816db6ca440bdd7c6b11acc823fa70250396b902eb1d46835fbc",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a5b8ca0f0b97816db6ca440bdd7c6b11acc823fa70250396b902eb1d46835fbc",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322476091,
+            "queries": [
+                "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322477705,
+            "queries": [
+                "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_3.base_table_2` (date_utc timestamp, revenue INTEGER);\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322477705,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322477705,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4942,22 +4887,580 @@
     "aspectName": "operation",
     "aspect": {
         "json": {
-            "timestampMillis": 1724065178298,
+            "timestampMillis": 1724050800000,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
             "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8"
-            },
-            "lastUpdatedTimestamp": 1721549583501
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322478955,
+            "queries": [
+                "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8"
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178299,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.derived_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322481569,
+            "queries": [
+                "urn:li:query:88c4674d369ef49e881a5ea67ed3485e48f09b9a4924d5282c3ae25004737f95"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322484293,
+            "queries": [
+                "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322485618,
+            "queries": [
+                "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.sharded_table1_20230101` OPTIONS(description=\"Description of sharded table ending with _yyyyMMdd\") as (select * from `gcp-staging.smoke_test_db_2.table_from_other_db`) ;\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322485618,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322485618,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322488551,
+            "queries": [
+                "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "INSERT",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322491425,
+            "queries": [
+                "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "insert into `gcp-staging-2.smoke_test_db_4.sharded_table1_20230201` values (CURRENT_TIMESTAMP(), 100)",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322491425,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322491425,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322495660,
+            "queries": [
+                "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n          CREATE  or REPLACE TABLE\n            `gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition` (transaction_id INT64)\n          PARTITION BY\n            _PARTITIONDATE\n            OPTIONS (\n              description = \"Description of Ingestion time partitioned table\",\n              partition_expiration_days = 3,\n              require_partition_filter = TRUE);\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322495660,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322495660,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD),transaction_id)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "operation",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322497080,
+            "queries": [
+                "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n          CREATE or REPLACE TABLE `gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition` (customer_id INT64, date1 DATE)\n          PARTITION BY\n            RANGE_BUCKET(customer_id, GENERATE_ARRAY(0, 100, 10))\n            OPTIONS (\n              description = \"Description of Integer Range partitioned table\",\n              require_partition_filter = TRUE);\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322497080,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322497080,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD),customer_id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD),date1)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4989,59 +5492,34 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
         "json": {
-            "timestampMillis": 1724065178300,
+            "timestampMillis": 1724050800000,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
             "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d"
-            },
-            "lastUpdatedTimestamp": 1721549598252
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322498418,
+            "queries": [
+                "urn:li:query:2d4a0fdd933c8f9009a21f00b3b0213b025d97ff5e6a39cd031e9d5e5c31f832"
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178302,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724065178307,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c"
-            },
-            "lastUpdatedTimestamp": 1721549596155
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178308,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5052,68 +5530,25 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "\n          CREATE OR REPLACE TABLE `gcp-staging-2.smoke_test_db_4.table_with_nested_fields` (\n            id STRING,\n            first_name STRING OPTIONS(description = \"First name\"),\n            last_name STRING OPTIONS(description = \"Last name\"),\n            dob DATE OPTIONS(description = \"Date of birth\"),\n            addresses\n              ARRAY<\n                STRUCT<\n                  status STRING,\n                  address STRING OPTIONS(description = \"Full Address\"),\n                  city STRING,\n                  state STRING,\n                  zip STRING,\n                  numberOfYears STRING>>\n          ) OPTIONS (\n              description = 'Example name and addresses table');\n        ",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1721549597638,
+                "time": 1724322498418,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1721549597638,
+                "time": 1724322498418,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178307,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "create or replace table smoke_test_db.lineage_from_base as (select * from smoke_test_db.base_table)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549569547,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549569547,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498937,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2d4a0fdd933c8f9009a21f00b3b0213b025d97ff5e6a39cd031e9d5e5c31f832",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178308,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5147,152 +5582,14 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178307,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724065178296,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d"
-            },
-            "lastUpdatedTimestamp": 1721549591093
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178298,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.derived_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724065178302,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:88c4674d369ef49e881a5ea67ed3485e48f09b9a4924d5282c3ae25004737f95"
-            },
-            "lastUpdatedTimestamp": 1721549585813
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178303,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724065178304,
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
-            "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:2d4a0fdd933c8f9009a21f00b3b0213b025d97ff5e6a39cd031e9d5e5c31f832"
-            },
-            "lastUpdatedTimestamp": 1721549597638
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178306,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "insert into `gcp-staging-2.smoke_test_db_4.sharded_table1_20230201` values (CURRENT_TIMESTAMP(), 100)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549593090,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549593090,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178296,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a5b8ca0f0b97816db6ca440bdd7c6b11acc823fa70250396b902eb1d46835fbc",
+    "entityUrn": "urn:li:query:2d4a0fdd933c8f9009a21f00b3b0213b025d97ff5e6a39cd031e9d5e5c31f832",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -5301,14 +5598,14 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064498939,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
+    "entityUrn": "urn:li:query:2d4a0fdd933c8f9009a21f00b3b0213b025d97ff5e6a39cd031e9d5e5c31f832",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -5334,130 +5631,34 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
+    "aspectName": "operation",
     "aspect": {
         "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178297,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
+            "timestampMillis": 1724050800000,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322500148,
+            "queries": [
+                "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d"
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a5b8ca0f0b97816db6ca440bdd7c6b11acc823fa70250396b902eb1d46835fbc",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178297,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498937,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5468,153 +5669,50 @@
     "aspectName": "operation",
     "aspect": {
         "json": {
-            "timestampMillis": 1724065178284,
+            "timestampMillis": 1724050800000,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
             "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930"
-            },
-            "lastUpdatedTimestamp": 1721549600590
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178285,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498937,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.snapshot_from_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997317,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1dcc7521d850077c51d832bc4da7c90aa7f4ea89ede1039363082d8db5c23132",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "SELECT\n  (SUM(CASE WHEN amount BETWEEN 0 AND 10 THEN 1 ELSE 0 END) * 100.0) / COUNT(*) AS percentage_in_range\nFROM\n  gcp-staging.customer_demo.purchase_event;",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724323167170,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724323167170,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997317,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1dcc7521d850077c51d832bc4da7c90aa7f4ea89ede1039363082d8db5c23132",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1dcc7521d850077c51d832bc4da7c90aa7f4ea89ede1039363082d8db5c23132",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD),amount)"
-                }
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322502689,
+            "queries": [
+                "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930"
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_external_table,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "operation",
     "aspect": {
         "json": {
-            "removed": false
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322505477,
+            "queries": [
+                "urn:li:query:6e250c6966754a5e6532fbb444172dacf5813b0b7afceefbf7772a29878f48f8"
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724064997315,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5625,769 +5723,23 @@
     "aspectName": "operation",
     "aspect": {
         "json": {
-            "timestampMillis": 1724065178323,
+            "timestampMillis": 1724050800000,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
             "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab"
-            },
-            "lastUpdatedTimestamp": 1721549605511
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178324,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322508214,
+            "queries": [
+                "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab"
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_table",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322528915,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322528915,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997316,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging-2.smoke_test_db_4.sharded_table1_20230101",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322557063,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322557063,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n    SELECT\n        customer_id,\n        date1\n    FROM\n        `gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition`\n    WHERE\n        customer_id=1\n",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322609673,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322609673,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD),date1)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD),customer_id)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997320,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_4.sharded_table1_20230101` OPTIONS(description=\"Description of sharded table ending with _yyyyMMdd\") as (select * from `gcp-staging.smoke_test_db_2.table_from_other_db`) ;\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549588804,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549588804,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178294,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997318,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178295,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178326,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:577b11663e044d6b6cab9e2732b49f9ddbd4ad02fa4244c1d338c5d4167b3a9d",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging-2.smoke_test_db_3.base_table_2",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322551240,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322551240,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
-                },
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178294,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9b7b2966ae76644cacd808f503c9c5a9d2328e6526fd0b9f4d37fd70fbcf6553",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "SELECT COUNT(*) FROM gcp-staging.customer_demo.purchase_event WHERE user_id IS NULL",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724323170390,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724323170390,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:70d19c139e7fa4f808045ce1b60c3d3a0d9284ae4acc00b5446c27fe1111a6a6",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 21,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 21
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9b7b2966ae76644cacd808f503c9c5a9d2328e6526fd0b9f4d37fd70fbcf6553",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9b7b2966ae76644cacd808f503c9c5a9d2328e6526fd0b9f4d37fd70fbcf6553",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498948,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6395,77 +5747,97 @@
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.destination_table_of_select_query,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "operation",
     "aspect": {
         "json": {
-            "removed": false
+            "timestampMillis": 1724050800000,
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "actor": "urn:li:corpuser:dh-bigquery-smoke-test",
+            "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1724322510656,
+            "queries": [
+                "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4"
+            ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
+    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.lineage_from_tmp_table",
+                "value": "create or replace table _smoke_test_db_tmp_tables.tmp_table as (select * from smoke_test_db.base_table)",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322522802,
+                "time": 1724322455205,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1724322522802,
+                "time": 1724322455205,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
+    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
     "changeType": "UPSERT",
-    "aspectName": "queryProperties",
+    "aspectName": "querySubjects",
     "aspect": {
         "json": {
-            "statement": {
-                "value": "\n            create or replace table `gcp-staging-2.smoke_test_db_3.base_table_2` (date_utc timestamp, revenue INTEGER);\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549582803,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549582803,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                }
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178290,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
+    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -6491,183 +5863,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a5b8ca0f0b97816db6ca440bdd7c6b11acc823fa70250396b902eb1d46835fbc",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498951,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178291,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.table_from_another_project",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322555601,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322555601,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),date_utc)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178290,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6678,6 +5874,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "select revenue, date_utc from gcp-staging.smoke_test_db.base_table",
                 "language": "SQL"
@@ -6695,51 +5892,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3989b79902a8974efeffb0c6e2fb5f5e935abd1ce2beb278a876286038a352d0",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.lineage_from_base",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322525871,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322525871,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:039ed54536f1c5bb1ee61f6a6e1f67878c952190620ea30e48768cac208fbe57",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6755,46 +5908,23 @@
                     "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
-                },
-                {
                     "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD),revenue)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:3989b79902a8974efeffb0c6e2fb5f5e935abd1ce2beb278a876286038a352d0",
+    "entityUrn": "urn:li:query:039ed54536f1c5bb1ee61f6a6e1f67878c952190620ea30e48768cac208fbe57",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -6804,243 +5934,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:3989b79902a8974efeffb0c6e2fb5f5e935abd1ce2beb278a876286038a352d0",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498948,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498949,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997314,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498952,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498952,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:34e3010e0e6a4b83d275086601e9ece3083e1ecc5dae3945bbd75631fa5d4126",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.materialized_view_from_table",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322541401,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322541401,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178327,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:34e3010e0e6a4b83d275086601e9ece3083e1ecc5dae3945bbd75631fa5d4126",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
+    "entityUrn": "urn:li:query:039ed54536f1c5bb1ee61f6a6e1f67878c952190620ea30e48768cac208fbe57",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -7066,179 +5966,68 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:34e3010e0e6a4b83d275086601e9ece3083e1ecc5dae3945bbd75631fa5d4126",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064498952,
-        "runId": "bigquery-queries-2024_08_19-16_18_14",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997317,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
+    "entityUrn": "urn:li:query:32b43422c0184159f4f812fb8e698ed2423a421a7086864aeb11efc3c339246e",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_view_on_table",
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.partition_test",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322532005,
+                "time": 1724322518956,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1724322532005,
+                "time": 1724322518956,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:055def6c8c2745212afa56be1f58fbdc936cd7f37a420a7df6715416fddae4dc",
+    "entityUrn": "urn:li:query:32b43422c0184159f4f812fb8e698ed2423a421a7086864aeb11efc3c339246e",
     "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
+    "aspectName": "querySubjects",
     "aspect": {
         "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
+            "subjects": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997318,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
+    "entityUrn": "urn:li:query:32b43422c0184159f4f812fb8e698ed2423a421a7086864aeb11efc3c339246e",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -7248,457 +6037,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997320,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997319,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.lineage_from_tmp_table",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322524291,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322524291,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging-2.smoke_test_db_4.sharded_table1_20230201",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322561765,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322561765,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.lineage_from_base",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322527479,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322527479,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n    select \n        transaction_id \n    from \n        `gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition` \n    where \n        _PARTITIONDATE = CURRENT_DATE()\n",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322608186,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322608186,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:577b11663e044d6b6cab9e2732b49f9ddbd4ad02fa4244c1d338c5d4167b3a9d",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db_2.table_from_other_db",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322549851,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322549851,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD),transaction_id)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:577b11663e044d6b6cab9e2732b49f9ddbd4ad02fa4244c1d338c5d4167b3a9d",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6264af081391592ea07c46c6aea5ec4359b4ac5ec695976469b461b9de5be3f2",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 36,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 36
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:577b11663e044d6b6cab9e2732b49f9ddbd4ad02fa4244c1d338c5d4167b3a9d",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7730,96 +6069,68 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997319,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
+    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "select revenue from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`",
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.lineage_from_tmp_table",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322565044,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+                "time": 1724322522802,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1724322565044,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+                "time": 1724322522802,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
+    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
         "json": {
             "subjects": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
+    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -7829,13 +6140,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
+    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -7861,170 +6172,84 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724064997332,
-        "runId": "bigquery-queries-2024_08_19-16_26_33",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD),customer_id)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD),date1)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178301,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
+    "entityUrn": "urn:li:query:3989b79902a8974efeffb0c6e2fb5f5e935abd1ce2beb278a876286038a352d0",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "select key from gcp-staging.smoke_test_db.usage_test",
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.lineage_from_base",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322595586,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+                "time": 1724322525871,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1724322595586,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+                "time": 1724322525871,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
+    "entityUrn": "urn:li:query:3989b79902a8974efeffb0c6e2fb5f5e935abd1ce2beb278a876286038a352d0",
     "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
+    "aspectName": "querySubjects",
     "aspect": {
         "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 3,
-            "uniqueUserCount": 1,
-            "userCounts": [
+            "subjects": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 3
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
+    "entityUrn": "urn:li:query:3989b79902a8974efeffb0c6e2fb5f5e935abd1ce2beb278a876286038a352d0",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:3989b79902a8974efeffb0c6e2fb5f5e935abd1ce2beb278a876286038a352d0",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -8050,35 +6275,490 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539",
+    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "\n          CREATE or REPLACE TABLE `gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition` (customer_id INT64, date1 DATE)\n          PARTITION BY\n            RANGE_BUCKET(customer_id, GENERATE_ARRAY(0, 100, 10))\n            OPTIONS (\n              description = \"Description of Integer Range partitioned table\",\n              require_partition_filter = TRUE);\n        ",
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_table",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1721549596824,
+                "time": 1724322528915,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1721549596824,
+                "time": 1724322528915,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178301,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_view_on_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322532005,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322532005,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.table_from_view",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322535333,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322535333,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.table_from_view_and_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322538350,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322538350,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:34e3010e0e6a4b83d275086601e9ece3083e1ecc5dae3945bbd75631fa5d4126",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.materialized_view_from_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322541401,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322541401,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:34e3010e0e6a4b83d275086601e9ece3083e1ecc5dae3945bbd75631fa5d4126",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:34e3010e0e6a4b83d275086601e9ece3083e1ecc5dae3945bbd75631fa5d4126",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8110,112 +6790,68 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
+    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.materialized_view_from_table",
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_multiple_tables",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322543069,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+                "time": 1724322544870,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1724322543069,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+                "time": 1724322544870,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
+    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
         "json": {
             "subjects": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),key)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),date_utc)"
+                },
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
+    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -8225,13 +6861,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:039ed54536f1c5bb1ee61f6a6e1f67878c952190620ea30e48768cac208fbe57",
+    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -8257,62 +6893,213 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
+    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db_2.table_from_other_db",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322548392,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322548392,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
         "json": {
             "subjects": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD),revenue)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539",
+    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "removed": false
+            "platform": "urn:li:dataPlatform:bigquery"
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178339,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table,PROD)",
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "queryUsageStatistics",
     "aspect": {
         "json": {
-            "removed": false
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178325,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue, date_utc from gcp-staging-2.smoke_test_db_3.base_table_2",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322551240,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322551240,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8323,6 +7110,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "select revenue, date_utc from gcp-staging.smoke_test_db.table_from_another_project",
                 "language": "SQL"
@@ -8340,39 +7128,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.derived_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178325,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:859633a51baed3d25e0fda695c858b9981f7f5a2f7a7073b251847704e184083",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8388,23 +7144,23 @@
                     "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD),revenue)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD),date_utc)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD),date_utc)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539",
+    "entityUrn": "urn:li:query:859633a51baed3d25e0fda695c858b9981f7f5a2f7a7073b251847704e184083",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -8413,24 +7169,8 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178301,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178328,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8462,101 +7202,68 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:ef372dc8ac2bd484b844e59ea85f81361950f4897a7382df59fb0d4584468fc6",
+    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
     "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
+    "aspectName": "queryProperties",
     "aspect": {
         "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue, date_utc from gcp-staging-2.smoke_test_db_4.sharded_table1_20230101",
+                "language": "SQL"
             },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322557063,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
-            "queryCount": 4,
-            "uniqueUserCount": 1,
-            "userCounts": [
+            "lastModified": {
+                "time": 1724322557063,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 4
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:dd46e45d678f4e7a2755637ac76b97a1d1c723602f767b2fa0f8653920bb8d99",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.table_from_view_and_table",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322539969,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322539969,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.base_table FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322611320,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322611320,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:dd46e45d678f4e7a2755637ac76b97a1d1c723602f767b2fa0f8653920bb8d99",
+    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -8566,518 +7273,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:dd46e45d678f4e7a2755637ac76b97a1d1c723602f767b2fa0f8653920bb8d99",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178346,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178328,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3b9dab2ff83d72565bd19daefcee18b938db280a5c030ccf36fb511f19f929c6",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging-2.smoke_test_db_3.base_table_2",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322552655,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322552655,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.view_from_table",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322530411,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322530411,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3b9dab2ff83d72565bd19daefcee18b938db280a5c030ccf36fb511f19f929c6",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.base_table FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322612787,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322612787,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3b9dab2ff83d72565bd19daefcee18b938db280a5c030ccf36fb511f19f929c6",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178338,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178326,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD),transaction_id)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178310,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n    select name, post_abbr from `gcp-staging-2.smoke_test_db_4.external_table_us_states`\n",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322605248,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322605248,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:d326639002bca6c0fe8515dc1599fd1a81f35bbde61806f2fa19487201f7a79f",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n          CREATE  or REPLACE TABLE\n            `gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition` (transaction_id INT64)\n          PARTITION BY\n            _PARTITIONDATE\n            OPTIONS (\n              description = \"Description of Ingestion time partitioned table\",\n              partition_expiration_days = 3,\n              require_partition_filter = TRUE);\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1721549596155,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1721549596155,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178309,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
+    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -9103,55 +7305,68 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
+    "entityUrn": "urn:li:query:055def6c8c2745212afa56be1f58fbdc936cd7f37a420a7df6715416fddae4dc",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue, date_utc from gcp-staging-2.smoke_test_db_4.sharded_table1_20230201",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322560058,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322560058,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:055def6c8c2745212afa56be1f58fbdc936cd7f37a420a7df6715416fddae4dc",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
         "json": {
             "subjects": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD),name)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),date_utc)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD),post_abbr)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178336,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
+    "entityUrn": "urn:li:query:055def6c8c2745212afa56be1f58fbdc936cd7f37a420a7df6715416fddae4dc",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -9160,14 +7375,14 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1724065178310,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
+    "entityUrn": "urn:li:query:055def6c8c2745212afa56be1f58fbdc936cd7f37a420a7df6715416fddae4dc",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -9185,7 +7400,7 @@
             "uniqueUserCount": 1,
             "userCounts": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
                     "count": 1
                 }
             ]
@@ -9193,35 +7408,281 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:aabff37598818c2571a6f1d31137c66ba2a19cae73cc65514a92e703a0b70511",
+    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.view_from_multiple_tables",
+                "value": "select revenue, date_utc from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322546639,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+                "time": 1724322563212,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1724322546639,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+                "time": 1724322563212,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n    select revenue from gcp-staging.smoke_test_db.partition_test t\n    where cast(t.date_utc as DATE) < (select max(date_utc) from gcp-staging.smoke_test_db.partition_test)\n",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322579451,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322579451,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 5,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 5
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f5c935d2377600d41fa76c69b80586aaa0c373b527b9ae46ca62982c53193ad5",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n    select extract(month from date_utc) month, count(*) count, sum(revenue) gross from gcp-staging.smoke_test_db.partition_test\n    group by month\n    order by gross\n",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322581032,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322581032,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f5c935d2377600d41fa76c69b80586aaa0c373b527b9ae46ca62982c53193ad5",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f5c935d2377600d41fa76c69b80586aaa0c373b527b9ae46ca62982c53193ad5",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -9253,29 +7714,65 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178329,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:aabff37598818c2571a6f1d31137c66ba2a19cae73cc65514a92e703a0b70511",
+    "entityUrn": "urn:li:query:1f994d5cfc676f126b1d43b02e1c2f6640e7375c9d8d50b3a5bad6ba057745ab",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select value from gcp-staging.smoke_test_db.usage_test",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322594074,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322594074,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1f994d5cfc676f126b1d43b02e1c2f6640e7375c9d8d50b3a5bad6ba057745ab",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),value)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1f994d5cfc676f126b1d43b02e1c2f6640e7375c9d8d50b3a5bad6ba057745ab",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -9285,7 +7782,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -9317,13 +7814,84 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
+    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n    select extract(month from date_utc) month, count(*) count, sum(value) total from gcp-staging.smoke_test_db.usage_test\n    group by month\n    order by total\n    ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322602823,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322602823,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),value)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -9341,7 +7909,7 @@
             "uniqueUserCount": 1,
             "userCounts": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
                     "count": 1
                 }
             ]
@@ -9349,13 +7917,84 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
+    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n    select name, post_abbr from `gcp-staging-2.smoke_test_db_4.external_table_us_states`\n",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322605248,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322605248,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD),name)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD),post_abbr)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -9373,7 +8012,7 @@
             "uniqueUserCount": 1,
             "userCounts": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
                     "count": 1
                 }
             ]
@@ -9381,63 +8020,684 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:1f994d5cfc676f126b1d43b02e1c2f6640e7375c9d8d50b3a5bad6ba057745ab",
+    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "select value from gcp-staging.smoke_test_db.usage_test",
+                "value": "\n    SELECT\n        first_name,\n        last_name,\n        dob,\n        addresses[offset(0)].address,\n        addresses[offset(0)].city\n    FROM        \n    gcp-staging-2.smoke_test_db_4.table_with_nested_fields\n",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322594074,
+                "time": 1724322606806,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1724322594074,
+                "time": 1724322606806,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:ef372dc8ac2bd484b844e59ea85f81361950f4897a7382df59fb0d4584468fc6",
+    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD),addresses)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD),dob)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD),first_name)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD),last_name)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "select * from gcp-staging.smoke_test_db.usage_test",
+                "value": "\n    select \n        transaction_id \n    from \n        `gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition` \n    where \n        _PARTITIONDATE = CURRENT_DATE()\n",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322601431,
+                "time": 1724322608186,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             },
             "lastModified": {
-                "time": 1724322601431,
+                "time": 1724322608186,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD),transaction_id)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n    SELECT\n        customer_id,\n        date1\n    FROM\n        `gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition`\n    WHERE\n        customer_id=1\n",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322609673,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322609673,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD),customer_id)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD),date1)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.base_table FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322611320,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322611320,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),date_utc)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n            SELECT COUNT(*)\n            FROM gcp-staging.customer_demo.purchase_event\n            WHERE quantity < 0\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724323108678,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724323108678,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 5,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 5
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1dcc7521d850077c51d832bc4da7c90aa7f4ea89ede1039363082d8db5c23132",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "SELECT\n  (SUM(CASE WHEN amount BETWEEN 0 AND 10 THEN 1 ELSE 0 END) * 100.0) / COUNT(*) AS percentage_in_range\nFROM\n  gcp-staging.customer_demo.purchase_event;",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724323167170,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724323167170,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1dcc7521d850077c51d832bc4da7c90aa7f4ea89ede1039363082d8db5c23132",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD),amount)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1dcc7521d850077c51d832bc4da7c90aa7f4ea89ede1039363082d8db5c23132",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1dcc7521d850077c51d832bc4da7c90aa7f4ea89ede1039363082d8db5c23132",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 3,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 3
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9b7b2966ae76644cacd808f503c9c5a9d2328e6526fd0b9f4d37fd70fbcf6553",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "SELECT COUNT(*) FROM gcp-staging.customer_demo.purchase_event WHERE user_id IS NULL",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724323170390,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724323170390,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9b7b2966ae76644cacd808f503c9c5a9d2328e6526fd0b9f4d37fd70fbcf6553",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:9b7b2966ae76644cacd808f503c9c5a9d2328e6526fd0b9f4d37fd70fbcf6553",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -9469,1663 +8729,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1f994d5cfc676f126b1d43b02e1c2f6640e7375c9d8d50b3a5bad6ba057745ab",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1f994d5cfc676f126b1d43b02e1c2f6640e7375c9d8d50b3a5bad6ba057745ab",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),value)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:aabff37598818c2571a6f1d31137c66ba2a19cae73cc65514a92e703a0b70511",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ef372dc8ac2bd484b844e59ea85f81361950f4897a7382df59fb0d4584468fc6",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ef372dc8ac2bd484b844e59ea85f81361950f4897a7382df59fb0d4584468fc6",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178336,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178344,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n            SELECT COUNT(*)\n            FROM gcp-staging.customer_demo.purchase_event\n            WHERE quantity < 0\n        ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724323108678,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724323108678,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178339,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.view_from_multiple_tables",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322544870,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322544870,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322563212,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322563212,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178327,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:2d4a0fdd933c8f9009a21f00b3b0213b025d97ff5e6a39cd031e9d5e5c31f832",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178335,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 5,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 5
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:32b43422c0184159f4f812fb8e698ed2423a421a7086864aeb11efc3c339246e",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.partition_test",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322518956,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322518956,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 5,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 5
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:88c4674d369ef49e881a5ea67ed3485e48f09b9a4924d5282c3ae25004737f95",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178340,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 3,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 3
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:32b43422c0184159f4f812fb8e698ed2423a421a7086864aeb11efc3c339246e",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:32b43422c0184159f4f812fb8e698ed2423a421a7086864aeb11efc3c339246e",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178327,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_external_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178325,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n    SELECT\n        first_name,\n        last_name,\n        dob,\n        addresses[offset(0)].address,\n        addresses[offset(0)].city\n    FROM        \n    gcp-staging-2.smoke_test_db_4.table_with_nested_fields\n",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322606806,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322606806,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178324,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD),last_name)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD),first_name)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD),addresses)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD),dob)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178337,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178345,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178331,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178341,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6e250c6966754a5e6532fbb444172dacf5813b0b7afceefbf7772a29878f48f8",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724065178339,
-        "runId": "bigquery-queries-2024_08_19-16_29_19",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1dcc7521d850077c51d832bc4da7c90aa7f4ea89ede1039363082d8db5c23132",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 3,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 3
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3989b79902a8974efeffb0c6e2fb5f5e935abd1ce2beb278a876286038a352d0",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n    select revenue from gcp-staging.smoke_test_db.partition_test t\n    where cast(t.date_utc as DATE) < (select max(date_utc) from gcp-staging.smoke_test_db.partition_test)\n",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322579451,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322579451,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n    select revenue from gcp-staging.smoke_test_db.partition_test t\n    where cast(t.date_utc as DATE) = (select max(date_utc) from gcp-staging.smoke_test_db.partition_test)\n",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322585961,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322585961,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.partition_test",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322521153,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322521153,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db_2.table_from_other_db",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322548392,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322548392,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.base_table",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322517386,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322517386,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3b9dab2ff83d72565bd19daefcee18b938db280a5c030ccf36fb511f19f929c6",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "create or replace table _smoke_test_db_tmp_tables.tmp_table as (select * from smoke_test_db.base_table)",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322455205,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322455205,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f5c935d2377600d41fa76c69b80586aaa0c373b527b9ae46ca62982c53193ad5",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n    select extract(month from date_utc) month, count(*) count, sum(revenue) gross from gcp-staging.smoke_test_db.partition_test\n    group by month\n    order by gross\n",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322581032,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322581032,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),date_utc)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),value)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f5c935d2377600d41fa76c69b80586aaa0c373b527b9ae46ca62982c53193ad5",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:1f994d5cfc676f126b1d43b02e1c2f6640e7375c9d8d50b3a5bad6ba057745ab",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:aabff37598818c2571a6f1d31137c66ba2a19cae73cc65514a92e703a0b70511",
-    "changeType": "UPSERT",
-    "aspectName": "queryUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1724284800000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "queryCount": 1,
-            "uniqueUserCount": 1,
-            "userCounts": [
-                {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
-                    "count": 1
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -11136,6 +8740,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "SELECT AVG(amount) FROM gcp-staging.customer_demo.purchase_event",
                 "language": "SQL"
@@ -11153,49 +8758,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f5c935d2377600d41fa76c69b80586aaa0c373b527b9ae46ca62982c53193ad5",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:70d19c139e7fa4f808045ce1b60c3d3a0d9284ae4acc00b5446c27fe1111a6a6",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -11218,57 +8781,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "\n    select extract(month from date_utc) month, count(*) count, sum(value) total from gcp-staging.smoke_test_db.usage_test\n    group by month\n    order by total\n    ",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322602823,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322602823,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
+    "entityUrn": "urn:li:query:70d19c139e7fa4f808045ce1b60c3d3a0d9284ae4acc00b5446c27fe1111a6a6",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -11278,71 +8797,68 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:34e3010e0e6a4b83d275086601e9ece3083e1ecc5dae3945bbd75631fa5d4126",
+    "entityUrn": "urn:li:query:70d19c139e7fa4f808045ce1b60c3d3a0d9284ae4acc00b5446c27fe1111a6a6",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "queryUsageStatistics",
     "aspect": {
         "json": {
-            "removed": false
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 21,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 21
+                }
+            ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
+    "entityUrn": "urn:li:query:6264af081391592ea07c46c6aea5ec4359b4ac5ec695976469b461b9de5be3f2",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "queryProperties",
     "aspect": {
         "json": {
-            "removed": false
+            "customProperties": {},
+            "statement": {
+                "value": "\n            SELECT COUNT(*)\n            FROM gcp-staging.customer_demo.purchase_event\n            WHERE amount < 0\n        ",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724323321938,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724323321938,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -11362,7 +8878,823 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6264af081391592ea07c46c6aea5ec4359b4ac5ec695976469b461b9de5be3f2",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6264af081391592ea07c46c6aea5ec4359b4ac5ec695976469b461b9de5be3f2",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 36,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 36
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.base_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322517386,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322517386,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.partition_test",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322521153,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322521153,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.lineage_from_tmp_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322524291,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322524291,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.lineage_from_base",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322527479,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322527479,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.view_from_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322530411,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322530411,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.view_from_view_on_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322533604,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322533604,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.table_from_view",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322536837,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322536837,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:dd46e45d678f4e7a2755637ac76b97a1d1c723602f767b2fa0f8653920bb8d99",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.table_from_view_and_table",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322539969,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322539969,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:dd46e45d678f4e7a2755637ac76b97a1d1c723602f767b2fa0f8653920bb8d99",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:dd46e45d678f4e7a2755637ac76b97a1d1c723602f767b2fa0f8653920bb8d99",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -11394,57 +9726,65 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:6264af081391592ea07c46c6aea5ec4359b4ac5ec695976469b461b9de5be3f2",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6264af081391592ea07c46c6aea5ec4359b4ac5ec695976469b461b9de5be3f2",
+    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "\n            SELECT COUNT(*)\n            FROM gcp-staging.customer_demo.purchase_event\n            WHERE amount < 0\n        ",
+                "value": "select revenue from gcp-staging.smoke_test_db.materialized_view_from_table",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724323321938,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                "time": 1724322543069,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
             },
             "lastModified": {
-                "time": 1724323321938,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+                "time": 1724322543069,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:6264af081391592ea07c46c6aea5ec4359b4ac5ec695976469b461b9de5be3f2",
+    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -11454,115 +9794,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.table_from_view_and_table",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322538350,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322538350,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
+    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -11580,7 +9818,7 @@
             "uniqueUserCount": 1,
             "userCounts": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
                     "count": 1
                 }
             ]
@@ -11588,13 +9826,65 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
+    "entityUrn": "urn:li:query:aabff37598818c2571a6f1d31137c66ba2a19cae73cc65514a92e703a0b70511",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.view_from_multiple_tables",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322546639,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322546639,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:aabff37598818c2571a6f1d31137c66ba2a19cae73cc65514a92e703a0b70511",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:aabff37598818c2571a6f1d31137c66ba2a19cae73cc65514a92e703a0b70511",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -11604,7 +9894,39 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:aabff37598818c2571a6f1d31137c66ba2a19cae73cc65514a92e703a0b70511",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -11612,76 +9934,73 @@
     "entityType": "query",
     "entityUrn": "urn:li:query:577b11663e044d6b6cab9e2732b49f9ddbd4ad02fa4244c1d338c5d4167b3a9d",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "queryProperties",
     "aspect": {
         "json": {
-            "removed": false
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db_2.table_from_other_db",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322549851,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322549851,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:859633a51baed3d25e0fda695c858b9981f7f5a2f7a7073b251847704e184083",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
+    "entityUrn": "urn:li:query:577b11663e044d6b6cab9e2732b49f9ddbd4ad02fa4244c1d338c5d4167b3a9d",
     "changeType": "UPSERT",
     "aspectName": "querySubjects",
     "aspect": {
         "json": {
             "subjects": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)"
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)"
                 },
                 {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD),revenue)"
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD),revenue)"
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
+    "entityUrn": "urn:li:query:577b11663e044d6b6cab9e2732b49f9ddbd4ad02fa4244c1d338c5d4167b3a9d",
     "changeType": "UPSERT",
-    "aspectName": "status",
+    "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "removed": false
+            "platform": "urn:li:dataPlatform:bigquery"
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
+    "entityUrn": "urn:li:query:577b11663e044d6b6cab9e2732b49f9ddbd4ad02fa4244c1d338c5d4167b3a9d",
     "changeType": "UPSERT",
     "aspectName": "queryUsageStatistics",
     "aspect": {
@@ -11699,7 +10018,7 @@
             "uniqueUserCount": 1,
             "userCounts": [
                 {
-                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
                     "count": 1
                 }
             ]
@@ -11707,85 +10026,65 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
+    "entityUrn": "urn:li:query:3b9dab2ff83d72565bd19daefcee18b938db280a5c030ccf36fb511f19f929c6",
     "changeType": "UPSERT",
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.view_from_view_on_table",
+                "value": "select revenue from gcp-staging-2.smoke_test_db_3.base_table_2",
                 "language": "SQL"
             },
             "source": "SYSTEM",
             "created": {
-                "time": 1724322533604,
+                "time": 1724322552655,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
             },
             "lastModified": {
-                "time": 1724322533604,
+                "time": 1724322552655,
                 "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:055def6c8c2745212afa56be1f58fbdc936cd7f37a420a7df6715416fddae4dc",
+    "entityUrn": "urn:li:query:3b9dab2ff83d72565bd19daefcee18b938db280a5c030ccf36fb511f19f929c6",
     "changeType": "UPSERT",
-    "aspectName": "queryProperties",
+    "aspectName": "querySubjects",
     "aspect": {
         "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging-2.smoke_test_db_4.sharded_table1_20230201",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322560058,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322560058,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD),revenue)"
+                }
+            ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
+    "entityUrn": "urn:li:query:3b9dab2ff83d72565bd19daefcee18b938db280a5c030ccf36fb511f19f929c6",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -11795,13 +10094,97 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:055def6c8c2745212afa56be1f58fbdc936cd7f37a420a7df6715416fddae4dc",
+    "entityUrn": "urn:li:query:3b9dab2ff83d72565bd19daefcee18b938db280a5c030ccf36fb511f19f929c6",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.table_from_another_project",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322555601,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322555601,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -11811,72 +10194,39 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:055def6c8c2745212afa56be1f58fbdc936cd7f37a420a7df6715416fddae4dc",
+    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
     "changeType": "UPSERT",
-    "aspectName": "querySubjects",
+    "aspectName": "queryUsageStatistics",
     "aspect": {
         "json": {
-            "subjects": [
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),date_utc)"
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:d326639002bca6c0fe8515dc1599fd1a81f35bbde61806f2fa19487201f7a79f",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:d326639002bca6c0fe8515dc1599fd1a81f35bbde61806f2fa19487201f7a79f",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -11887,6 +10237,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "select revenue from gcp-staging-2.smoke_test_db_4.sharded_table1_20230101",
                 "language": "SQL"
@@ -11904,7 +10255,30 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:d326639002bca6c0fe8515dc1599fd1a81f35bbde61806f2fa19487201f7a79f",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -11920,36 +10294,642 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
+    "entityUrn": "urn:li:query:d326639002bca6c0fe8515dc1599fd1a81f35bbde61806f2fa19487201f7a79f",
     "changeType": "UPSERT",
-    "aspectName": "querySubjects",
+    "aspectName": "queryUsageStatistics",
     "aspect": {
         "json": {
-            "subjects": [
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
                 {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD),revenue)"
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
                 }
             ]
         }
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
+    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging-2.smoke_test_db_4.sharded_table1_20230201",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322561765,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322561765,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from `gcp-staging-2.smoke_test_db_4.sharded_table1_*`",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322565044,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322565044,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "\n    select revenue from gcp-staging.smoke_test_db.partition_test t\n    where cast(t.date_utc as DATE) = (select max(date_utc) from gcp-staging.smoke_test_db.partition_test)\n",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322585961,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322585961,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 3,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 3
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select key from gcp-staging.smoke_test_db.usage_test",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322595586,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322595586,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD),key)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 3,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 3
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ef372dc8ac2bd484b844e59ea85f81361950f4897a7382df59fb0d4584468fc6",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select * from gcp-staging.smoke_test_db.usage_test",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322601431,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            },
+            "lastModified": {
+                "time": 1724322601431,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ef372dc8ac2bd484b844e59ea85f81361950f4897a7382df59fb0d4584468fc6",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ef372dc8ac2bd484b844e59ea85f81361950f4897a7382df59fb0d4584468fc6",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ef372dc8ac2bd484b844e59ea85f81361950f4897a7382df59fb0d4584468fc6",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 4,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test",
+                    "count": 4
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "statement": {
+                "value": "select revenue from gcp-staging.smoke_test_db.base_table FOR SYSTEM_TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR)",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 1724322612787,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            },
+            "lastModified": {
+                "time": 1724322612787,
+                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD),revenue)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
+    "changeType": "UPSERT",
+    "aspectName": "queryUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1724284800000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "queryCount": 1,
+            "uniqueUserCount": 1,
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:dh-bigquery-smoke-test-2",
+                    "count": 1
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -11959,7 +10939,455 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.derived_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_external_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_sharded_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_timetravelled_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.destination_table_of_select_query,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.external_table_us_states,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.sharded_table1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.customer_demo.purchase_event,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.base_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_tmp_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.materialized_view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.partition_test,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.snapshot_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.usage_test,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:005ef53d98fe9ce2d807a16f00695367e6923b11729f2fba0db3e694bd2fe9c9",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -11975,201 +11403,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue from gcp-staging.smoke_test_db.table_from_view",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322536837,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            },
-            "lastModified": {
-                "time": 1724322536837,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test-2"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:f5c935d2377600d41fa76c69b80586aaa0c373b527b9ae46ca62982c53193ad5",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
-    "changeType": "UPSERT",
-    "aspectName": "querySubjects",
-    "aspect": {
-        "json": {
-            "subjects": [
-                {
-                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD),revenue)"
-                },
-                {
-                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view,PROD),date_utc)"
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
-    "changeType": "UPSERT",
-    "aspectName": "queryProperties",
-    "aspect": {
-        "json": {
-            "statement": {
-                "value": "select revenue, date_utc from gcp-staging.smoke_test_db.table_from_view",
-                "language": "SQL"
-            },
-            "source": "SYSTEM",
-            "created": {
-                "time": 1724322535333,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            },
-            "lastModified": {
-                "time": 1724322535333,
-                "actor": "urn:li:corpuser:dh-bigquery-smoke-test"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:bigquery"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:32b43422c0184159f4f812fb8e698ed2423a421a7086864aeb11efc3c339246e",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12185,13 +11419,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
+    "entityUrn": "urn:li:query:101f80da8c082437fb8997d9fa1df63c1c65258e51d89516922e6b61b39c32dc",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -12201,13 +11435,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
+    "entityUrn": "urn:li:query:1796e9c3a125d6474ce2f1fbe1f498d028015b5d7bfd90549dcfcd026826a68f",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -12217,71 +11451,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12297,7 +11467,119 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:1f994d5cfc676f126b1d43b02e1c2f6640e7375c9d8d50b3a5bad6ba057745ab",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:276cc9d6fa5b1277b2de3d278060c5628f13907b0c1a748edd7595a7e38b1181",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:2957e74d80b00aef4f3dc7b0b323d1fa863c78fd882d858186579c0737df00e2",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:2d4a0fdd933c8f9009a21f00b3b0213b025d97ff5e6a39cd031e9d5e5c31f832",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:2fa44cc9d306c7523477fad59ff43e2e580081ee770da69b9b9f66e119b4dcab",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:32b43422c0184159f4f812fb8e698ed2423a421a7086864aeb11efc3c339246e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:34e3010e0e6a4b83d275086601e9ece3083e1ecc5dae3945bbd75631fa5d4126",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12313,151 +11595,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:70d19c139e7fa4f808045ce1b60c3d3a0d9284ae4acc00b5446c27fe1111a6a6",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "query",
-    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12473,13 +11611,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:dd46e45d678f4e7a2755637ac76b97a1d1c723602f767b2fa0f8653920bb8d99",
+    "entityUrn": "urn:li:query:3ec450841af8056dd02a1f9f059b234119985c2780a30dc38dda726a8b4426dc",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -12489,7 +11627,471 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:420cad6350235517b34e6e376414d89be0734f87fba6789754be420051d4901c",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:44c19e1fccfa56779f6958f62d3476819b48af701bbee43ccecf5c9e04d63fc4",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:49b267d0cd050c6a45b4d26bcdc6d9ddceb51aa7ed29399c52ef967e8da2b58d",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4bd08adca1e16a1e10673f736ae2c91e0ee68fd56b187bd507f360e429dbcb8c",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4c01c67bbeca250453b9063e03964cc1bd358921ca0b650140515e79d1970db8",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:4f5fd82d4808115ef07900a543b7d6e3551899815d11a945870c607d2dbda56e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:53d20616e4dd30dfc16ccc5771998f5ed93c9afa9b846104a19d072ba364fb5c",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:56740f3a3d46afdf0177aadf1dbf4937a4b83c0116aef2773a5de9b7e87895f2",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:577b11663e044d6b6cab9e2732b49f9ddbd4ad02fa4244c1d338c5d4167b3a9d",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:59c53a03b1fbf71b46518f56b26e7cc3cf03a726567e15cc9d37e6dd2f5c1f60",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:5efacf0ddad8fd852ba394b29e7a4654ea454915930fb8dd4882c6f294b95cf8",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:604fa496a50ed8bd340161bebdc475d68daffeaaed31ec649370a2ce392eed90",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6264af081391592ea07c46c6aea5ec4359b4ac5ec695976469b461b9de5be3f2",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:630f9169072a11dfd8d08a44479f2466acdf2dc2b078b946a739db437b74ad1d",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6422d5a3e23d0bfce3783edc019406cc6cc574044faa5c48edb97cf22294ba33",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6684f16158660588d874f7ac46dbd7e56ad42acfb95b8a3d1f01292de8dcb930",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6bbebdb71c5ef982b74fb6bbef58f7f33162566fd9b14385f2da971503317539",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:6e250c6966754a5e6532fbb444172dacf5813b0b7afceefbf7772a29878f48f8",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:70d19c139e7fa4f808045ce1b60c3d3a0d9284ae4acc00b5446c27fe1111a6a6",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:741bb9b00959a800b366a27cd477f8f24292c3b3f0198213c5e06a79b0e00555",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:7a4b43ffafd0fb61a647ed56a9383a42fb902f5632a9608c72229ad9da5d4d1c",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:82edd8e24a1c289c4c7487b5a3c1b61e4ed6f1c89d5cd2fab5424b085ad0b7d6",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:84a5f2c31752cc1a4e180c86da34c84f1a04df3b69aebe0d69222d0d8e07f8e0",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:859633a51baed3d25e0fda695c858b9981f7f5a2f7a7073b251847704e184083",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:8714510dd7dc19deccb3188a5e9896076244ff203155e5fa4b61b70121789153",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:88c4674d369ef49e881a5ea67ed3485e48f09b9a4924d5282c3ae25004737f95",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:8f7bb4efb71d494b2bfe115937d6022db0ab9e6ea3d293839a457480e75430e1",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:95daf40bccda9fbc9dc15b1109fa105a3c19d83de58625b7265e81cbe8dae940",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:991a14a8ed8d532c930c8dfd2ace42a7a5fafb76a7a505e14f373e62e8807e0b",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12505,13 +12107,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
+    "entityUrn": "urn:li:query:9e7801810f6e4012bcbe249a5b9e20a5b3582065c09a3563124703315170dce4",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -12521,13 +12123,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
+    "entityUrn": "urn:li:query:9f2cdfe3c23dd5eb43051d0b683a9e76cd40453f3cba44c750f98de294134e03",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -12537,7 +12139,71 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a049f27174fa88a7a7b1b7d5f60d2c353f3e9dd3d4994a8e35c91adb986eac4d",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a1dd41eea989d820907358b594b3fb41e0d6812119f5ff657bb02e98dd4c6177",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a4d62b3996203c5661d02d28c1908d209a56e9966cefc274600a76335bc75de0",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:a5b8ca0f0b97816db6ca440bdd7c6b11acc823fa70250396b902eb1d46835fbc",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12553,13 +12219,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "query",
-    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
+    "entityUrn": "urn:li:query:b30be114c7808b5af8eb79c3ef07a96927372b12f7b03f23d786844ba0301882",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -12569,7 +12235,375 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b5f379bdbfa48c81469b0a5893bb649ba02ff71fcd4ff151675c8728472c9219",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b66112fa9691aa02354115b5cef8356390b524fa67c6b06e018c362ac8d0b31d",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b828588160530bade966b0dbe1c1d09fb3262f6b9137c0956a6f3ed4ef467a91",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:b9c1cbdddc1018284bdfb113865f5dc95b5c5a106c8e1dad1297bc9ef70debf1",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:bb1e3c0fd1f6a26c2645cf4ba088a22ff346a9e323c6be451459ecfa7329a991",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:bb3d7f6685e1f71868d0821451e52bfcf1a3bdfeb34c739c0305386256c38f9b",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:bf9835d210e6e397beb91a558bdf36ecb21f3bca9a4789f1f98d617f0aaaf441",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c0182ee336ef4bb9c8e957bc621616573c9aea2a2c0ed08ddd04b1aab2e0ab39",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c0552a77514094a5c86fc63041e11a30bcf8985511a85d086695db70939abcc0",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c1c334538a103cfd23352131c5de23677521e78bf74a16021d4877695074c63a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:c45ca09d68c89c18308b4eb97b2497a1a7c40a21de17b6ea06beab10704a3e3e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:cb345cc231c81ec7b871d6727437a87b5bc18a95ecf37e857f07096254c2d2c1",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ccc4a40bb7abb852c9a97a2dc80c0928447bf28b91be0e41a80f691ca8e34e35",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:composite_29c38b444a8740d9cc549168e2e0e3657fc00430520f615119bfc3e9fb94112d",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:d326639002bca6c0fe8515dc1599fd1a81f35bbde61806f2fa19487201f7a79f",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:dc49a3d580b4df6c8d24961c39a18b3569d8e58783fe9895324876da32d98d1e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:dd46e45d678f4e7a2755637ac76b97a1d1c723602f767b2fa0f8653920bb8d99",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e0e0eb18099d8d8a8ef58c5c7cdaf0948774f0fe02ccd1c1c940b502b69c8483",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e1769381f2d261efecb105f3ab6fc8a2fc6717a1509cc65ba125c03841b0923d",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e1b3aa8663b4502df2c6f2db4aaeea00df94105fcbe0519e224549c9d982987e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e4e43fe8e17490b4b360a704a5604dd8d55763afd40f10c335e340132a9fe178",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:e8ab557dc3577da354c52bb0acf3363d444578aeceeeed82cd6bcaa50453fd40",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:ebfe552aa0ddb538f3a6c4d444aff757e6df574f16a6dffc3ac146ce587fc491",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12585,7 +12619,87 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f0faa4e0dbe3a28dc69369034ffde5f0cbba1f0a068a1db914bf143dc212aeb6",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f23fd4d501b4de8c50e206db9d8c62f23f92016bab643a168231da54c4a64c88",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f53151fa3d689ec865c53fa535479e3fc3cc5794be5daaa9a5a4f7f40a7c660f",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:f5c935d2377600d41fa76c69b80586aaa0c373b527b9ae46ca62982c53193ad5",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:fdeaa6e036cca324d7f80811a5f3563986866007bfc7ab1b8bb69515cc38f5f6",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12607,7 +12721,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12629,29 +12743,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/lastModified",
-                "value": {
-                    "time": 1724322464098
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12673,73 +12765,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/lastModified",
-                "value": {
-                    "time": 1724322502689
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.destination_table_of_select_query,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/lastModified",
-                "value": {
-                    "time": 1724322510656
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/lastModified",
-                "value": {
-                    "time": 1724322478955
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12761,13 +12787,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.derived_table_from_wildcard_table,PROD)",
     "changeType": "PATCH",
     "aspectName": "datasetProperties",
     "aspect": {
@@ -12776,20 +12802,20 @@
                 "op": "add",
                 "path": "/lastModified",
                 "value": {
-                    "time": 1724322460257
+                    "time": 1724322502689
                 }
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.destination_table_of_select_query,PROD)",
     "changeType": "PATCH",
     "aspectName": "datasetProperties",
     "aspect": {
@@ -12798,14 +12824,14 @@
                 "op": "add",
                 "path": "/lastModified",
                 "value": {
-                    "time": 1724322472836
+                    "time": 1724322510656
                 }
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12827,7 +12853,29 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.lineage_from_base,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/lastModified",
+                "value": {
+                    "time": 1724322460257
+                }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12849,29 +12897,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/lastModified",
-                "value": {
-                    "time": 1724322471500
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12893,13 +12919,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_another_project,PROD)",
     "changeType": "PATCH",
     "aspectName": "datasetProperties",
     "aspect": {
@@ -12908,14 +12934,14 @@
                 "op": "add",
                 "path": "/lastModified",
                 "value": {
-                    "time": 1724322484293
+                    "time": 1724322478955
                 }
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -12937,13 +12963,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.table_from_view_and_table,PROD)",
     "changeType": "PATCH",
     "aspectName": "datasetProperties",
     "aspect": {
@@ -12952,20 +12978,20 @@
                 "op": "add",
                 "path": "/lastModified",
                 "value": {
-                    "time": 1724322495660
+                    "time": 1724322472836
                 }
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_multiple_tables,PROD)",
     "changeType": "PATCH",
     "aspectName": "datasetProperties",
     "aspect": {
@@ -12974,14 +13000,36 @@
                 "op": "add",
                 "path": "/lastModified",
                 "value": {
-                    "time": 1724322467835
+                    "time": 1724322484293
                 }
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_snapshot_on_table,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/lastModified",
+                "value": {
+                    "time": 1724322471500
+                }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -13003,13 +13051,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db.view_from_view_on_table,PROD)",
     "changeType": "PATCH",
     "aspectName": "datasetProperties",
     "aspect": {
@@ -13018,20 +13066,20 @@
                 "op": "add",
                 "path": "/lastModified",
                 "value": {
-                    "time": 1724322498418
+                    "time": 1724322464098
                 }
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging.smoke_test_db_2.table_from_other_db,PROD)",
     "changeType": "PATCH",
     "aspectName": "datasetProperties",
     "aspect": {
@@ -13040,36 +13088,14 @@
                 "op": "add",
                 "path": "/lastModified",
                 "value": {
-                    "time": 1724322477705
+                    "time": 1724322467835
                 }
             }
         ]
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/lastModified",
-                "value": {
-                    "time": 1724322497080
-                }
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -13091,7 +13117,29 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_3.base_table_2,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/lastModified",
+                "value": {
+                    "time": 1724322477705
+                }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -13113,7 +13161,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -13135,7 +13183,73 @@
     },
     "systemMetadata": {
         "lastObserved": 1724050800000,
-        "runId": "bigquery-queries-2024_08_19-07_00_00",
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_nested_fields,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/lastModified",
+                "value": {
+                    "time": 1724322498418
+                }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_ingestion_time_partition,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/lastModified",
+                "value": {
+                    "time": 1724322495660
+                }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,gcp-staging-2.smoke_test_db_4.table_with_integer_range_partition,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/lastModified",
+                "value": {
+                    "time": 1724322497080
+                }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1724050800000,
+        "runId": "bigquery-queries-2024_08_19-07_00_00-qox17h",
         "lastRunId": "no-run-id-provided"
     }
 }

--- a/metadata-ingestion/tests/unit/sql_parsing/aggregator_goldens/test_add_known_query_lineage.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/aggregator_goldens/test_add_known_query_lineage.json
@@ -69,6 +69,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "INSERT INTO foo (\n  a,\n  b,\n  c\n)\nSELECT\n  a,\n  b,\n  c\nFROM bar",
                 "language": "SQL"
@@ -136,10 +137,11 @@
                 "type": "FULL_TABLE"
             },
             "operationType": "INSERT",
-            "customProperties": {
-                "query_urn": "urn:li:query:02e2ec36678bea2a8c4c855fed5255d087cfeb2710d326e95fd9b48a9c4fc0ae"
-            },
-            "lastUpdatedTimestamp": 20000
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 20000,
+            "queries": [
+                "urn:li:query:02e2ec36678bea2a8c4c855fed5255d087cfeb2710d326e95fd9b48a9c4fc0ae"
+            ]
         }
     }
 }

--- a/metadata-ingestion/tests/unit/sql_parsing/aggregator_goldens/test_aggregate_operations.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/aggregator_goldens/test_aggregate_operations.json
@@ -8,11 +8,12 @@
         "json": {
             "timestampMillis": 1707182625000,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:user2",
             "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
             "lastUpdatedTimestamp": 25000
         }
     }
@@ -26,11 +27,12 @@
         "json": {
             "timestampMillis": 1707182625000,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "actor": "urn:li:corpuser:user3",
             "operationType": "CREATE",
+            "sourceType": "DATA_PLATFORM",
             "lastUpdatedTimestamp": 26000
         }
     }

--- a/metadata-ingestion/tests/unit/sql_parsing/aggregator_goldens/test_create_table_query_mcps.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/aggregator_goldens/test_create_table_query_mcps.json
@@ -12,10 +12,11 @@
                 "type": "FULL_TABLE"
             },
             "operationType": "CREATE",
-            "customProperties": {
-                "query_urn": "urn:li:query:f2e61c641cf14eae74147b6280ae40648516c4b7b58cfca6c4f7fb14ab255ce2"
-            },
-            "lastUpdatedTimestamp": 1707182625000
+            "sourceType": "DATA_PLATFORM",
+            "lastUpdatedTimestamp": 1707182625000,
+            "queries": [
+                "urn:li:query:f2e61c641cf14eae74147b6280ae40648516c4b7b58cfca6c4f7fb14ab255ce2"
+            ]
         }
     }
 },
@@ -26,6 +27,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "CREATE OR REPLACE TABLE `dataset.foo` (\n  date_utc TIMESTAMP,\n  revenue INT64\n)",
                 "language": "SQL"

--- a/metadata-models/src/main/pegasus/com/linkedin/common/Operation.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/Operation.pdl
@@ -45,12 +45,12 @@ record Operation includes TimeseriesAspectBase {
    * Source Type
    */
    @TimeseriesField = {}
-   sourceType: optional OperationSourceType
+  sourceType: optional OperationSourceType
 
   /**
    * Custom properties
    */
-   customProperties: optional map[string, string]
+  customProperties: optional map[string, string]
 
   /**
    * The time at which the operation occurred. Would be better named 'operationTime'
@@ -58,4 +58,10 @@ record Operation includes TimeseriesAspectBase {
   @TimeseriesField = {}
   @Searchable = { "fieldType": "DATETIME", "fieldName": "lastOperationTime" }
   lastUpdatedTimestamp: long
+
+  /**
+   * Which queries were used in this operation.
+   */
+  @TimeseriesFieldCollection = {"key":"query"}
+  queries: optional array[Urn]
 }


### PR DESCRIPTION
1. Adds a queries field to the operation model
2. Starts populating that field for queries v2 (e.g. snowflake, bigquery)

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
