### PR TITLE
fix(build): fix regression in local quickstart builds

### DIFF
--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -224,6 +224,7 @@ quickstart_configs.each { taskName, config ->
 
             config.modules.each { module ->
                 def moduleProject = project.project(module)
+                project.ext.isDebug = config.isDebug
                 def generateBakeSnippetsTask = moduleProject.tasks.getByName("generateBakeSnippet")
                 bakeSnippets.putAll(generateBakeSnippetsTask.bakeSpec.target)
                 targets.addAll(generateBakeSnippetsTask.bakeSpec.target.keySet())

--- a/gradle/docker/docker.gradle
+++ b/gradle/docker/docker.gradle
@@ -43,6 +43,10 @@ def _cleanLocalDockerImages(String fullImageTag) {
   }
 }
 
+ext {
+  isDebug = false;  // quickStart configs have an isDebug flag set to indicate debug builds
+}
+
 // Create extension object
 class DockerPluginExtension {
   Project project
@@ -61,7 +65,7 @@ class DockerPluginExtension {
   // For quickStart debug builds that use APP_ENV=dev like pattern. Not used in matrix builds.
   MapProperty<String, String> debugBuildArgs
 
-  
+
 
   DockerPluginExtension(Project project) {
     this.project = project
@@ -261,7 +265,9 @@ project.afterEvaluate {
         def dockerTag = project.property("tag")
         bake_spec_target.tags = extension.tags.get().values().findAll({ tag -> tag.contains(dockerTag) }).toList()
       } else {
-        bake_spec_target.tags = extension.tags.get().values().toList()
+        bake_spec_target.tags = extension.tags.get().values().findAll({tag ->
+          project.ext.isDebug ||  !tag.contains("debug")  //Add the debug tag only if this is this is a debug build.
+        }).toList()
       }
       if (extension.buildArgs.get()) {
         bake_spec_target.args = extension.buildArgs.get()


### PR DESCRIPTION
When adding bake builds, there was a bug in the quickstart path (non-debug) that when explicit tags are not supplied, the debug tag got added and resulting dev APP_ENV setting passed to image builds. This caused failures to local quickstart builds. CI always passed explicit tags and as a result, debug was excluded. 
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
