### PR TITLE
feat(ingestion): Make jsonProps of schemaMetadata less verbose

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
+++ b/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
@@ -290,6 +290,12 @@ class AvroToMceSchemaConverter:
           This way we can use the type/description of the non-null type if needed.
         """
 
+        # props to skip when building jsonProps
+        json_props_to_skip = [
+            "_nullable",
+            "native_data_type",
+        ]
+
         def __init__(
             self,
             schema: SchemaOrField,
@@ -407,6 +413,16 @@ class AvroToMceSchemaConverter:
                     or self._actual_schema.props.get("logicalType"),
                 )
 
+                json_props: Optional[Dict[str, Any]] = (
+                    {
+                        k: v
+                        for k, v in merged_props.items()
+                        if k not in self.json_props_to_skip
+                    }
+                    if merged_props
+                    else None
+                )
+
                 field = SchemaField(
                     fieldPath=field_path,
                     # Populate it with the simple native type for now.
@@ -421,7 +437,7 @@ class AvroToMceSchemaConverter:
                     isPartOfKey=self._converter._is_key_schema,
                     globalTags=tags_aspect,
                     glossaryTerms=meta_terms_aspect,
-                    jsonProps=json.dumps(merged_props) if merged_props else None,
+                    jsonProps=json.dumps(json_props) if json_props else None,
                 )
                 yield field
 

--- a/metadata-ingestion/tests/integration/athena/athena_mce_golden.json
+++ b/metadata-ingestion/tests/integration/athena/athena_mce_golden.json
@@ -158,8 +158,7 @@
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": false}"
+                                "isPartitioningKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].annual_salary",
@@ -173,8 +172,7 @@
                                 "nativeDataType": "BIGINT",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"BIGINT\", \"_nullable\": true}"
+                                "isPartitioningKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].employee_name",
@@ -188,8 +186,7 @@
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": false}"
+                                "isPartitioningKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history",
@@ -207,7 +204,7 @@
                                 "recursive": false,
                                 "isPartOfKey": false,
                                 "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"MapType(String(), STRUCT(year=INTEGER(), company=String(), role=String()))\", \"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history.[type=int].year",
@@ -219,8 +216,7 @@
                                 },
                                 "nativeDataType": "INTEGER",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"INTEGER\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history.[type=string].company",
@@ -232,8 +228,7 @@
                                 },
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history.[type=string].role",
@@ -245,8 +240,7 @@
                                 },
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=long].department_budgets",
@@ -264,7 +258,7 @@
                                 "recursive": false,
                                 "isPartOfKey": false,
                                 "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"MapType(String(), BIGINT())\", \"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=string].skills",
@@ -282,8 +276,7 @@
                                 "nativeDataType": "array<VARCHAR>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<VARCHAR>\"}"
+                                "isPartitioningKey": false
                             }
                         ]
                     }
@@ -407,8 +400,7 @@
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": false}"
+                                "isPartitioningKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].annual_salary",
@@ -422,8 +414,7 @@
                                 "nativeDataType": "BIGINT",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"BIGINT\", \"_nullable\": true}"
+                                "isPartitioningKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].employee_name",
@@ -437,8 +428,7 @@
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": false}"
+                                "isPartitioningKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history",
@@ -456,7 +446,7 @@
                                 "recursive": false,
                                 "isPartOfKey": false,
                                 "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"MapType(String(), STRUCT(year=INTEGER(), company=String(), role=String()))\", \"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history.[type=int].year",
@@ -468,8 +458,7 @@
                                 },
                                 "nativeDataType": "INTEGER",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"INTEGER\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history.[type=string].company",
@@ -481,8 +470,7 @@
                                 },
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history.[type=string].role",
@@ -494,8 +482,7 @@
                                 },
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=long].department_budgets",
@@ -513,7 +500,7 @@
                                 "recursive": false,
                                 "isPartOfKey": false,
                                 "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"MapType(String(), BIGINT())\", \"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=string].skills",
@@ -531,8 +518,7 @@
                                 "nativeDataType": "array<VARCHAR>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<VARCHAR>\"}"
+                                "isPartitioningKey": false
                             }
                         ]
                     }
@@ -674,8 +660,7 @@
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": false}"
+                                "isPartitioningKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].annual_salary",
@@ -689,8 +674,7 @@
                                 "nativeDataType": "BIGINT",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"BIGINT\", \"_nullable\": true}"
+                                "isPartitioningKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].employee_name",
@@ -704,8 +688,7 @@
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": false}"
+                                "isPartitioningKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history",
@@ -723,7 +706,7 @@
                                 "recursive": false,
                                 "isPartOfKey": false,
                                 "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"MapType(String(), STRUCT(year=INTEGER(), company=String(), role=String()))\", \"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history.[type=int].year",
@@ -735,8 +718,7 @@
                                 },
                                 "nativeDataType": "INTEGER",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"INTEGER\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history.[type=string].company",
@@ -748,8 +730,7 @@
                                 },
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=struct].job_history.[type=string].role",
@@ -761,8 +742,7 @@
                                 },
                                 "nativeDataType": "VARCHAR",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=long].department_budgets",
@@ -780,7 +760,7 @@
                                 "recursive": false,
                                 "isPartOfKey": false,
                                 "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"MapType(String(), BIGINT())\", \"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"string\", \"native_data_type\": \"VARCHAR\", \"_nullable\": true}, \"key_native_data_type\": \"VARCHAR\"}"
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=string].skills",
@@ -798,8 +778,7 @@
                                 "nativeDataType": "array<VARCHAR>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<VARCHAR>\"}"
+                                "isPartitioningKey": false
                             }
                         ]
                     }
@@ -1078,6 +1057,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "CREATE VIEW \"test_schema\".test_view_1 AS\nSELECT\n  *\nFROM \"test_schema\".\"test_table\"",
                 "language": "SQL"
@@ -1249,6 +1229,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "CREATE VIEW \"test_schema\".test_view_2 AS\nSELECT\n  employee_id,\n  employee_name,\n  skills\nFROM \"test_schema\".\"test_view_1\"",
                 "language": "SQL"

--- a/metadata-ingestion/tests/integration/delta_lake/delta_lake_minio_mces_golden.json
+++ b/metadata-ingestion/tests/integration/delta_lake/delta_lake_minio_mces_golden.json
@@ -12,12 +12,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "3",
                             "partition_columns": "[]",
                             "table_creation_time": "1655664813952",
                             "id": "eca9d2a0-4ce6-4ace-a732-75fda0157fb8",
                             "version": "0",
-                            "location": "s3://my-test-bucket/delta_tables/sales"
+                            "location": "s3://my-test-bucket/delta_tables/sales",
+                            "number_of_files": "3"
                         },
                         "name": "my_table",
                         "description": "my table description",
@@ -54,8 +54,7 @@
                                 },
                                 "nativeDataType": "float",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"float\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].day",
@@ -67,8 +66,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].month",
@@ -80,8 +78,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].year",
@@ -93,8 +90,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].customer",
@@ -106,8 +102,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].sale_id",
@@ -119,8 +114,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -226,6 +220,22 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:acebf8bcf966274632d3d2b710ef4947",
     "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:34fc0473e206bb1f4307aadf4177b2fd"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1672531200000,
+        "runId": "delta-lake-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:acebf8bcf966274632d3d2b710ef4947",
+    "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
         "json": {
@@ -286,22 +296,6 @@
             "typeNames": [
                 "Folder"
             ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1672531200000,
-        "runId": "delta-lake-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:acebf8bcf966274632d3d2b710ef4947",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:34fc0473e206bb1f4307aadf4177b2fd"
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_allow_table.json
+++ b/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_allow_table.json
@@ -12,12 +12,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "5",
                             "partition_columns": "['foo', 'bar']",
                             "table_creation_time": "1655831476360",
                             "id": "628d06df-ecb0-4314-a97e-75d8872db7c3",
                             "version": "4",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables",
+                            "number_of_files": "5"
                         },
                         "name": "test-table-basic",
                         "description": "test delta table basic with table name",
@@ -54,8 +54,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].foo",
@@ -67,8 +66,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].zip",
@@ -80,8 +78,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -194,6 +191,22 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
     "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:189046201d696e7810132cfa64dad337"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+    "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
         "json": {
@@ -268,22 +281,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:189046201d696e7810132cfa64dad337"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "allow_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -297,6 +294,22 @@
                     "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
         }
     },
     "systemMetadata": {
@@ -383,22 +396,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:1876d057d0ee364677b85427342e2c82",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "allow_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:1876d057d0ee364677b85427342e2c82",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -416,6 +413,22 @@
                     "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:1876d057d0ee364677b85427342e2c82"
         }
     },
     "systemMetadata": {
@@ -502,22 +515,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:1876d057d0ee364677b85427342e2c82"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "allow_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -539,6 +536,22 @@
                     "urn": "urn:li:container:1876d057d0ee364677b85427342e2c82"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:a282913be26fceff334523c2be119df1",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
         }
     },
     "systemMetadata": {
@@ -613,22 +626,6 @@
             "typeNames": [
                 "Folder"
             ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "allow_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:a282913be26fceff334523c2be119df1",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
         }
     },
     "systemMetadata": {
@@ -893,12 +890,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "3",
                             "partition_columns": "[]",
                             "table_creation_time": "1655664813952",
                             "id": "eca9d2a0-4ce6-4ace-a732-75fda0157fb8",
                             "version": "0",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables",
+                            "number_of_files": "3"
                         },
                         "name": "my_table",
                         "description": "my table description",
@@ -935,8 +932,7 @@
                                 },
                                 "nativeDataType": "float",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"float\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].day",
@@ -948,8 +944,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].month",
@@ -961,8 +956,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].year",
@@ -974,8 +968,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].customer",
@@ -987,8 +980,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].sale_id",
@@ -1000,8 +992,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1114,12 +1105,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "5",
                             "partition_columns": "['foo', 'bar']",
                             "table_creation_time": "1655831648843",
                             "id": "de711767-c7b9-4c33-99d7-510978dc1fa5",
                             "version": "4",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables",
+                            "number_of_files": "5"
                         },
                         "name": "my_table_no_name",
                         "tags": []
@@ -1155,8 +1146,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].foo",
@@ -1168,8 +1158,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].zip",
@@ -1181,8 +1170,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1415,12 +1403,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "5",
                             "partition_columns": "['foo', 'bar']",
                             "table_creation_time": "1655831864836",
                             "id": "3775a0fd-4f58-4dea-b71a-e3fedb10f5b4",
                             "version": "4",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables",
+                            "number_of_files": "5"
                         },
                         "name": "test-table-inner",
                         "description": "test delta table basic with table name at inner location",
@@ -1457,8 +1445,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].foo",
@@ -1470,8 +1457,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].zip",
@@ -1483,13 +1469,28 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:3df8f6b0f3a70d42cf70612a2fe5e5ef",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:a282913be26fceff334523c2be119df1"
         }
     },
     "systemMetadata": {
@@ -1564,22 +1565,6 @@
             "typeNames": [
                 "Folder"
             ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "allow_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:3df8f6b0f3a70d42cf70612a2fe5e5ef",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:a282913be26fceff334523c2be119df1"
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_inner_table.json
+++ b/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_inner_table.json
@@ -12,12 +12,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "5",
                             "partition_columns": "['foo', 'bar']",
                             "table_creation_time": "1655831476360",
                             "id": "628d06df-ecb0-4314-a97e-75d8872db7c3",
                             "version": "4",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables",
+                            "number_of_files": "5"
                         },
                         "name": "test-table-basic",
                         "description": "test delta table basic with table name",
@@ -54,8 +54,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].foo",
@@ -67,8 +66,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].zip",
@@ -80,8 +78,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -187,6 +184,22 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
     "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+    "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
         "json": {
@@ -259,10 +272,15 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
     "changeType": "UPSERT",
-    "aspectName": "container",
+    "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "container": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -273,17 +291,12 @@
 },
 {
     "entityType": "container",
-    "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+    "entityUrn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
     "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
+    "aspectName": "container",
     "aspect": {
         "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
-                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
-                }
-            ]
+            "container": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
         }
     },
     "systemMetadata": {
@@ -368,22 +381,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "inner_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -397,6 +394,22 @@
                     "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
         }
     },
     "systemMetadata": {
@@ -481,22 +494,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "inner_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -514,6 +511,22 @@
                     "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
         }
     },
     "systemMetadata": {
@@ -586,22 +599,6 @@
             "typeNames": [
                 "Folder"
             ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "inner_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
         }
     },
     "systemMetadata": {
@@ -858,12 +855,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "3",
                             "partition_columns": "[]",
                             "table_creation_time": "1655664813952",
                             "id": "eca9d2a0-4ce6-4ace-a732-75fda0157fb8",
                             "version": "0",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables",
+                            "number_of_files": "3"
                         },
                         "name": "my_table",
                         "description": "my table description",
@@ -900,8 +897,7 @@
                                 },
                                 "nativeDataType": "float",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"float\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].day",
@@ -913,8 +909,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].month",
@@ -926,8 +921,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].year",
@@ -939,8 +933,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].customer",
@@ -952,8 +945,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].sale_id",
@@ -965,8 +957,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1075,12 +1066,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "5",
                             "partition_columns": "['foo', 'bar']",
                             "table_creation_time": "1655831648843",
                             "id": "de711767-c7b9-4c33-99d7-510978dc1fa5",
                             "version": "4",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables",
+                            "number_of_files": "5"
                         },
                         "name": "my_table_no_name",
                         "tags": []
@@ -1116,8 +1107,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].foo",
@@ -1129,8 +1119,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].zip",
@@ -1142,8 +1131,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1372,12 +1360,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "5",
                             "partition_columns": "['foo', 'bar']",
                             "table_creation_time": "1655831864836",
                             "id": "3775a0fd-4f58-4dea-b71a-e3fedb10f5b4",
                             "version": "4",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables",
+                            "number_of_files": "5"
                         },
                         "name": "test-table-inner",
                         "description": "test delta table basic with table name at inner location",
@@ -1414,8 +1402,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].foo",
@@ -1427,8 +1414,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].zip",
@@ -1440,13 +1426,28 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:6bb6dc6de93177210067d00b45b481bb",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:ad4b596846e8e010114b1ec82b324fab"
         }
     },
     "systemMetadata": {
@@ -1519,22 +1520,6 @@
             "typeNames": [
                 "Folder"
             ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "inner_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:6bb6dc6de93177210067d00b45b481bb",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:ad4b596846e8e010114b1ec82b324fab"
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_relative_path.json
+++ b/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_relative_path.json
@@ -12,12 +12,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "5",
                             "partition_columns": "['foo', 'bar']",
                             "table_creation_time": "1655831476360",
                             "id": "628d06df-ecb0-4314-a97e-75d8872db7c3",
                             "version": "4",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables/my_table_basic/"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables/my_table_basic/",
+                            "number_of_files": "5"
                         },
                         "name": "test-table-basic",
                         "description": "test delta table basic with table name",
@@ -54,8 +54,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].foo",
@@ -67,8 +66,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].zip",
@@ -80,8 +78,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_single_table.json
+++ b/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_single_table.json
@@ -53,8 +53,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].foo",
@@ -66,8 +65,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].zip",
@@ -79,8 +77,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -186,6 +183,22 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
     "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "single_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+    "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
         "json": {
@@ -258,10 +271,15 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
     "changeType": "UPSERT",
-    "aspectName": "container",
+    "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "container": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -272,17 +290,12 @@
 },
 {
     "entityType": "container",
-    "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+    "entityUrn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
     "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
+    "aspectName": "container",
     "aspect": {
         "json": {
-            "path": [
-                {
-                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
-                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
-                }
-            ]
+            "container": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
         }
     },
     "systemMetadata": {
@@ -367,22 +380,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "single_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -396,6 +393,22 @@
                     "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "single_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
         }
     },
     "systemMetadata": {
@@ -480,22 +493,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "single_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -513,6 +510,22 @@
                     "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "single_table.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
         }
     },
     "systemMetadata": {
@@ -585,22 +598,6 @@
             "typeNames": [
                 "Folder"
             ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "single_table.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_tables_with_nested_datatypes.json
+++ b/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_tables_with_nested_datatypes.json
@@ -12,12 +12,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "2",
                             "partition_columns": "[]",
                             "table_creation_time": "1709535902908",
                             "id": "363c76ca-3357-48c6-b14d-71262be23dbc",
                             "version": "0",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype",
+                            "number_of_files": "2"
                         },
                         "name": "table_with_nested_struct_1",
                         "tags": []
@@ -53,8 +53,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data",
@@ -66,8 +65,7 @@
                                 },
                                 "nativeDataType": "struct<_1:string,_2:struct<_1:long,_2:string>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<_1:string,_2:struct<_1:long,_2:string>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=string]._1",
@@ -79,8 +77,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._2",
@@ -92,8 +89,7 @@
                                 },
                                 "nativeDataType": "struct<_1:long,_2:string>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<_1:long,_2:string>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._2.[type=long]._1",
@@ -105,8 +101,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._2.[type=string]._2",
@@ -118,8 +113,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -232,6 +226,22 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
     "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:189046201d696e7810132cfa64dad337"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "tables_with_nested_datatypes.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+    "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
         "json": {
@@ -306,22 +316,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:189046201d696e7810132cfa64dad337"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "tables_with_nested_datatypes.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -335,6 +329,22 @@
                     "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "tables_with_nested_datatypes.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
         }
     },
     "systemMetadata": {
@@ -421,22 +431,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:1876d057d0ee364677b85427342e2c82",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "tables_with_nested_datatypes.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:1876d057d0ee364677b85427342e2c82",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -454,6 +448,22 @@
                     "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "tables_with_nested_datatypes.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:1876d057d0ee364677b85427342e2c82"
         }
     },
     "systemMetadata": {
@@ -540,22 +550,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:1876d057d0ee364677b85427342e2c82"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "tables_with_nested_datatypes.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -577,6 +571,22 @@
                     "urn": "urn:li:container:1876d057d0ee364677b85427342e2c82"
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "tables_with_nested_datatypes.json",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:401e53437a2ce6094ab3021cb32919d9",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
         }
     },
     "systemMetadata": {
@@ -651,22 +661,6 @@
             "typeNames": [
                 "Folder"
             ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "tables_with_nested_datatypes.json",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:401e53437a2ce6094ab3021cb32919d9",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
         }
     },
     "systemMetadata": {
@@ -817,12 +811,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "2",
                             "partition_columns": "[]",
                             "table_creation_time": "1709110539186",
                             "id": "73cae4a6-3988-4337-89ca-af58dd528b0b",
                             "version": "0",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype",
+                            "number_of_files": "2"
                         },
                         "name": "table_with_nested_struct",
                         "tags": []
@@ -858,8 +852,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data",
@@ -871,8 +864,7 @@
                                 },
                                 "nativeDataType": "struct<_1:string,_2:struct<_1:long,_2:string>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<_1:string,_2:struct<_1:long,_2:string>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=string]._1",
@@ -884,8 +876,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._2",
@@ -897,8 +888,7 @@
                                 },
                                 "nativeDataType": "struct<_1:long,_2:string>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<_1:long,_2:string>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._2.[type=long]._1",
@@ -910,8 +900,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._2.[type=string]._2",
@@ -923,8 +912,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1043,12 +1031,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "2",
                             "partition_columns": "[]",
                             "table_creation_time": "1708329075098",
                             "id": "bccc302c-006d-4de9-b572-0c1939e64fc5",
                             "version": "0",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype",
+                            "number_of_files": "2"
                         },
                         "name": "table_with_string_and_array",
                         "tags": []
@@ -1084,8 +1072,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=string].data",
@@ -1101,8 +1088,7 @@
                                 },
                                 "nativeDataType": "array<string>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<string>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1221,12 +1207,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "2",
                             "partition_columns": "[]",
                             "table_creation_time": "1708329893422",
                             "id": "6f3b01e4-ae1e-415a-979a-34861346809b",
                             "version": "0",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype",
+                            "number_of_files": "2"
                         },
                         "name": "table_with_string_and_array_of_struct",
                         "tags": []
@@ -1262,8 +1248,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].data",
@@ -1279,8 +1264,7 @@
                                 },
                                 "nativeDataType": "array<struct<name:string,value:integer>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<name:string,value:integer>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].data.[type=int].value",
@@ -1292,8 +1276,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].data.[type=string].name",
@@ -1305,8 +1288,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1425,12 +1407,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "2",
                             "partition_columns": "[]",
                             "table_creation_time": "1709536362734",
                             "id": "58b63865-38fa-4478-98cf-3a7fd3425e24",
                             "version": "0",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype",
+                            "number_of_files": "2"
                         },
                         "name": "table_with_nested_struct_2",
                         "tags": []
@@ -1466,8 +1448,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data",
@@ -1479,8 +1460,7 @@
                                 },
                                 "nativeDataType": "struct<_1:struct<_1:long,_2:string>,_2:struct<_1:long,_2:string>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<_1:struct<_1:long,_2:string>,_2:struct<_1:long,_2:string>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._1",
@@ -1492,8 +1472,7 @@
                                 },
                                 "nativeDataType": "struct<_1:long,_2:string>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<_1:long,_2:string>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._1.[type=long]._1",
@@ -1505,8 +1484,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._1.[type=string]._2",
@@ -1518,8 +1496,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._2",
@@ -1531,8 +1508,7 @@
                                 },
                                 "nativeDataType": "struct<_1:long,_2:string>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<_1:long,_2:string>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._2.[type=long]._1",
@@ -1544,8 +1520,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].data.[type=struct]._2.[type=string]._2",
@@ -1557,8 +1532,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1677,12 +1651,12 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "number_of_files": "2",
                             "partition_columns": "[]",
                             "table_creation_time": "1708330174792",
                             "id": "9b656138-6370-412a-826b-4f20e659d5c2",
                             "version": "0",
-                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype"
+                            "location": "tests/integration/delta_lake/test_data/delta_tables_nested_datatype",
+                            "number_of_files": "2"
                         },
                         "name": "table_with_string_and_nested_array_of_numbers",
                         "tags": []
@@ -1718,8 +1692,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=array].[type=array].[type=long].data",
@@ -1735,8 +1708,7 @@
                                 },
                                 "nativeDataType": "array<array<array<long>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<array<array<long>>>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_1.json
+++ b/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_1.json
@@ -238,7 +238,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298453"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -268,7 +268,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -318,8 +318,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=string].recordid",
@@ -335,7 +334,7 @@
                                 "nativeDataType": "map<int,string>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"map<int,string>\", \"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
                             }
                         ]
                     }
@@ -428,7 +427,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298453"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -463,7 +462,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -573,8 +572,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct0].foo.[type=string].b",
@@ -586,8 +584,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -680,7 +677,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298453"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -715,7 +712,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -765,8 +762,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
@@ -778,8 +774,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:struct<name:varchar(50),id:tinyint>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:struct<name:varchar(50),id:tinyint>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -791,8 +786,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
@@ -804,8 +798,7 @@
                                 },
                                 "nativeDataType": "struct<name:varchar(50),id:tinyint>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<name:varchar(50),id:tinyint>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
@@ -817,8 +810,7 @@
                                 },
                                 "nativeDataType": "varchar(50)",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"varchar(50)\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
@@ -830,8 +822,7 @@
                                 },
                                 "nativeDataType": "tinyint",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"tinyint\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -949,7 +940,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298448"
+                "value": "1746461120"
             },
             {
                 "op": "add",
@@ -974,7 +965,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1025,8 +1016,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service",
@@ -1043,8 +1033,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -1056,8 +1045,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -1073,8 +1061,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1167,7 +1154,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298442"
+                "value": "1746461116"
             },
             {
                 "op": "add",
@@ -1202,7 +1189,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1252,8 +1239,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
@@ -1265,8 +1251,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:array<int>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:array<int>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1278,8 +1263,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1295,8 +1279,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1389,7 +1372,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298441"
+                "value": "1746461116"
             },
             {
                 "op": "add",
@@ -1424,7 +1407,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1474,8 +1457,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].bar",
@@ -1487,8 +1469,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1576,7 +1557,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298433"
+                "value": "1746461113"
             },
             {
                 "op": "add",
@@ -1591,7 +1572,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             },
             {
                 "op": "add",
@@ -1646,8 +1627,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].baz",
@@ -1660,8 +1640,7 @@
                                 "nativeDataType": "string",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": true,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartitioningKey": true
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].bar",
@@ -1673,8 +1652,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1787,8 +1765,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1935,8 +1912,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service",
@@ -1952,8 +1928,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -1965,8 +1940,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -1982,8 +1956,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_2.json
+++ b/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_2.json
@@ -91,6 +91,22 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:5bd3e4d159b00200dfe53d79a486ce7f",
     "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f4ec3d97ca6750de28020a0d393c289d"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1632398400000,
+        "runId": "hive-metastore-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:5bd3e4d159b00200dfe53d79a486ce7f",
+    "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
         "json": {
@@ -164,22 +180,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:5bd3e4d159b00200dfe53d79a486ce7f",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:f4ec3d97ca6750de28020a0d393c289d"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1632398400000,
-        "runId": "hive-metastore-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:5bd3e4d159b00200dfe53d79a486ce7f",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -238,7 +238,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258696"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -268,7 +268,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -318,8 +318,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=string].recordid",
@@ -335,7 +334,7 @@
                                 "nativeDataType": "map<int,string>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"map<int,string>\", \"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
                             }
                         ]
                     }
@@ -428,7 +427,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258696"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -463,7 +462,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -573,8 +572,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct0].foo.[type=string].b",
@@ -586,8 +584,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -674,8 +671,13 @@
             },
             {
                 "op": "add",
+                "path": "/customProperties/totalSize",
+                "value": "0"
+            },
+            {
+                "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258695"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -699,11 +701,6 @@
             },
             {
                 "op": "add",
-                "path": "/customProperties/totalSize",
-                "value": "0"
-            },
-            {
-                "op": "add",
                 "path": "/customProperties/table_type",
                 "value": "MANAGED_TABLE"
             },
@@ -715,7 +712,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -765,8 +762,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
@@ -778,8 +774,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:struct<name:varchar(50),id:tinyint>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:struct<name:varchar(50),id:tinyint>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -791,8 +786,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
@@ -804,8 +798,7 @@
                                 },
                                 "nativeDataType": "struct<name:varchar(50),id:tinyint>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<name:varchar(50),id:tinyint>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
@@ -817,8 +810,7 @@
                                 },
                                 "nativeDataType": "varchar(50)",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"varchar(50)\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
@@ -830,8 +822,7 @@
                                 },
                                 "nativeDataType": "tinyint",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"tinyint\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -928,11 +919,6 @@
             },
             {
                 "op": "add",
-                "path": "/customProperties/numFiles",
-                "value": "1"
-            },
-            {
-                "op": "add",
                 "path": "/customProperties/numRows",
                 "value": "1"
             },
@@ -943,13 +929,18 @@
             },
             {
                 "op": "add",
-                "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258689"
+                "path": "/customProperties/totalSize",
+                "value": "33"
             },
             {
                 "op": "add",
-                "path": "/customProperties/totalSize",
-                "value": "33"
+                "path": "/customProperties/numFiles",
+                "value": "1"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/transient_lastDdlTime",
+                "value": "1746461120"
             },
             {
                 "op": "add",
@@ -974,7 +965,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1025,8 +1016,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service",
@@ -1043,8 +1033,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -1056,8 +1045,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -1073,8 +1061,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1166,6 +1153,11 @@
             },
             {
                 "op": "add",
+                "path": "/customProperties/transient_lastDdlTime",
+                "value": "1746461116"
+            },
+            {
+                "op": "add",
                 "path": "/customProperties/numFiles",
                 "value": "0"
             },
@@ -1173,11 +1165,6 @@
                 "op": "add",
                 "path": "/customProperties/COLUMN_STATS_ACCURATE",
                 "value": "{\"BASIC_STATS\":\"true\"}"
-            },
-            {
-                "op": "add",
-                "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258680"
             },
             {
                 "op": "add",
@@ -1202,7 +1189,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1252,8 +1239,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
@@ -1265,8 +1251,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:array<int>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:array<int>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1278,8 +1263,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1295,8 +1279,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1388,6 +1371,11 @@
             },
             {
                 "op": "add",
+                "path": "/customProperties/transient_lastDdlTime",
+                "value": "1746461116"
+            },
+            {
+                "op": "add",
                 "path": "/customProperties/numFiles",
                 "value": "0"
             },
@@ -1395,11 +1383,6 @@
                 "op": "add",
                 "path": "/customProperties/COLUMN_STATS_ACCURATE",
                 "value": "{\"BASIC_STATS\":\"true\"}"
-            },
-            {
-                "op": "add",
-                "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258680"
             },
             {
                 "op": "add",
@@ -1424,7 +1407,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1474,8 +1457,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].bar",
@@ -1487,8 +1469,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1576,7 +1557,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258672"
+                "value": "1746461113"
             },
             {
                 "op": "add",
@@ -1591,7 +1572,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             },
             {
                 "op": "add",
@@ -1637,6 +1618,18 @@
                         },
                         "fields": [
                             {
+                                "fieldPath": "[version=2.0].[type=int].foo",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "int",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
                                 "fieldPath": "[version=2.0].[type=string].baz",
                                 "nullable": true,
                                 "type": {
@@ -1647,21 +1640,7 @@
                                 "nativeDataType": "string",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": true,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=int].foo",
-                                "nullable": true,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "int",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartitioningKey": true
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].bar",
@@ -1673,8 +1652,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1787,8 +1765,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=null].service",
@@ -1800,8 +1777,7 @@
                                 },
                                 "nativeDataType": "array(row(\"type\" varchar,\"provider\" array(integer)))",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array(row(\\\"type\\\" varchar,\\\"provider\\\" array(integer)))\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_3.json
+++ b/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_3.json
@@ -238,7 +238,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298453"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -268,7 +268,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -318,8 +318,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=string].recordid",
@@ -335,7 +334,7 @@
                                 "nativeDataType": "map<int,string>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"map<int,string>\", \"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
                             }
                         ]
                     }
@@ -428,7 +427,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298453"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -463,7 +462,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -573,8 +572,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct0].foo.[type=string].b",
@@ -586,8 +584,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -680,7 +677,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298453"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -715,7 +712,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -765,8 +762,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
@@ -778,8 +774,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:struct<name:varchar(50),id:tinyint>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:struct<name:varchar(50),id:tinyint>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -791,8 +786,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
@@ -804,8 +798,7 @@
                                 },
                                 "nativeDataType": "struct<name:varchar(50),id:tinyint>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<name:varchar(50),id:tinyint>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
@@ -817,8 +810,7 @@
                                 },
                                 "nativeDataType": "varchar(50)",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"varchar(50)\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
@@ -830,8 +822,7 @@
                                 },
                                 "nativeDataType": "tinyint",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"tinyint\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -949,7 +940,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298448"
+                "value": "1746461120"
             },
             {
                 "op": "add",
@@ -974,7 +965,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1025,8 +1016,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service",
@@ -1043,8 +1033,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -1056,8 +1045,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -1073,8 +1061,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1167,7 +1154,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298442"
+                "value": "1746461116"
             },
             {
                 "op": "add",
@@ -1202,7 +1189,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1252,8 +1239,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
@@ -1265,8 +1251,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:array<int>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:array<int>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1278,8 +1263,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1295,8 +1279,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1389,7 +1372,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298441"
+                "value": "1746461116"
             },
             {
                 "op": "add",
@@ -1424,7 +1407,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1474,8 +1457,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].bar",
@@ -1487,8 +1469,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1576,7 +1557,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298433"
+                "value": "1746461113"
             },
             {
                 "op": "add",
@@ -1591,7 +1572,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             },
             {
                 "op": "add",
@@ -1646,8 +1627,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].baz",
@@ -1660,8 +1640,7 @@
                                 "nativeDataType": "string",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": true,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartitioningKey": true
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].bar",
@@ -1673,8 +1652,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1787,8 +1765,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1935,8 +1912,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service",
@@ -1952,8 +1928,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -1965,8 +1940,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -1982,8 +1956,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_4.json
+++ b/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_4.json
@@ -91,6 +91,22 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:5bd3e4d159b00200dfe53d79a486ce7f",
     "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:f4ec3d97ca6750de28020a0d393c289d"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1632398400000,
+        "runId": "hive-metastore-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:5bd3e4d159b00200dfe53d79a486ce7f",
+    "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
         "json": {
@@ -164,22 +180,6 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:5bd3e4d159b00200dfe53d79a486ce7f",
     "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:f4ec3d97ca6750de28020a0d393c289d"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1632398400000,
-        "runId": "hive-metastore-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:5bd3e4d159b00200dfe53d79a486ce7f",
-    "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
@@ -238,7 +238,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258696"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -268,7 +268,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -318,8 +318,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=map].[type=string].recordid",
@@ -335,7 +334,7 @@
                                 "nativeDataType": "map<int,string>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"map<int,string>\", \"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
                             }
                         ]
                     }
@@ -428,7 +427,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258696"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -463,7 +462,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -573,8 +572,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct0].foo.[type=string].b",
@@ -586,8 +584,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -674,8 +671,13 @@
             },
             {
                 "op": "add",
+                "path": "/customProperties/totalSize",
+                "value": "0"
+            },
+            {
+                "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258695"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -699,11 +701,6 @@
             },
             {
                 "op": "add",
-                "path": "/customProperties/totalSize",
-                "value": "0"
-            },
-            {
-                "op": "add",
                 "path": "/customProperties/table_type",
                 "value": "MANAGED_TABLE"
             },
@@ -715,7 +712,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -765,8 +762,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
@@ -778,8 +774,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:struct<name:varchar(50),id:tinyint>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:struct<name:varchar(50),id:tinyint>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -791,8 +786,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
@@ -804,8 +798,7 @@
                                 },
                                 "nativeDataType": "struct<name:varchar(50),id:tinyint>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<name:varchar(50),id:tinyint>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
@@ -817,8 +810,7 @@
                                 },
                                 "nativeDataType": "varchar(50)",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"varchar(50)\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
@@ -830,8 +822,7 @@
                                 },
                                 "nativeDataType": "tinyint",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"tinyint\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -928,11 +919,6 @@
             },
             {
                 "op": "add",
-                "path": "/customProperties/numFiles",
-                "value": "1"
-            },
-            {
-                "op": "add",
                 "path": "/customProperties/numRows",
                 "value": "1"
             },
@@ -943,13 +929,18 @@
             },
             {
                 "op": "add",
-                "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258689"
+                "path": "/customProperties/totalSize",
+                "value": "33"
             },
             {
                 "op": "add",
-                "path": "/customProperties/totalSize",
-                "value": "33"
+                "path": "/customProperties/numFiles",
+                "value": "1"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/transient_lastDdlTime",
+                "value": "1746461120"
             },
             {
                 "op": "add",
@@ -974,7 +965,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1025,8 +1016,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service",
@@ -1043,8 +1033,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -1056,8 +1045,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -1073,8 +1061,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1166,6 +1153,11 @@
             },
             {
                 "op": "add",
+                "path": "/customProperties/transient_lastDdlTime",
+                "value": "1746461116"
+            },
+            {
+                "op": "add",
                 "path": "/customProperties/numFiles",
                 "value": "0"
             },
@@ -1173,11 +1165,6 @@
                 "op": "add",
                 "path": "/customProperties/COLUMN_STATS_ACCURATE",
                 "value": "{\"BASIC_STATS\":\"true\"}"
-            },
-            {
-                "op": "add",
-                "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258680"
             },
             {
                 "op": "add",
@@ -1202,7 +1189,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1252,8 +1239,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
@@ -1265,8 +1251,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:array<int>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:array<int>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1278,8 +1263,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1295,8 +1279,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1388,6 +1371,11 @@
             },
             {
                 "op": "add",
+                "path": "/customProperties/transient_lastDdlTime",
+                "value": "1746461116"
+            },
+            {
+                "op": "add",
                 "path": "/customProperties/numFiles",
                 "value": "0"
             },
@@ -1395,11 +1383,6 @@
                 "op": "add",
                 "path": "/customProperties/COLUMN_STATS_ACCURATE",
                 "value": "{\"BASIC_STATS\":\"true\"}"
-            },
-            {
-                "op": "add",
-                "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258680"
             },
             {
                 "op": "add",
@@ -1424,7 +1407,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1474,8 +1457,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].bar",
@@ -1487,8 +1469,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1576,7 +1557,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1715258672"
+                "value": "1746461113"
             },
             {
                 "op": "add",
@@ -1591,7 +1572,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-05-09"
+                "value": "2025-05-05"
             },
             {
                 "op": "add",
@@ -1637,6 +1618,18 @@
                         },
                         "fields": [
                             {
+                                "fieldPath": "[version=2.0].[type=int].foo",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "int",
+                                "recursive": false,
+                                "isPartOfKey": false
+                            },
+                            {
                                 "fieldPath": "[version=2.0].[type=string].baz",
                                 "nullable": true,
                                 "type": {
@@ -1647,21 +1640,7 @@
                                 "nativeDataType": "string",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": true,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=int].foo",
-                                "nullable": true,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "int",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartitioningKey": true
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].bar",
@@ -1673,8 +1652,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1787,8 +1765,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=null].service",
@@ -1800,8 +1777,7 @@
                                 },
                                 "nativeDataType": "array(row(\"type\" varchar,\"provider\" array(integer)))",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array(row(\\\"type\\\" varchar,\\\"provider\\\" array(integer)))\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_5.json
+++ b/metadata-ingestion/tests/integration/hive-metastore/hive_metastore_mces_golden_5.json
@@ -238,7 +238,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298453"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -268,7 +268,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -318,8 +318,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "recordid",
@@ -335,7 +334,7 @@
                                 "nativeDataType": "map<int,string>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"map<int,string>\", \"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
                             }
                         ]
                     }
@@ -428,7 +427,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298453"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -463,7 +462,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -573,8 +572,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct0].foo.[type=string].b",
@@ -586,8 +584,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -680,7 +677,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298453"
+                "value": "1746461123"
             },
             {
                 "op": "add",
@@ -715,7 +712,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -765,8 +762,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "service",
@@ -778,8 +774,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:struct<name:varchar(50),id:tinyint>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:struct<name:varchar(50),id:tinyint>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "service.type",
@@ -791,8 +786,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "service.provider",
@@ -804,8 +798,7 @@
                                 },
                                 "nativeDataType": "struct<name:varchar(50),id:tinyint>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<name:varchar(50),id:tinyint>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "service.provider.name",
@@ -817,8 +810,7 @@
                                 },
                                 "nativeDataType": "varchar(50)",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"varchar(50)\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "service.provider.id",
@@ -830,8 +822,7 @@
                                 },
                                 "nativeDataType": "tinyint",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"tinyint\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -949,7 +940,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298448"
+                "value": "1746461120"
             },
             {
                 "op": "add",
@@ -974,7 +965,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1025,8 +1016,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service",
@@ -1043,8 +1033,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -1056,8 +1045,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -1073,8 +1061,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1167,7 +1154,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298442"
+                "value": "1746461116"
             },
             {
                 "op": "add",
@@ -1202,7 +1189,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1252,8 +1239,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service",
@@ -1265,8 +1251,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:array<int>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:array<int>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1278,8 +1263,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1295,8 +1279,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1389,7 +1372,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298441"
+                "value": "1746461116"
             },
             {
                 "op": "add",
@@ -1424,7 +1407,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             }
         ]
     },
@@ -1474,8 +1457,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "bar",
@@ -1487,8 +1469,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1576,7 +1557,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/transient_lastDdlTime",
-                "value": "1735298433"
+                "value": "1746461113"
             },
             {
                 "op": "add",
@@ -1591,7 +1572,7 @@
             {
                 "op": "add",
                 "path": "/customProperties/create_date",
-                "value": "2024-12-27"
+                "value": "2025-05-05"
             },
             {
                 "op": "add",
@@ -1646,8 +1627,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "baz",
@@ -1660,8 +1640,7 @@
                                 "nativeDataType": "string",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "isPartitioningKey": true,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartitioningKey": true
                             },
                             {
                                 "fieldPath": "bar",
@@ -1673,8 +1652,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1787,8 +1765,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1935,8 +1912,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service",
@@ -1952,8 +1928,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -1965,8 +1940,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -1982,8 +1956,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/integration/hive/hive_mces_all_db_golden.json
+++ b/metadata-ingestion/tests/integration/hive/hive_mces_all_db_golden.json
@@ -118,7 +118,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:17 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:34:55 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/_test_table_underscore",
@@ -128,7 +128,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852937",
+                            "Table Parameters: transient_lastDdlTime": "1746455695",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -268,7 +268,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:17 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:34:55 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/array_struct_test",
@@ -280,7 +280,7 @@
                             "Table Parameters: numRows": "1",
                             "Table Parameters: rawDataSize": "32",
                             "Table Parameters: totalSize": "33",
-                            "Table Parameters: transient_lastDdlTime": "1744852940",
+                            "Table Parameters: transient_lastDdlTime": "1746455698",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -343,8 +343,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -356,8 +355,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -373,8 +371,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -458,11 +455,11 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:22 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:01 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Table Type:": "VIRTUAL_VIEW",
-                            "Table Parameters: transient_lastDdlTime": "1744852942",
+                            "Table Parameters: transient_lastDdlTime": "1746455701",
                             "SerDe Library:": "null",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -524,8 +521,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -537,8 +533,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -554,8 +549,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -639,11 +633,11 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:22 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:02 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Table Type:": "VIRTUAL_VIEW",
-                            "Table Parameters: transient_lastDdlTime": "1744852942",
+                            "Table Parameters: transient_lastDdlTime": "1746455702",
                             "SerDe Library:": "null",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -730,8 +724,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -743,8 +736,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -760,8 +752,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -845,7 +836,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:22 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:02 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/map_test",
@@ -855,7 +846,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852942",
+                            "Table Parameters: transient_lastDdlTime": "1746455702",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -915,7 +906,7 @@
                                 "nativeDataType": "map<int,string>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"map<int,string>\", \"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
                             }
                         ]
                     }
@@ -999,7 +990,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:22 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:02 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/nested_struct_test",
@@ -1009,7 +1000,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852942",
+                            "Table Parameters: transient_lastDdlTime": "1746455702",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -1065,8 +1056,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:struct<name:varchar(50),id:tinyint>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:struct<name:varchar(50),id:tinyint>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1078,8 +1068,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
@@ -1091,8 +1080,7 @@
                                 },
                                 "nativeDataType": "struct<name:varchar(50),id:tinyint>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<name:varchar(50),id:tinyint>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
@@ -1104,8 +1092,7 @@
                                 },
                                 "nativeDataType": "varchar(50)",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"varchar(50)\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
@@ -1117,8 +1104,7 @@
                                 },
                                 "nativeDataType": "tinyint",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"tinyint\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1202,7 +1188,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:15 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:34:51 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/pokes",
@@ -1212,7 +1198,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "5812",
-                            "Table Parameters: transient_lastDdlTime": "1744852935",
+                            "Table Parameters: transient_lastDdlTime": "1746455691",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -1365,7 +1351,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:17 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:34:55 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/struct_test",
@@ -1375,7 +1361,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852937",
+                            "Table Parameters: transient_lastDdlTime": "1746455695",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -1431,8 +1417,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:array<int>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:array<int>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1444,8 +1429,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1461,8 +1445,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1546,14 +1529,14 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:22 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:01 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/struct_test_view_materialized",
                             "Table Type:": "MATERIALIZED_VIEW",
                             "Table Parameters: numFiles": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852942",
+                            "Table Parameters: transient_lastDdlTime": "1746455701",
                             "SerDe Library:": "org.apache.hadoop.hive.ql.io.orc.OrcSerde",
                             "InputFormat:": "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
@@ -1611,8 +1594,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:array<int>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:array<int>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1624,8 +1606,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1641,8 +1622,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1726,7 +1706,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:22 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:02 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/union_test",
@@ -1736,7 +1716,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852942",
+                            "Table Parameters: transient_lastDdlTime": "1746455702",
                             "SerDe Library:": "org.apache.hadoop.hive.ql.io.orc.OrcSerde",
                             "InputFormat:": "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
@@ -1840,8 +1820,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct0].foo.[type=string].b",
@@ -1853,8 +1832,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct1].foo",
@@ -1878,8 +1856,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct1].foo.[type=double].d",
@@ -1891,8 +1868,7 @@
                                 },
                                 "nativeDataType": "double",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -2100,7 +2076,7 @@
                         "customProperties": {
                             "Database:": "db2",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:22:17 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:34:54 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db2.db/pokes",
@@ -2109,7 +2085,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "5812",
-                            "Table Parameters: transient_lastDdlTime": "1744852937",
+                            "Table Parameters: transient_lastDdlTime": "1746455694",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",

--- a/metadata-ingestion/tests/integration/hive/hive_mces_golden.json
+++ b/metadata-ingestion/tests/integration/hive/hive_mces_golden.json
@@ -118,7 +118,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:32 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:34:55 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/_test_table_underscore",
@@ -128,7 +128,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852712",
+                            "Table Parameters: transient_lastDdlTime": "1746455695",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -268,7 +268,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:32 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:34:55 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/array_struct_test",
@@ -280,7 +280,7 @@
                             "Table Parameters: numRows": "1",
                             "Table Parameters: rawDataSize": "32",
                             "Table Parameters: totalSize": "33",
-                            "Table Parameters: transient_lastDdlTime": "1744852715",
+                            "Table Parameters: transient_lastDdlTime": "1746455698",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -343,8 +343,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -356,8 +355,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -373,8 +371,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -458,11 +455,11 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:37 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:01 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Table Type:": "VIRTUAL_VIEW",
-                            "Table Parameters: transient_lastDdlTime": "1744852717",
+                            "Table Parameters: transient_lastDdlTime": "1746455701",
                             "SerDe Library:": "null",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -524,8 +521,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -537,8 +533,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -554,8 +549,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -639,11 +633,11 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:38 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:02 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Table Type:": "VIRTUAL_VIEW",
-                            "Table Parameters: transient_lastDdlTime": "1744852718",
+                            "Table Parameters: transient_lastDdlTime": "1746455702",
                             "SerDe Library:": "null",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -730,8 +724,7 @@
                                 },
                                 "nativeDataType": "array<struct<type:string,provider:array<int>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<type:string,provider:array<int>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -743,8 +736,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -760,8 +752,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -845,7 +836,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:38 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:02 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/map_test",
@@ -855,7 +846,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852718",
+                            "Table Parameters: transient_lastDdlTime": "1746455702",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -915,7 +906,7 @@
                                 "nativeDataType": "map<int,string>",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"map<int,string>\", \"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"int\", \"native_data_type\": \"int\", \"_nullable\": true}, \"key_native_data_type\": \"int\"}"
                             }
                         ]
                     }
@@ -999,7 +990,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:38 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:02 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/nested_struct_test",
@@ -1009,7 +1000,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852718",
+                            "Table Parameters: transient_lastDdlTime": "1746455702",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -1065,8 +1056,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:struct<name:varchar(50),id:tinyint>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:struct<name:varchar(50),id:tinyint>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1078,8 +1068,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
@@ -1091,8 +1080,7 @@
                                 },
                                 "nativeDataType": "struct<name:varchar(50),id:tinyint>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<name:varchar(50),id:tinyint>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
@@ -1104,8 +1092,7 @@
                                 },
                                 "nativeDataType": "varchar(50)",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"varchar(50)\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
@@ -1117,8 +1104,7 @@
                                 },
                                 "nativeDataType": "tinyint",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"tinyint\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1202,7 +1188,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:30 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:34:51 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/pokes",
@@ -1212,7 +1198,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "5812",
-                            "Table Parameters: transient_lastDdlTime": "1744852710",
+                            "Table Parameters: transient_lastDdlTime": "1746455691",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -1365,7 +1351,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:32 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:34:55 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/struct_test",
@@ -1375,7 +1361,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852712",
+                            "Table Parameters: transient_lastDdlTime": "1746455695",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -1431,8 +1417,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:array<int>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:array<int>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1444,8 +1429,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1461,8 +1445,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1546,14 +1529,14 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:37 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:01 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/struct_test_view_materialized",
                             "Table Type:": "MATERIALIZED_VIEW",
                             "Table Parameters: numFiles": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852717",
+                            "Table Parameters: transient_lastDdlTime": "1746455701",
                             "SerDe Library:": "org.apache.hadoop.hive.ql.io.orc.OrcSerde",
                             "InputFormat:": "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
@@ -1611,8 +1594,7 @@
                                 },
                                 "nativeDataType": "struct<type:string,provider:array<int>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"struct<type:string,provider:array<int>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1624,8 +1606,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1641,8 +1622,7 @@
                                 },
                                 "nativeDataType": "array<int>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<int>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1726,7 +1706,7 @@
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Thu Apr 17 01:18:38 UTC 2025",
+                            "CreateTime:": "Mon May 05 14:35:02 UTC 2025",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/union_test",
@@ -1736,7 +1716,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1744852718",
+                            "Table Parameters: transient_lastDdlTime": "1746455702",
                             "SerDe Library:": "org.apache.hadoop.hive.ql.io.orc.OrcSerde",
                             "InputFormat:": "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat",
@@ -1840,8 +1820,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct0].foo.[type=string].b",
@@ -1853,8 +1832,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct1].foo",
@@ -1878,8 +1856,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=union].[type=struct1].foo.[type=double].d",
@@ -1891,8 +1868,7 @@
                                 },
                                 "nativeDataType": "double",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/integration/iceberg/iceberg_deleted_table_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/iceberg/iceberg_deleted_table_mcps_golden.json
@@ -215,8 +215,7 @@
                     },
                     "nativeDataType": "long",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=long].trip_date",
@@ -229,7 +228,7 @@
                     "nativeDataType": "timestamptz",
                     "recursive": false,
                     "isPartOfKey": false,
-                    "jsonProps": "{\"logicalType\": \"timestamp-micros\", \"native_data_type\": \"timestamptz\", \"_nullable\": true}"
+                    "jsonProps": "{\"logicalType\": \"timestamp-micros\"}"
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=long].trip_id",
@@ -241,8 +240,7 @@
                     },
                     "nativeDataType": "long",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=float].trip_distance",
@@ -254,8 +252,7 @@
                     },
                     "nativeDataType": "float",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"float\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=double].fare_amount",
@@ -267,8 +264,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=string].store_and_fwd_flag",
@@ -280,8 +276,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/iceberg/iceberg_ingest_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/iceberg/iceberg_ingest_mcps_golden.json
@@ -201,8 +201,7 @@
                     },
                     "nativeDataType": "long",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=long].trip_date",
@@ -215,7 +214,7 @@
                     "nativeDataType": "timestamptz",
                     "recursive": false,
                     "isPartOfKey": false,
-                    "jsonProps": "{\"logicalType\": \"timestamp-micros\", \"native_data_type\": \"timestamptz\", \"_nullable\": true}"
+                    "jsonProps": "{\"logicalType\": \"timestamp-micros\"}"
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=long].trip_id",
@@ -227,8 +226,7 @@
                     },
                     "nativeDataType": "long",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=float].trip_distance",
@@ -240,8 +238,7 @@
                     },
                     "nativeDataType": "float",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"float\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=double].fare_amount",
@@ -253,8 +250,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=string].store_and_fwd_flag",
@@ -266,8 +262,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/iceberg/iceberg_profile_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/iceberg/iceberg_profile_mcps_golden.json
@@ -201,8 +201,7 @@
                     },
                     "nativeDataType": "long",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=long].trip_date",
@@ -215,7 +214,7 @@
                     "nativeDataType": "timestamptz",
                     "recursive": false,
                     "isPartOfKey": false,
-                    "jsonProps": "{\"logicalType\": \"timestamp-micros\", \"native_data_type\": \"timestamptz\", \"_nullable\": true}"
+                    "jsonProps": "{\"logicalType\": \"timestamp-micros\"}"
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=long].trip_id",
@@ -227,8 +226,7 @@
                     },
                     "nativeDataType": "long",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=float].trip_distance",
@@ -240,8 +238,7 @@
                     },
                     "nativeDataType": "float",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"float\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=double].fare_amount",
@@ -253,8 +250,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=string].store_and_fwd_flag",
@@ -266,8 +262,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/trino/trino_hive_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/trino/trino_hive_instance_mces_golden.json
@@ -246,7 +246,7 @@
                             "numrows": "1",
                             "rawdatasize": "32",
                             "totalsize": "33",
-                            "transient_lastddltime": "1735206396"
+                            "transient_lastddltime": "1746463134"
                         },
                         "name": "array_struct_test",
                         "description": "This table has array of structs",
@@ -301,8 +301,7 @@
                                 },
                                 "nativeDataType": "ARRAY(ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))]))",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))]))\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -314,8 +313,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -331,8 +329,7 @@
                                 },
                                 "nativeDataType": "ARRAY(INTEGER())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(INTEGER())\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -507,7 +504,7 @@
                             "numrows": "3",
                             "rawdatasize": "94",
                             "totalsize": "97",
-                            "transient_lastddltime": "1735206403"
+                            "transient_lastddltime": "1746463139"
                         },
                         "name": "classification_test",
                         "tags": []
@@ -766,7 +763,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206400"
+                            "transient_lastddltime": "1746463137"
                         },
                         "name": "map_test",
                         "tags": []
@@ -818,7 +815,7 @@
                                 "nativeDataType": "MAP(INTEGER(), VARCHAR())",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"MAP(INTEGER(), VARCHAR())\", \"key_type\": {\"type\": \"int\", \"native_data_type\": \"INTEGER()\", \"_nullable\": true}, \"key_native_data_type\": \"INTEGER()\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"int\", \"native_data_type\": \"INTEGER()\", \"_nullable\": true}, \"key_native_data_type\": \"INTEGER()\"}"
                             }
                         ]
                     }
@@ -993,7 +990,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206400"
+                            "transient_lastddltime": "1746463137"
                         },
                         "name": "nested_struct_test",
                         "tags": []
@@ -1041,8 +1038,7 @@
                                 },
                                 "nativeDataType": "ROW([('type', VARCHAR()), ('provider', ROW([('name', VARCHAR(length=50)), ('id', SMALLINT())]))])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('type', VARCHAR()), ('provider', ROW([('name', VARCHAR(length=50)), ('id', SMALLINT())]))])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1054,8 +1050,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
@@ -1067,8 +1062,7 @@
                                 },
                                 "nativeDataType": "ROW([('name', VARCHAR(length=50)), ('id', SMALLINT())])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('name', VARCHAR(length=50)), ('id', SMALLINT())])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
@@ -1080,8 +1074,7 @@
                                 },
                                 "nativeDataType": "VARCHAR(length=50)",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR(length=50)\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
@@ -1093,8 +1086,7 @@
                                 },
                                 "nativeDataType": "SMALLINT()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"SMALLINT()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1264,7 +1256,7 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "transient_lastddltime": "1735206384"
+                            "transient_lastddltime": "1746463127"
                         },
                         "name": "pokes",
                         "tags": []
@@ -1499,7 +1491,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206390"
+                            "transient_lastddltime": "1746463130"
                         },
                         "name": "struct_test",
                         "tags": []
@@ -1547,8 +1539,7 @@
                                 },
                                 "nativeDataType": "ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1560,8 +1551,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1577,8 +1567,7 @@
                                 },
                                 "nativeDataType": "ARRAY(INTEGER())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(INTEGER())\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1750,7 +1739,7 @@
                         "customProperties": {
                             "numfiles": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206399"
+                            "transient_lastddltime": "1746463136"
                         },
                         "name": "struct_test_view_materialized",
                         "tags": []
@@ -1798,8 +1787,7 @@
                                 },
                                 "nativeDataType": "ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1811,8 +1799,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1828,8 +1815,7 @@
                                 },
                                 "nativeDataType": "ARRAY(INTEGER())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(INTEGER())\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -2004,7 +1990,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206390"
+                            "transient_lastddltime": "1746463130"
                         },
                         "name": "_test_table_underscore",
                         "tags": []
@@ -2227,7 +2213,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206400"
+                            "transient_lastddltime": "1746463137"
                         },
                         "name": "union_test",
                         "tags": []
@@ -2263,8 +2249,7 @@
                                 },
                                 "nativeDataType": "ROW([('tag', SMALLINT()), ('field0', INTEGER()), ('field1', DOUBLE()), ('field2', ARRAY(VARCHAR())), ('field3', ROW([('a', INTEGER()), ('b', VARCHAR())]))])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('tag', SMALLINT()), ('field0', INTEGER()), ('field1', DOUBLE()), ('field2', ARRAY(VARCHAR())), ('field3', ROW([('a', INTEGER()), ('b', VARCHAR())]))])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=int].tag",
@@ -2276,8 +2261,7 @@
                                 },
                                 "nativeDataType": "SMALLINT()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"SMALLINT()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=int].field0",
@@ -2289,8 +2273,7 @@
                                 },
                                 "nativeDataType": "INTEGER()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"INTEGER()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=double].field1",
@@ -2302,8 +2285,7 @@
                                 },
                                 "nativeDataType": "DOUBLE()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"DOUBLE()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=array].[type=string].field2",
@@ -2319,8 +2301,7 @@
                                 },
                                 "nativeDataType": "ARRAY(VARCHAR())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(VARCHAR())\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=struct].field3",
@@ -2332,8 +2313,7 @@
                                 },
                                 "nativeDataType": "ROW([('a', INTEGER()), ('b', VARCHAR())])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('a', INTEGER()), ('b', VARCHAR())])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=struct].field3.[type=int].a",
@@ -2345,8 +2325,7 @@
                                 },
                                 "nativeDataType": "INTEGER()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"INTEGER()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=struct].field3.[type=string].b",
@@ -2358,8 +2337,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -2529,7 +2507,7 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "transient_lastddltime": "1735206400",
+                            "transient_lastddltime": "1746463137",
                             "is_view": "True",
                             "view_definition": "SELECT \"property_id\", \"service\"\nFROM \"db1\".\"array_struct_test\""
                         },
@@ -2583,8 +2561,7 @@
                                 },
                                 "nativeDataType": "ARRAY(ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))]))",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))]))\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -2596,8 +2573,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -2613,8 +2589,7 @@
                                 },
                                 "nativeDataType": "ARRAY(INTEGER())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(INTEGER())\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -2811,6 +2786,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "SELECT\n  \"property_id\",\n  \"service\"\nFROM \"db1\".\"array_struct_test\"",
                 "language": "SQL"

--- a/metadata-ingestion/tests/integration/trino/trino_hive_mces_golden.json
+++ b/metadata-ingestion/tests/integration/trino/trino_hive_mces_golden.json
@@ -233,7 +233,7 @@
                             "numrows": "1",
                             "rawdatasize": "32",
                             "totalsize": "33",
-                            "transient_lastddltime": "1735206396"
+                            "transient_lastddltime": "1746463134"
                         },
                         "name": "array_struct_test",
                         "description": "This table has array of structs",
@@ -288,8 +288,7 @@
                                 },
                                 "nativeDataType": "ARRAY(ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))]))",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))]))\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -301,8 +300,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -318,8 +316,7 @@
                                 },
                                 "nativeDataType": "ARRAY(INTEGER())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(INTEGER())\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -473,7 +470,7 @@
                             "numrows": "3",
                             "rawdatasize": "94",
                             "totalsize": "97",
-                            "transient_lastddltime": "1735206403"
+                            "transient_lastddltime": "1746463139"
                         },
                         "name": "classification_test",
                         "tags": []
@@ -755,7 +752,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206400"
+                            "transient_lastddltime": "1746463137"
                         },
                         "name": "map_test",
                         "tags": []
@@ -807,7 +804,7 @@
                                 "nativeDataType": "MAP(INTEGER(), VARCHAR())",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"MAP(INTEGER(), VARCHAR())\", \"key_type\": {\"type\": \"int\", \"native_data_type\": \"INTEGER()\", \"_nullable\": true}, \"key_native_data_type\": \"INTEGER()\"}"
+                                "jsonProps": "{\"key_type\": {\"type\": \"int\", \"native_data_type\": \"INTEGER()\", \"_nullable\": true}, \"key_native_data_type\": \"INTEGER()\"}"
                             }
                         ]
                     }
@@ -961,7 +958,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206400"
+                            "transient_lastddltime": "1746463137"
                         },
                         "name": "nested_struct_test",
                         "tags": []
@@ -1009,8 +1006,7 @@
                                 },
                                 "nativeDataType": "ROW([('type', VARCHAR()), ('provider', ROW([('name', VARCHAR(length=50)), ('id', SMALLINT())]))])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('type', VARCHAR()), ('provider', ROW([('name', VARCHAR(length=50)), ('id', SMALLINT())]))])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1022,8 +1018,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider",
@@ -1035,8 +1030,7 @@
                                 },
                                 "nativeDataType": "ROW([('name', VARCHAR(length=50)), ('id', SMALLINT())])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('name', VARCHAR(length=50)), ('id', SMALLINT())])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=string].name",
@@ -1048,8 +1042,7 @@
                                 },
                                 "nativeDataType": "VARCHAR(length=50)",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR(length=50)\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=struct].provider.[type=int].id",
@@ -1061,8 +1054,7 @@
                                 },
                                 "nativeDataType": "SMALLINT()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"SMALLINT()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1211,7 +1203,7 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "transient_lastddltime": "1735206384"
+                            "transient_lastddltime": "1746463127"
                         },
                         "name": "pokes",
                         "tags": []
@@ -1425,7 +1417,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206390"
+                            "transient_lastddltime": "1746463130"
                         },
                         "name": "struct_test",
                         "tags": []
@@ -1473,8 +1465,7 @@
                                 },
                                 "nativeDataType": "ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1486,8 +1477,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1503,8 +1493,7 @@
                                 },
                                 "nativeDataType": "ARRAY(INTEGER())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(INTEGER())\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1655,7 +1644,7 @@
                         "customProperties": {
                             "numfiles": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206399"
+                            "transient_lastddltime": "1746463136"
                         },
                         "name": "struct_test_view_materialized",
                         "tags": []
@@ -1703,8 +1692,7 @@
                                 },
                                 "nativeDataType": "ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=string].type",
@@ -1716,8 +1704,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].service.[type=array].[type=int].provider",
@@ -1733,8 +1720,7 @@
                                 },
                                 "nativeDataType": "ARRAY(INTEGER())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(INTEGER())\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -1888,7 +1874,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206390"
+                            "transient_lastddltime": "1746463130"
                         },
                         "name": "_test_table_underscore",
                         "tags": []
@@ -2090,7 +2076,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1735206400"
+                            "transient_lastddltime": "1746463137"
                         },
                         "name": "union_test",
                         "tags": []
@@ -2126,8 +2112,7 @@
                                 },
                                 "nativeDataType": "ROW([('tag', SMALLINT()), ('field0', INTEGER()), ('field1', DOUBLE()), ('field2', ARRAY(VARCHAR())), ('field3', ROW([('a', INTEGER()), ('b', VARCHAR())]))])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('tag', SMALLINT()), ('field0', INTEGER()), ('field1', DOUBLE()), ('field2', ARRAY(VARCHAR())), ('field3', ROW([('a', INTEGER()), ('b', VARCHAR())]))])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=int].tag",
@@ -2139,8 +2124,7 @@
                                 },
                                 "nativeDataType": "SMALLINT()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"SMALLINT()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=int].field0",
@@ -2152,8 +2136,7 @@
                                 },
                                 "nativeDataType": "INTEGER()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"INTEGER()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=double].field1",
@@ -2165,8 +2148,7 @@
                                 },
                                 "nativeDataType": "DOUBLE()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"DOUBLE()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=array].[type=string].field2",
@@ -2182,8 +2164,7 @@
                                 },
                                 "nativeDataType": "ARRAY(VARCHAR())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(VARCHAR())\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=struct].field3",
@@ -2195,8 +2176,7 @@
                                 },
                                 "nativeDataType": "ROW([('a', INTEGER()), ('b', VARCHAR())])",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ROW([('a', INTEGER()), ('b', VARCHAR())])\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=struct].field3.[type=int].a",
@@ -2208,8 +2188,7 @@
                                 },
                                 "nativeDataType": "INTEGER()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"INTEGER()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=struct].foo.[type=struct].field3.[type=string].b",
@@ -2221,8 +2200,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -2371,7 +2349,7 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "transient_lastddltime": "1735206400",
+                            "transient_lastddltime": "1746463137",
                             "is_view": "True",
                             "view_definition": "SELECT \"property_id\", \"service\"\nFROM \"db1\".\"array_struct_test\""
                         },
@@ -2425,8 +2403,7 @@
                                 },
                                 "nativeDataType": "ARRAY(ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))]))",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(ROW([('type', VARCHAR()), ('provider', ARRAY(INTEGER()))]))\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=string].type",
@@ -2438,8 +2415,7 @@
                                 },
                                 "nativeDataType": "VARCHAR()",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"VARCHAR()\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].service.[type=array].[type=int].provider",
@@ -2455,8 +2431,7 @@
                                 },
                                 "nativeDataType": "ARRAY(INTEGER())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(INTEGER())\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -2632,6 +2607,7 @@
     "aspectName": "queryProperties",
     "aspect": {
         "json": {
+            "customProperties": {},
             "statement": {
                 "value": "SELECT\n  \"property_id\",\n  \"service\"\nFROM \"db1\".\"array_struct_test\"",
                 "language": "SQL"

--- a/metadata-ingestion/tests/integration/trino/trino_mces_golden.json
+++ b/metadata-ingestion/tests/integration/trino/trino_mces_golden.json
@@ -91,6 +91,22 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:2d206e03e435f48a5b8bacf444bf565c",
     "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:ad9f7c5e0d4bf83d6278f62271c28761"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1632398400000,
+        "runId": "trino-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:2d206e03e435f48a5b8bacf444bf565c",
+    "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
         "json": {
@@ -152,22 +168,6 @@
             "typeNames": [
                 "Schema"
             ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1632398400000,
-        "runId": "trino-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:2d206e03e435f48a5b8bacf444bf565c",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:ad9f7c5e0d4bf83d6278f62271c28761"
         }
     },
     "systemMetadata": {
@@ -324,8 +324,7 @@
                                 },
                                 "nativeDataType": "ARRAY(INTEGER())",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"ARRAY(INTEGER())\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/integration/unity/unity_catalog_mces_golden.json
+++ b/metadata-ingestion/tests/integration/unity/unity_catalog_mces_golden.json
@@ -384,8 +384,7 @@
                     },
                     "nativeDataType": "struct<combinationref:bigint,currentodds:double,eachway:boolean,livebetting:boolean,odds:double,outcomes:array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>,payout:double,rewardextrapayout:double,stake:double>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"struct<combinationref:bigint,currentodds:double,eachway:boolean,livebetting:boolean,odds:double,outcomes:array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>,payout:double,rewardextrapayout:double,stake:double>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=long].combinationref",
@@ -397,8 +396,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].currentodds",
@@ -410,8 +408,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=boolean].eachway",
@@ -423,8 +420,7 @@
                     },
                     "nativeDataType": "boolean",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"boolean\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=boolean].livebetting",
@@ -436,8 +432,7 @@
                     },
                     "nativeDataType": "boolean",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"boolean\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].odds",
@@ -449,8 +444,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes",
@@ -466,8 +460,7 @@
                     },
                     "nativeDataType": "array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].betoffertypeid",
@@ -479,8 +472,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].criterionid",
@@ -492,8 +484,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].criterionname",
@@ -505,8 +496,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=double].currentodds",
@@ -518,8 +508,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].eventgroupid",
@@ -531,8 +520,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=struct].eventgrouppath",
@@ -548,8 +536,7 @@
                     },
                     "nativeDataType": "array<struct<id:bigint,name:string>>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"array<struct<id:bigint,name:string>>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=struct].eventgrouppath.[type=long].id",
@@ -561,8 +548,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=struct].eventgrouppath.[type=string].name",
@@ -574,8 +560,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].eventid",
@@ -587,8 +572,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].eventname",
@@ -600,8 +584,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].eventstartdate",
@@ -613,8 +596,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=boolean].live",
@@ -626,8 +608,7 @@
                     },
                     "nativeDataType": "boolean",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"boolean\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=double].odds",
@@ -639,8 +620,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=long].outcomeids",
@@ -656,8 +636,7 @@
                     },
                     "nativeDataType": "array<bigint>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"array<bigint>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].outcomelabel",
@@ -669,8 +648,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].sportid",
@@ -682,8 +660,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].status",
@@ -695,8 +672,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].voidreason",
@@ -708,8 +684,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].payout",
@@ -721,8 +696,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].rewardextrapayout",
@@ -734,8 +708,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].stake",
@@ -747,8 +720,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 }
             ]
         }
@@ -756,7 +728,8 @@
     "systemMetadata": {
         "lastObserved": 1638860400000,
         "runId": "unity-catalog-test",
-        "lastRunId": "no-run-id-provided"
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-test-pipeline"
     }
 },
 {
@@ -895,8 +868,7 @@
                     },
                     "nativeDataType": "struct<combinationref:bigint,currentodds:double,eachway:boolean,livebetting:boolean,odds:double,outcomes:array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>,payout:double,rewardextrapayout:double,stake:double>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"struct<combinationref:bigint,currentodds:double,eachway:boolean,livebetting:boolean,odds:double,outcomes:array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>,payout:double,rewardextrapayout:double,stake:double>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=long].combinationref",
@@ -908,8 +880,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].currentodds",
@@ -921,8 +892,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=boolean].eachway",
@@ -934,8 +904,7 @@
                     },
                     "nativeDataType": "boolean",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"boolean\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=boolean].livebetting",
@@ -947,8 +916,7 @@
                     },
                     "nativeDataType": "boolean",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"boolean\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].odds",
@@ -960,8 +928,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes",
@@ -977,8 +944,7 @@
                     },
                     "nativeDataType": "array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].betoffertypeid",
@@ -990,8 +956,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].criterionid",
@@ -1003,8 +968,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].criterionname",
@@ -1016,8 +980,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=double].currentodds",
@@ -1029,8 +992,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].eventgroupid",
@@ -1042,8 +1004,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=struct].eventgrouppath",
@@ -1059,8 +1020,7 @@
                     },
                     "nativeDataType": "array<struct<id:bigint,name:string>>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"array<struct<id:bigint,name:string>>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=struct].eventgrouppath.[type=long].id",
@@ -1072,8 +1032,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=struct].eventgrouppath.[type=string].name",
@@ -1085,8 +1044,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].eventid",
@@ -1098,8 +1056,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].eventname",
@@ -1111,8 +1068,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].eventstartdate",
@@ -1124,8 +1080,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=boolean].live",
@@ -1137,8 +1092,7 @@
                     },
                     "nativeDataType": "boolean",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"boolean\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=double].odds",
@@ -1150,8 +1104,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=long].outcomeids",
@@ -1167,8 +1120,7 @@
                     },
                     "nativeDataType": "array<bigint>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"array<bigint>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].outcomelabel",
@@ -1180,8 +1132,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].sportid",
@@ -1193,8 +1144,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].status",
@@ -1206,8 +1156,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].voidreason",
@@ -1219,8 +1168,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].payout",
@@ -1232,8 +1180,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].rewardextrapayout",
@@ -1245,8 +1192,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].stake",
@@ -1258,8 +1204,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 }
             ]
         }
@@ -1267,7 +1212,8 @@
     "systemMetadata": {
         "lastObserved": 1638860400000,
         "runId": "unity-catalog-test",
-        "lastRunId": "no-run-id-provided"
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-test-pipeline"
     }
 },
 {
@@ -1821,8 +1767,7 @@
                     },
                     "nativeDataType": "struct<combinationref:bigint,currentodds:double,eachway:boolean,livebetting:boolean,odds:double,outcomes:array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>,payout:double,rewardextrapayout:double,stake:double>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"struct<combinationref:bigint,currentodds:double,eachway:boolean,livebetting:boolean,odds:double,outcomes:array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>,payout:double,rewardextrapayout:double,stake:double>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=long].combinationref",
@@ -1834,8 +1779,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].currentodds",
@@ -1847,8 +1791,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=boolean].eachway",
@@ -1860,8 +1803,7 @@
                     },
                     "nativeDataType": "boolean",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"boolean\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=boolean].livebetting",
@@ -1873,8 +1815,7 @@
                     },
                     "nativeDataType": "boolean",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"boolean\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].odds",
@@ -1886,8 +1827,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes",
@@ -1903,8 +1843,7 @@
                     },
                     "nativeDataType": "array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"array<struct<betoffertypeid:bigint,criterionid:bigint,criterionname:string,currentodds:double,eventgroupid:bigint,eventgrouppath:array<struct<id:bigint,name:string>>,eventid:bigint,eventname:string,eventstartdate:string,live:boolean,odds:double,outcomeids:array<bigint>,outcomelabel:string,sportid:string,status:string,voidreason:string>>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].betoffertypeid",
@@ -1916,8 +1855,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].criterionid",
@@ -1929,8 +1867,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].criterionname",
@@ -1942,8 +1879,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=double].currentodds",
@@ -1955,8 +1891,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].eventgroupid",
@@ -1968,8 +1903,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=struct].eventgrouppath",
@@ -1985,8 +1919,7 @@
                     },
                     "nativeDataType": "array<struct<id:bigint,name:string>>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"array<struct<id:bigint,name:string>>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=struct].eventgrouppath.[type=long].id",
@@ -1998,8 +1931,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=struct].eventgrouppath.[type=string].name",
@@ -2011,8 +1943,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=long].eventid",
@@ -2024,8 +1955,7 @@
                     },
                     "nativeDataType": "bigint",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"bigint\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].eventname",
@@ -2037,8 +1967,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].eventstartdate",
@@ -2050,8 +1979,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=boolean].live",
@@ -2063,8 +1991,7 @@
                     },
                     "nativeDataType": "boolean",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"boolean\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=double].odds",
@@ -2076,8 +2003,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=array].[type=long].outcomeids",
@@ -2093,8 +2019,7 @@
                     },
                     "nativeDataType": "array<bigint>",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"array<bigint>\"}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].outcomelabel",
@@ -2106,8 +2031,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].sportid",
@@ -2119,8 +2043,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].status",
@@ -2132,8 +2055,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=array].[type=struct].outcomes.[type=string].voidreason",
@@ -2145,8 +2067,7 @@
                     },
                     "nativeDataType": "string",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].payout",
@@ -2158,8 +2079,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].rewardextrapayout",
@@ -2171,8 +2091,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 },
                 {
                     "fieldPath": "[version=2.0].[type=struct].[type=struct].combination.[type=double].stake",
@@ -2184,8 +2103,7 @@
                     },
                     "nativeDataType": "double",
                     "recursive": false,
-                    "isPartOfKey": false,
-                    "jsonProps": "{\"native_data_type\": \"double\", \"_nullable\": true}"
+                    "isPartOfKey": false
                 }
             ]
         }
@@ -2193,7 +2111,8 @@
     "systemMetadata": {
         "lastObserved": 1638860400000,
         "runId": "unity-catalog-test",
-        "lastRunId": "no-run-id-provided"
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-test-pipeline"
     }
 },
 {

--- a/metadata-ingestion/tests/unit/glue/glue_deleted_actor_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_deleted_actor_mces_golden.json
@@ -18,7 +18,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -35,7 +35,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -52,7 +52,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -71,7 +71,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -88,7 +88,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -165,8 +165,7 @@
                                 },
                                 "nativeDataType": "array<struct<name:string,position:array<double>,location:array<double>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<name:string,position:array<double>,location:array<double>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=string].name",
@@ -178,8 +177,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].position",
@@ -195,8 +193,7 @@
                                 },
                                 "nativeDataType": "array<double>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].location",
@@ -212,8 +209,7 @@
                                 },
                                 "nativeDataType": "array<double>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -243,7 +239,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -262,7 +258,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -279,7 +275,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -301,7 +297,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -374,8 +370,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].quarter",
@@ -387,8 +382,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].month",
@@ -400,8 +394,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].dayofmonth",
@@ -413,8 +406,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
@@ -426,8 +418,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -457,7 +448,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -476,7 +467,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -493,7 +484,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -515,24 +506,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
-        "lastRunId": "no-run-id-provided",
-        "pipelineName": "statefulpipeline"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": true
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }
@@ -549,7 +523,24 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "glue-2020_04_14-07_00_00",
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "statefulpipeline"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": true
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "glue-2020_04_14-07_00_00-p9t9ts",
         "lastRunId": "no-run-id-provided",
         "pipelineName": "statefulpipeline"
     }

--- a/metadata-ingestion/tests/unit/glue/glue_delta_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_delta_mces_golden.json
@@ -19,7 +19,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1744091634014,
+        "lastObserved": 1746455647690,
         "runId": "glue-source-tes",
         "lastRunId": "no-run-id-provided"
     }
@@ -35,7 +35,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1744091634014,
+        "lastObserved": 1746455647690,
         "runId": "glue-source-tes",
         "lastRunId": "no-run-id-provided"
     }
@@ -52,7 +52,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1744091634014,
+        "lastObserved": 1746455647690,
         "runId": "glue-source-tes",
         "lastRunId": "no-run-id-provided"
     }
@@ -70,7 +70,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1744091634014,
+        "lastObserved": 1746455647690,
         "runId": "glue-source-tes",
         "lastRunId": "no-run-id-provided"
     }
@@ -91,7 +91,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1744091634014,
+        "lastObserved": 1746455647690,
         "runId": "glue-source-tes",
         "lastRunId": "no-run-id-provided"
     }
@@ -151,8 +151,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].page_type_txt",
@@ -164,8 +163,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].clsfd_pltfrm_id",
@@ -177,8 +175,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].clsfd_dvic_id",
@@ -190,8 +187,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].ga_vstr_id",
@@ -203,8 +199,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].src_ad_id",
@@ -216,8 +211,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_ad_id",
@@ -229,8 +223,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_user_id",
@@ -242,8 +235,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].src_categ_id",
@@ -255,8 +247,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].clsfd_categ_ref_id",
@@ -268,8 +259,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].clsfd_geo_ref_id",
@@ -281,8 +271,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].src_loc_id",
@@ -294,8 +283,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_region_name",
@@ -307,8 +295,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_cntry_name",
@@ -320,8 +307,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_city_name",
@@ -333,8 +319,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].ga_prfl_id",
@@ -346,8 +331,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].clsfd_ga_prfl_name",
@@ -359,8 +343,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].ga_vst_id",
@@ -372,8 +355,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].app_vrsn_txt",
@@ -385,8 +367,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].chnl_group",
@@ -398,8 +379,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].clsfd_trffc_chnl_name",
@@ -411,8 +391,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].vst_mdm_txt",
@@ -424,8 +403,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].vst_src_txt",
@@ -437,8 +415,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].vst_src_cmpgn_code",
@@ -450,8 +427,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].vst_src_cmpgn_txt",
@@ -463,8 +439,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].vst_src_cntnt_txt",
@@ -476,8 +451,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].vst_src_ad_kywrd_txt",
@@ -489,8 +463,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_vst_drtn_num",
@@ -502,8 +475,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].home_page_txt",
@@ -515,8 +487,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].session_start_time_num",
@@ -528,8 +499,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].brwsr_name",
@@ -541,8 +511,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].brwsr_vrsn_txt",
@@ -554,8 +523,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].clsfd_is_user_login_flag",
@@ -567,8 +535,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].lang_code",
@@ -580,8 +547,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].clsfd_is_direct_flag",
@@ -593,8 +559,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].os_vrsn_txt",
@@ -606,8 +571,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].os_name",
@@ -619,8 +583,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].host_name",
@@ -632,8 +595,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].vst_src_is_direct_flag",
@@ -645,8 +607,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].clsfd_is_session_flag",
@@ -658,8 +619,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].app_id",
@@ -671,8 +631,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].encypted_user_id",
@@ -684,8 +643,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].decypted_user_id",
@@ -697,8 +655,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].encrptd_email",
@@ -710,8 +667,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].page_path_txt",
@@ -723,8 +679,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].scrn_name",
@@ -736,8 +691,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].socl_engmnt_type",
@@ -749,8 +703,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].vst_src_path_txt",
@@ -762,8 +715,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].adword_user_id",
@@ -775,8 +727,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].adword_cmpgn_id",
@@ -788,8 +739,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].adword_adgroup_id",
@@ -801,8 +751,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].adword_crtv_id",
@@ -814,8 +763,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].adword_criteria_id",
@@ -827,8 +775,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].adword_criteria_param_txt",
@@ -840,8 +787,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].adword_page_num",
@@ -853,8 +799,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].adword_slot_txt",
@@ -866,8 +811,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].adword_click_id",
@@ -879,8 +823,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].adword_ntwrk_type",
@@ -892,8 +835,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].adword_is_videoad_flag",
@@ -905,8 +847,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].adword_criteria_boomuserlist_id",
@@ -918,8 +859,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].brwsr_size_txt",
@@ -931,8 +871,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].mbl_dvic_brand_name",
@@ -944,8 +883,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].mbl_dvic_model_name",
@@ -957,8 +895,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].mbl_input_slctr_name",
@@ -970,8 +907,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].mbl_dvic_info_txt",
@@ -983,8 +919,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].mbl_dvic_mkt_name",
@@ -996,8 +931,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flash_vrsn_txt",
@@ -1009,8 +943,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].is_java_enabled_flag",
@@ -1022,8 +955,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].scrn_color_txt",
@@ -1035,8 +967,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].scrn_rsln_txt",
@@ -1048,8 +979,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_cntint_name",
@@ -1061,8 +991,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_subcntint_name",
@@ -1074,8 +1003,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_metro_name",
@@ -1087,8 +1015,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_city_id",
@@ -1100,8 +1027,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_ntwrk_dmn_name",
@@ -1113,8 +1039,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_ltitd",
@@ -1126,8 +1051,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_lngtd",
@@ -1139,8 +1063,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].geo_ntwrk_loc_name",
@@ -1152,8 +1075,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].session_ab_test_group_txt",
@@ -1165,8 +1087,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_vst_cnt",
@@ -1178,8 +1099,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_new_vstr_cnt",
@@ -1191,8 +1111,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_vst_num",
@@ -1204,8 +1123,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_hit_cnt",
@@ -1217,8 +1135,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_pv_cnt",
@@ -1230,8 +1147,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_srp_pv_cnt",
@@ -1243,8 +1159,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_unq_srp_pv_cnt",
@@ -1256,8 +1171,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_vip_pv_cnt",
@@ -1269,8 +1183,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_unq_vip_pv_cnt",
@@ -1282,8 +1195,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_scrn_view_cnt",
@@ -1295,8 +1207,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_uniq_scrn_view_cnt",
@@ -1308,8 +1219,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_scrn_drtn_num",
@@ -1321,8 +1231,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_bnc_cnt",
@@ -1334,8 +1243,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_trxn_cnt",
@@ -1347,8 +1255,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=long].clsfd_trxn_rev_amt",
@@ -1360,8 +1267,7 @@
                                 },
                                 "nativeDataType": "long",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"long\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].ga_session_list_array",
@@ -1377,8 +1283,7 @@
                                 },
                                 "nativeDataType": "array<struct<clsfd_session_id:string,clsfd_sum_dt:date>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<clsfd_session_id:string,clsfd_sum_dt:date>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].ga_session_list_array.[type=string].clsfd_session_id",
@@ -1390,8 +1295,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].ga_session_list_array.[type=int].clsfd_sum_dt",
@@ -1404,7 +1308,7 @@
                                 "nativeDataType": "date",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"logicalType\": \"date\", \"native_data_type\": \"date\", \"_nullable\": true}"
+                                "jsonProps": "{\"logicalType\": \"date\"}"
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=null].sess_cd",
@@ -1416,8 +1320,7 @@
                                 },
                                 "nativeDataType": "",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=null].lp_hit_cd",
@@ -1429,8 +1332,7 @@
                                 },
                                 "nativeDataType": "",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=null].ext_map",
@@ -1442,8 +1344,7 @@
                                 },
                                 "nativeDataType": "",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].clsfd_cntry_name",
@@ -1455,8 +1356,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].cre_date",
@@ -1469,7 +1369,7 @@
                                 "nativeDataType": "date",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"logicalType\": \"date\", \"native_data_type\": \"date\", \"_nullable\": true}"
+                                "jsonProps": "{\"logicalType\": \"date\"}"
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].cre_user",
@@ -1481,8 +1381,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].upd_date",
@@ -1495,7 +1394,7 @@
                                 "nativeDataType": "date",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"logicalType\": \"date\", \"native_data_type\": \"date\", \"_nullable\": true}"
+                                "jsonProps": "{\"logicalType\": \"date\"}"
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].upd_user",
@@ -1507,8 +1406,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].clsfd_site_id",
@@ -1520,8 +1418,7 @@
                                 },
                                 "nativeDataType": "integer",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"integer\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].ecg_session_start_dt",
@@ -1534,7 +1431,7 @@
                                 "nativeDataType": "date",
                                 "recursive": false,
                                 "isPartOfKey": false,
-                                "jsonProps": "{\"logicalType\": \"date\", \"native_data_type\": \"date\", \"_nullable\": true}"
+                                "jsonProps": "{\"logicalType\": \"date\"}"
                             }
                         ]
                     }
@@ -1564,7 +1461,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1744091634026,
+        "lastObserved": 1746455647704,
         "runId": "glue-source-tes",
         "lastRunId": "no-run-id-provided"
     }
@@ -1582,7 +1479,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1744091634026,
+        "lastObserved": 1746455647704,
         "runId": "glue-source-tes",
         "lastRunId": "no-run-id-provided"
     }
@@ -1598,7 +1495,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1744091634026,
+        "lastObserved": 1746455647704,
         "runId": "glue-source-tes",
         "lastRunId": "no-run-id-provided"
     }
@@ -1623,7 +1520,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1744091634027,
+        "lastObserved": 1746455647704,
         "runId": "glue-source-tes",
         "lastRunId": "no-run-id-provided"
     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
@@ -342,8 +342,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightdate",
@@ -355,8 +354,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].uniquecarrier",
@@ -368,8 +366,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].airlineid",
@@ -381,8 +378,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].carrier",
@@ -394,8 +390,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightnum",
@@ -407,8 +402,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].origin",
@@ -420,8 +414,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
@@ -434,8 +427,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -608,8 +600,7 @@
                                 },
                                 "nativeDataType": "array<struct<name:string,position:array<double>,location:array<double>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<name:string,position:array<double>,location:array<double>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=string].name",
@@ -621,8 +612,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].position",
@@ -638,8 +628,7 @@
                                 },
                                 "nativeDataType": "array<double>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].location",
@@ -655,8 +644,7 @@
                                 },
                                 "nativeDataType": "array<double>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -825,8 +813,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].quarter",
@@ -838,8 +825,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].month",
@@ -851,8 +837,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].dayofmonth",
@@ -864,8 +849,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
@@ -877,8 +861,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden_profiling.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden_profiling.json
@@ -162,8 +162,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightdate",
@@ -175,8 +174,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].uniquecarrier",
@@ -188,8 +186,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].airlineid",
@@ -201,8 +198,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].carrier",
@@ -214,8 +210,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightnum",
@@ -227,8 +222,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].origin",
@@ -240,8 +234,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden_table_column_lineage.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden_table_column_lineage.json
@@ -162,8 +162,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightdate",
@@ -175,8 +174,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].uniquecarrier",
@@ -188,8 +186,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].airlineid",
@@ -201,8 +198,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].carrier",
@@ -214,8 +210,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightnum",
@@ -227,8 +222,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].origin",
@@ -240,8 +234,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
@@ -254,8 +247,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden_table_lineage.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden_table_lineage.json
@@ -342,8 +342,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightdate",
@@ -355,8 +354,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].uniquecarrier",
@@ -368,8 +366,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].airlineid",
@@ -381,8 +378,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].carrier",
@@ -394,8 +390,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightnum",
@@ -407,8 +402,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].origin",
@@ -420,8 +414,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
@@ -434,8 +427,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -633,8 +625,7 @@
                                 },
                                 "nativeDataType": "array<struct<name:string,position:array<double>,location:array<double>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<name:string,position:array<double>,location:array<double>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=string].name",
@@ -646,8 +637,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].position",
@@ -663,8 +653,7 @@
                                 },
                                 "nativeDataType": "array<double>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].location",
@@ -680,8 +669,7 @@
                                 },
                                 "nativeDataType": "array<double>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -875,8 +863,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].quarter",
@@ -888,8 +875,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].month",
@@ -901,8 +887,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].dayofmonth",
@@ -914,8 +899,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
@@ -927,8 +911,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
@@ -363,8 +363,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightdate",
@@ -376,8 +375,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].uniquecarrier",
@@ -389,8 +387,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].airlineid",
@@ -402,8 +399,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].carrier",
@@ -415,8 +411,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].flightnum",
@@ -428,8 +423,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].origin",
@@ -441,8 +435,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
@@ -455,8 +448,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -634,8 +626,7 @@
                                 },
                                 "nativeDataType": "array<struct<name:string,position:array<double>,location:array<double>>>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<name:string,position:array<double>,location:array<double>>>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=string].name",
@@ -647,8 +638,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].position",
@@ -664,8 +654,7 @@
                                 },
                                 "nativeDataType": "array<double>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].location",
@@ -681,8 +670,7 @@
                                 },
                                 "nativeDataType": "array<double>",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                "isPartOfKey": false
                             }
                         ]
                     }
@@ -856,8 +844,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].quarter",
@@ -869,8 +856,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].month",
@@ -882,8 +868,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=int].dayofmonth",
@@ -895,8 +880,7 @@
                                 },
                                 "nativeDataType": "int",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
@@ -908,8 +892,7 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                "isPartOfKey": false
                             }
                         ]
                     }


### PR DESCRIPTION
`native_data_type` and `nullable` information are already stored in the dedicated fields of `schemaMetadata` aspect - by skipping adding them, redundantly, to `jsonProps` field, we avoid exceeding maximum allowed payload size (16 million bytes) too early - it is still possible of course, but more fields will be included in the trimmed aspect.
