### PR TITLE
fix(snowflake): fixes view pattern if case sensitive

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
@@ -59,6 +59,7 @@ from datahub.ingestion.source.snowflake.snowflake_utils import (
     SnowflakeIdentifierBuilder,
     SnowflakeStructuredReportMixin,
     SnowsightUrlBuilder,
+    combine_identifier_parts,
     split_qualified_name,
 )
 from datahub.ingestion.source.sql.sql_utils import (
@@ -606,13 +607,15 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
         try:
             views: List[SnowflakeView] = []
             for view in self.get_views_for_schema(schema_name, db_name):
-                view_name = self.identifiers.get_dataset_identifier(
-                    view.name, schema_name, db_name
+                view_name = combine_identifier_parts(
+                    table_name=view.name, schema_name=schema_name, db_name=db_name
                 )
 
                 self.report.report_entity_scanned(view_name, "view")
 
-                if not self.filters.filter_config.view_pattern.allowed(view_name):
+                if not self.filters.is_dataset_pattern_allowed(
+                    dataset_name=view_name, dataset_type=SnowflakeObjectDomain.VIEW
+                ):
                     self.report.report_dropped(view_name)
                 else:
                     views.append(view)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -188,9 +188,7 @@ class SnowflakeFilter:
         return self.filter_config.procedure_pattern.allowed(procedure_name)
 
 
-def _combine_identifier_parts(
-    *, table_name: str, schema_name: str, db_name: str
-) -> str:
+def combine_identifier_parts(*, table_name: str, schema_name: str, db_name: str) -> str:
     return f"{db_name}.{schema_name}.{table_name}"
 
 
@@ -257,7 +255,7 @@ def _cleanup_qualified_name(
                 context=f"{qualified_name} has {len(name_parts)} parts",
             )
         return qualified_name.replace('"', "")
-    return _combine_identifier_parts(
+    return combine_identifier_parts(
         db_name=name_parts[0],
         schema_name=name_parts[1],
         table_name=name_parts[2],
@@ -285,7 +283,7 @@ class SnowflakeIdentifierBuilder:
         self, table_name: str, schema_name: str, db_name: str
     ) -> str:
         return self.snowflake_identifier(
-            _combine_identifier_parts(
+            combine_identifier_parts(
                 table_name=table_name, schema_name=schema_name, db_name=db_name
             )
         )


### PR DESCRIPTION
We were using `self.identifiers.get_dataset_identifier` when checking allow/deny filter patterns. The issue with that approach is that the mapping function lowercases the view name when `convert_urns_to_lowercase=True`.

This only becomes a problem when `ignoreCase=False` (which is not the default), so it's not critical — but still worth addressing.

The fix is to use `combine_identifier_parts` instead, which preserves the original casing. Additionally, since the `SnowflakeFilter` class is already centralizing all filtering logic, the code was refactored to go through that class instead.

