### PR TITLE
fix(ui): Return default navbar state when there is no local storage value set

### DIFF
--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarContext.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarContext.tsx
@@ -22,7 +22,9 @@ export type LocalState = {
  * Loads a persisted object from the local browser storage.
  */
 const loadLocalState = () => {
-    return JSON.parse(localStorage.getItem(LOCAL_STATE_KEY) || '{}') as LocalState;
+    return JSON.parse(
+        localStorage.getItem(LOCAL_STATE_KEY) || `{"state" : ${NavBarStateType.Collapsed}}`,
+    ) as LocalState;
 };
 
 /**

--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarContext.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavBarContext.tsx
@@ -23,7 +23,7 @@ export type LocalState = {
  */
 const loadLocalState = () => {
     return JSON.parse(
-        localStorage.getItem(LOCAL_STATE_KEY) || `{"state" : ${NavBarStateType.Collapsed}}`,
+        localStorage.getItem(LOCAL_STATE_KEY) || `{"state" : "${NavBarStateType.Collapsed}"}`,
     ) as LocalState;
 };
 


### PR DESCRIPTION
On a fresh browser, when there is no local state variable, the initial state is set to { } which makes the isCollapsed false, and the navbar open up by default where it shouldn't be.
Two solutions to fix this:
- Either the isCollapsed variable needs to handle empty object properly
- Or don't allow empty object at all, as it's different from the available states. 

Did the latter to fix the issue.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
