### PR TITLE
updated search menu items after search update

### DIFF
--- a/datahub-web-react/src/app/sharedV2/search/SearchMenuItems.tsx
+++ b/datahub-web-react/src/app/sharedV2/search/SearchMenuItems.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 
 import DownloadAsCsvModal from '@app/entityV2/shared/components/styled/search/DownloadAsCsvModal';
 import { DownloadSearchResults, DownloadSearchResultsInput } from '@app/searchV2/utils/types';
@@ -6,6 +7,12 @@ import DownloadButton from '@app/sharedV2/search/DownloadButton';
 import EditButton from '@app/sharedV2/search/EditButton';
 
 import { AndFilterInput } from '@types';
+
+const ButtonContainer = styled.div`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+`;
 
 type Props = {
     filters: AndFilterInput[];
@@ -31,12 +38,16 @@ export default function SearchMenuItems({
 
     return (
         <>
-            <DownloadButton
-                disabled={totalResultsIsZero}
-                isDownloadingCsv={isDownloadingCsv}
-                setShowDownloadAsCsvModal={setShowDownloadAsCsvModal}
-            />
-            {setShowSelectMode && <EditButton setShowSelectMode={setShowSelectMode} disabled={totalResultsIsZero} />}
+            <ButtonContainer>
+                <DownloadButton
+                    disabled={totalResultsIsZero}
+                    isDownloadingCsv={isDownloadingCsv}
+                    setShowDownloadAsCsvModal={setShowDownloadAsCsvModal}
+                />
+                {setShowSelectMode && (
+                    <EditButton setShowSelectMode={setShowSelectMode} disabled={totalResultsIsZero} />
+                )}
+            </ButtonContainer>
             <DownloadAsCsvModal
                 downloadSearchResults={downloadSearchResults}
                 filters={filters}


### PR DESCRIPTION
- minor update after search results page 
- added 8px gap 
Before: 
<img width="199" alt="Screenshot 2025-05-05 at 11 54 58 AM" src="https://github.com/user-attachments/assets/faaeaacf-6272-4ae0-afce-ebf8bdf8e023" />
<img width="1796" alt="Screenshot 2025-05-05 at 11 55 02 AM" src="https://github.com/user-attachments/assets/2d0a2bed-2359-4b40-b693-73e82c164636" />

After
<img width="1840" alt="Screenshot 2025-05-05 at 11 54 45 AM" src="https://github.com/user-attachments/assets/0ff149c4-f120-41f1-a5ed-bd6896696a15" />


<img width="189" alt="Screenshot 2025-05-05 at 11 54 51 AM" src="https://github.com/user-attachments/assets/c8ee7d5b-9b6d-4a18-bf3f-88e9d9f8a10f" />
<img width="419" alt="Screenshot 2025-05-05 at 11 54 48 AM" src="https://github.com/user-attachments/assets/0877167d-3301-4081-b60d-07847a627031" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
