### PR TITLE
fix(build): fix version in jars

### DIFF
--- a/gradle/versioning/versioning-global.gradle
+++ b/gradle/versioning/versioning-global.gradle
@@ -22,6 +22,9 @@ import groovy.json.JsonBuilder
 def detailedVersionString = "0.0.0-unknown-SNAPSHOT"
 def cliMajorVersion = "0.15.0" // base default cli major version
 def snapshotVersion = false
+
+// This is the version field that had a slightly different implementation for embedding in jars.
+// metadata-integration/java/versioning.gradle reads javaVersion as version.
 def javaVersion = ""
 
 // Used to tag docker images. If the project property tag is set, use it as is (posssibly add suffixes like slim, pythonVersion if applicable). 
@@ -32,6 +35,7 @@ def versionTag = ""
 if (project.hasProperty("releaseVersion")) {
   version = releaseVersion
   detailedVersionString = releaseVersion
+  javaVersion = version
 } else {
   try {
       // apply this plugin in a try-catch block so that we can handle cases without .git directory


### PR DESCRIPTION
There were multiple versioning.gradle build scripts, one in metadata-integration/java -- used for within the subprojects in that folder and one at the gradle/versioning used everywhere else. 
Both these have some logic to compute a version from git examining the labels and git status. 
The `javaVersion` stores the result from the implementation that used to exist in metadata-integration/java  and `version`  is the result of the implementation used everywhere else. 

Over time, CI computed versions directly via .github/scripts/docker_helpers.sh and the schemes used by CI to tag images based on this version and that computed by versioning.gradle diverged. 

Part of making build script consistent with CI versioning is to just use releaseVersion and tag if passed by CI as is, and go through all this computation only if nothing was passed -- more for local builds. 
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
