### PR TITLE
fix(docker): Fix for metadata ingestion docker build

### DIFF
--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -140,7 +140,9 @@ RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_u
 
 FROM add-code AS install-slim
 
+# zstd needs to be pinned because the latest version causes issues on arm
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000 \
+    UV_LINK_MODE=copy uv pip install "zstd<1.5.6.8" && \
     UV_LINK_MODE=copy uv pip install -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,snowflake,bigquery,redshift,mysql,postgres,hive,clickhouse,glue,dbt,looker,lookml,tableau,powerbi,superset,datahub-business-glossary]" && \
     datahub --version
 

--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -140,8 +140,6 @@ RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_u
 
 FROM add-code AS install-slim
 
-RUN cat /metadata-ingestion/setup.py
-# zstd needs to be pinned because the latest version causes issues on arm
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000 \
     UV_LINK_MODE=copy uv pip install -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,snowflake,bigquery,redshift,mysql,postgres,hive,clickhouse,glue,dbt,looker,lookml,tableau,powerbi,superset,datahub-business-glossary]" && \
     datahub --version

--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -140,9 +140,9 @@ RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_u
 
 FROM add-code AS install-slim
 
+RUN cat /metadata-ingestion/setup.py
 # zstd needs to be pinned because the latest version causes issues on arm
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000 \
-    UV_LINK_MODE=copy uv pip install "zstd<1.5.6.8" && \
     UV_LINK_MODE=copy uv pip install -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,snowflake,bigquery,redshift,mysql,postgres,hive,clickhouse,glue,dbt,looker,lookml,tableau,powerbi,superset,datahub-business-glossary]" && \
     datahub --version
 

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -208,6 +208,8 @@ clickhouse_common = {
     # Clickhouse 0.2.0 adds support for SQLAlchemy 1.4.x
     # Disallow 0.2.5 because of https://github.com/xzkostyan/clickhouse-sqlalchemy/issues/272.
     # Note that there's also a known issue around nested map types: https://github.com/xzkostyan/clickhouse-sqlalchemy/issues/269.
+    # zstd needs to be pinned because the latest version causes issues on arm
+    "zstd<1.5.6.8",
     "clickhouse-sqlalchemy>=0.2.0,<0.2.5",
 }
 


### PR DESCRIPTION
In the metadata-ingestion docker image, we install Clickhouse, which depends on the zstd package.
With the latest zstd package we got:

```
      [stderr]
      /home/datahub/.cache/uv/builds-v0/.tmpFGjFmE/lib/python3.10/site-packages/setuptools/_distutils/dist.py:289:
      UserWarning: Unknown distribution option: 'test_suite'
        warnings.warn(msg)
      error: command 'aarch64-linux-gnu-gcc' failed: No such file or directory

      hint: This usually indicates a problem with the package or the build environment.
  help: `zstd` (v1.5.7.0) was included because `clickhouse-sqlalchemy` (v0.2.4) depends on `asynch` (v0.3.0)
        which depends on `zstd`
```

This pr pins zstd to the latest working version.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
