### PR TITLE
fix(cli): ignore extra configs

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/config.py
@@ -17,8 +17,6 @@ DATAHUB_COMPONENT_ENV: str = os.getenv("DATAHUB_COMPONENT", "datahub").lower()
 class DatahubClientConfig(ConfigModel):
     """Configuration class for holding connectivity to datahub gms"""
 
-    # TODO: Having a default for the server doesn't make a ton of sense. This should be handled
-    # by callers / the CLI, but the actual client should not have any magic.
     server: str
     token: Optional[str] = None
     timeout_sec: Optional[float] = None
@@ -31,3 +29,6 @@ class DatahubClientConfig(ConfigModel):
     openapi_ingestion: Optional[bool] = None
     client_mode: Optional[ClientMode] = None
     datahub_component: Optional[str] = None
+
+    class Config:
+        extra = "ignore"


### PR DESCRIPTION
Without this if someone upgrades to a new CLI and then downgrades to older CLI and tries to read `~/.datahubenv` it will fail with 
```
Error loading your ~/.datahubenv
3 validation errors for DatahubConfig
gms -> client_mode
  extra fields not permitted (type=value_error.extra)
gms -> datahub_component
  extra fields not permitted (type=value_error.extra)
gms -> openapi_ingestion
  extra fields not permitted (type=value_error.extra)
```

This can easily happen in case of multiple `venv` containing different versions of the CLI

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
