### PR TITLE
feat(UI): funnel subtype for dataflows and datajobs all the way to the UI

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataflow/DataFlowType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataflow/DataFlowType.java
@@ -78,6 +78,7 @@ public class DataFlowType
           DATA_PRODUCTS_ASPECT_NAME,
           BROWSE_PATHS_V2_ASPECT_NAME,
           STRUCTURED_PROPERTIES_ASPECT_NAME,
+          SUB_TYPES_ASPECT_NAME,
           FORMS_ASPECT_NAME);
   private static final Set<String> FACET_FIELDS = ImmutableSet.of("orchestrator", "cluster");
   private final EntityClient _entityClient;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataflow/mappers/DataFlowMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataflow/mappers/DataFlowMapper.java
@@ -12,6 +12,7 @@ import com.linkedin.common.GlossaryTerms;
 import com.linkedin.common.InstitutionalMemory;
 import com.linkedin.common.Ownership;
 import com.linkedin.common.Status;
+import com.linkedin.common.SubTypes;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataMap;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -30,6 +31,7 @@ import com.linkedin.datahub.graphql.types.common.mappers.DeprecationMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.SubTypesMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.SystemMetadataUtils;
 import com.linkedin.datahub.graphql.types.domain.DomainAssociationMapper;
@@ -122,6 +124,10 @@ public class DataFlowMapper implements ModelMapper<EntityResponse, DataFlow> {
         FORMS_ASPECT_NAME,
         ((entity, dataMap) ->
             entity.setForms(FormsMapper.map(new Forms(dataMap), entityUrn.toString()))));
+    mappingHelper.mapToResult(
+        SUB_TYPES_ASPECT_NAME,
+        (entity, dataMap) ->
+            entity.setSubTypes(SubTypesMapper.map(context, new SubTypes(dataMap))));
 
     if (context != null && !canView(context.getOperationContext(), entityUrn)) {
       return AuthorizationUtils.restrictEntity(mappingHelper.getResult(), DataFlow.class);

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -6534,6 +6534,11 @@ type DataFlow implements EntityWithRelationships & Entity & BrowsableEntity {
   Privileges given to a user relevant to this entity
   """
   privileges: EntityPrivileges
+
+  """
+  Sub Types that this entity implements
+  """
+  subTypes: SubTypes
 }
 
 """

--- a/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
@@ -179,7 +179,6 @@ export class DataFlowEntity implements Entity<DataFlow> {
 
     renderPreview = (previewType: PreviewType, data: DataFlow) => {
         const genericProperties = this.getGenericEntityProperties(data);
-        console.log('data', data);
         return (
             <Preview
                 urn={data.urn}

--- a/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
@@ -179,6 +179,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
 
     renderPreview = (previewType: PreviewType, data: DataFlow) => {
         const genericProperties = this.getGenericEntityProperties(data);
+        console.log('data', data);
         return (
             <Preview
                 urn={data.urn}
@@ -196,6 +197,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
                 externalUrl={data.properties?.externalUrl}
                 headerDropdownItems={headerDropdownItems}
                 previewType={previewType}
+                subTypes={genericProperties?.subTypes}
             />
         );
     };
@@ -227,6 +229,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
                 isOutputPort={isOutputPort(result)}
                 headerDropdownItems={headerDropdownItems}
                 parentContainers={data.parentContainers}
+                subTypes={genericProperties?.subTypes}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/dataFlow/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/preview/Preview.tsx
@@ -19,7 +19,13 @@ import {
     Owner,
     ParentContainersResult,
     SearchInsight,
-} from '@types';
+    SubTypes,
+} from '../../../../types.generated';
+import DefaultPreviewCard from '../../../previewV2/DefaultPreviewCard';
+import { useEntityRegistry } from '../../../useEntityRegistry';
+import { IconStyleType, PreviewType } from '../../Entity';
+import { ANTD_GRAY } from '../../shared/constants';
+import { EntityMenuItems } from '../../shared/EntityDropdown/EntityMenuActions';
 
 const StatText = styled(Typography.Text)`
     color: ${ANTD_GRAY[8]};
@@ -48,6 +54,7 @@ export const Preview = ({
     headerDropdownItems,
     previewType,
     parentContainers,
+    subTypes,
 }: {
     urn: string;
     data: GenericEntityProperties | null;
@@ -71,8 +78,10 @@ export const Preview = ({
     headerDropdownItems?: Set<EntityMenuItems>;
     previewType?: PreviewType;
     parentContainers?: ParentContainersResult | null;
+    subTypes?: SubTypes | null;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
+    console.log('subTypes', subTypes);
     return (
         <DefaultPreviewCard
             url={entityRegistry.getEntityUrl(EntityType.DataFlow, urn)}
@@ -107,6 +116,7 @@ export const Preview = ({
             headerDropdownItems={headerDropdownItems}
             previewType={previewType}
             parentEntities={parentContainers?.containers}
+            type={subTypes?.typeNames?.[0]}
         />
     );
 };

--- a/datahub-web-react/src/app/entityV2/dataFlow/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/preview/Preview.tsx
@@ -20,12 +20,7 @@ import {
     ParentContainersResult,
     SearchInsight,
     SubTypes,
-} from '../../../../types.generated';
-import DefaultPreviewCard from '../../../previewV2/DefaultPreviewCard';
-import { useEntityRegistry } from '../../../useEntityRegistry';
-import { IconStyleType, PreviewType } from '../../Entity';
-import { ANTD_GRAY } from '../../shared/constants';
-import { EntityMenuItems } from '../../shared/EntityDropdown/EntityMenuActions';
+} from '@types';
 
 const StatText = styled(Typography.Text)`
     color: ${ANTD_GRAY[8]};
@@ -81,7 +76,6 @@ export const Preview = ({
     subTypes?: SubTypes | null;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
-    console.log('subTypes', subTypes);
     return (
         <DefaultPreviewCard
             url={entityRegistry.getEntityUrl(EntityType.DataFlow, urn)}

--- a/datahub-web-react/src/graphql/dataFlow.graphql
+++ b/datahub-web-react/src/graphql/dataFlow.graphql
@@ -62,6 +62,9 @@ fragment dataFlowFields on DataFlow {
     activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
         total
     }
+    subTypes {
+        typeNames
+    }
 }
 
 query getDataFlow($urn: String!) {

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -494,6 +494,9 @@ fragment nonRecursiveDataFlowFields on DataFlow {
     deprecation {
         ...deprecationFields
     }
+    subTypes {
+        typeNames
+    }
 }
 
 fragment nonRecursiveDataJobFields on DataJob {

--- a/datahub-web-react/src/graphql/preview.graphql
+++ b/datahub-web-react/src/graphql/preview.graphql
@@ -195,6 +195,9 @@ fragment entityPreview on Entity {
         health {
             ...entityHealth
         }
+        subTypes {
+            typeNames
+        }
     }
     ... on DataJob {
         urn

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -171,6 +171,9 @@ fragment autoCompleteFields on Entity {
         parentContainers {
             ...parentContainersFields
         }
+        subTypes {
+            typeNames
+        }
     }
     ... on DataJob {
         dataFlow {
@@ -191,6 +194,9 @@ fragment autoCompleteFields on Entity {
         }
         parentContainers {
             ...parentContainersFields
+        }
+        subTypes {
+            typeNames
         }
     }
     ... on GlossaryTerm {
@@ -769,6 +775,9 @@ fragment searchResultsWithoutSchemaField on Entity {
             properties {
                 ...structuredPropertiesFields
             }
+        }
+        subTypes {
+            typeNames
         }
     }
     ... on DataJob {


### PR DESCRIPTION
Subtypes is supported in the metadata model for dataflows and datajobs. However, there were a few issues,

1. Java code was missing to bring that forward for DataFlows
2. Javascript code was missing to bring that forward for DataFlows and DataJobs.


![CleanShot 2025-05-07 at 17 46 33@2x](https://github.com/user-attachments/assets/88c1a581-7dcf-458d-bd30-51dd58be68fa)
