### PR TITLE
fix(ui): enable to edit tag when properties aspect was not present

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
@@ -138,11 +138,11 @@ public class DescriptionUtils {
                 entityService,
                 null);
     if (tagProperties == null) {
-      // If there are no properties for the tag already, then we should throw since the properties
-      // model also requires a name.
-      throw new IllegalArgumentException("Properties for this Tag do not yet exist!");
+      tagProperties =
+          new TagProperties().setName(resourceUrn.getId()).setDescription(newDescription);
+    } else {
+      tagProperties.setDescription(newDescription);
     }
-    tagProperties.setDescription(newDescription);
     persistAspect(
         opContext,
         resourceUrn,


### PR DESCRIPTION
Tested locally and the UI works

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
