### PR TITLE
tests(smoke): removes non existing `mix_stderr` param in `CliRunner`

### DIFF
--- a/smoke-test/tests/cli/dataset_cmd/test_dataset_command.py
+++ b/smoke-test/tests/cli/dataset_cmd/test_dataset_command.py
@@ -24,7 +24,7 @@ dataset_id = f"test_dataset_sync_{start_index}"
 dataset_urn = make_dataset_urn("snowflake", dataset_id)
 
 sleep_sec, sleep_times = get_sleep_info()
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 @pytest.fixture(scope="module")

--- a/smoke-test/tests/cli/delete_cmd/test_timeseries_delete.py
+++ b/smoke-test/tests/cli/delete_cmd/test_timeseries_delete.py
@@ -24,7 +24,7 @@ test_dataset_urn: str = builder.make_dataset_urn_with_platform_instance(
     "TEST",
 )
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 def sync_elastic() -> None:

--- a/smoke-test/tests/cli/ingest_cmd/test_timeseries_rollback.py
+++ b/smoke-test/tests/cli/ingest_cmd/test_timeseries_rollback.py
@@ -9,7 +9,7 @@ from datahub.entrypoints import datahub
 from datahub.metadata.schema_classes import DatasetProfileClass
 from tests.utils import ingest_file_via_rest, wait_for_writes_to_sync
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 def sync_elastic() -> None:

--- a/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
@@ -11,7 +11,7 @@ from datahub.entrypoints import datahub
 from datahub.ingestion.graph.client import DataHubGraph
 from tests.utils import wait_for_writes_to_sync
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 def sync_elastic() -> None:

--- a/smoke-test/tests/cli/user_groups_cmd/test_user_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_user_cmd.py
@@ -11,7 +11,7 @@ from datahub.api.entities.corpuser.corpuser import CorpUser
 from datahub.entrypoints import datahub
 from tests.consistency_utils import wait_for_writes_to_sync
 
-runner = CliRunner(mix_stderr=False)
+runner = CliRunner()
 
 
 def datahub_upsert_user(auth_session, user: CorpUser) -> None:


### PR DESCRIPTION
`click` 8.2.0 was just released (May 10th, 2025) https://github.com/pallets/click/blob/main/CHANGES.rst#version-820 and removes `mix_stderr` param

> Keep stdout and stderr streams independent in CliRunner. Always collect stderr output and never raise an exception. Add a new output stream to simulate what the user sees in its terminal. Removes the mix_stderr parameter in CliRunner. [:issue:`2522`](https://github.com/pallets/click/blob/main/CHANGES.rst#id29) [:pr:`2523`](https://github.com/pallets/click/blob/main/CHANGES.rst#id31)