### PR TITLE
fix(ingest/presto): Presto/Trino property extraction fix

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/presto.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/presto.py
@@ -114,3 +114,17 @@ class PrestoSource(TrinoSource):
     def create(cls, config_dict, ctx):
         config = PrestoConfig.parse_obj(config_dict)
         return cls(config, ctx)
+
+# Unfortunately, the Presto dialect provide catalog_name as a column
+# therefore we we need some workaround to not fail.
+# This is a workaround to not fail which casuses to only get the table comment as property which is still better than to fail.
+@functools.lru_cache
+def gen_catalog_connector_dict(engine: Engine) -> Dict[str, str]:
+    query = dedent(
+        """
+        SELECT *
+        FROM "system"."metadata"."catalogs"
+        """
+    ).strip()
+    res = engine.execute(sql.text(query))
+    return {row.catalog_name: "" for row in res}

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/presto.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/presto.py
@@ -1,10 +1,12 @@
+import functools
 from textwrap import dedent
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic.fields import Field
 from pyhive.sqlalchemy_presto import PrestoDialect
 from sqlalchemy import exc, sql
 from sqlalchemy.engine import reflection
+from sqlalchemy.engine.base import Engine
 
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
@@ -114,6 +116,7 @@ class PrestoSource(TrinoSource):
     def create(cls, config_dict, ctx):
         config = PrestoConfig.parse_obj(config_dict)
         return cls(config, ctx)
+
 
 # Unfortunately, the Presto dialect provide catalog_name as a column
 # therefore we we need some workaround to not fail.

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
@@ -134,19 +134,40 @@ def get_table_comment(self, connection, table_name: str, schema: str = None, **k
         ):
             properties_table = self._get_full_table(f"{table_name}$properties", schema)
             query = f"SELECT * FROM {properties_table}"
-            row = connection.execute(sql.text(query)).fetchone()
+            rows = connection.execute(sql.text(query)).fetchall()
 
             # Generate properties dictionary.
             properties = {}
-            if row:
+
+            if len(rows) == 0:
+                # No properties found, return empty dictionary
+                return {}
+
+            # Check if using the old format (key, value columns)
+            if (
+                connector_name == "iceberg"
+                and len(rows[0]) == 2
+                and "key" in rows[0]
+                and "value" in rows[0]
+            ):
+                # Old format: multiple rows with key, value columns
+                for row in rows:
+                    if row["value"] is not None:
+                        properties[row["key"]] = row["value"]
+                return {"text": properties.get("comment"), "properties": properties}
+            elif connector_name == "hive" and len(rows[0]) > 1 and len(rows) == 1:
+                row = rows[0]
                 for col_name, col_value in row.items():
                     if col_value is not None:
                         properties[col_name] = col_value
+                return {"text": properties.get("comment"), "properties": properties}
 
-            return {"text": properties.get("comment"), "properties": properties}
-        else:
-            return self.get_table_comment_default(connection, table_name, schema)
-    except Exception:
+            # If we can't get the properties we still fallback to the default
+        return self.get_table_comment_default(connection, table_name, schema)
+    except Exception as e:
+        logging.warning(
+            f"Failed to get table comment for {table_name} in {schema}: {e}"
+        )
         return {}
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
@@ -150,12 +150,13 @@ def get_table_comment(self, connection, table_name: str, schema: str = None, **k
                 and "key" in rows[0]
                 and "value" in rows[0]
             ):
-                # Old format: multiple rows with key, value columns
+                #  https://trino.io/docs/current/connector/iceberg.html#properties-table
                 for row in rows:
                     if row["value"] is not None:
                         properties[row["key"]] = row["value"]
                 return {"text": properties.get("comment"), "properties": properties}
             elif connector_name == "hive" and len(rows[0]) > 1 and len(rows) == 1:
+                #https://trino.io/docs/current/connector/hive.html#properties-table
                 row = rows[0]
                 for col_name, col_value in row.items():
                     if col_value is not None:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
@@ -156,7 +156,7 @@ def get_table_comment(self, connection, table_name: str, schema: str = None, **k
                         properties[row["key"]] = row["value"]
                 return {"text": properties.get("comment"), "properties": properties}
             elif connector_name == "hive" and len(rows[0]) > 1 and len(rows) == 1:
-                #https://trino.io/docs/current/connector/hive.html#properties-table
+                # https://trino.io/docs/current/connector/hive.html#properties-table
                 row = rows[0]
                 for col_name, col_value in row.items():
                     if col_value is not None:


### PR DESCRIPTION
1. Workaround for Presto to not fail on missing system column
Unfortunately, the Presto dialect provides catalog_name as a column; therefore, we need a workaround to avoid failure.
This is a workaround not to fail, which causes only the table comment to be returned as a property, which is still better than failing.

2. Fix Trino property extraction from Iceberg tables

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
