### PR TITLE
feat(ingest): improve join extraction

### DIFF
--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_bigquery_information_schema_query.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_bigquery_information_schema_query.json
@@ -228,8 +228,8 @@
         {
             "join_type": "JOIN",
             "tables": [
-                "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)"
+                "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS,PROD)"
             ],
             "on_clause": "`cfp`.`table_name` = `c`.`table_name` AND `cfp`.`column_name` = `c`.`column_name`",
             "columns_involved": [

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_cross_join.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_cross_join.json
@@ -97,7 +97,17 @@
             }
         }
     ],
-    "joins": [],
+    "joins": [
+        {
+            "join_type": "CROSS JOIN",
+            "tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.my_table1,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.my_table2,PROD)"
+            ],
+            "on_clause": null,
+            "columns_involved": []
+        }
+    ],
     "debug_info": {
         "confidence": 0.9,
         "generalized_statement": "SELECT * FROM my_table1 CROSS JOIN my_table2"

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_lateral_join.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_lateral_join.json
@@ -75,7 +75,17 @@
             }
         }
     ],
-    "joins": [],
+    "joins": [
+        {
+            "join_type": "LATERAL JOIN",
+            "tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.my_table1,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.my_table2,PROD)"
+            ],
+            "on_clause": null,
+            "columns_involved": []
+        }
+    ],
     "debug_info": {
         "confidence": 0.9,
         "generalized_statement": "SELECT t1.id, t1.name, t2.value FROM my_table1 AS t1, LATERAL (SELECT value FROM my_table2 WHERE t1.id = my_table2.id LIMIT ?) AS t2"

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_natural_join.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_natural_join.json
@@ -75,7 +75,17 @@
             }
         }
     ],
-    "joins": [],
+    "joins": [
+        {
+            "join_type": "NATURAL JOIN",
+            "tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.my_table1,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.my_table2,PROD)"
+            ],
+            "on_clause": null,
+            "columns_involved": []
+        }
+    ],
     "debug_info": {
         "confidence": 0.9,
         "generalized_statement": "SELECT t1.id, t1.name, t2.value FROM my_table1 AS t1 NATURAL JOIN my_table2 AS t2"

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_postgres_select_subquery.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_postgres_select_subquery.json
@@ -79,8 +79,8 @@
         {
             "join_type": "LEFT JOIN",
             "tables": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.table2,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.table1,PROD)"
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.table1,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.table2,PROD)"
             ],
             "on_clause": "\"_u_0\".\"_u_1\" = \"table1\".\"id\"",
             "columns_involved": [

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_postgres_update_subselect.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_postgres_update_subselect.json
@@ -37,8 +37,8 @@
         {
             "join_type": "LEFT JOIN",
             "tables": [
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.employees,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.accounts,PROD)"
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.accounts,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:postgres,my_db.my_schema.employees,PROD)"
             ],
             "on_clause": "\"_u_0\".\"_u_1\" = \"accounts\".\"sales_person_id\"",
             "columns_involved": [

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_redshift_materialized_view_auto_refresh.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_redshift_materialized_view_auto_refresh.json
@@ -71,8 +71,8 @@
         {
             "join_type": "JOIN",
             "tables": [
-                "urn:li:dataset:(urn:li:dataPlatform:redshift,customer,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:redshift,orders,PROD)"
+                "urn:li:dataset:(urn:li:dataPlatform:redshift,orders,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:redshift,customer,PROD)"
             ],
             "on_clause": "\"c\".\"cust_id\" = \"o\".\"customer_id\"",
             "columns_involved": [

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_unused_cte.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_unused_cte.json
@@ -50,8 +50,8 @@
         {
             "join_type": "JOIN",
             "tables": [
-                "urn:li:dataset:(urn:li:dataPlatform:snowflake,table3,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:snowflake,table1,PROD)"
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,table1,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,table3,PROD)"
             ],
             "on_clause": "\"TABLE3\".\"COL5\" = \"CTE1\".\"COL2\"",
             "columns_involved": [

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_update_from_table.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_snowflake_update_from_table.json
@@ -82,6 +82,15 @@
                     "column": "ID"
                 }
             ]
+        },
+        {
+            "join_type": "JOIN",
+            "tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.table1,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_db.my_schema.my_table,PROD)"
+            ],
+            "on_clause": null,
+            "columns_involved": []
         }
     ],
     "debug_info": {

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_teradata_default_normalization.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_teradata_default_normalization.json
@@ -53,8 +53,8 @@
         {
             "join_type": "JOIN",
             "tables": [
-                "urn:li:dataset:(urn:li:dataPlatform:teradata,myteradata.demo_user.pima_patient_diagnoses,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:teradata,myteradata.demo_user.pima_patient_features,PROD)"
+                "urn:li:dataset:(urn:li:dataPlatform:teradata,myteradata.demo_user.pima_patient_features,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:teradata,myteradata.demo_user.pima_patient_diagnoses,PROD)"
             ],
             "on_clause": "\"ppd\".\"patientid\" = \"ppf\".\"patientid\"",
             "columns_involved": [

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -1406,7 +1406,6 @@ JOIN table_1_day_ago ON my_table.id = table_1_day_ago.id
 
 
 def test_cross_join() -> None:
-    # Because `cross join` does not have an `on` clause, we don't generate any joins.
     assert_sql_result(
         """\
 SELECT * FROM my_table1
@@ -1430,7 +1429,7 @@ CROSS JOIN my_table2
 
 
 def test_lateral_join() -> None:
-    # Because `lateral join` does not have an `on` clause, we don't generate any joins.
+    # We don't fully support extracting the columns involved in a lateral join.
     assert_sql_result(
         """\
 SELECT t1.id, t1.name, t2.value
@@ -1479,7 +1478,6 @@ RIGHT JOIN my_table2 t2 ON t1.id = t2.id
 
 
 def test_natural_join() -> None:
-    # Because `natural join` does not have an `on` clause, we don't generate any joins.
     assert_sql_result(
         """\
 SELECT t1.id, t1.name, t2.value


### PR DESCRIPTION
- Improve the ordering of the joined tables list to ensure the left-side tables appear before the right-side ones.
- Add support for joins that don't have an `on` clause e.g. cross join, natural join, lateral join.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
