### PR TITLE
fix(sdk): change deprecated value use

### DIFF
--- a/metadata-ingestion/src/datahub/api/graphql/base.py
+++ b/metadata-ingestion/src/datahub/api/graphql/base.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from gql import Client
 from gql.transport.requests import RequestsHTTPTransport
@@ -39,16 +39,18 @@ class BaseApi:
 
     def gen_filter(
         self, filters: Dict[str, Optional[str]]
-    ) -> Optional[Dict[str, List[Dict[str, str]]]]:
-        filter_expression: Optional[Dict[str, List[Dict[str, str]]]] = None
+    ) -> Optional[Dict[str, List[Dict[str, Union[str, List[str]]]]]]:
+        filter_expression: Optional[
+            Dict[str, List[Dict[str, Union[str, List[str]]]]]
+        ] = None
         if not filters:
             return None
 
-        filter = []
+        filter_list: List[Dict[str, Union[str, List[str]]]] = []
         for key, value in filters.items():
             if value is None:
                 continue
-            filter.append({"field": key, "values": [value]})
+            filter_list.append({"field": key, "values": [value]})
 
-        filter_expression = {"and": filter}
+        filter_expression = {"and": filter_list}
         return filter_expression

--- a/metadata-ingestion/src/datahub/api/graphql/base.py
+++ b/metadata-ingestion/src/datahub/api/graphql/base.py
@@ -48,7 +48,7 @@ class BaseApi:
         for key, value in filters.items():
             if value is None:
                 continue
-            filter.append({"field": key, "value": value})
+            filter.append({"field": key, "values": [value]})
 
         filter_expression = {"and": filter}
         return filter_expression

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -474,7 +474,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
         filter_criteria_map: Dict[str, str],
     ) -> Optional[Aspect]:
         filter_criteria = [
-            {"field": k, "value": v, "condition": "EQUAL"}
+            {"field": k, "values": [v], "condition": "EQUAL"}
             for k, v in filter_criteria_map.items()
         ]
         filter = {"or": [{"and": filter_criteria}]}
@@ -669,7 +669,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
         filter_criteria = [
             {
                 "field": "name",
-                "value": domain_name,
+                "values": [domain_name],
                 "condition": "EQUAL",
             }
         ]
@@ -789,7 +789,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
             filter_criteria.append(
                 {
                     "field": "customProperties",
-                    "value": f"instance={env}",
+                    "values": [f"instance={env}"],
                     "condition": "EQUAL",
                 }
             )
@@ -797,7 +797,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
             filter_criteria.append(
                 {
                     "field": "typeNames",
-                    "value": container_subtype,
+                    "values": [container_subtype],
                     "condition": "EQUAL",
                 }
             )

--- a/metadata-ingestion/src/datahub/ingestion/graph/filters.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/filters.py
@@ -168,7 +168,7 @@ def _get_env_filters(env: str) -> List[RawSearchFilterRule]:
         # For most entity types, we look at the origin field.
         {
             "field": "origin",
-            "value": env,
+            "values": [env],
             "condition": "EQUAL",
         },
         # For containers, we look at the customProperties field.
@@ -176,15 +176,15 @@ def _get_env_filters(env: str) -> List[RawSearchFilterRule]:
         # we look for the "env" property. Otherwise, we use the "instance" property.
         {
             "field": "customProperties",
-            "value": f"env={env}",
+            "values": [f"env={env}"],
         },
         {
             "field": "customProperties",
-            "value": f"instance={env}",
+            "values": [f"instance={env}"],
         },
         {
             "field": "env",
-            "value": env,
+            "values": [env],
         },
         # Note that not all entity types have an env (e.g. dashboards / charts).
         # If the env filter is specified, these will be excluded.


### PR DESCRIPTION
In our monitoring was seeing this error
```
Deprecated use of a filter using Criterion's `value` has been detected and corrected. Please migrate to `values` instead.
```

Changing a few places where I saw `value` in filter. I have not tested this locally. I am assuming that we have automated tests for these places. Will let CI tell me if I am wrong here.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
