### PR TITLE
fix(mcp-processor): prevent exception in mcp processor

### DIFF
--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeProposalsProcessor.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeProposalsProcessor.java
@@ -125,11 +125,9 @@ public class MetadataChangeProposalsProcessor {
                 if (log.isDebugEnabled()) {
                   log.debug("MetadataChangeProposal {}", event);
                 }
-                String urn = entityClient.ingestProposal(systemOperationContext, event, false);
-                if (urn == null) {
-                  throw new IllegalStateException("Failed to ingest MCP.");
-                }
-                log.info("Successfully processed MCP event urn: {}", urn);
+                entityClient.ingestProposal(systemOperationContext, event, false);
+
+                log.info("Successfully processed MCP event urn: {}", event.getEntityUrn());
               } catch (Throwable throwable) {
                 log.error("MCP Processor Error", throwable);
                 log.error("Message: {}", record);


### PR DESCRIPTION
This code path used to consider a `null` string as an exception case, however it can also represent a no-op case as well. While this interface (returns a string) is limited, the requirement to emit a failed mcp was moved to the other side of the interface for tracing at a stage where more detailed information is available. This is now handled [here](https://github.com/datahub-project/datahub/blob/master/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java#L897) in the `EntityServiceImpl`

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
