### PR TITLE
fix(docs): broken link in spark docs

### DIFF
--- a/metadata-integration/java/acryl-spark-lineage/README.md
+++ b/metadata-integration/java/acryl-spark-lineage/README.md
@@ -8,7 +8,7 @@ datasets that are being read from and written to. Read on to learn how to config
 ## Configuring Spark agent
 
 The Spark agent can be configured using a config file or while creating a Spark Session. If you are using Spark on
-Databricks, refer [Configuration Instructions for Databricks](#configuration-instructions--databricks).
+Databricks, refer to [Configuration Instructions for Databricks](#configuration-instructions-databricks).
 
 ### Before you begin: Versions and Release Notes
 


### PR DESCRIPTION
Extra dash in the url there

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
