### PR TITLE
build(quickstart): skip composeForceDownOnFailure for debug variants

### DIFF
--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -165,6 +165,7 @@ dockerCompose {
             buildBeforePull = false
             stopContainers = false
             removeVolumes = false
+            retainContainersOnStartupFailure = config.isDebug ? true: false //forcing nulls to bool
 
             // Apply common configuration
             common_config.each { key, value ->


### PR DESCRIPTION
For debug variants of quickstart, any container startup failure retains containers to help debug any failures. 
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
