### PR TITLE
build(ci): fix a gradle implicit dependency error

### DIFF
--- a/metadata-service/plugin/build.gradle
+++ b/metadata-service/plugin/build.gradle
@@ -38,6 +38,8 @@ test {
   systemProperty 'datahub.project.root.dir', "$rootDir" // used in security.policy
 }
 
+processTestResources.dependsOn(":metadata-service:plugin:src:test:sample-test-plugins:copyJar")
+
 clean {
   dependsOn ':metadata-service:plugin:src:test:sample-test-plugins:clean'
 }


### PR DESCRIPTION
Gradle was reporting an implicit dependency that can cause errors depending on the order of execution. This gradle error appears to be inconsistent -- but when it failed, it fails with 

```
A problem was found with the configuration of task ':metadata-service:plugin:processTestResources' (type 'ProcessResources').
  - Gradle detected a problem with the following location: '/home/runner/work/datahub/datahub/metadata-service/plugin/src/test/resources'.
    
    Reason: Task ':metadata-service:plugin:processTestResources' uses this output of task ':metadata-service:plugin:src:test:sample-test-plugins:copyJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':metadata-service:plugin:src:test:sample-test-plugins:copyJar' as an input of ':metadata-service:plugin:processTestResources'.
      2. Declare an explicit dependency on ':metadata-service:plugin:src:test:sample-test-plugins:copyJar' from ':metadata-service:plugin:processTestResources' using Task#dependsOn.
      3. Declare an explicit dependency on ':metadata-service:plugin:src:test:sample-test-plugins:copyJar' from ':metadata-service:plugin:processTestResources' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.11.1/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
