### PR TITLE
fix(graphql): Add default parameters to access token resolver

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/ListAccessTokensResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/ListAccessTokensResolver.java
@@ -32,6 +32,9 @@ public class ListAccessTokensResolver
 
   private static final String EXPIRES_AT_FIELD_NAME = "expiresAt";
 
+  private static final Integer DEFAULT_START = 0;
+  private static final Integer DEFAULT_COUNT = 20;
+
   private final EntityClient _entityClient;
 
   public ListAccessTokensResolver(final EntityClient entityClient) {
@@ -46,8 +49,8 @@ public class ListAccessTokensResolver
           final QueryContext context = environment.getContext();
           final ListAccessTokenInput input =
               bindArgument(environment.getArgument("input"), ListAccessTokenInput.class);
-          final Integer start = input.getStart();
-          final Integer count = input.getCount();
+          final Integer start = input.getStart() == null ? DEFAULT_START : input.getStart();
+          final Integer count = input.getCount() == null ? DEFAULT_COUNT : input.getCount();
           final List<FacetFilterInput> filters =
               input.getFilters() == null ? Collections.emptyList() : input.getFilters();
 

--- a/datahub-graphql-core/src/main/resources/auth.graphql
+++ b/datahub-graphql-core/src/main/resources/auth.graphql
@@ -157,17 +157,17 @@ Input arguments for listing access tokens
 """
 input ListAccessTokenInput {
   """
-  The starting offset of the result set
+  The starting offset of the result set, default is 0
   """
   start: Int
 
   """
-  The number of results to be returned
+  The number of results to be returned, default is 20
   """
   count: Int
 
   """
-  Facet filters to apply to search results
+  Facet filters to apply to search results, default is no filters
   """
   filters: [FacetFilterInput!]
 }


### PR DESCRIPTION
This is to bring the code in line with the graphQL schema definition.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
