### PR TITLE
fix(smoke-test): use full quickstart image instead of slim for spark tests

### DIFF
--- a/metadata-integration/java/spark-lineage-legacy/build.gradle
+++ b/metadata-integration/java/spark-lineage-legacy/build.gradle
@@ -150,7 +150,7 @@ assemble {
     dependsOn shadowJar
 }
 
-task integrationTest(type: Exec, dependsOn: [shadowJar, ':docker:quickstartSlim'] ) {
+task integrationTest(type: Exec, dependsOn: [shadowJar, ':docker:quickstart'] ) {
     environment "RUN_QUICKSTART", "false"
     commandLine "spark-smoke-test/smoke.sh"
 }


### PR DESCRIPTION

`:metadata-integration:java:spark-lineage:integrationTest` is currently failing due an attempt to use an unavailable docker image:

https://github.com/datahub-project/datahub/actions/runs/15010274145
```
Task :docker:quickstartSlimComposeUp FAILED
 opensearch Pulling 
 mysql Pulling 
 kafka-broker Pulling 
 datahub-actions-quickstart Error manifest for acryldata/datahub-ingestion:v1.1.0rc3-slim not found: manifest unknown: manifest unknown
 mysql Error manifest for acryldata/datahub-ingestion:v1.1.0rc3-slim not found: manifest unknown: manifest unknown
 opensearch Error manifest for acryldata/datahub-ingestion:v1.1.0rc3-slim not found: manifest unknown: manifest unknown
 kafka-broker Error manifest for acryldata/datahub-ingestion:v1.1.0rc3-slim not found: manifest unknown: manifest unknown
Error response from daemon: manifest for acryldata/datahub-ingestion:v1.1.0rc3-slim not found: manifest unknown: manifest unknown

FAILURE: Build failed with an exception.
```

Using the full quickstart docker image for this integration test solves the problem.



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
