### PR TITLE
fix(UI): Enforce required URL validation for Institutional Memory

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/AddLinkModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/AddLinkModal.tsx
@@ -90,7 +90,6 @@ export const AddLinkModal = ({ buttonProps, refetch }: AddLinkProps) => {
                             },
                             {
                                 type: 'url',
-                                warningOnly: true,
                                 message: 'This field must be a valid url.',
                             },
                         ]}

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/LinkList.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/LinkList.tsx
@@ -146,7 +146,6 @@ export const LinkList = ({ refetch }: LinkListProps) => {
                             },
                             {
                                 type: 'url',
-                                warningOnly: true,
                                 message: 'This field must be a valid url.',
                             },
                         ]}

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/AddLinkModal.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/AddLinkModal.tsx
@@ -116,7 +116,6 @@ export const AddLinkModal = ({ buttonProps, refetch, buttonType }: AddLinkProps)
                             },
                             {
                                 type: 'url',
-                                warningOnly: true,
                                 message: 'This field must be a valid url.',
                             },
                         ]}


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

# Recording of defect

https://github.com/user-attachments/assets/ef42ec9b-8510-408e-b038-0adc94185ce1

# Summary
Previously, setting `warningOnly: true` was causing the required URL validation to be skipped entirely. This PR updates the logic to ensure that validation for required fields is applied.

As a result of this fix:
- The required URL validation is now properly enforced.
- The corresponding error is displayed in the UI as expected.

