### PR TITLE
ci(publish): restore image publish on push to master

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -101,7 +101,7 @@ jobs:
         env:
           ENABLE_PUBLISH: >-
             ${{
-               (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'release' ) 
+               (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/master')) 
                && ( secrets.ACRYL_DOCKER_PASSWORD != '' )
             }}
         run: |


### PR DESCRIPTION
Restoring image publish on push to master branch
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
