### PR TITLE
fix(siblings): Fix siblings search to apply consistent ordering.

### DIFF
--- a/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
+++ b/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
@@ -2,14 +2,13 @@ import { CombinedEntity, createSiblingEntityCombiner } from '@app/entity/shared/
 
 import { Entity, EntityPath, MatchedField } from '@types';
 
-// Restore type hints for safety
 type MaybeEntityWithPlatform = Entity & { platform?: { name?: string }; urn?: string };
 type MaybeEntityWithSiblings = Entity & { platform?: { name?: string }; urn?: string } & {
     siblingsSearch?: { searchResults?: { entity?: MaybeEntityWithPlatform }[] };
 };
 
 type UncombinedSeaerchResults = {
-    entity: MaybeEntityWithSiblings; // Restore specific type
+    entity: MaybeEntityWithSiblings;
     matchedFields: Array<MatchedField>;
     paths?: EntityPath[];
 };
@@ -25,7 +24,6 @@ export function combineSiblingsInSearchResults(
     const combine = createSiblingEntityCombiner();
     const combinedSearchResults: Array<CombinedSearchResult> = [];
 
-    // Create a list of URNs from the original search results, preserving order
     const originalUrnList = searchResults.map((result) => result.entity.urn);
 
     searchResults.forEach((searchResult) => {
@@ -38,7 +36,7 @@ export function combineSiblingsInSearchResults(
         const isSiblingAheadInTheList =
             originalUrnList.indexOf(siblingUrn) < originalUrnList.indexOf(entityToProcess?.urn);
 
-        if (hasSiblingInList) {
+        if (hasSiblingInList && !showSeparateSiblings) {
             if (entityPlatform === 'dbt' && isSiblingAheadInTheList) {
                 // skip this- the snowflake will render
                 return;

--- a/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
+++ b/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
@@ -28,7 +28,9 @@ export function combineSiblingsInSearchResults(
 
     const originalUrnList = searchResults.map((result) => result.entity.urn);
 
-    // we need to apply this fix up because
+    // With usage propagation from snowflake to dbt, dbt and snowflake siblings do not rank
+    // consistently in search. in cases where they both show up in the same page, we should have
+    // the warehouse urn win for consistency.
     searchResults.forEach((searchResult) => {
         let entityToProcess = searchResult.entity;
 

--- a/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
+++ b/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
@@ -30,7 +30,6 @@ export function combineSiblingsInSearchResults(
         let entityToProcess = searchResult.entity;
 
         // Check if there is exactly one sibling search result and it's from snowflake
-        // @ts-ignore
         const siblingsSearch = entityToProcess?.siblingsSearch;
         const siblingEntity = siblingsSearch?.searchResults?.[0]?.entity;
 
@@ -39,7 +38,8 @@ export function combineSiblingsInSearchResults(
             siblingEntity && // Ensure sibling entity exists
             'platform' in siblingEntity && // Type guard: Check for platform property
             siblingEntity.platform?.name === 'snowflake' &&
-            siblingEntity.urn && originalUrns.has(siblingEntity.urn) // Check if snowflake sibling URN is in original results
+            siblingEntity.urn &&
+            originalUrns.has(siblingEntity.urn) // Check if snowflake sibling URN is in original results
         ) {
             // Use the snowflake sibling's URN
             entityToProcess = {

--- a/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
+++ b/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
@@ -20,9 +20,30 @@ export function combineSiblingsInSearchResults(
     const combinedSearchResults: Array<CombinedSearchResult> = [];
 
     searchResults.forEach((searchResult) => {
+        let entityToProcess = searchResult.entity;
+
+        // Check if there is exactly one sibling search result and it's from snowflake
+        // @ts-ignore
+        const siblingsSearch = entityToProcess?.siblingsSearch;
+        const siblingEntity = siblingsSearch?.searchResults?.[0]?.entity;
+
+        if (
+            siblingsSearch?.searchResults?.length === 1 &&
+            siblingEntity && // Ensure sibling entity exists
+            'platform' in siblingEntity && // Type guard: Check for platform property
+            siblingEntity.platform?.name === 'snowflake' &&
+            siblingEntity.urn // Ensure the sibling urn exists
+        ) {
+            // Use the snowflake sibling's URN
+            entityToProcess = {
+                ...entityToProcess,
+                urn: siblingEntity.urn,
+            };
+        }
+
         const combinedResult = showSeparateSiblings
-            ? { combinedEntity: searchResult.entity, skipped: false }
-            : combine(searchResult.entity);
+            ? { combinedEntity: entityToProcess, skipped: false }
+            : combine(entityToProcess);
         if (!combinedResult.skipped) {
             combinedSearchResults.push({
                 ...searchResult,


### PR DESCRIPTION
With the addition of usage propagation from the warehouse to dbt, we reached a point of non-determinism where dbt and warehouse results will somewhat arbitrarily be ahead of each other in search results. Currently, our search will link the user to whichever result happened to be ranked higher. Rather than leaving things up to chance, in cases where both show up on the same page, we are changing the logic to consistently link to the warehouse. This lines up with the behavior before we added usage propagation to dbt, which was that the warehous was consistently ranked higher.

Test plan:
- tested live
- added unit tests