### PR TITLE
ci(coverage): run coverage without ci-optimization on release and schedule

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Upload backend coverage to Codecov
         if: ${{  (matrix.command == 'except_metadata_ingestion' && needs.setup.outputs.backend_change == 'true' && github.event_name != 'release') }}
         uses: codecov/codecov-action@v5
-        with: &codecov-backend-params
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.BACKEND_FILES }}
           disable_search: true
@@ -151,13 +151,20 @@ jobs:
         if: ${{  (matrix.command == 'except_metadata_ingestion' && github.event_name == 'release' ) }}
         uses: codecov/codecov-action@v5
         with:
-          <<: *codecov-backend-params
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.BACKEND_FILES }}
+          disable_search: true
+          #handle_no_reports_found: true
+          fail_ci_if_error: false
+          flags: backend
+          name: ${{ matrix.command }}
+          verbose: true
           override_branch: ${{ github.head_ref || github.ref_name }}
 
       - name: Upload frontend coverage to Codecov
         if: ${{  (matrix.command == 'frontend' && needs.setup.outputs.frontend_change == 'true' && github.event_name != 'release') }}
         uses: codecov/codecov-action@v5
-        with: &codecov-frontend-params
+        with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.FRONTEND_FILES }}
           disable_search: true
@@ -171,7 +178,14 @@ jobs:
         if: ${{  (matrix.command == 'frontend' &&  github.event_name == 'release') }}
         uses: codecov/codecov-action@v5
         with:
-          <<: *codecov-frontend-params
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.FRONTEND_FILES }}
+          disable_search: true
+          #handle_no_reports_found: true
+          fail_ci_if_error: false
+          flags: frontend
+          name: ${{ matrix.command }}
+          verbose: true
           override_branch: ${{ github.head_ref || github.ref_name }}
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && github.event_name != 'release'  }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - "**"
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Run at midnight UTC every day
   release:
     types: [published]
 
@@ -134,9 +136,9 @@ jobs:
       - name: Ensure codegen is updated
         uses: ./.github/actions/ensure-codegen-updated
       - name: Upload backend coverage to Codecov
-        if: ${{  matrix.command == 'except_metadata_ingestion' && needs.setup.outputs.backend_change == 'true' }}
+        if: ${{  (matrix.command == 'except_metadata_ingestion' && needs.setup.outputs.backend_change == 'true' && github.event_name != 'release') }}
         uses: codecov/codecov-action@v5
-        with:
+        with: &codecov-backend-params
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.BACKEND_FILES }}
           disable_search: true
@@ -145,11 +147,17 @@ jobs:
           flags: backend
           name: ${{ matrix.command }}
           verbose: true
-          override_branch: ${{ github.head_ref || github.ref_name }}
-      - name: Upload frontend coverage to Codecov
-        if: ${{  matrix.command == 'frontend' && needs.setup.outputs.frontend_change == 'true' }}
+      - name: Upload backend coverage to Codecov on release
+        if: ${{  (matrix.command == 'except_metadata_ingestion' && github.event_name == 'release' ) }}
         uses: codecov/codecov-action@v5
         with:
+          <<: *codecov-backend-params
+          override_branch: ${{ github.head_ref || github.ref_name }}
+
+      - name: Upload frontend coverage to Codecov
+        if: ${{  (matrix.command == 'frontend' && needs.setup.outputs.frontend_change == 'true' && github.event_name != 'release') }}
+        uses: codecov/codecov-action@v5
+        with: &codecov-frontend-params
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.FRONTEND_FILES }}
           disable_search: true
@@ -158,9 +166,20 @@ jobs:
           flags: frontend
           name: ${{ matrix.command }}
           verbose: true
+
+      - name: Upload frontend coverage to Codecov on Release
+        if: ${{  (matrix.command == 'frontend' &&  github.event_name == 'release') }}
+        uses: codecov/codecov-action@v5
+        with:
+          <<: *codecov-frontend-params
           override_branch: ${{ github.head_ref || github.ref_name }}
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name != 'release'  }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov on release
+        if: ${{ !cancelled() && github.event_name == 'release'  }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
1. If a commit to master missed tests due to some failure, its coverage is not uploaded. A base branch having no coverage for a commit  (when there are changes) prevents  computation of patch coverage of all PRs using that base commit. Running on schedule helps restore base branch coverage at regular intervals.
2. On releases, branch is not auto-computed, so override_branch is required to upload codecoverage, however, use of override-branch causes codecov to think this is not a public repo and requires tokens. This breaks coverage for all PRs from forks.  So, use override-branch only when the trigger is release.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
