### PR TITLE
feat(web): display external assertion result links in run event view

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/shared/result/AssertionResultPopoverContent.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/shared/result/AssertionResultPopoverContent.tsx
@@ -207,6 +207,20 @@ export const AssertionResultPopoverContent = ({
                                       </div>
                                   ))}
                               </PlatformRow>,
+                              ...(result.externalUrl
+                                  ? [
+                                        <ThinDivider />,
+                                        <PlatformRow>
+                                            <a href={result.externalUrl} target="_blank" rel="noopener noreferrer">
+                                                View results in{' '}
+                                                {assertion.platform?.name &&
+                                                assertion.platform?.name.toLowerCase() !== 'unknown'
+                                                    ? assertion.platform?.name
+                                                    : 'source system.'}
+                                            </a>
+                                        </PlatformRow>,
+                                    ]
+                                  : []),
                           ]
                         : null}
                     {hasPlatform && (


### PR DESCRIPTION

<img width="376" alt="Screenshot 2025-05-21 at 2 05 23 PM" src="https://github.com/user-attachments/assets/189c1c00-ae0c-49f7-8c9b-7c965bda018d" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
