### PR TITLE
docs: update markdown_process_inline_directive to work with indentations

### DIFF
--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -416,8 +416,8 @@ function markdown_process_inline_directives(
   filepath: string
 ): void {
   const new_content = contents.content.replace(
-    /^{{\s+inline\s+(\S+)\s+(show_path_as_comment\s+)?\s*}}$/gm,
-    (_, inline_file_path: string, show_path_as_comment: string) => {
+    /^(\s*){{(\s*)inline(\s+)(\S+)(\s+)(show_path_as_comment\s+)?(\s*)}}$/gm,
+    (_, indent: string, __, ___, inline_file_path: string, ____, show_path_as_comment: string, _____) => {
       if (!inline_file_path.startsWith("/")) {
         throw new Error(`inline path must be absolute: ${inline_file_path}`);
       }
@@ -432,9 +432,13 @@ function markdown_process_inline_directives(
       // that can be used to limit the inlined content to a specific range of lines.
       let new_contents = "";
       if (show_path_as_comment) {
-        new_contents += `# Inlined from ${inline_file_path}\n`;
+        new_contents += `${indent}# Inlined from ${inline_file_path}\n`;
       }
-      new_contents += referenced_file;
+      // Split the referenced file into lines and add the indentation to each line
+      new_contents += referenced_file
+        .split('\n')
+        .map(line => `${indent}${line}`)
+        .join('\n');
 
       return new_contents;
     }

--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -417,7 +417,14 @@ function markdown_process_inline_directives(
 ): void {
   const new_content = contents.content.replace(
     /^(\s*){{(\s*)inline\s+(\S+)(\s+)(show_path_as_comment\s+)?(\s*)}}$/gm,
-    (_, indent, __, inline_file_path, ___, show_path_as_comment) => {
+    (
+      _,
+      indent: string,
+      __,
+      inline_file_path: string,
+      ___,
+      show_path_as_comment: string
+    ) => {
       if (!inline_file_path.startsWith("/")) {
         throw new Error(`inline path must be absolute: ${inline_file_path}`);
       }

--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -416,17 +416,8 @@ function markdown_process_inline_directives(
   filepath: string
 ): void {
   const new_content = contents.content.replace(
-    /^(\s*){{(\s*)inline(\s+)(\S+)(\s+)(show_path_as_comment\s+)?(\s*)}}$/gm,
-    (
-      _,
-      indent: string,
-      __,
-      ___,
-      inline_file_path: string,
-      ____,
-      show_path_as_comment: string,
-      _____
-    ) => {
+    /^(\s*){{(\s*)inline\s+(\S+)(\s+)(show_path_as_comment\s+)?(\s*)}}$/gm,
+    (_, indent, __, inline_file_path, ___, show_path_as_comment) => {
       if (!inline_file_path.startsWith("/")) {
         throw new Error(`inline path must be absolute: ${inline_file_path}`);
       }
@@ -443,7 +434,8 @@ function markdown_process_inline_directives(
       if (show_path_as_comment) {
         new_contents += `${indent}# Inlined from ${inline_file_path}\n`;
       }
-      // Split the referenced file into lines and add the indentation to each line
+
+      // Add indentation to each line of the referenced file
       new_contents += referenced_file
         .split("\n")
         .map((line) => `${indent}${line}`)

--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -417,7 +417,16 @@ function markdown_process_inline_directives(
 ): void {
   const new_content = contents.content.replace(
     /^(\s*){{(\s*)inline(\s+)(\S+)(\s+)(show_path_as_comment\s+)?(\s*)}}$/gm,
-    (_, indent: string, __, ___, inline_file_path: string, ____, show_path_as_comment: string, _____) => {
+    (
+      _,
+      indent: string,
+      __,
+      ___,
+      inline_file_path: string,
+      ____,
+      show_path_as_comment: string,
+      _____
+    ) => {
       if (!inline_file_path.startsWith("/")) {
         throw new Error(`inline path must be absolute: ${inline_file_path}`);
       }
@@ -436,9 +445,9 @@ function markdown_process_inline_directives(
       }
       // Split the referenced file into lines and add the indentation to each line
       new_contents += referenced_file
-        .split('\n')
-        .map(line => `${indent}${line}`)
-        .join('\n');
+        .split("\n")
+        .map((line) => `${indent}${line}`)
+        .join("\n");
 
       return new_contents;
     }


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->


fixing the rendering error for indented inline code blocks

## AS-IS

this code block with indentation

https://github.com/datahub-project/datahub/blob/a02d31c60402a915fdd81ed26dfe05716ae03de5/docs/lineage/dagster.md?plain=1#L37

breaks in docs site 
https://docs.datahub.com/docs/lineage/dagster#setup

## TO-BE

this looks like this now : https://docs-website-git-docs-fix-inline-render-acryldata.vercel.app/docs/lineage/dagster/#setup

existing inline code blocks (w/o indentation) works as well : https://docs-website-git-docs-fix-inline-render-acryldata.vercel.app/docs/dataproducts#creating-a-data-product-yaml--git