### PR TITLE
fix(forms) Remove schema field entities from form assignment entity types

### DIFF
--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/util/SearchBasedFormAssignmentManager.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/util/SearchBasedFormAssignmentManager.java
@@ -35,8 +35,7 @@ public class SearchBasedFormAssignmentManager {
           Constants.ML_FEATURE_TABLE_ENTITY_NAME,
           Constants.ML_FEATURE_ENTITY_NAME,
           Constants.ML_PRIMARY_KEY_ENTITY_NAME,
-          Constants.DATA_PRODUCT_ENTITY_NAME,
-          Constants.SCHEMA_FIELD_ENTITY_NAME);
+          Constants.DATA_PRODUCT_ENTITY_NAME);
 
   public static void apply(
       OperationContext opContext,


### PR DESCRIPTION
Right now we don't want to directly assign forms to schema fields since that's not supported on the UI in any way, we can only answer forms questions for schema fields when a form is assigned to the parent level dataset and we have schema field questions.

Therefore if someone has schema field entities defined, we will try to assign forms to those schema fields if they match the form assignment filter defined. This is just unnecessary work we're doing even though it doesn't actually break anything.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
