### PR TITLE
fix(ingest): restrict duckdb dep on old python versions

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -377,7 +377,9 @@ plugins: Dict[str, Set[str]] = {
     "datahub-rest": rest_common,
     "sync-file-emitter": {"filelock"},
     "datahub-lite": {
-        "duckdb",
+        "duckdb>=1.0.0",
+        # duckdb dropped support for python 3.8 in 1.3.0
+        "duckdb<1.3.0; python_version < '3.9'",
         "fastapi",
         "uvicorn",
     },


### PR DESCRIPTION
See https://github.com/duckdb/duckdb/issues/17600

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
