### PR TITLE
feat(components): show the remaining number in stacked avatar component

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/AvatarStack/AvatarStack.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AvatarStack/AvatarStack.stories.tsx
@@ -75,3 +75,17 @@ export const withSingleAvatar = () => (
 );
 
 export const withNoAvatar = () => <AvatarStack avatars={[]} />;
+
+export const withMoreAvatars = () => (
+    <AvatarStack
+        avatars={[
+            { name: 'John Doe', imageUrl: 'https://randomuser.me/api/portraits/men/1.jpg' },
+            { name: 'Test User', imageUrl: 'https://randomuser.me/api/portraits/men/1.jpg' },
+            { name: 'Micky Test', imageUrl: 'https://randomuser.me/api/portraits/men/1.jpg' },
+            { name: 'Jake', imageUrl: 'https://randomuser.me/api/portraits/men/1.jpg' },
+            { name: 'Mike', imageUrl: 'https://randomuser.me/api/portraits/men/1.jpg' },
+        ]}
+        size="md"
+        maxToShow={3}
+    />
+);

--- a/datahub-web-react/src/alchemy-components/components/AvatarStack/AvatarStack.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AvatarStack/AvatarStack.tsx
@@ -7,18 +7,28 @@ import { AvatarItemProps, AvatarStackProps } from '@components/components/Avatar
 export const avatarListDefaults: AvatarStackProps = {
     avatars: [
         { name: 'John Doe', imageUrl: 'https://randomuser.me/api/portraits/men/1.jpg' },
-        { name: 'Test User', imageUrl: 'https://robohash.org/sample-profile.png' },
-        { name: 'Micky Test', imageUrl: 'https://randomuser.me/api/portraits/women/1.jpg' },
+        { name: 'Test User', imageUrl: 'https://randomuser.me/api/portraits/men/1.jpg' },
+        { name: 'Micky Test', imageUrl: 'https://randomuser.me/api/portraits/men/1.jpg' },
     ],
     size: 'md',
 };
 
-export const AvatarStack = ({ avatars, size = 'md' }: AvatarStackProps) => {
+export const AvatarStack = ({ avatars, size = 'md', showRemainingNumber = true, maxToShow = 4 }: AvatarStackProps) => {
     if (avatars?.length === 0) return <div>-</div>;
-    const renderAvatarStack = avatars?.map((avatar: AvatarItemProps) => (
+    const remainingNumber = avatars.length - maxToShow;
+    const renderAvatarStack = avatars?.slice(0, maxToShow).map((avatar: AvatarItemProps) => (
         <AvatarContainer key={avatar.name}>
             <Avatar size={size} isOutlined imageUrl={avatar.imageUrl} name={avatar.name} />
         </AvatarContainer>
     ));
-    return <AvatarStackContainer>{renderAvatarStack}</AvatarStackContainer>;
+    return (
+        <AvatarStackContainer>
+            {renderAvatarStack}
+            {showRemainingNumber && remainingNumber > 0 && (
+                <AvatarContainer key="more-avatars">
+                    <Avatar size={size} isOutlined name={`+${remainingNumber}`} />
+                </AvatarContainer>
+            )}
+        </AvatarStackContainer>
+    );
 };

--- a/datahub-web-react/src/alchemy-components/components/AvatarStack/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/AvatarStack/types.ts
@@ -8,4 +8,6 @@ export interface AvatarItemProps {
 export type AvatarStackProps = {
     avatars: AvatarItemProps[];
     size?: AvatarSizeOptions;
+    showRemainingNumber?: boolean;
+    maxToShow?: number;
 };

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Incident/IncidentAssigneeAvatarStack.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Incident/IncidentAssigneeAvatarStack.tsx
@@ -7,7 +7,7 @@ import { AvatarStack } from '@src/alchemy-components/components/AvatarStack/Avat
 export const IncidentAssigneeAvatarStack = ({ assignees }: { assignees: any[] }) => {
     return (
         <AssigneeAvatarStackContainer data-testid="incident-avatar-stack">
-            <AvatarStack avatars={assignees?.slice(0, MAX_VISIBLE_ASSIGNEE)} />
+            <AvatarStack avatars={assignees?.slice(0, MAX_VISIBLE_ASSIGNEE)} showRemainingNumber={false} />
             {assignees?.length > MAX_VISIBLE_ASSIGNEE && <span>{`+${assignees.length - MAX_VISIBLE_ASSIGNEE}`}</span>}
         </AssigneeAvatarStackContainer>
     );


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-357/create-components-for-owner-pills-if-they-dont-already-exist

**Screenshots:**
![Screenshot from 2025-05-27 18-50-35](https://github.com/user-attachments/assets/f480884a-dfa3-4ccd-b9d5-1e5f1ed4137f)


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
