### PR TITLE
feat(openapi): add verify_ssl configuration option

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -82,6 +82,9 @@ class OpenApiConfig(ConfigModel):
     get_token: dict = Field(
         default={}, description="Retrieving a token from the endpoint."
     )
+    verify_ssl: bool = Field(
+        default=True, description="Enable SSL certificate verification"
+    )
 
     @validator("bearer_token", always=True)
     def ensure_only_one_token(
@@ -129,12 +132,14 @@ class OpenApiConfig(ConfigModel):
                     tok_url=url4req,
                     method=self.get_token["request_type"],
                     proxies=self.proxies,
+                    verify_ssl=self.verify_ssl,
                 )
             sw_dict = get_swag_json(
                 self.url,
                 token=self.token,
                 swagger_file=self.swagger_file,
                 proxies=self.proxies,
+                verify_ssl=self.verify_ssl,
             )  # load the swagger file
 
         else:  # using basic auth for accessing endpoints
@@ -144,6 +149,7 @@ class OpenApiConfig(ConfigModel):
                 password=self.password,
                 swagger_file=self.swagger_file,
                 proxies=self.proxies,
+                verify_ssl=self.verify_ssl,
             )
         return sw_dict
 
@@ -343,6 +349,7 @@ class APISource(Source, ABC):
                         tot_url,
                         token=config.token,
                         proxies=config.proxies,
+                        verify_ssl=config.verify_ssl,
                     )
                 else:
                     response = request_call(
@@ -350,6 +357,7 @@ class APISource(Source, ABC):
                         username=config.username,
                         password=config.password,
                         proxies=config.proxies,
+                        verify_ssl=config.verify_ssl,
                     )
                 if response.status_code == 200:
                     fields2add, root_dataset_samples[dataset_name] = extract_fields(
@@ -380,6 +388,7 @@ class APISource(Source, ABC):
                             tot_url,
                             token=config.token,
                             proxies=config.proxies,
+                            verify_ssl=config.verify_ssl,
                         )
                     else:
                         response = request_call(
@@ -387,6 +396,7 @@ class APISource(Source, ABC):
                             username=config.username,
                             password=config.password,
                             proxies=config.proxies,
+                            verify_ssl=config.verify_ssl,
                         )
                     if response.status_code == 200:
                         fields2add, _ = extract_fields(response, dataset_name)
@@ -415,6 +425,7 @@ class APISource(Source, ABC):
                             tot_url,
                             token=config.token,
                             proxies=config.proxies,
+                            verify_ssl=config.verify_ssl,
                         )
                     else:
                         response = request_call(
@@ -422,6 +433,7 @@ class APISource(Source, ABC):
                             username=config.username,
                             password=config.password,
                             proxies=config.proxies,
+                            verify_ssl=config.verify_ssl,
                         )
                     if response.status_code == 200:
                         fields2add, _ = extract_fields(response, dataset_name)

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
@@ -59,17 +59,21 @@ def request_call(
     username: Optional[str] = None,
     password: Optional[str] = None,
     proxies: Optional[dict] = None,
+    verify_ssl: bool = True,
 ) -> requests.Response:
     headers = {"accept": "application/json"}
     if username is not None and password is not None:
         return requests.get(
-            url, headers=headers, auth=HTTPBasicAuth(username, password)
+            url,
+            headers=headers,
+            auth=HTTPBasicAuth(username, password),
+            verify=verify_ssl,
         )
     elif token is not None:
         headers["Authorization"] = f"{token}"
-        return requests.get(url, proxies=proxies, headers=headers)
+        return requests.get(url, proxies=proxies, headers=headers, verify=verify_ssl)
     else:
-        return requests.get(url, headers=headers)
+        return requests.get(url, headers=headers, verify=verify_ssl)
 
 
 def get_swag_json(
@@ -79,10 +83,16 @@ def get_swag_json(
     password: Optional[str] = None,
     swagger_file: str = "",
     proxies: Optional[dict] = None,
+    verify_ssl: bool = True,
 ) -> Dict:
     tot_url = url + swagger_file
     response = request_call(
-        url=tot_url, token=token, username=username, password=password, proxies=proxies
+        url=tot_url,
+        token=token,
+        username=username,
+        password=password,
+        proxies=proxies,
+        verify_ssl=verify_ssl,
     )
 
     if response.status_code != 200:
@@ -358,6 +368,7 @@ def get_tok(
     tok_url: str = "",
     method: str = "post",
     proxies: Optional[dict] = None,
+    verify_ssl: bool = True,
 ) -> str:
     """
     Trying to post username/password to get auth.
@@ -368,7 +379,7 @@ def get_tok(
         # this will make a POST call with username and password
         data = {"username": username, "password": password, "maxDuration": True}
         # url2post = url + "api/authenticate/"
-        response = requests.post(url4req, proxies=proxies, json=data)
+        response = requests.post(url4req, proxies=proxies, json=data, verify=verify_ssl)
         if response.status_code == 200:
             cont = json.loads(response.content)
             if "token" in cont:  # other authentication scheme
@@ -377,7 +388,7 @@ def get_tok(
                 token = f"Bearer {cont['tokens']['access']}"
     elif method == "get":
         # this will make a GET call with username and password
-        response = requests.get(url4req)
+        response = requests.get(url4req, verify=verify_ssl)
         if response.status_code == 200:
             cont = json.loads(response.content)
             token = cont["token"]


### PR DESCRIPTION
## Summary
- Add `verify_ssl` boolean configuration option to OpenAPI source
- Enables users to disable SSL certificate verification for self-signed certificates
- Fixes ingestion issues with endpoints using self-signed certificates

## Changes
- Added `verify_ssl` field to `OpenApiConfig` with default `True` for security
- Updated `request_call`, `get_swag_json`, and `get_tok` functions to accept `verify_ssl` parameter
- Pass `verify_ssl` through all HTTP request chains for consistent SSL verification control

## Test plan
Can be tested with a simple HTTPS server using self-signed certificates:

```python
#\!/usr/bin/env python3
"""
Simple test server with self-signed certificate for testing SSL verification
"""
import ssl
import json
from http.server import HTTPServer, BaseHTTPRequestHandler

class OpenAPIHandler(BaseHTTPRequestHandler):
    def do_GET(self):
        if self.path == '/openapi.json':
            self.send_response(200)
            self.send_header('Content-type', 'application/json')
            self.end_headers()
            
            openapi_spec = {
                "openapi": "3.0.0",
                "info": {"title": "Test API", "version": "1.0.0"},
                "paths": {
                    "/users": {
                        "get": {
                            "responses": {
                                "200": {
                                    "description": "List users",
                                    "content": {
                                        "application/json": {
                                            "example": [{"id": 1, "name": "John"}]
                                        }
                                    }
                                }
                            }
                        }
                    }
                }
            }
            self.wfile.write(json.dumps(openapi_spec).encode())
        elif self.path == '/users':
            self.send_response(200)
            self.send_header('Content-type', 'application/json')
            self.end_headers()
            users = [{"id": 1, "name": "John"}, {"id": 2, "name": "Jane"}]
            self.wfile.write(json.dumps(users).encode())
        else:
            self.send_response(404)
            self.end_headers()

if __name__ == '__main__':
    # Create self-signed certificate
    import subprocess
    import os
    
    if not os.path.exists('server.pem'):
        subprocess.run([
            'openssl', 'req', '-new', '-x509', '-keyout', 'server.pem', '-out', 'server.pem',
            '-days', '365', '-nodes', '-subj', '/CN=localhost'
        ])
    
    server = HTTPServer(('localhost', 8443), OpenAPIHandler)
    server.socket = ssl.wrap_socket(server.socket, certfile='./server.pem', server_side=True)
    
    print("HTTPS Server running on https://localhost:8443")
    print("OpenAPI spec: https://localhost:8443/openapi.json")
    server.serve_forever()
```

Test with `verify_ssl: false` (should work):
```yaml
source:
  type: openapi
  config:
    name: "test_ssl_false"
    url: "https://localhost:8443"
    swagger_file: "/openapi.json"
    verify_ssl: false

sink:
  type: console
```

Test with `verify_ssl: true` (should fail with SSL error):
```yaml
source:
  type: openapi
  config:
    name: "test_ssl_true"
    url: "https://localhost:8443"
    swagger_file: "/openapi.json"
    verify_ssl: true

sink:
  type: console
```

🤖 Generated with [Claude Code](https://claude.ai/code)