### PR TITLE
fix(snowflake): pass correct BaseTimeWindowConfig instead of SnowflakeV2Config

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -9,6 +9,7 @@ import re
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional, Union
 
+from datahub.configuration.time_window_config import BaseTimeWindowConfig
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SupportStatus,
@@ -571,7 +572,11 @@ class SnowflakeV2Source(
                 queries_extractor = SnowflakeQueriesExtractor(
                     connection=self.connection,
                     config=SnowflakeQueriesExtractorConfig(
-                        window=self.config,
+                        window=BaseTimeWindowConfig(
+                            start_time=self.config.start_time,
+                            end_time=self.config.end_time,
+                            bucket_duration=self.config.bucket_duration,
+                        ),
                         temporary_tables_pattern=self.config.temporary_tables_pattern,
                         include_lineage=self.config.include_table_lineage,
                         include_usage_statistics=self.config.include_usage_stats,


### PR DESCRIPTION
## Summary

Fixes Snowflake queries extractor time window configuration that may lead to processing unnecessary large time ranges (55 years).

## Problem Description

The issue was discovered through traces showing:
```
'lineage_start_time': '1970-01-01 00:00:00+00:00 (55 years, 30 weeks and 5 days ago)',
'lineage_end_time': '2025-05-27 18:16:54.442718+00:00 (57.86 seconds ago)',
```

**Root Cause**: A combination of two issues:
1. **Type mismatch**: Passing `SnowflakeV2Config` instead of proper `BaseTimeWindowConfig` to the `window` parameter
2. **Pydantic validation failure**: When Pydantic tried to convert `SnowflakeV2Config` to `BaseTimeWindowConfig`, it failed silently and fell back to the default `BaseTimeWindowConfig()` which uses Unix epoch (1970-01-01)

## Changes

- Fixed initialization in `snowflake_v2.py` to properly create `BaseTimeWindowConfig` with correct time fields from parent config
- Added required import for `BaseTimeWindowConfig`

🤖 Generated with [Claude Code](https://claude.ai/code)