### PR TITLE
fix(docs): Correct Access Policy references to GraphQL endpoints

### DIFF
--- a/docs/authorization/access-policies-guide.md
+++ b/docs/authorization/access-policies-guide.md
@@ -256,10 +256,10 @@ Policies only affect REST APIs when the environment variable `REST_API_AUTHORIZA
 
 ### GraphQL
 
-- [listPolicies](../../graphql/queries.md#listPolicies)
-- [createPolicy](../../graphql/mutations.md#createPolicy)
-- [updatePolicy](../../graphql/mutations.md#updatePolicy)
-- [deletePolicy](../../graphql/mutations.md#deletePolicy)
+- [listPolicies](../../graphql/queries.md#listpolicies)
+- [createPolicy](../../graphql/mutations.md#createpolicy)
+- [updatePolicy](../../graphql/mutations.md#updatepolicy)
+- [deletePolicy](../../graphql/mutations.md#deletepolicy)
 
 ## FAQ and Troubleshooting
 


### PR DESCRIPTION
The camel casing breaks linkage in the docs website

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
