### PR TITLE
fix(log): improve log for list-source-runs without privileges

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
@@ -50,79 +50,75 @@ public class ListIngestionSourcesResolver
 
     final QueryContext context = environment.getContext();
 
-    if (IngestionAuthUtils.canManageIngestion(context)) {
-      final ListIngestionSourcesInput input =
-          bindArgument(environment.getArgument("input"), ListIngestionSourcesInput.class);
-      final Integer start = input.getStart() == null ? DEFAULT_START : input.getStart();
-      final Integer count = input.getCount() == null ? DEFAULT_COUNT : input.getCount();
-      final String query = input.getQuery() == null ? DEFAULT_QUERY : input.getQuery();
-      final List<FacetFilterInput> filters =
-          input.getFilters() == null ? Collections.emptyList() : input.getFilters();
-
-      // construct sort criteria, defaulting to systemCreated
-      final SortCriterion sortCriterion;
-
-      // if query is expecting to sort by something, use that
-      final com.linkedin.datahub.graphql.generated.SortCriterion sortCriterionInput =
-          input.getSort();
-      if (sortCriterionInput != null) {
-        sortCriterion =
-            new SortCriterion()
-                .setField(sortCriterionInput.getField())
-                .setOrder(SortOrder.valueOf(sortCriterionInput.getSortOrder().name()));
-      } else {
-        // TODO: default to last executed
-        sortCriterion = null;
-      }
-
-      return GraphQLConcurrencyUtils.supplyAsync(
-          () -> {
-            try {
-              // First, get all ingestion sources Urns.
-              final SearchResult gmsResult =
-                  _entityClient.search(
-                      context
-                          .getOperationContext()
-                          .withSearchFlags(flags -> flags.setFulltext(true)),
-                      Constants.INGESTION_SOURCE_ENTITY_NAME,
-                      query,
-                      buildFilter(filters, Collections.emptyList()),
-                      sortCriterion != null ? List.of(sortCriterion) : null,
-                      start,
-                      count);
-
-              final List<Urn> entitiesUrnList =
-                  gmsResult.getEntities().stream().map(SearchEntity::getEntity).toList();
-              // Then, resolve all ingestion sources
-              final Map<Urn, EntityResponse> entities =
-                  _entityClient.batchGetV2(
-                      context.getOperationContext(),
-                      Constants.INGESTION_SOURCE_ENTITY_NAME,
-                      new HashSet<>(entitiesUrnList),
-                      ImmutableSet.of(
-                          Constants.INGESTION_INFO_ASPECT_NAME,
-                          Constants.INGESTION_SOURCE_KEY_ASPECT_NAME));
-
-              final List<EntityResponse> entitiesOrdered =
-                  entitiesUrnList.stream().map(entities::get).filter(Objects::nonNull).toList();
-
-              // Now that we have entities we can bind this to a result.
-              final ListIngestionSourcesResult result = new ListIngestionSourcesResult();
-              result.setStart(gmsResult.getFrom());
-              result.setCount(gmsResult.getPageSize());
-              result.setTotal(gmsResult.getNumEntities());
-              result.setIngestionSources(
-                  IngestionResolverUtils.mapIngestionSources(entitiesOrdered));
-              return result;
-
-            } catch (Exception e) {
-              throw new RuntimeException("Failed to list ingestion sources", e);
-            }
-          },
-          this.getClass().getSimpleName(),
-          "get");
+    if (!IngestionAuthUtils.canManageIngestion(context)) {
+      throw new AuthorizationException(
+          "You are not authorized to list ingestion sources. Please contact your DataHub administrator.");
     }
-    throw new AuthorizationException(
-        "Unauthorized to perform this action. Please contact your DataHub administrator.");
+    final ListIngestionSourcesInput input =
+        bindArgument(environment.getArgument("input"), ListIngestionSourcesInput.class);
+    final Integer start = input.getStart() == null ? DEFAULT_START : input.getStart();
+    final Integer count = input.getCount() == null ? DEFAULT_COUNT : input.getCount();
+    final String query = input.getQuery() == null ? DEFAULT_QUERY : input.getQuery();
+    final List<FacetFilterInput> filters =
+        input.getFilters() == null ? Collections.emptyList() : input.getFilters();
+
+    // construct sort criteria, defaulting to systemCreated
+    final SortCriterion sortCriterion;
+
+    // if query is expecting to sort by something, use that
+    final com.linkedin.datahub.graphql.generated.SortCriterion sortCriterionInput = input.getSort();
+    if (sortCriterionInput != null) {
+      sortCriterion =
+          new SortCriterion()
+              .setField(sortCriterionInput.getField())
+              .setOrder(SortOrder.valueOf(sortCriterionInput.getSortOrder().name()));
+    } else {
+      // TODO: default to last executed
+      sortCriterion = null;
+    }
+
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          try {
+            // First, get all ingestion sources Urns.
+            final SearchResult gmsResult =
+                _entityClient.search(
+                    context.getOperationContext().withSearchFlags(flags -> flags.setFulltext(true)),
+                    Constants.INGESTION_SOURCE_ENTITY_NAME,
+                    query,
+                    buildFilter(filters, Collections.emptyList()),
+                    sortCriterion != null ? List.of(sortCriterion) : null,
+                    start,
+                    count);
+
+            final List<Urn> entitiesUrnList =
+                gmsResult.getEntities().stream().map(SearchEntity::getEntity).toList();
+            // Then, resolve all ingestion sources
+            final Map<Urn, EntityResponse> entities =
+                _entityClient.batchGetV2(
+                    context.getOperationContext(),
+                    Constants.INGESTION_SOURCE_ENTITY_NAME,
+                    new HashSet<>(entitiesUrnList),
+                    ImmutableSet.of(
+                        Constants.INGESTION_INFO_ASPECT_NAME,
+                        Constants.INGESTION_SOURCE_KEY_ASPECT_NAME));
+
+            final List<EntityResponse> entitiesOrdered =
+                entitiesUrnList.stream().map(entities::get).filter(Objects::nonNull).toList();
+
+            // Now that we have entities we can bind this to a result.
+            final ListIngestionSourcesResult result = new ListIngestionSourcesResult();
+            result.setStart(gmsResult.getFrom());
+            result.setCount(gmsResult.getPageSize());
+            result.setTotal(gmsResult.getNumEntities());
+            result.setIngestionSources(IngestionResolverUtils.mapIngestionSources(entitiesOrdered));
+            return result;
+
+          } catch (Exception e) {
+            throw new RuntimeException("Failed to list ingestion sources", e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
   }
 }

--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -388,7 +388,10 @@ def mcps(path: str) -> None:
 @upgrade.check_upgrade
 @telemetry.with_telemetry()
 def list_source_runs(page_offset: int, page_size: int, urn: str, source: str) -> None:
-    """List ingestion source runs with their details, optionally filtered by URN or source."""
+    """
+    List ingestion source runs with their details, optionally filtered by URN or source.
+    Required the Manage Metadata Ingestion permission.
+    """
 
     query = """
     query listIngestionRuns($input: ListIngestionSourcesInput!) {
@@ -445,6 +448,11 @@ def list_source_runs(page_offset: int, page_size: int, urn: str, source: str) ->
 
     if not data:
         click.echo("No response received from the server.")
+        return
+    if "errors" in data:
+        click.echo("Errors in response:")
+        for error in data["errors"]:
+            click.echo(f"- {error.get('message', 'Unknown error')}")
         return
 
     # a lot of responses can be null if there's errors in the run


### PR DESCRIPTION
The big change in `datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java` is just changing the brackets so the indentation is less. This just makes it easier to read what is happening there.

The PR is just changing/adding log messages in case there are issues with privileges

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
