### PR TITLE
fix(quickstart): Enable V2 UI by default

### DIFF
--- a/docker/datahub-gms/env/docker-without-neo4j.env
+++ b/docker/datahub-gms/env/docker-without-neo4j.env
@@ -22,6 +22,7 @@ MCE_CONSUMER_ENABLED=true
 PE_CONSUMER_ENABLED=true
 UI_INGESTION_ENABLED=true
 ENTITY_SERVICE_ENABLE_RETENTION=true
+THEME_V2_DEFAULT=true
 
 # Uncomment to disable persistence of client-side analytics events
 # DATAHUB_ANALYTICS_ENABLED=false

--- a/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
@@ -99,8 +99,8 @@ services:
     - MCE_CONSUMER_ENABLED=true
     - METADATA_SERVICE_AUTH_ENABLED=${METADATA_SERVICE_AUTH_ENABLED:-false}
     - PE_CONSUMER_ENABLED=true
-    - UI_INGESTION_ENABLED=true
     - THEME_V2_DEFAULT=true
+    - UI_INGESTION_ENABLED=true
     healthcheck:
       interval: 1s
       retries: 3

--- a/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
@@ -100,6 +100,7 @@ services:
     - METADATA_SERVICE_AUTH_ENABLED=${METADATA_SERVICE_AUTH_ENABLED:-false}
     - PE_CONSUMER_ENABLED=true
     - UI_INGESTION_ENABLED=true
+    - THEME_V2_DEFAULT=true
     healthcheck:
       interval: 1s
       retries: 3

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -99,8 +99,8 @@ services:
     - MCE_CONSUMER_ENABLED=true
     - METADATA_SERVICE_AUTH_ENABLED=${METADATA_SERVICE_AUTH_ENABLED:-false}
     - PE_CONSUMER_ENABLED=true
-    - UI_INGESTION_ENABLED=true
     - THEME_V2_DEFAULT=true
+    - UI_INGESTION_ENABLED=true
     healthcheck:
       interval: 1s
       retries: 3

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -100,6 +100,7 @@ services:
     - METADATA_SERVICE_AUTH_ENABLED=${METADATA_SERVICE_AUTH_ENABLED:-false}
     - PE_CONSUMER_ENABLED=true
     - UI_INGESTION_ENABLED=true
+    - THEME_V2_DEFAULT=true
     healthcheck:
       interval: 1s
       retries: 3


### PR DESCRIPTION
Change OSS quickstart default docker-compose files for m1 machines & otherwise to use the new UI. This requires that the docker-compose file stored `~/.docker/quickstart` be removed to be in effect I think.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
