### PR TITLE
feat(sdk): add audit_actor and audit_stamp methods to DataHubClient

### DIFF
--- a/metadata-ingestion/src/datahub/sdk/_utils.py
+++ b/metadata-ingestion/src/datahub/sdk/_utils.py
@@ -4,6 +4,7 @@ from datahub.errors import ItemNotFoundError
 from datahub.metadata.urns import CorpUserUrn
 
 # TODO: Change __ingestion to _ingestion.
+# TODO: remove use of this, use DataHubCient#audit_actor instead
 DEFAULT_ACTOR_URN = CorpUserUrn("__ingestion").urn()
 
 

--- a/metadata-ingestion/tests/unit/sdk_v2/test_client_v2.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_client_v2.py
@@ -1,12 +1,15 @@
+from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
+from freezegun import freeze_time
 
 from datahub.errors import ItemNotFoundError, MultipleItemsFoundError, SdkUsageError
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.graph.config import DatahubClientConfig
-from datahub.metadata.urns import CorpUserUrn
-from datahub.sdk.main_client import DataHubClient
+from datahub.metadata.schema_classes import AuditStampClass
+from datahub.metadata.urns import CorpGroupUrn, CorpUserUrn
+from datahub.sdk.main_client import DEFAULT_ACTOR_URN, DataHubClient
 
 
 @pytest.fixture
@@ -53,3 +56,149 @@ def test_resolve_user(mock_graph: Mock) -> None:
     ]
     with pytest.raises(MultipleItemsFoundError):
         client.resolve.user(name="User")
+
+
+def create_jwt_token(payload: dict) -> str:
+    """Helper function to create a JWT token for testing."""
+    import jwt
+
+    return jwt.encode(payload, "secret", algorithm="HS256")
+
+
+@pytest.mark.parametrize(
+    "token,fallback_actor,expected_result",
+    [
+        pytest.param(
+            create_jwt_token({"actorId": "test_user", "type": "PERSONAL"}),
+            None,
+            CorpUserUrn.create_from_id("test_user"),
+            id="valid_jwt_personal_type",
+        ),
+        pytest.param(
+            None,
+            None,
+            DEFAULT_ACTOR_URN,
+            id="no_token_default_actor",
+        ),
+        pytest.param(
+            None,
+            CorpUserUrn.create_from_id("fallback_user"),
+            CorpUserUrn.create_from_id("fallback_user"),
+            id="no_token_with_fallback",
+        ),
+        pytest.param(
+            create_jwt_token({"type": "PERSONAL"}),
+            None,
+            DEFAULT_ACTOR_URN,
+            id="missing_actor_id",
+        ),
+        pytest.param(
+            create_jwt_token({"actorId": "", "type": "PERSONAL"}),
+            CorpGroupUrn.create_from_id("fallback_group"),
+            CorpGroupUrn.create_from_id("fallback_group"),
+            id="empty_actor_id_with_fallback",
+        ),
+        pytest.param(
+            create_jwt_token({"actorId": "test_user", "type": "SERVICE"}),
+            None,
+            DEFAULT_ACTOR_URN,
+            id="non_personal_type",
+        ),
+        pytest.param(
+            create_jwt_token({"actorId": "test_user"}),
+            CorpUserUrn.create_from_id("custom_fallback"),
+            CorpUserUrn.create_from_id("custom_fallback"),
+            id="missing_type_field",
+        ),
+        pytest.param(
+            "invalid.jwt.token",
+            None,
+            DEFAULT_ACTOR_URN,
+            id="invalid_jwt_format",
+        ),
+        pytest.param(
+            "malformed_jwt",
+            CorpUserUrn.create_from_id("error_fallback"),
+            CorpUserUrn.create_from_id("error_fallback"),
+            id="malformed_jwt_with_fallback",
+        ),
+    ],
+)
+def test_audit_actor(token, fallback_actor, expected_result):
+    """Test audit_actor method with various JWT token scenarios."""
+    mock_graph = Mock(spec=DataHubGraph)
+    mock_config = Mock()
+    mock_config.token = token
+    mock_graph.config = mock_config
+
+    client = DataHubClient(graph=mock_graph)
+
+    result = client.audit_actor(fallback_actor=fallback_actor)
+
+    assert result == expected_result
+
+
+FROZEN_TIME = "2024-01-15 12:30:45"
+
+
+@freeze_time(FROZEN_TIME)
+@pytest.mark.parametrize(
+    "token,fallback_actor,fallback_timestamp,expected_actor,expected_time_ms",
+    [
+        pytest.param(
+            create_jwt_token({"actorId": "stamp_user", "type": "PERSONAL"}),
+            None,
+            None,
+            CorpUserUrn.create_from_id("stamp_user"),
+            1705321845000,  # FROZEN_TIME in milliseconds (UTC)
+            id="valid_jwt_current_time",
+        ),
+        pytest.param(
+            None,
+            CorpUserUrn.create_from_id("fallback_user"),
+            None,
+            CorpUserUrn.create_from_id("fallback_user"),
+            1705321845000,  # FROZEN_TIME in milliseconds (UTC)
+            id="fallback_actor_current_time",
+        ),
+        pytest.param(
+            None,
+            None,
+            datetime(2023, 6, 15, 10, 30, 0),
+            DEFAULT_ACTOR_URN,
+            1686817800000,  # Custom timestamp in milliseconds
+            id="custom_timestamp",
+        ),
+        pytest.param(
+            create_jwt_token({"actorId": "jwt_user", "type": "PERSONAL"}),
+            CorpGroupUrn.create_from_id("group_fallback"),
+            datetime(2023, 12, 25, 18, 45, 30),
+            CorpUserUrn.create_from_id("jwt_user"),
+            1703526330000,  # Custom timestamp in milliseconds
+            id="jwt_overrides_fallback_with_custom_time",
+        ),
+    ],
+)
+def test_audit_stamp(
+    token, fallback_actor, fallback_timestamp, expected_actor, expected_time_ms
+):
+    """Test audit_stamp method with various scenarios."""
+    mock_graph = Mock(spec=DataHubGraph)
+    mock_config = Mock()
+    mock_config.token = token
+    mock_graph.config = mock_config
+
+    client = DataHubClient(graph=mock_graph)
+
+    result = client.audit_stamp(
+        fallback_actor=fallback_actor, fallback_timestamp=fallback_timestamp
+    )
+
+    # Verify the result is an AuditStampClass
+    assert isinstance(result, AuditStampClass)
+
+    # Verify the actor is correct
+    assert result.actor == str(expected_actor)
+
+    # Verify the timestamp is exactly what we expect
+    assert result.time == expected_time_ms


### PR DESCRIPTION
## Summary
- Add `audit_actor` method to extract actor from JWT tokens with fallback support
- Add `audit_stamp` method to create `AuditStampClass` with actor and timestamp
- Use PyJWT library for secure JWT token parsing instead of manual base64 decoding
- Comprehensive test coverage with parameterized tests using freezegun for deterministic time testing

## Key Features
- **JWT Token Parsing**: Extracts actor ID from JWT tokens with proper error handling
- **Fallback Support**: Uses fallback actors or DEFAULT_ACTOR_URN when JWT parsing fails
- **Audit Stamp Creation**: Generates standardized audit stamps for metadata operations
- **Type Safety**: Full mypy compliance with proper type annotations

## TODO
Making use of these new methods across the codebase to replace hardcoded actor usage is a follow-up task.

## Test Plan
- [x] All existing tests pass
- [x] New parameterized tests cover all JWT scenarios (valid, invalid, missing fields)
- [x] Time-dependent tests use freezegun for deterministic behavior
- [x] Code formatting and type checking pass

🤖 Generated with [Claude Code](https://claude.ai/code)