### PR TITLE
fix(web): Only display assertion tab buttons if there is more than one button

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionProfile.tsx
@@ -57,7 +57,7 @@ export const AssertionProfile = ({ urn, contract, close, refetch }: Props) => {
                     close={close}
                 />
             )}
-            <AssertionTabs defaultSelectedTab={TabType.Summary} tabs={tabs} />
+            {tabs.length > 1 && <AssertionTabs defaultSelectedTab={TabType.Summary} tabs={tabs} />}
             <AssertionProfileFooter />
         </>
     );

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionProfile.tsx
@@ -57,7 +57,7 @@ export const AssertionProfile = ({ urn, contract, close, refetch }: Props) => {
                     close={close}
                 />
             )}
-            {tabs.length > 1 && <AssertionTabs defaultSelectedTab={TabType.Summary} tabs={tabs} />}
+            <AssertionTabs defaultSelectedTab={TabType.Summary} tabs={tabs} />
             <AssertionProfileFooter />
         </>
     );

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionTabs.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionTabs.tsx
@@ -58,11 +58,12 @@ export const AssertionTabs = ({ defaultSelectedTab, tabs }: Props) => {
             <Tabs>
                 {tabs.map((tab) => (
                     <Tooltip title={tab.tooltip} placement="bottom" showArrow={false}>
-                        {tabs.length > 1 && (<TabButton
-                            selected={selectedTab === tab.key}
-                            disabled={tab.disabled}
-                            key={tab.key}
-                            onClick={() => (!tab.disabled ? setSelectedTab(tab.key) : null)}
+                        {tabs.length > 1 && (
+                            <TabButton
+                                selected={selectedTab === tab.key}
+                                disabled={tab.disabled}
+                                key={tab.key}
+                                onClick={() => (!tab.disabled ? setSelectedTab(tab.key) : null)}
                             >
                                 {tab.label}
                             </TabButton>

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionTabs.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionTabs.tsx
@@ -58,14 +58,15 @@ export const AssertionTabs = ({ defaultSelectedTab, tabs }: Props) => {
             <Tabs>
                 {tabs.map((tab) => (
                     <Tooltip title={tab.tooltip} placement="bottom" showArrow={false}>
-                        <TabButton
+                        {tabs.length > 1 && (<TabButton
                             selected={selectedTab === tab.key}
                             disabled={tab.disabled}
                             key={tab.key}
                             onClick={() => (!tab.disabled ? setSelectedTab(tab.key) : null)}
-                        >
-                            {tab.label}
-                        </TabButton>
+                            >
+                                {tab.label}
+                            </TabButton>
+                        )}
                     </Tooltip>
                 ))}
             </Tabs>

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionTabs.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/AssertionTabs.tsx
@@ -55,23 +55,25 @@ export const AssertionTabs = ({ defaultSelectedTab, tabs }: Props) => {
     const [selectedTab, setSelectedTab] = useState<string>(defaultSelectedTab);
     return (
         <>
-            <Tabs>
-                {tabs.map((tab) => (
-                    <Tooltip title={tab.tooltip} placement="bottom" showArrow={false}>
-                        {tabs.length > 1 && (
-                            <TabButton
-                                selected={selectedTab === tab.key}
-                                disabled={tab.disabled}
-                                key={tab.key}
-                                onClick={() => (!tab.disabled ? setSelectedTab(tab.key) : null)}
-                            >
-                                {tab.label}
-                            </TabButton>
-                        )}
-                    </Tooltip>
-                ))}
-            </Tabs>
-            <StyledDivider />
+            {tabs.length > 1 && (
+                <>
+                    <Tabs>
+                        {tabs.map((tab) => (
+                            <Tooltip title={tab.tooltip} placement="bottom" showArrow={false}>
+                                <TabButton
+                                    selected={selectedTab === tab.key}
+                                    disabled={tab.disabled}
+                                    key={tab.key}
+                                    onClick={() => (!tab.disabled ? setSelectedTab(tab.key) : null)}
+                                >
+                                    {tab.label}
+                                </TabButton>
+                            </Tooltip>
+                        ))}
+                    </Tabs>
+                    <StyledDivider />
+                </>
+            )}
             <TabContent>{tabs.find((tab) => tab.key === selectedTab)?.content}</TabContent>
         </>
     );


### PR DESCRIPTION
When there is only one button the UI of the assertion drawer is somewhat confusing so we remove the buttons from the display

## Before
![image](https://github.com/user-attachments/assets/82fe4a36-5975-4da2-a49d-4af09b27a464)

## After
![image](https://github.com/user-attachments/assets/d1dc3a9f-3bd2-4f78-aa90-492dabbb498c)



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
