### PR TITLE
docs: skip release note details for 1.1.0 on docs site to fix build

### DIFF
--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -568,11 +568,12 @@ custom_edit_url: https://github.com/datahub-project/datahub/blob/master/docs-web
   }
   contents.content += "\n\n";
 
-  const releases_list_filtered = releases_list.filter(release => release.tag_name !== "v1.1.0");
   // Full details
-  for (const release of releases_list_filtered) {
+  for (const release of releases_list) {
     let body: string;
-    if (releaseNoteVersions.has(release.tag_name)) {
+    if (release.tag_name === "v1.1.0") {
+      body = `View the [release notes](${release.html_url}) for ${release.name} on GitHub.`;
+    } else if (releaseNoteVersions.has(release.tag_name)) {
       body = release.body ?? "";
       body = markdown_sanitize_and_linkify(body);
 

--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -568,8 +568,9 @@ custom_edit_url: https://github.com/datahub-project/datahub/blob/master/docs-web
   }
   contents.content += "\n\n";
 
+  const releases_list_filtered = releases_list.filter(release => release.tag_name !== "v1.1.0");
   // Full details
-  for (const release of releases_list) {
+  for (const release of releases_list_filtered) {
     let body: string;
     if (releaseNoteVersions.has(release.tag_name)) {
       body = release.body ?? "";


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

skipping release note details for 1.1.0 

release note preview : https://docs-website-ebo2qt0to-acryldata.vercel.app/docs/releases#v1-1-0
