### PR TITLE
fix(ui/ingestion): filter current user to prevent the owner from getting added twice

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
@@ -345,9 +345,7 @@ export const IngestionSourceList = ({ showCreateModal, setShowCreateModal, shoul
                         },
                         platform: null,
                         executions: null,
-                        ownership: {
-                            owners: ownersToAdd,
-                        },
+                        ownership: null,
                     };
 
                     if (ownersToAdd && ownersToAdd.length > 0) {

--- a/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
@@ -7,6 +7,7 @@ import { useDebounce } from 'react-use';
 import styled from 'styled-components';
 
 import analytics, { EventType } from '@app/analytics';
+import { useUserContext } from '@app/context/useUserContext';
 import EmptySources from '@app/ingestV2/EmptySources';
 import { CLI_EXECUTOR_ID } from '@app/ingestV2/constants';
 import { ExecutionDetailsModal } from '@app/ingestV2/executions/components/ExecutionDetailsModal';
@@ -123,6 +124,7 @@ interface Props {
 
 export const IngestionSourceList = ({ showCreateModal, setShowCreateModal, shouldPreserveParams }: Props) => {
     const location = useLocation();
+    const me = useUserContext();
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
     const paramsQuery = (params?.query as string) || undefined;
     const [query, setQuery] = useState<undefined | string>(undefined);
@@ -330,6 +332,8 @@ export const IngestionSourceList = ({ showCreateModal, setShowCreateModal, shoul
             createIngestionSource({ variables: { input } })
                 .then((result) => {
                     message.loading({ content: 'Loading...', duration: 2 });
+                    const ownersToAdd = owners?.filter((owner) => owner.ownerUrn !== me.urn);
+
                     const newSource = {
                         urn: result?.data?.createIngestionSource || PLACEHOLDER_URN,
                         name: input.name,
@@ -341,14 +345,16 @@ export const IngestionSourceList = ({ showCreateModal, setShowCreateModal, shoul
                         },
                         platform: null,
                         executions: null,
-                        ownership: null,
+                        ownership: {
+                            owners: ownersToAdd,
+                        },
                     };
 
-                    if (owners && owners.length > 0) {
+                    if (ownersToAdd && ownersToAdd.length > 0) {
                         batchAddOwnersMutation({
                             variables: {
                                 input: {
-                                    owners,
+                                    owners: ownersToAdd,
                                     resources: [{ resourceUrn: newSource.urn }],
                                 },
                             },


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-394/owner-gets-added-twice-when-adding-current-user-as-the-owner


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
