### PR TITLE
fix(ui/ ingestion): fix double onboarding modals on ingestion page

### DIFF
--- a/datahub-web-react/src/app/ingestV2/ManageIngestionPage.tsx
+++ b/datahub-web-react/src/app/ingestV2/ManageIngestionPage.tsx
@@ -11,7 +11,10 @@ import { SecretsList } from '@app/ingestV2/secret/SecretsList';
 import { IngestionSourceList } from '@app/ingestV2/source/IngestionSourceList';
 import { TabType, tabUrlMap } from '@app/ingestV2/types';
 import { OnboardingTour } from '@app/onboarding/OnboardingTour';
-import { INGESTION_CREATE_SOURCE_ID } from '@app/onboarding/config/IngestionOnboardingConfig';
+import {
+    INGESTION_CREATE_SOURCE_ID,
+    INGESTION_REFRESH_SOURCES_ID,
+} from '@app/onboarding/config/IngestionOnboardingConfig';
 import { useAppConfig } from '@app/useAppConfig';
 import { useShowNavBarRedesign } from '@app/useShowNavBarRedesign';
 
@@ -134,7 +137,7 @@ export const ManageIngestionPage = () => {
 
     return (
         <PageContainer $isShowNavBarRedesign={isShowNavBarRedesign}>
-            <OnboardingTour stepIds={[INGESTION_CREATE_SOURCE_ID]} />
+            <OnboardingTour stepIds={[INGESTION_CREATE_SOURCE_ID, INGESTION_REFRESH_SOURCES_ID]} />
             <PageHeaderContainer>
                 <TitleContainer>
                     <PageTitle

--- a/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
@@ -24,7 +24,6 @@ import {
     getSortInput,
     removeFromListIngestionSourcesCache,
 } from '@app/ingestV2/source/utils';
-import { OnboardingTour } from '@app/onboarding/OnboardingTour';
 import { INGESTION_REFRESH_SOURCES_ID } from '@app/onboarding/config/IngestionOnboardingConfig';
 import { Message } from '@app/shared/Message';
 import { scrollToTop } from '@app/shared/searchUtils';
@@ -515,7 +514,6 @@ export const IngestionSourceList = ({ showCreateModal, setShowCreateModal, shoul
                 <Message type="error" content="Failed to load ingestion sources! An unexpected error occurred." />
             )}
             <SourceContainer>
-                <OnboardingTour stepIds={[INGESTION_REFRESH_SOURCES_ID]} />
                 <HeaderContainer>
                     <StyledTabToolbar>
                         <SearchContainer>


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-410/competing-modals-welcome-tutorial-modals-for-first-time-user

**Screenshot:**

![image](https://github.com/user-attachments/assets/4792516d-5cb2-4b6b-9221-f9b5f8742df3)

![image](https://github.com/user-attachments/assets/d9a4c08c-f0b9-4c66-849f-052576ed9480)


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
