### PR TITLE
feat(schema): add AuditStampClass.from_token static method

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -56,6 +56,7 @@ framework_common = {
     "jsonref",
     "jsonschema",
     "ruamel.yaml",
+    "PyJWT>=2.0.0",
 }
 
 pydantic_no_v2 = {


### PR DESCRIPTION
## Summary
Add `from_token` static method to `AuditStampClass` for JWT-based audit stamp creation with actor extraction and fallback handling.

This PR supersedes https://github.com/datahub-project/datahub/pull/13676 Compared to that one, this is pushing down the feature as much as possible, so it is accessible to all sdk users, regardless of the layer/module they are using.

🤖 Generated with [Claude Code](https://claude.ai/code)