### PR TITLE
fix(ui): Move buttons outside the form

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/RecipeForm.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/RecipeForm.tsx
@@ -148,99 +148,104 @@ function RecipeForm(props: Props) {
     }
 
     return (
-        <RequiredFieldForm
-            layout="vertical"
-            initialValues={getInitialValues(displayRecipe, allFields)}
-            onFinish={onClickNext}
-            form={form}
-            onValuesChange={updateFormValues}
-        >
-            <StyledCollapse defaultActiveKey="0">
-                <Collapse.Panel forceRender header={<SectionHeader icon={<ApiOutlined />} text="Connection" />} key="0">
-                    {fields.map((field, i) => (
-                        <FormField
-                            key={field.name}
-                            field={field}
-                            secrets={secrets}
-                            refetchSecrets={refetchSecrets}
-                            removeMargin={i === fields.length - 1}
-                            updateFormValue={updateFormValue}
-                        />
-                    ))}
-                    {CONNECTORS_WITH_TEST_CONNECTION.has(type as string) && (
-                        <TestConnectionWrapper>
-                            <TestConnectionButton
-                                recipe={displayRecipe}
-                                sourceConfigs={sourceConfigs}
-                                version={version}
+        <>
+            <RequiredFieldForm
+                layout="vertical"
+                initialValues={getInitialValues(displayRecipe, allFields)}
+                form={form}
+                onValuesChange={updateFormValues}
+            >
+                <StyledCollapse defaultActiveKey="0">
+                    <Collapse.Panel
+                        forceRender
+                        header={<SectionHeader icon={<ApiOutlined />} text="Connection" />}
+                        key="0"
+                    >
+                        {fields.map((field, i) => (
+                            <FormField
+                                key={field.name}
+                                field={field}
+                                secrets={secrets}
+                                refetchSecrets={refetchSecrets}
+                                removeMargin={i === fields.length - 1}
+                                updateFormValue={updateFormValue}
                             />
-                        </TestConnectionWrapper>
-                    )}
-                </Collapse.Panel>
-            </StyledCollapse>
-            {filterFields.length > 0 && (
-                <StyledCollapse defaultActiveKey={defaultOpenSections?.includes(RecipeSections.Filter) ? '1' : ''}>
+                        ))}
+                        {CONNECTORS_WITH_TEST_CONNECTION.has(type as string) && (
+                            <TestConnectionWrapper>
+                                <TestConnectionButton
+                                    recipe={displayRecipe}
+                                    sourceConfigs={sourceConfigs}
+                                    version={version}
+                                />
+                            </TestConnectionWrapper>
+                        )}
+                    </Collapse.Panel>
+                </StyledCollapse>
+                {filterFields.length > 0 && (
+                    <StyledCollapse defaultActiveKey={defaultOpenSections?.includes(RecipeSections.Filter) ? '1' : ''}>
+                        <Collapse.Panel
+                            forceRender
+                            header={
+                                <SectionHeader
+                                    icon={<FilterOutlined />}
+                                    text="Filter"
+                                    sectionTooltip={filterSectionTooltip}
+                                />
+                            }
+                            key="1"
+                        >
+                            {filterFields.map((field, i) => (
+                                <Fragment key={field.name}>
+                                    {shouldRenderFilterSectionHeader(field, i, filterFields) && (
+                                        <Typography.Title level={4}>{field.section}</Typography.Title>
+                                    )}
+                                    <MarginWrapper>
+                                        <FormField
+                                            field={field}
+                                            secrets={secrets}
+                                            refetchSecrets={refetchSecrets}
+                                            removeMargin={i === filterFields.length - 1}
+                                            updateFormValue={updateFormValue}
+                                        />
+                                    </MarginWrapper>
+                                </Fragment>
+                            ))}
+                        </Collapse.Panel>
+                    </StyledCollapse>
+                )}
+                <StyledCollapse defaultActiveKey={defaultOpenSections?.includes(RecipeSections.Advanced) ? '2' : ''}>
                     <Collapse.Panel
                         forceRender
                         header={
                             <SectionHeader
-                                icon={<FilterOutlined />}
-                                text="Filter"
-                                sectionTooltip={filterSectionTooltip}
+                                icon={<SettingOutlined />}
+                                text="Settings"
+                                sectionTooltip={advancedSectionTooltip}
                             />
                         }
-                        key="1"
+                        key="2"
                     >
-                        {filterFields.map((field, i) => (
-                            <Fragment key={field.name}>
-                                {shouldRenderFilterSectionHeader(field, i, filterFields) && (
-                                    <Typography.Title level={4}>{field.section}</Typography.Title>
-                                )}
-                                <MarginWrapper>
-                                    <FormField
-                                        field={field}
-                                        secrets={secrets}
-                                        refetchSecrets={refetchSecrets}
-                                        removeMargin={i === filterFields.length - 1}
-                                        updateFormValue={updateFormValue}
-                                    />
-                                </MarginWrapper>
-                            </Fragment>
+                        {advancedFields.map((field, i) => (
+                            <FormField
+                                key={field.name}
+                                field={field}
+                                secrets={secrets}
+                                refetchSecrets={refetchSecrets}
+                                removeMargin={i === advancedFields.length - 1}
+                                updateFormValue={updateFormValue}
+                            />
                         ))}
                     </Collapse.Panel>
                 </StyledCollapse>
-            )}
-            <StyledCollapse defaultActiveKey={defaultOpenSections?.includes(RecipeSections.Advanced) ? '2' : ''}>
-                <Collapse.Panel
-                    forceRender
-                    header={
-                        <SectionHeader
-                            icon={<SettingOutlined />}
-                            text="Settings"
-                            sectionTooltip={advancedSectionTooltip}
-                        />
-                    }
-                    key="2"
-                >
-                    {advancedFields.map((field, i) => (
-                        <FormField
-                            key={field.name}
-                            field={field}
-                            secrets={secrets}
-                            refetchSecrets={refetchSecrets}
-                            removeMargin={i === advancedFields.length - 1}
-                            updateFormValue={updateFormValue}
-                        />
-                    ))}
-                </Collapse.Panel>
-            </StyledCollapse>
+            </RequiredFieldForm>
             <ControlsContainer>
                 <Button variant="outline" color="gray" disabled={isEditing} onClick={goToPrevious}>
                     Previous
                 </Button>
-                <Button>Next</Button>
+                <Button onClick={onClickNext}>Next</Button>
             </ControlsContainer>
-        </RequiredFieldForm>
+        </>
     );
 }
 


### PR DESCRIPTION
The Define Step in the Ingestion Sources creation UI has issues with the form, where hitting enter in the form triggers the goToPrevious button. This is because the buttons are put within the Form and enter triggers the first available button. Moving the buttons out will resolve the issue

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
