### PR TITLE
assigment property on front-end module

### DIFF
--- a/datahub-frontend/app/client/KafkaTrackingProducer.java
+++ b/datahub-frontend/app/client/KafkaTrackingProducer.java
@@ -151,6 +151,11 @@ public class KafkaTrackingProducer {
             props,
             SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
             "analytics.kafka.sasl.client.callback.handler.class");
+        setConfig(
+            config,
+            props,
+            SaslConfigs.SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL,
+            "analytics.kafka.sasl.oauthbearer.token.endpoint.url");
       }
     }
 

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -255,6 +255,7 @@ analytics.kafka.sasl.jaas.config = ${?KAFKA_PROPERTIES_SASL_JAAS_CONFIG}
 analytics.kafka.sasl.kerberos.service.name = ${?KAFKA_PROPERTIES_SASL_KERBEROS_SERVICE_NAME}
 analytics.kafka.sasl.login.callback.handler.class = ${?KAFKA_PROPERTIES_SASL_LOGIN_CALLBACK_HANDLER_CLASS}
 analytics.kafka.sasl.client.callback.handler.class = ${?KAFKA_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS}
+analytics.kafka.sasl.oauthbearer.token.endpoint.url = ${?KAFKA_PROPERTIES_SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL}
 
 # Required Elastic Client Configuration
 analytics.elastic.host =  ${?ELASTIC_CLIENT_HOST}


### PR DESCRIPTION
fix: parsing needed property on frontend module for oauth authentication

As it was commeted on the pr: [https://github.com/datahub-project/datahub/pull/13667](https://github.com/datahub-project/datahub/pull/13667) Right now we are stuck due to this error, that's why, even though it was mentioned that a refactor was going to be done to solve this problem, I wonder if this PR can be applied to get us unstuck.

we have found a problem trying to configure OAUTH on kafka on the frontend project , we have this error on logs:
![image](https://github.com/user-attachments/assets/1cc14966-afac-4408-8885-ea19df123914)

As you can see despite we have previously configured correctly the oauth bearer token endpoint , this configuration is not properly applied , it appears as null:
![image](https://github.com/user-attachments/assets/5b845b83-7b86-44c9-b4e6-5e5f0828fe53)


Our configuration is:

springKafkaConfigurationOverrides:
security.protocol: SASL_SSL
sasl.mechanism: OAUTHBEARER
sasl.login.callback.handler.class: org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler
sasl.oauthbearer.token.endpoint.url: https://login.microsoftonline.com/xxxxxx/oauth2/v2.0/token
sasl.oauthbearer.method: oidc

We think maybe it is necessary to set the assignment of this property on these files:

datahub-frontend/app/client/KafkaTrackingProducer.java
datahub-frontend/conf/application.conf


Copyright 2025 Santander Global Tech & Operations All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0


