### PR TITLE
feat(ui/ingestion): show the newly added ingestion source at the top of the list

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
@@ -208,7 +208,6 @@ export const IngestionSourceList = ({ showCreateModal, setShowCreateModal, shoul
     const focusSource = finalSources.find((s) => s.urn === focusSourceUrn);
     const isLastPage = totalSources <= pageSize * page;
 
-
     useEffect(() => {
         const sources = (data?.listIngestionSources?.ingestionSources || []) as IngestionSource[];
         setFinalSources(sources);

--- a/datahub-web-react/src/app/ingestV2/source/IngestionSourceRefetcher.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestionSourceRefetcher.tsx
@@ -1,0 +1,17 @@
+import usePollIngestionSource from '@app/ingestV2/source/usePollSources';
+
+import { IngestionSource, ListIngestionSourcesInput } from '@types';
+
+interface Props {
+    urn: string;
+    setFinalSources: React.Dispatch<React.SetStateAction<IngestionSource[]>>;
+    setSourcesToRefetch: React.Dispatch<React.SetStateAction<Set<string>>>;
+    queryInputs: ListIngestionSourcesInput;
+}
+
+const IngestionSourceRefetcher = ({ urn, setFinalSources, setSourcesToRefetch, queryInputs }: Props) => {
+    usePollIngestionSource({ urn, setFinalSources, setSourcesToRefetch, queryInputs });
+    return null;
+};
+
+export default IngestionSourceRefetcher;

--- a/datahub-web-react/src/app/ingestV2/source/cacheUtils.ts
+++ b/datahub-web-react/src/app/ingestV2/source/cacheUtils.ts
@@ -1,0 +1,109 @@
+import { ListIngestionSourcesDocument, ListIngestionSourcesQuery } from '@graphql/ingestion.generated';
+
+/**
+ * Add an entry to the ListIngestionSources cache.
+ */
+export const addToListIngestionSourcesCache = (client, newSource, queryInputs) => {
+    // Read the data from our cache for this query.
+    const currData: ListIngestionSourcesQuery | null = client.readQuery({
+        query: ListIngestionSourcesDocument,
+        variables: {
+            input: queryInputs,
+        },
+    });
+
+    // Add our new source into the existing list.
+    const newSources = [newSource, ...(currData?.listIngestionSources?.ingestionSources || [])];
+
+    // Write our data back to the cache.
+    client.writeQuery({
+        query: ListIngestionSourcesDocument,
+        variables: {
+            input: queryInputs,
+        },
+        data: {
+            listIngestionSources: {
+                start: 0,
+                count: (currData?.listIngestionSources?.count || 0) + 1,
+                total: (currData?.listIngestionSources?.total || 0) + 1,
+                ingestionSources: newSources,
+            },
+        },
+    });
+};
+
+/**
+ * Update an entry in the ListIngestionSources cache.
+ */
+export const updateListIngestionSourcesCache = (client, updatedSource, queryInputs) => {
+    // Read the data from our cache for this query
+    const currData: ListIngestionSourcesQuery | null = client.readQuery({
+        query: ListIngestionSourcesDocument,
+        variables: {
+            input: queryInputs,
+        },
+    });
+
+    if (!currData?.listIngestionSources?.ingestionSources) return;
+
+    // Update the given source in the existing list
+    const newSources = currData.listIngestionSources.ingestionSources.map((source) =>
+        source.urn === updatedSource.urn ? updatedSource : source,
+    );
+
+    // Write our data back to the cache
+    client.writeQuery({
+        query: ListIngestionSourcesDocument,
+        variables: {
+            input: queryInputs,
+        },
+        data: {
+            listIngestionSources: {
+                ...currData.listIngestionSources,
+                ingestionSources: newSources,
+            },
+        },
+    });
+};
+
+/**
+ * Remove an entry from the ListIngestionSources cache.
+ */
+export const removeFromListIngestionSourcesCache = (client, urn, page, pageSize, query) => {
+    // Read the data from our cache for this query.
+    const currData: ListIngestionSourcesQuery | null = client.readQuery({
+        query: ListIngestionSourcesDocument,
+        variables: {
+            input: {
+                start: (page - 1) * pageSize,
+                count: pageSize,
+                query,
+            },
+        },
+    });
+
+    // Remove the source from the existing sources set.
+    const newSources = [
+        ...(currData?.listIngestionSources?.ingestionSources || []).filter((source) => source.urn !== urn),
+    ];
+
+    // Write our data back to the cache.
+    client.writeQuery({
+        query: ListIngestionSourcesDocument,
+        variables: {
+            input: {
+                start: (page - 1) * pageSize,
+                count: pageSize,
+                query,
+            },
+        },
+        data: {
+            listIngestionSources: {
+                start: currData?.listIngestionSources?.start || 0,
+                count: (currData?.listIngestionSources?.count || 1) - 1,
+                total: (currData?.listIngestionSources?.total || 1) - 1,
+                ingestionSources: newSources,
+            },
+        },
+    });
+};

--- a/datahub-web-react/src/app/ingestV2/source/usePollSources.ts
+++ b/datahub-web-react/src/app/ingestV2/source/usePollSources.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+
+import { isExecutionRequestActive } from '@app/ingestV2/executions/utils';
+import { updateListIngestionSourcesCache } from '@app/ingestV2/source/cacheUtils';
+
+import { useGetIngestionSourceLazyQuery } from '@graphql/ingestion.generated';
+import { IngestionSource, ListIngestionSourcesInput } from '@types';
+
+const REFRESH_INTERVAL_MS = 3000;
+
+interface Props {
+    urn: string;
+    setFinalSources: React.Dispatch<React.SetStateAction<IngestionSource[]>>;
+    setSourcesToRefetch: React.Dispatch<React.SetStateAction<Set<string>>>;
+    queryInputs: ListIngestionSourcesInput;
+}
+
+export default function usePollSources({ urn, setFinalSources, setSourcesToRefetch, queryInputs }: Props) {
+    const [startPolling, setStartPolling] = useState(false);
+
+    const [getIngestionSourceQuery, { client }] = useGetIngestionSourceLazyQuery({
+        fetchPolicy: 'network-only',
+        onCompleted: (data) => {
+            const updatedSource = data?.ingestionSource;
+            if (!updatedSource?.executions?.executionRequests) return;
+
+            setFinalSources(
+                (prev) =>
+                    prev.map((source) =>
+                        source.urn === updatedSource.urn ? updatedSource : source,
+                    ) as IngestionSource[],
+            );
+
+            updateListIngestionSourcesCache(client, updatedSource, queryInputs);
+
+            const stillRunning = updatedSource.executions?.executionRequests?.some((req) =>
+                isExecutionRequestActive(req),
+            );
+
+            if (!stillRunning) {
+                setSourcesToRefetch((prev) => {
+                    const newSet = new Set(prev);
+                    newSet.delete(urn);
+                    return newSet;
+                });
+            }
+        },
+    });
+
+    useEffect(() => {
+        if (!urn) return undefined;
+
+        const timeout = setTimeout(() => {
+            getIngestionSourceQuery({
+                variables: { urn },
+            });
+            setStartPolling(true);
+        }, REFRESH_INTERVAL_MS);
+
+        return () => {
+            clearTimeout(timeout);
+        };
+    }, [getIngestionSourceQuery, urn]);
+
+    useEffect(() => {
+        if (!startPolling) return undefined;
+
+        const interval = setInterval(() => {
+            getIngestionSourceQuery({
+                variables: { urn },
+            });
+        }, REFRESH_INTERVAL_MS);
+
+        return () => clearInterval(interval);
+    }, [startPolling, getIngestionSourceQuery, urn]);
+}

--- a/datahub-web-react/src/app/ingestV2/source/utils.ts
+++ b/datahub-web-react/src/app/ingestV2/source/utils.ts
@@ -362,16 +362,19 @@ export const extractEntityTypeCountsFromFacets = (
 /**
  * Add an entry to the ListIngestionSources cache.
  */
-export const addToListIngestionSourcesCache = (client, newSource, pageSize, query) => {
+export const addToListIngestionSourcesCache = (client, newSource, start, pageSize, query, filters, sort) => {
+    const inputs = {
+        start,
+        count: pageSize,
+        query: query?.length ? query : undefined,
+        filters: filters.length ? filters : undefined,
+        sort,
+    };
     // Read the data from our cache for this query.
     const currData: ListIngestionSourcesQuery | null = client.readQuery({
         query: ListIngestionSourcesDocument,
         variables: {
-            input: {
-                start: 0,
-                count: pageSize,
-                query,
-            },
+            input: inputs,
         },
     });
 
@@ -382,11 +385,7 @@ export const addToListIngestionSourcesCache = (client, newSource, pageSize, quer
     client.writeQuery({
         query: ListIngestionSourcesDocument,
         variables: {
-            input: {
-                start: 0,
-                count: pageSize,
-                query,
-            },
+            input: inputs,
         },
         data: {
             listIngestionSources: {

--- a/datahub-web-react/src/app/ingestV2/source/utils.ts
+++ b/datahub-web-react/src/app/ingestV2/source/utils.ts
@@ -16,7 +16,6 @@ import {
 import { SourceConfig } from '@app/ingestV2/source/builder/types';
 import { capitalizeFirstLetterOnly, pluralize } from '@app/shared/textUtil';
 
-import { ListIngestionSourcesDocument, ListIngestionSourcesQuery } from '@graphql/ingestion.generated';
 import { EntityType, ExecutionRequestResult, FacetFilterInput, FacetMetadata, SortCriterion, SortOrder } from '@types';
 
 export const getSourceConfigs = (ingestionSources: SourceConfig[], sourceType: string) => {
@@ -357,87 +356,6 @@ export const extractEntityTypeCountsFromFacets = (
     }
 
     return finalCounts;
-};
-
-/**
- * Add an entry to the ListIngestionSources cache.
- */
-export const addToListIngestionSourcesCache = (client, newSource, start, pageSize, query, filters, sort) => {
-    const inputs = {
-        start,
-        count: pageSize,
-        query: query?.length ? query : undefined,
-        filters: filters.length ? filters : undefined,
-        sort,
-    };
-    // Read the data from our cache for this query.
-    const currData: ListIngestionSourcesQuery | null = client.readQuery({
-        query: ListIngestionSourcesDocument,
-        variables: {
-            input: inputs,
-        },
-    });
-
-    // Add our new source into the existing list.
-    const newSources = [newSource, ...(currData?.listIngestionSources?.ingestionSources || [])];
-
-    // Write our data back to the cache.
-    client.writeQuery({
-        query: ListIngestionSourcesDocument,
-        variables: {
-            input: inputs,
-        },
-        data: {
-            listIngestionSources: {
-                start: 0,
-                count: (currData?.listIngestionSources?.count || 0) + 1,
-                total: (currData?.listIngestionSources?.total || 0) + 1,
-                ingestionSources: newSources,
-            },
-        },
-    });
-};
-
-/**
- * Remove an entry from the ListIngestionSources cache.
- */
-export const removeFromListIngestionSourcesCache = (client, urn, page, pageSize, query) => {
-    // Read the data from our cache for this query.
-    const currData: ListIngestionSourcesQuery | null = client.readQuery({
-        query: ListIngestionSourcesDocument,
-        variables: {
-            input: {
-                start: (page - 1) * pageSize,
-                count: pageSize,
-                query,
-            },
-        },
-    });
-
-    // Remove the source from the existing sources set.
-    const newSources = [
-        ...(currData?.listIngestionSources?.ingestionSources || []).filter((source) => source.urn !== urn),
-    ];
-
-    // Write our data back to the cache.
-    client.writeQuery({
-        query: ListIngestionSourcesDocument,
-        variables: {
-            input: {
-                start: (page - 1) * pageSize,
-                count: pageSize,
-                query,
-            },
-        },
-        data: {
-            listIngestionSources: {
-                start: currData?.listIngestionSources?.start || 0,
-                count: (currData?.listIngestionSources?.count || 1) - 1,
-                total: (currData?.listIngestionSources?.total || 1) - 1,
-                ingestionSources: newSources,
-            },
-        },
-    });
 };
 
 export function getSortInput(field: string, order: SortingState): SortCriterion | undefined {


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-409/creating-a-new-ingestion-source-should-be-added-to-the-top-of-the-list

**Description:**

- Adds the newly added source to cache and shows at the top of the list
- Fetches only the single source after create/update/execute instead of the entire list
- Keeps polling the individual sources after create/update/execute till execution is complete

**Video:**

Create:

https://github.com/user-attachments/assets/ff4ddd92-e509-4cd0-8cff-95c03bc37e7e

Run source:

https://github.com/user-attachments/assets/8d8dcc17-0595-4098-b07a-6645b06f8bd5



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
