### PR TITLE
fix(ui) Fix location of data-testid for schema field drawer

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/SchemaFieldDrawerTabs.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/SchemaFieldDrawerTabs.tsx
@@ -286,7 +286,10 @@ export const SchemaFieldDrawerTabs = ({ tabs, selectedTab, onSelectTab }: Props)
                         <Tab
                             tab={
                                 <TabIconContainer $isSelected={isSelected}>
-                                    <IconWrapper $isSelected={isSelected}>
+                                    <IconWrapper
+                                        $isSelected={isSelected}
+                                        data-testid={`${name}-field-drawer-tab-header`}
+                                    >
                                         {isSelected ? (
                                             <SelectedTabIcon size={20} weight="fill" />
                                         ) : (
@@ -297,7 +300,6 @@ export const SchemaFieldDrawerTabs = ({ tabs, selectedTab, onSelectTab }: Props)
                                 </TabIconContainer>
                             }
                             key={tab.name}
-                            data-testid={`${name}-field-drawer-tab-header`}
                         />
                     );
                 })}


### PR DESCRIPTION
Place the test id on an element that will show up in the UI instead of an ent design component.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
