### PR TITLE
fix(application): adjusting applicatino to new search signature

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/application/ApplicationType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/application/ApplicationType.java
@@ -108,7 +108,7 @@ public class ApplicationType
       @Nonnull String query,
       @Nullable String field,
       @Nullable Filter filters,
-      int limit,
+      @Nullable Integer limit,
       @Nonnull final QueryContext context)
       throws Exception {
     final AutoCompleteResult result =
@@ -122,7 +122,7 @@ public class ApplicationType
       @Nonnull String query,
       @Nullable List<FacetFilterInput> filters,
       int start,
-      int count,
+      @Nullable Integer count,
       @Nonnull final QueryContext context)
       throws Exception {
     throw new NotImplementedException(


### PR DESCRIPTION
Introduced by: https://github.com/acryldata/datahub-fork/pull/5966/files

This PR was not fully rebased on master, so was passing CI. However once merged, it introduced this breakage with applications.