### PR TITLE
fix(ui) Take users to page 1 after page size change

### DIFF
--- a/datahub-web-react/src/app/searchV2/SearchResults.tsx
+++ b/datahub-web-react/src/app/searchV2/SearchResults.tsx
@@ -197,8 +197,14 @@ export const SearchResults = ({
         }
     }, []);
 
-    function handlePageChange(p: number) {
-        onChangePage(p);
+    function handlePageChange(newPage: number, newPageSize: number) {
+        const didPageSizeChange = numResultsPerPage !== newPageSize;
+        if (didPageSizeChange) {
+            onChangePage(1);
+            setNumResultsPerPage(newPageSize);
+        } else {
+            onChangePage(newPage);
+        }
         setAreAllEntitiesSelected?.(false);
     }
 
@@ -284,10 +290,7 @@ export const SearchResults = ({
                                                         showLessItems
                                                         onChange={handlePageChange}
                                                         showSizeChanger={totalResults > SearchCfg.RESULTS_PER_PAGE}
-                                                        onShowSizeChange={(_currNum, newNum) =>
-                                                            setNumResultsPerPage(newNum)
-                                                        }
-                                                        pageSizeOptions={['10', '20', '50', '100']}
+                                                        pageSizeOptions={['10', '20', '30']}
                                                     />
                                                 </PaginationControlContainer>
                                             )}


### PR DESCRIPTION
We've seen an issue where users will change the page size on one of the last pages and then get stuck on a page that doesn't exist - showing no results and sometimes causing bigger issues.

After analyzing similar experiences in other apps (ie. Stack Overflow) we saw that people were taking users back to page 1 whenever they changed the size of the page. To keep it simple we're doing that here too.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
