### PR TITLE
fix(graphql) Allow updating names of groups without corpGroupInfo

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
@@ -5,6 +5,8 @@ import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.persis
 
 import com.linkedin.businessattribute.BusinessAttributeInfo;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.CorpGroupUrnArray;
+import com.linkedin.common.CorpuserUrnArray;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -215,7 +217,7 @@ public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean
                     targetUrn.toString(),
                     Constants.CORP_GROUP_INFO_ASPECT_NAME,
                     _entityService,
-                    null);
+                    createDefaultCorpGroupInfo());
         if (corpGroupInfo == null) {
           throw new IllegalArgumentException("Group does not exist");
         }
@@ -237,6 +239,14 @@ public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean
     }
     throw new AuthorizationException(
         "Unauthorized to perform this action. Please contact your DataHub administrator.");
+  }
+
+  private CorpGroupInfo createDefaultCorpGroupInfo() {
+    CorpGroupInfo corpGroupInfo = new CorpGroupInfo();
+    corpGroupInfo.setAdmins(new CorpuserUrnArray());
+    corpGroupInfo.setMembers(new CorpuserUrnArray());
+    corpGroupInfo.setGroups(new CorpGroupUrnArray());
+    return corpGroupInfo;
   }
 
   // udpates editable dataset properties aspect's name field

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/group/UpdateGroupNameResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/group/UpdateGroupNameResolverTest.java
@@ -1,0 +1,88 @@
+package com.linkedin.datahub.graphql.resolvers.group;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.CorpGroupUrn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.UpdateNameInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.UpdateNameResolver;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.identity.CorpGroupInfo;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class UpdateGroupNameResolverTest {
+
+  private EntityService _entityService;
+  private EntityClient _entityClient;
+  private DataFetchingEnvironment _dataFetchingEnvironment;
+  private QueryContext _mockContext;
+  private UpdateNameResolver _resolver;
+  private static final String TEST_GROUP_URN = "urn:li:corpGroup:testGroup";
+  private static final String TEST_ACTOR_URN = "urn:li:corpuser:testUser";
+
+  @BeforeMethod
+  public void setupTest() {
+    _entityService = mock(EntityService.class);
+    _entityClient = mock(EntityClient.class);
+    _dataFetchingEnvironment = mock(DataFetchingEnvironment.class);
+    _mockContext = getMockAllowContext();
+    _resolver = new UpdateNameResolver(_entityService, _entityClient);
+    UpdateNameInput input = new UpdateNameInput();
+    input.setName("new name");
+    input.setUrn(TEST_GROUP_URN);
+
+    when(_dataFetchingEnvironment.getContext()).thenReturn(_mockContext);
+    when(_mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN);
+    when(_dataFetchingEnvironment.getArgument(eq("input"))).thenReturn(input);
+  }
+
+  @Test
+  public void testUpdateGroupNameWithExistingInfo() throws Exception {
+    // Setup
+    CorpGroupUrn groupUrn = CorpGroupUrn.createFromString(TEST_GROUP_URN);
+    CorpGroupInfo existingInfo = new CorpGroupInfo();
+    existingInfo.setDisplayName("Old Name");
+
+    when(_entityService.exists(any(), eq(groupUrn), eq(true))).thenReturn(true);
+    when(_entityService.getAspect(any(), eq(groupUrn), eq("corpGroupInfo"), eq(0)))
+        .thenReturn(existingInfo);
+
+    // Execute
+    CompletableFuture<Boolean> result = _resolver.get(_dataFetchingEnvironment);
+
+    // Verify
+    assertTrue(result.get());
+    verify(_entityService)
+        .ingestProposal(any(), any(MetadataChangeProposal.class), any(AuditStamp.class), eq(false));
+  }
+
+  @Test
+  public void testUpdateGroupNameWithNullInfo() throws Exception {
+    // Setup
+    CorpGroupUrn groupUrn = CorpGroupUrn.createFromString(TEST_GROUP_URN);
+
+    when(_entityService.exists(any(), eq(groupUrn), eq(true))).thenReturn(true);
+    when(_entityService.getAspect(any(), eq(groupUrn), eq("corpGroupInfo"), eq(0)))
+        .thenReturn(null);
+
+    // Execute
+    CompletableFuture<Boolean> result = _resolver.get(_dataFetchingEnvironment);
+
+    // Verify
+    assertTrue(result.get());
+    verify(_entityService)
+        .ingestProposal(any(), any(MetadataChangeProposal.class), any(AuditStamp.class), eq(false));
+  }
+}


### PR DESCRIPTION
If someone creates groups without a corpGroupInfo aspect, like with a SCIM integration, they should be able to edit the group name. Right now they cannot because the `corpGroupInfo` aspect does not exist and we throw an error. This PR changes that implementation to have a default `corpGroupInfo` aspect they can update the name.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
