### PR TITLE
fix(ingest/bigquery): Set qualified name for bigquery containers

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
@@ -286,6 +286,7 @@ class BigQuerySchemaGenerator:
         yield from gen_database_container(
             database=database,
             name=database,
+            qualified_name=database,
             sub_types=[DatasetContainerSubTypes.BIGQUERY_PROJECT],
             domain_registry=self.domain_registry,
             domain_config=self.config.domain,
@@ -332,6 +333,7 @@ class BigQuerySchemaGenerator:
         yield from gen_schema_container(
             database=project_id,
             schema=dataset,
+            qualified_name=f"{project_id}.{dataset}",
             sub_types=[DatasetContainerSubTypes.BIGQUERY_DATASET],
             domain_registry=self.domain_registry,
             domain_config=self.config.domain,

--- a/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_golden.json
+++ b/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_golden.json
@@ -12,12 +12,13 @@
                 "project_id": "project-id-1"
             },
             "name": "project-id-1",
+            "qualifiedName": "project-id-1",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-jjnkc6",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -103,12 +104,13 @@
             },
             "externalUrl": "https://console.cloud.google.com/bigquery?project=project-id-1&ws=!1m4!1m3!3m2!1sproject-id-1!2sbigquery-dataset-1",
             "name": "bigquery-dataset-1",
+            "qualifiedName": "project-id-1.bigquery-dataset-1",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-jjnkc6",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_lineage_golden_1.json
+++ b/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_lineage_golden_1.json
@@ -12,12 +12,13 @@
                 "project_id": "project-id-1"
             },
             "name": "project-id-1",
+            "qualifiedName": "project-id-1",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00-0mn4n3",
+        "runId": "bigquery-2022_02_03-07_00_00-rxfj1j",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -119,12 +120,13 @@
             },
             "externalUrl": "https://console.cloud.google.com/bigquery?project=project-id-1&ws=!1m4!1m3!3m2!1sproject-id-1!2sbigquery-dataset-1",
             "name": "bigquery-dataset-1",
+            "qualifiedName": "project-id-1.bigquery-dataset-1",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00-0mn4n3",
+        "runId": "bigquery-2022_02_03-07_00_00-rxfj1j",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_lineage_golden_2.json
+++ b/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_lineage_golden_2.json
@@ -12,12 +12,13 @@
                 "project_id": "project-id-1"
             },
             "name": "project-id-1",
+            "qualifiedName": "project-id-1",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00-k4o1z9",
+        "runId": "bigquery-2022_02_03-07_00_00-xyx9kz",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -119,12 +120,13 @@
             },
             "externalUrl": "https://console.cloud.google.com/bigquery?project=project-id-1&ws=!1m4!1m3!3m2!1sproject-id-1!2sbigquery-dataset-1",
             "name": "bigquery-dataset-1",
+            "qualifiedName": "project-id-1.bigquery-dataset-1",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00-k4o1z9",
+        "runId": "bigquery-2022_02_03-07_00_00-xyx9kz",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_queries_golden.json
+++ b/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_queries_golden.json
@@ -12,12 +12,13 @@
                 "project_id": "project-id-1"
             },
             "name": "project-id-1",
+            "qualifiedName": "project-id-1",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-o98ox9",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -103,12 +104,13 @@
             },
             "externalUrl": "https://console.cloud.google.com/bigquery?project=project-id-1&ws=!1m4!1m3!3m2!1sproject-id-1!2sbigquery-dataset-1",
             "name": "bigquery-dataset-1",
+            "qualifiedName": "project-id-1.bigquery-dataset-1",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-o98ox9",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/bigquery_v2/bigquery_project_label_mcp_golden.json
+++ b/metadata-ingestion/tests/integration/bigquery_v2/bigquery_project_label_mcp_golden.json
@@ -12,12 +12,13 @@
                 "project_id": "dev"
             },
             "name": "dev",
+            "qualifiedName": "dev",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-c7ra94",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -102,12 +103,13 @@
             },
             "externalUrl": "https://console.cloud.google.com/bigquery?project=dev&ws=!1m4!1m3!3m2!1sdev!2sbigquery-dataset-1",
             "name": "bigquery-dataset-1",
+            "qualifiedName": "dev.bigquery-dataset-1",
             "env": "PROD"
         }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "bigquery-2022_02_03-07_00_00",
+        "runId": "bigquery-2022_02_03-07_00_00-c7ra94",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
+++ b/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
@@ -74,6 +74,7 @@ class ConfluentSchemaRegistryTest(unittest.TestCase):
 
         def new_get_latest_version(subject_name: str) -> RegisteredSchema:
             return RegisteredSchema(
+                guid=None,
                 schema_id="schema_id_1",
                 schema=Schema(schema_str=schema_str_ref, schema_type="AVRO"),
                 subject="test",

--- a/metadata-ingestion/tests/unit/test_kafka_source.py
+++ b/metadata-ingestion/tests/unit/test_kafka_source.py
@@ -236,6 +236,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
         # TopicNameStrategy is used for subject
         "topic1": (
             RegisteredSchema(
+                guid=None,
                 schema_id="schema_id_2",
                 schema=Schema(
                     schema_str='{"type":"record", "name":"Topic1Key", "namespace": "test.acryl", "fields": [{"name":"t1key", "type": "string"}]}',
@@ -245,6 +246,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
                 version=1,
             ),
             RegisteredSchema(
+                guid=None,
                 schema_id="schema_id_1",
                 schema=Schema(
                     schema_str='{"type":"record", "name":"Topic1Value", "namespace": "test.acryl", "fields": [{"name":"t1value", "type": "string"}]}',
@@ -257,6 +259,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
         # RecordNameStrategy is used for subject
         "topic2": (
             RegisteredSchema(
+                guid=None,
                 schema_id="schema_id_3",
                 schema=Schema(
                     schema_str='{"type":"record", "name":"Topic2Key", "namespace": "test.acryl", "fields": [{"name":"t2key", "type": "string"}]}',
@@ -266,6 +269,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
                 version=1,
             ),
             RegisteredSchema(
+                guid=None,
                 schema_id="schema_id_4",
                 schema=Schema(
                     schema_str='{"type":"record", "name":"Topic2Value", "namespace": "test.acryl", "fields": [{"name":"t2value", "type": "string"}]}',
@@ -278,6 +282,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
         # TopicRecordNameStrategy is used for subject
         "topic3": (
             RegisteredSchema(
+                guid=None,
                 schema_id="schema_id_4",
                 schema=Schema(
                     schema_str='{"type":"record", "name":"Topic3Key", "namespace": "test.acryl", "fields": [{"name":"t3key", "type": "string"}]}',
@@ -287,6 +292,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
                 version=1,
             ),
             RegisteredSchema(
+                guid=None,
                 schema_id="schema_id_5",
                 schema=Schema(
                     schema_str='{"type":"record", "name":"Topic3Value", "namespace": "test.acryl", "fields": [{"name":"t3value", "type": "string"}]}',
@@ -429,6 +435,7 @@ def test_kafka_ignore_warnings_on_schema_type(
 ):
     # define the key and value schemas for topic1
     topic1_key_schema = RegisteredSchema(
+        guid=None,
         schema_id="schema_id_2",
         schema=Schema(
             schema_str="{}",
@@ -438,6 +445,7 @@ def test_kafka_ignore_warnings_on_schema_type(
         version=1,
     )
     topic1_value_schema = RegisteredSchema(
+        guid=None,
         schema_id="schema_id_1",
         schema=Schema(
             schema_str="{}",
@@ -563,6 +571,7 @@ def test_kafka_source_topic_meta_mappings(
     topic_subject_schema_map: Dict[str, Tuple[RegisteredSchema, RegisteredSchema]] = {
         "topic1": (
             RegisteredSchema(
+                guid=None,
                 schema_id="schema_id_2",
                 schema=Schema(
                     schema_str='{"type":"record", "name":"Topic1Key", "namespace": "test.acryl", "fields": [{"name":"t1key", "type": "string"}]}',
@@ -572,6 +581,7 @@ def test_kafka_source_topic_meta_mappings(
                 version=1,
             ),
             RegisteredSchema(
+                guid=None,
                 schema_id="schema_id_1",
                 schema=Schema(
                     schema_str=json.dumps(


### PR DESCRIPTION
### Schema Generation Enhancements:
* Added `qualifiedName` to project-level containers in the `gen_project_id_containers` function, using the database name as the identifier. (`metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py`)
* Added `qualifiedName` to dataset-level containers in the `gen_dataset_containers` function, using a combination of project ID and dataset name. (`metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py`)

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
