### PR TITLE
fix(ingestion): replace nonexistent icon

### DIFF
--- a/datahub-web-react/src/app/ingestV2/executions/utils.ts
+++ b/datahub-web-react/src/app/ingestV2/executions/utils.ts
@@ -24,7 +24,7 @@ export const getExecutionRequestStatusIcon = (status: string) => {
     return (
         (status === EXECUTION_REQUEST_STATUS_RUNNING && 'CircleNotch') ||
         (status === EXECUTION_REQUEST_STATUS_SUCCESS && 'Check') ||
-        (status === EXECUTION_REQUEST_STATUS_SUCCEEDED_WITH_WARNINGS && 'ExclamationMark') ||
+        (status === EXECUTION_REQUEST_STATUS_SUCCEEDED_WITH_WARNINGS && 'WarningCircle') ||
         (status === EXECUTION_REQUEST_STATUS_FAILURE && 'X') ||
         (status === EXECUTION_REQUEST_STATUS_CANCELLED && 'Prohibit') ||
         (status === EXECUTION_REQUEST_STATUS_UP_FOR_RETRY && 'CircleNotch') ||


### PR DESCRIPTION
Replaced ExclamationMark icon with WarningCircle

ExclamationMark doesn't exist in the current version of phosphor

![image](https://github.com/user-attachments/assets/15ca421a-6b09-4c9e-952d-c8cc062f9850)


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
