### PR TITLE
feat(ingest): add debug source

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -507,6 +507,10 @@ plugins: Dict[str, Set[str]] = {
         # It's technically wrong for packages to depend on setuptools. However, it seems mlflow does it anyways.
         "setuptools",
     },
+    "datahub-debug": {
+        "dnspython==2.7.0",
+        "requests"
+    },
     "mode": {"requests", "python-liquid", "tenacity>=8.0.1"} | sqlglot_lib,
     "mongodb": {"pymongo[srv]>=3.11", "packaging"},
     "mssql": sql_common | mssql_common,
@@ -799,6 +803,7 @@ entry_points = {
         "looker = datahub.ingestion.source.looker.looker_source:LookerDashboardSource",
         "lookml = datahub.ingestion.source.looker.lookml_source:LookMLSource",
         "datahub-gc = datahub.ingestion.source.gc.datahub_gc:DataHubGcSource",
+        "datahub-debug = datahub.ingestion.source.debug.datahub_debug:DataHubDebugSource",
         "datahub-apply = datahub.ingestion.source.apply.datahub_apply:DataHubApplySource",
         "datahub-lineage-file = datahub.ingestion.source.metadata.lineage:LineageFileSource",
         "datahub-business-glossary = datahub.ingestion.source.metadata.business_glossary:BusinessGlossaryFileSource",

--- a/metadata-ingestion/src/datahub/ingestion/source/debug/datahub_debug.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/debug/datahub_debug.py
@@ -154,55 +154,72 @@ class DataHubDebugSource(Source):
         """HTTP connectivity test using requests library"""
         try:
             # Test with different timeouts and methods
-            test_configs = [
-                {"timeout": 10, "method": "HEAD", "allow_redirects": True},
-                {"timeout": 10, "method": "GET", "allow_redirects": False},
-            ]
+            timeout = 10
+            allow_redirects_head = True
+            allow_redirects_get = False
 
-            for config in test_configs:
-                try:
-                    logger.info(
-                        f"Testing {config['method']} request with timeout {config['timeout']}s"
-                    )
-                    start_time = time.time()
+            # Test HEAD request
+            try:
+                logger.info(f"Testing HEAD request with timeout {timeout}s")
+                start_time = time.time()
 
-                    if config["method"] == "HEAD":
-                        response = requests.head(
-                            url, **{k: v for k, v in config.items() if k != "method"}
-                        )
-                    else:
-                        response = requests.get(
-                            url, **{k: v for k, v in config.items() if k != "method"}
-                        )
+                response = requests.head(
+                    url, timeout=timeout, allow_redirects=allow_redirects_head
+                )
 
-                    request_time = time.time() - start_time
+                request_time = time.time() - start_time
 
-                    logger.info(
-                        f"✓ {config['method']} request successful ({request_time:.3f}s)"
-                    )
-                    logger.info(f"  Status code: {response.status_code}")
-                    logger.info(
-                        f"  Response headers: {dict(list(response.headers.items())[:5])}"
-                    )
+                logger.info(f"✓ HEAD request successful ({request_time:.3f}s)")
+                logger.info(f"  Status code: {response.status_code}")
+                logger.info(
+                    f"  Response headers: {dict(list(response.headers.items())[:5])}"
+                )
 
-                    if hasattr(response, "url") and response.url != url:
-                        logger.info(f"  Final URL after redirects: {response.url}")
+                if hasattr(response, "url") and response.url != url:
+                    logger.info(f"  Final URL after redirects: {response.url}")
 
-                except requests.exceptions.Timeout:
-                    logger.error(
-                        f"✗ {config['method']} request timed out after {config['timeout']}s"
-                    )
-                except requests.exceptions.ConnectionError as e:
-                    logger.error(f"✗ {config['method']} connection error: {e}")
-                except requests.exceptions.RequestException as e:
-                    logger.error(f"✗ {config['method']} request failed: {e}")
-                except Exception as e:
-                    logger.error(f"✗ {config['method']} unexpected error: {e}")
+            except requests.exceptions.Timeout:
+                logger.error(f"✗ HEAD request timed out after {timeout}s")
+            except requests.exceptions.ConnectionError as e:
+                logger.error(f"✗ HEAD connection error: {e}")
+            except requests.exceptions.RequestException as e:
+                logger.error(f"✗ HEAD request failed: {e}")
+            except Exception as e:
+                logger.error(f"✗ HEAD unexpected error: {e}")
+
+            # Test GET request
+            try:
+                logger.info(f"Testing GET request with timeout {timeout}s")
+                start_time = time.time()
+
+                response = requests.get(
+                    url, timeout=timeout, allow_redirects=allow_redirects_get
+                )
+
+                request_time = time.time() - start_time
+
+                logger.info(f"✓ GET request successful ({request_time:.3f}s)")
+                logger.info(f"  Status code: {response.status_code}")
+                logger.info(
+                    f"  Response headers: {dict(list(response.headers.items())[:5])}"
+                )
+
+                if hasattr(response, "url") and response.url != url:
+                    logger.info(f"  Final URL after redirects: {response.url}")
+
+            except requests.exceptions.Timeout:
+                logger.error(f"✗ GET request timed out after {timeout}s")
+            except requests.exceptions.ConnectionError as e:
+                logger.error(f"✗ GET connection error: {e}")
+            except requests.exceptions.RequestException as e:
+                logger.error(f"✗ GET request failed: {e}")
+            except Exception as e:
+                logger.error(f"✗ GET unexpected error: {e}")
 
         except Exception as e:
             logger.error(f"HTTP probe failed: {e}", exc_info=True)
 
-    def _log_dns_troubleshooting(self):
+    def _log_dns_troubleshooting(self) -> None:
         """Log DNS troubleshooting information"""
         logger.info("DNS TROUBLESHOOTING SUGGESTIONS:")
         logger.info("- Check if the hostname is correct")
@@ -211,7 +228,7 @@ class DataHubDebugSource(Source):
         logger.info("- Try using a different DNS server (8.8.8.8, 1.1.1.1)")
         logger.info("- Check if there are firewall restrictions")
 
-    def _log_system_network_info(self):
+    def _log_system_network_info(self) -> None:
         """Log system network configuration information"""
         try:
             local_hostname = socket.gethostname()
@@ -245,7 +262,7 @@ class DataHubDebugSource(Source):
         except Exception as e:
             logger.warning(f"Could not gather system network info: {e}")
 
-    def _test_alternative_dns(self, hostname: str):
+    def _test_alternative_dns(self, hostname: str) -> None:
         """Test hostname resolution using alternative methods"""
         try:
             families = [(socket.AF_INET, "IPv4"), (socket.AF_INET6, "IPv6")]

--- a/metadata-ingestion/src/datahub/ingestion/source/debug/datahub_debug.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/debug/datahub_debug.py
@@ -1,0 +1,283 @@
+import logging
+import socket
+import time
+from typing import Iterable, Optional
+from urllib.parse import urlparse
+
+import dns.exception
+import dns.resolver
+import requests
+
+from datahub.configuration.common import ConfigModel
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.decorators import (
+    SupportStatus,
+    config_class,
+    platform_name,
+    support_status,
+)
+from datahub.ingestion.api.source import Source, SourceReport
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+
+logger = logging.getLogger(__name__)
+
+
+class DataHubDebugSourceConfig(ConfigModel):
+    dns_probe_url: Optional[str] = None
+
+
+@platform_name("DataHubDebug")
+@config_class(DataHubDebugSourceConfig)
+@support_status(SupportStatus.TESTING)
+class DataHubDebugSource(Source):
+    """
+    DataHubDebugSource is helper to debug things in executor where ingestion is running.
+
+    This source can perform the following tasks:
+    1. Network probe of a URL. Different from test connection in sources as that is after source starts.
+
+    """
+
+    def __init__(self, ctx: PipelineContext, config: DataHubDebugSourceConfig):
+        self.ctx = ctx
+        self.config = config
+        self.report = SourceReport()
+        self.report.event_not_produced_warn = False
+
+    @classmethod
+    def create(cls, config_dict, ctx):
+        config = DataHubDebugSourceConfig.parse_obj(config_dict)
+        return cls(ctx, config)
+
+    def perform_dns_probe(self, url: str) -> None:
+        """
+        Perform comprehensive DNS probe and network connectivity tests.
+        Logs detailed information to help diagnose network issues.
+        """
+        logger.info(f"Starting DNS probe for URL: {url}")
+        logger.info("=" * 60)
+        logger.info(f"DNS PROBE REPORT FOR: {url}")
+        logger.info("=" * 60)
+
+        try:
+            # Parse the URL to extract hostname
+            parsed_url = urlparse(
+                url if url.startswith(("http://", "https://")) else f"http://{url}"
+            )
+            hostname = parsed_url.hostname or parsed_url.netloc
+            port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
+
+            logger.info(f"Parsed hostname: {hostname}")
+            logger.info(f"Target port: {port}")
+            logger.info(f"URL scheme: {parsed_url.scheme}")
+            logger.info("-" * 60)
+
+            # Test 1: Enhanced DNS resolution with dnspython if available
+            logger.info("1. DNS RESOLUTION TEST")
+            self._dns_probe_with_dnspython(hostname)
+
+            logger.info("-" * 60)
+
+            # Test 2: HTTP/HTTPS connectivity test with requests if available
+            logger.info("2. HTTP CONNECTIVITY TEST")
+            self._http_probe_with_requests(url)
+
+            logger.info("-" * 60)
+
+            # Test 3: System network information
+            logger.info("3. SYSTEM NETWORK INFORMATION")
+            self._log_system_network_info()
+
+        except Exception as e:
+            logger.error(f"DNS probe failed with unexpected error: {e}", exc_info=True)
+
+        logger.info("=" * 60)
+        logger.info("DNS PROBE COMPLETED")
+        logger.info("=" * 60)
+
+    def _dns_probe_with_dnspython(self, hostname: str) -> None:
+        """Enhanced DNS probing using dnspython library"""
+        try:
+            # Test different record types
+            record_types = ["A", "AAAA", "CNAME", "MX"]
+
+            for record_type in record_types:
+                try:
+                    start_time = time.time()
+                    answers = dns.resolver.resolve(hostname, record_type)
+                    dns_time = time.time() - start_time
+
+                    logger.info(
+                        f"✓ {record_type} record resolution successful ({dns_time:.3f}s)"
+                    )
+                    for answer in answers:
+                        logger.info(f"  - {record_type}: {answer}")
+
+                except dns.resolver.NXDOMAIN:
+                    logger.info(f"✗ {record_type} record: Domain does not exist")
+                except dns.resolver.NoAnswer:
+                    logger.info(
+                        f"- {record_type} record: No answer (record type not available)"
+                    )
+                except dns.exception.Timeout:
+                    logger.error(f"✗ {record_type} record: DNS query timed out")
+                except Exception as e:
+                    logger.error(f"✗ {record_type} record query failed: {e}")
+
+            # Test different DNS servers
+            logger.info("Testing with different DNS servers:")
+            dns_servers = ["8.8.8.8", "1.1.1.1", "208.67.222.222"]
+
+            for dns_server in dns_servers:
+                try:
+                    resolver = dns.resolver.Resolver()
+                    resolver.nameservers = [dns_server]
+                    resolver.timeout = 5
+
+                    start_time = time.time()
+                    answers = resolver.resolve(hostname, "A")
+                    dns_time = time.time() - start_time
+
+                    logger.info(
+                        f"✓ DNS server {dns_server} responded ({dns_time:.3f}s)"
+                    )
+                    for answer in answers:
+                        logger.info(f"  - A: {answer}")
+
+                except Exception as e:
+                    logger.error(f"✗ DNS server {dns_server} failed: {e}")
+
+        except Exception as e:
+            logger.error(f"Enhanced DNS probe failed: {e}", exc_info=True)
+
+    def _http_probe_with_requests(self, url: str) -> None:
+        """HTTP connectivity test using requests library"""
+        try:
+            # Test with different timeouts and methods
+            test_configs = [
+                {"timeout": 10, "method": "HEAD", "allow_redirects": True},
+                {"timeout": 10, "method": "GET", "allow_redirects": False},
+            ]
+
+            for config in test_configs:
+                try:
+                    logger.info(
+                        f"Testing {config['method']} request with timeout {config['timeout']}s"
+                    )
+                    start_time = time.time()
+
+                    if config["method"] == "HEAD":
+                        response = requests.head(
+                            url, **{k: v for k, v in config.items() if k != "method"}
+                        )
+                    else:
+                        response = requests.get(
+                            url, **{k: v for k, v in config.items() if k != "method"}
+                        )
+
+                    request_time = time.time() - start_time
+
+                    logger.info(
+                        f"✓ {config['method']} request successful ({request_time:.3f}s)"
+                    )
+                    logger.info(f"  Status code: {response.status_code}")
+                    logger.info(
+                        f"  Response headers: {dict(list(response.headers.items())[:5])}"
+                    )
+
+                    if hasattr(response, "url") and response.url != url:
+                        logger.info(f"  Final URL after redirects: {response.url}")
+
+                except requests.exceptions.Timeout:
+                    logger.error(
+                        f"✗ {config['method']} request timed out after {config['timeout']}s"
+                    )
+                except requests.exceptions.ConnectionError as e:
+                    logger.error(f"✗ {config['method']} connection error: {e}")
+                except requests.exceptions.RequestException as e:
+                    logger.error(f"✗ {config['method']} request failed: {e}")
+                except Exception as e:
+                    logger.error(f"✗ {config['method']} unexpected error: {e}")
+
+        except Exception as e:
+            logger.error(f"HTTP probe failed: {e}", exc_info=True)
+
+    def _log_dns_troubleshooting(self):
+        """Log DNS troubleshooting information"""
+        logger.info("DNS TROUBLESHOOTING SUGGESTIONS:")
+        logger.info("- Check if the hostname is correct")
+        logger.info("- Verify DNS server configuration")
+        logger.info("- Check network connectivity")
+        logger.info("- Try using a different DNS server (8.8.8.8, 1.1.1.1)")
+        logger.info("- Check if there are firewall restrictions")
+
+    def _log_system_network_info(self):
+        """Log system network configuration information"""
+        try:
+            local_hostname = socket.gethostname()
+            logger.info(f"Local hostname: {local_hostname}")
+
+            try:
+                local_ips = socket.getaddrinfo(local_hostname, None)
+                logger.info("Local IP addresses:")
+                for addr_info in local_ips:
+                    if addr_info[0] in [socket.AF_INET, socket.AF_INET6]:
+                        family = "IPv4" if addr_info[0] == socket.AF_INET else "IPv6"
+                        logger.info(f"  - {addr_info[4][0]} ({family})")
+            except Exception as e:
+                logger.warning(f"Could not retrieve local IP addresses: {e}")
+
+            logger.info("DNS Server Connectivity:")
+            dns_servers = ["8.8.8.8", "1.1.1.1", "208.67.222.222"]
+            for dns_server in dns_servers:
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    sock.settimeout(5)
+                    result = sock.connect_ex((dns_server, 53))
+                    if result == 0:
+                        logger.info(f"  ✓ Can reach {dns_server}:53")
+                    else:
+                        logger.error(f"  ✗ Cannot reach {dns_server}:53")
+                    sock.close()
+                except Exception as e:
+                    logger.error(f"  ✗ Error testing {dns_server}:53 - {e}")
+
+        except Exception as e:
+            logger.warning(f"Could not gather system network info: {e}")
+
+    def _test_alternative_dns(self, hostname: str):
+        """Test hostname resolution using alternative methods"""
+        try:
+            families = [(socket.AF_INET, "IPv4"), (socket.AF_INET6, "IPv6")]
+
+            for family, family_name in families:
+                try:
+                    result = socket.getaddrinfo(hostname, None, family)
+                    if result:
+                        logger.info(f"✓ {family_name} resolution successful:")
+                        for addr_info in result[:3]:
+                            logger.info(f"  - {addr_info[4][0]}")
+                    else:
+                        logger.warning(
+                            f"✗ {family_name} resolution returned no results"
+                        )
+                except socket.gaierror:
+                    logger.error(f"✗ {family_name} resolution failed")
+                except Exception as e:
+                    logger.error(f"✗ {family_name} resolution error: {e}")
+
+        except Exception as e:
+            logger.error(f"Alternative DNS test failed: {e}")
+
+    def get_workunits_internal(
+        self,
+    ) -> Iterable[MetadataWorkUnit]:
+        if self.config.dns_probe_url is not None:
+            # Perform DNS probe
+            logger.info(f"Performing DNS probe for: {self.config.dns_probe_url}")
+            self.perform_dns_probe(self.config.dns_probe_url)
+
+        yield from []
+
+    def get_report(self) -> SourceReport:
+        return self.report


### PR DESCRIPTION
Sometimes we have various common issues like network in the environment where ingestion is running. At that point without having access to a shell debugging the issue is hard. This source adds the first capability so we can do the basic network resolution and print out the debugging information without having shell access.

Kept the name as debug source so that in future if we wanted to add more like checking disk space or anything else like that we have scope for incremental additions to this.

Some folks will do a DNS probe from within their enterprise network and see things working and assume the exact same restrictions are present in their deployed infra which is mostly not the case.

Most of the code is generated by AI. Ran it locally with internet and without internet. 

With internet saw this
```
-[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:277} - Performing DNS probe for: https://608f444c.datahub-wheels.pages.dev
[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:57} - Starting DNS probe for URL: https://608f444c.datahub-wheels.pages.dev
[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:58} - ============================================================
[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:59} - DNS PROBE REPORT FOR: https://608f444c.datahub-wheels.pages.dev
[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:60} - ============================================================
[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:70} - Parsed hostname: 608f444c.datahub-wheels.pages.dev
[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:71} - Target port: 443
[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:72} - URL scheme: https
[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:73} - ------------------------------------------------------------
[2025-06-12 17:30:55,185] INFO     {datahub.ingestion.source.debug.datahub_debug:76} - 1. DNS RESOLUTION TEST
/[2025-06-12 17:30:55,469] INFO     {datahub.ingestion.source.debug.datahub_debug:110} - ✓ A record resolution successful (0.284s)
[2025-06-12 17:30:55,469] INFO     {datahub.ingestion.source.debug.datahub_debug:114} -   - A: 172.66.47.203
[2025-06-12 17:30:55,469] INFO     {datahub.ingestion.source.debug.datahub_debug:114} -   - A: 172.66.44.53
|[2025-06-12 17:30:55,752] INFO     {datahub.ingestion.source.debug.datahub_debug:110} - ✓ AAAA record resolution successful (0.283s)
[2025-06-12 17:30:55,753] INFO     {datahub.ingestion.source.debug.datahub_debug:114} -   - AAAA: 2606:4700:310c::ac42:2c35
[2025-06-12 17:30:55,753] INFO     {datahub.ingestion.source.debug.datahub_debug:114} -   - AAAA: 2606:4700:310c::ac42:2fcb
\[2025-06-12 17:30:56,103] INFO     {datahub.ingestion.source.debug.datahub_debug:119} - - CNAME record: No answer (record type not available)
-[2025-06-12 17:30:56,408] INFO     {datahub.ingestion.source.debug.datahub_debug:119} - - MX record: No answer (record type not available)
[2025-06-12 17:30:56,408] INFO     {datahub.ingestion.source.debug.datahub_debug:128} - Testing with different DNS servers:
[2025-06-12 17:30:56,435] INFO     {datahub.ingestion.source.debug.datahub_debug:141} - ✓ DNS server 8.8.8.8 responded (0.026s)
[2025-06-12 17:30:56,435] INFO     {datahub.ingestion.source.debug.datahub_debug:145} -   - A: 172.66.44.53
[2025-06-12 17:30:56,436] INFO     {datahub.ingestion.source.debug.datahub_debug:145} -   - A: 172.66.47.203
/[2025-06-12 17:30:56,454] INFO     {datahub.ingestion.source.debug.datahub_debug:141} - ✓ DNS server 1.1.1.1 responded (0.017s)
[2025-06-12 17:30:56,454] INFO     {datahub.ingestion.source.debug.datahub_debug:145} -   - A: 172.66.47.203
[2025-06-12 17:30:56,454] INFO     {datahub.ingestion.source.debug.datahub_debug:145} -   - A: 172.66.44.53
|[2025-06-12 17:30:56,913] INFO     {datahub.ingestion.source.debug.datahub_debug:141} - ✓ DNS server 208.67.222.222 responded (0.459s)
[2025-06-12 17:30:56,913] INFO     {datahub.ingestion.source.debug.datahub_debug:145} -   - A: 172.66.47.203
[2025-06-12 17:30:56,913] INFO     {datahub.ingestion.source.debug.datahub_debug:145} -   - A: 172.66.44.53
[2025-06-12 17:30:56,913] INFO     {datahub.ingestion.source.debug.datahub_debug:79} - ------------------------------------------------------------
[2025-06-12 17:30:56,913] INFO     {datahub.ingestion.source.debug.datahub_debug:82} - 2. HTTP CONNECTIVITY TEST
[2025-06-12 17:30:56,914] INFO     {datahub.ingestion.source.debug.datahub_debug:164} - Testing HEAD request with timeout 10s
\[2025-06-12 17:30:56,992] INFO     {datahub.ingestion.source.debug.datahub_debug:180} - ✓ HEAD request successful (0.079s)
[2025-06-12 17:30:56,993] INFO     {datahub.ingestion.source.debug.datahub_debug:183} -   Status code: 200
[2025-06-12 17:30:56,993] INFO     {datahub.ingestion.source.debug.datahub_debug:184} -   Response headers: {'Date': 'Thu, 12 Jun 2025 12:00:57 GMT', 'Content-Type': 'text/html; charset=utf-8', 'Connection': 'keep-alive', 'Content-Encoding': 'gzip', 'Access-Control-Allow-Origin': '*'}
[2025-06-12 17:30:56,993] INFO     {datahub.ingestion.source.debug.datahub_debug:189} -   Final URL after redirects: https://608f444c.datahub-wheels.pages.dev/
[2025-06-12 17:30:56,993] INFO     {datahub.ingestion.source.debug.datahub_debug:164} - Testing GET request with timeout 10s
[2025-06-12 17:30:57,078] INFO     {datahub.ingestion.source.debug.datahub_debug:180} - ✓ GET request successful (0.085s)
[2025-06-12 17:30:57,079] INFO     {datahub.ingestion.source.debug.datahub_debug:183} -   Status code: 200
[2025-06-12 17:30:57,079] INFO     {datahub.ingestion.source.debug.datahub_debug:184} -   Response headers: {'Date': 'Thu, 12 Jun 2025 12:00:57 GMT', 'Content-Type': 'text/html; charset=utf-8', 'Transfer-Encoding': 'chunked', 'Connection': 'keep-alive', 'Content-Encoding': 'gzip'}
[2025-06-12 17:30:57,079] INFO     {datahub.ingestion.source.debug.datahub_debug:189} -   Final URL after redirects: https://608f444c.datahub-wheels.pages.dev/
[2025-06-12 17:30:57,080] INFO     {datahub.ingestion.source.debug.datahub_debug:85} - ------------------------------------------------------------
[2025-06-12 17:30:57,080] INFO     {datahub.ingestion.source.debug.datahub_debug:88} - 3. SYSTEM NETWORK INFORMATION
[2025-06-12 17:30:57,080] INFO     {datahub.ingestion.source.debug.datahub_debug:218} - Local hostname: ip-192-168-1-3.us-west-2.compute.internal
-[2025-06-12 17:30:57,435] INFO     {datahub.ingestion.source.debug.datahub_debug:222} - Local IP addresses:
[2025-06-12 17:30:57,435] INFO     {datahub.ingestion.source.debug.datahub_debug:226} -   - 192.168.1.3 (IPv4)
[2025-06-12 17:30:57,436] INFO     {datahub.ingestion.source.debug.datahub_debug:226} -   - 192.168.1.3 (IPv4)
[2025-06-12 17:30:57,436] INFO     {datahub.ingestion.source.debug.datahub_debug:230} - DNS Server Connectivity:
[2025-06-12 17:30:57,447] INFO     {datahub.ingestion.source.debug.datahub_debug:238} -   ✓ Can reach 8.8.8.8:53
[2025-06-12 17:30:57,459] INFO     {datahub.ingestion.source.debug.datahub_debug:238} -   ✓ Can reach 1.1.1.1:53
/[2025-06-12 17:30:57,496] INFO     {datahub.ingestion.source.debug.datahub_debug:238} -   ✓ Can reach 208.67.222.222:53
[2025-06-12 17:30:57,496] INFO     {datahub.ingestion.source.debug.datahub_debug:94} - ============================================================
[2025-06-12 17:30:57,496] INFO     {datahub.ingestion.source.debug.datahub_debug:95} - DNS PROBE COMPLETED

```

Without internet saw this
```
-[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:277} - Performing DNS probe for: https://608f444c.datahub-wheels.pages.dev
[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:57} - Starting DNS probe for URL: https://608f444c.datahub-wheels.pages.dev
[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:58} - ============================================================
[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:59} - DNS PROBE REPORT FOR: https://608f444c.datahub-wheels.pages.dev
[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:60} - ============================================================
[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:70} - Parsed hostname: 608f444c.datahub-wheels.pages.dev
[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:71} - Target port: 443
[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:72} - URL scheme: https
[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:73} - ------------------------------------------------------------
[2025-06-12 17:31:18,762] INFO     {datahub.ingestion.source.debug.datahub_debug:76} - 1. DNS RESOLUTION TEST
[2025-06-12 17:31:18,762] ERROR    {datahub.ingestion.source.debug.datahub_debug:125} - ✗ A record query failed: no nameservers
[2025-06-12 17:31:18,763] ERROR    {datahub.ingestion.source.debug.datahub_debug:125} - ✗ AAAA record query failed: no nameservers
[2025-06-12 17:31:18,763] ERROR    {datahub.ingestion.source.debug.datahub_debug:125} - ✗ CNAME record query failed: no nameservers
[2025-06-12 17:31:18,763] ERROR    {datahub.ingestion.source.debug.datahub_debug:125} - ✗ MX record query failed: no nameservers
[2025-06-12 17:31:18,763] INFO     {datahub.ingestion.source.debug.datahub_debug:128} - Testing with different DNS servers:
[2025-06-12 17:31:18,763] ERROR    {datahub.ingestion.source.debug.datahub_debug:148} - ✗ DNS server 8.8.8.8 failed: no nameservers
[2025-06-12 17:31:18,763] ERROR    {datahub.ingestion.source.debug.datahub_debug:148} - ✗ DNS server 1.1.1.1 failed: no nameservers
[2025-06-12 17:31:18,763] ERROR    {datahub.ingestion.source.debug.datahub_debug:148} - ✗ DNS server 208.67.222.222 failed: no nameservers
[2025-06-12 17:31:18,763] INFO     {datahub.ingestion.source.debug.datahub_debug:79} - ------------------------------------------------------------
[2025-06-12 17:31:18,763] INFO     {datahub.ingestion.source.debug.datahub_debug:82} - 2. HTTP CONNECTIVITY TEST
[2025-06-12 17:31:18,763] INFO     {datahub.ingestion.source.debug.datahub_debug:164} - Testing HEAD request with timeout 10s
[2025-06-12 17:31:18,765] ERROR    {datahub.ingestion.source.debug.datahub_debug:196} - ✗ HEAD connection error: HTTPSConnectionPool(host='608f444c.datahub-wheels.pages.dev', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x105dc4070>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
[2025-06-12 17:31:18,765] INFO     {datahub.ingestion.source.debug.datahub_debug:164} - Testing GET request with timeout 10s
[2025-06-12 17:31:18,766] ERROR    {datahub.ingestion.source.debug.datahub_debug:196} - ✗ GET connection error: HTTPSConnectionPool(host='608f444c.datahub-wheels.pages.dev', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x105dc4040>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
[2025-06-12 17:31:18,766] INFO     {datahub.ingestion.source.debug.datahub_debug:85} - ------------------------------------------------------------
[2025-06-12 17:31:18,766] INFO     {datahub.ingestion.source.debug.datahub_debug:88} - 3. SYSTEM NETWORK INFORMATION
[2025-06-12 17:31:18,766] INFO     {datahub.ingestion.source.debug.datahub_debug:218} - Local hostname: Aseems-MacBook-Pro.local
\[2025-06-12 17:31:23,795] WARNING  {datahub.ingestion.source.debug.datahub_debug:228} - Could not retrieve local IP addresses: [Errno 8] nodename nor servname provided, or not known
[2025-06-12 17:31:23,796] INFO     {datahub.ingestion.source.debug.datahub_debug:230} - DNS Server Connectivity:
[2025-06-12 17:31:23,796] ERROR    {datahub.ingestion.source.debug.datahub_debug:240} -   ✗ Cannot reach 8.8.8.8:53
[2025-06-12 17:31:23,796] ERROR    {datahub.ingestion.source.debug.datahub_debug:240} -   ✗ Cannot reach 1.1.1.1:53
[2025-06-12 17:31:23,797] ERROR    {datahub.ingestion.source.debug.datahub_debug:240} -   ✗ Cannot reach 208.67.222.222:53
[2025-06-12 17:31:23,797] INFO     {datahub.ingestion.source.debug.datahub_debug:94} - ============================================================
[2025-06-12 17:31:23,797] INFO     {datahub.ingestion.source.debug.datahub_debug:95} - DNS PROBE COMPLETED
[2025-06-12 17:31:23,797] INFO     {datahub.ingestion.source.debug.datahub_debug:96} - ============================================================
```

which should be enough to prove to a network admin that there is a issue in their infra

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
