### PR TITLE
fix(embedded search): making embedded search list use smart defaults for types

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
@@ -11,13 +11,17 @@ import {
     SearchResultsInterface,
 } from '@app/entity/shared/components/styled/search/types';
 import { useEntityQueryParams } from '@app/entity/shared/containers/profile/utils';
-import { EMBEDDED_LIST_SEARCH_ENTITY_TYPES, UnionType } from '@app/search/utils/constants';
+import {
+    EXTRA_EMBEDDED_LIST_SEARCH_ENTITY_TYPES_TO_SUPPLEMENT_SEARCHABLE_ENTITY_TYPES,
+    UnionType,
+} from '@app/search/utils/constants';
 import {
     DownloadSearchResults,
     DownloadSearchResultsInput,
     DownloadSearchResultsParams,
 } from '@app/search/utils/types';
 import useFilters from '@app/search/utils/useFilters';
+import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { FacetFilterInput } from '@types';
 
@@ -91,6 +95,15 @@ export const EmbeddedListSearchSection = ({
     const page: number = params.page && Number(params.page as string) > 0 ? Number(params.page as string) : 1;
     const unionType: UnionType = Number(params.unionType as any as UnionType) || UnionType.AND;
 
+    const entityRegistry = useEntityRegistry();
+
+    const searchableEntityTypes = entityRegistry.getSearchEntityTypes();
+
+    const embeddedListSearchEntityTypes = [
+        ...searchableEntityTypes,
+        ...EXTRA_EMBEDDED_LIST_SEARCH_ENTITY_TYPES_TO_SUPPLEMENT_SEARCHABLE_ENTITY_TYPES,
+    ];
+
     const filters: Array<FacetFilterInput> = useFilters(params);
 
     const onSearch = (q: string) => {
@@ -143,7 +156,7 @@ export const EmbeddedListSearchSection = ({
 
     return (
         <EmbeddedListSearch
-            entityTypes={EMBEDDED_LIST_SEARCH_ENTITY_TYPES}
+            entityTypes={embeddedListSearchEntityTypes}
             query={query || ''}
             page={page}
             unionType={unionType}

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/EmbeddedListSearchSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/EmbeddedListSearchSection.tsx
@@ -12,13 +12,17 @@ import {
 } from '@app/entityV2/shared/components/styled/search/types';
 import { useEntityQueryParams } from '@app/entityV2/shared/containers/profile/utils';
 import { decodeComma } from '@app/entityV2/shared/utils';
-import { EMBEDDED_LIST_SEARCH_ENTITY_TYPES, UnionType } from '@app/search/utils/constants';
+import {
+    EXTRA_EMBEDDED_LIST_SEARCH_ENTITY_TYPES_TO_SUPPLEMENT_SEARCHABLE_ENTITY_TYPES,
+    UnionType,
+} from '@app/search/utils/constants';
 import {
     DownloadSearchResults,
     DownloadSearchResultsInput,
     DownloadSearchResultsParams,
 } from '@app/search/utils/types';
 import useFilters from '@app/search/utils/useFilters';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 import { useSelectedSortOption } from '@src/app/search/context/SearchContext';
 import useSortInput from '@src/app/searchV2/sorting/useSortInput';
 
@@ -99,6 +103,14 @@ export const EmbeddedListSearchSection = ({
     const unionType: UnionType = Number(params.unionType as any as UnionType) || UnionType.AND;
     const selectedSortOption = useSelectedSortOption();
     const sortInput = useSortInput(selectedSortOption);
+    const entityRegistry = useEntityRegistryV2();
+
+    const searchableEntityTypes = entityRegistry.getSearchEntityTypes();
+
+    const embeddedListSearchEntityTypes = [
+        ...searchableEntityTypes,
+        ...EXTRA_EMBEDDED_LIST_SEARCH_ENTITY_TYPES_TO_SUPPLEMENT_SEARCHABLE_ENTITY_TYPES,
+    ];
 
     const filters: Array<FacetFilterInput> = useFilters(params);
 
@@ -152,7 +164,7 @@ export const EmbeddedListSearchSection = ({
 
     return (
         <EmbeddedListSearch
-            entityTypes={EMBEDDED_LIST_SEARCH_ENTITY_TYPES}
+            entityTypes={embeddedListSearchEntityTypes}
             query={query || ''}
             page={page}
             unionType={unionType}

--- a/datahub-web-react/src/app/search/utils/constants.ts
+++ b/datahub-web-react/src/app/search/utils/constants.ts
@@ -145,28 +145,8 @@ export type FilterMode = (typeof FilterModes)[keyof typeof FilterModes];
 
 export const MAX_COUNT_VAL = 10000;
 
-export const EMBEDDED_LIST_SEARCH_ENTITY_TYPES = [
-    EntityType.Dataset,
-    EntityType.Dashboard,
-    EntityType.Chart,
-    EntityType.Mlmodel,
-    EntityType.MlmodelGroup,
-    EntityType.MlfeatureTable,
-    EntityType.Mlfeature,
-    EntityType.MlprimaryKey,
-    EntityType.DataFlow,
-    EntityType.DataJob,
-    EntityType.GlossaryTerm,
-    EntityType.GlossaryNode,
-    EntityType.Tag,
-    EntityType.Role,
-    EntityType.CorpUser,
-    EntityType.CorpGroup,
-    EntityType.Container,
-    EntityType.Domain,
-    EntityType.DataProduct,
-    EntityType.Notebook,
-    EntityType.BusinessAttribute,
+// We don't want to show Data Process Instance in standard search since they would crowd the results
+// however, for embedded searches such as the DPIs for a given entity, it makes sense to show them
+export const EXTRA_EMBEDDED_LIST_SEARCH_ENTITY_TYPES_TO_SUPPLEMENT_SEARCHABLE_ENTITY_TYPES = [
     EntityType.DataProcessInstance,
-    EntityType.SchemaField,
 ];


### PR DESCRIPTION
Maintaining this list is tech debt, we can forget to update it easily. 

It was introduced here: https://github.com/asikowitz/datahub/commit/aaaa655c21bf66e38a318043942e36fee8a01c30

Just for the special case of DataProcessInstance. Since all other searchable entities should be in the list, and all other non searchable entities shouldn't, its much easier to maintain the list of exceptions.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
