### PR TITLE
allowed.urls mapping property due to kafka confluent update 8.0.0

### DIFF
--- a/datahub-frontend/app/client/KafkaTrackingProducer.java
+++ b/datahub-frontend/app/client/KafkaTrackingProducer.java
@@ -159,6 +159,11 @@ public class KafkaTrackingProducer {
             props,
             "sasl.oauthbearer.token.endpoint.url",
             "analytics.kafka.sasl.oauthbearer.token.endpoint.url");
+        setConfig(
+            config,
+            props,
+            "org.apache.kafka.sasl.oauthbearer.allowed.urls",
+            "analytics.kafka.sasl.oauthbearer.allowed.urls");
       }
     }
 

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -258,6 +258,7 @@ analytics.kafka.sasl.kerberos.service.name = ${?KAFKA_PROPERTIES_SASL_KERBEROS_S
 analytics.kafka.sasl.login.callback.handler.class = ${?KAFKA_PROPERTIES_SASL_LOGIN_CALLBACK_HANDLER_CLASS}
 analytics.kafka.sasl.client.callback.handler.class = ${?KAFKA_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS}
 analytics.kafka.sasl.oauthbearer.token.endpoint.url = ${?KAFKA_PROPERTIES_SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL}
+analytics.kafka.sasl.oauthbearer.allowed.urls = ${?KAFKA_PROPERTIES_SASL_OAUTHBEARER_ALLOWED_URLS}
 
 # Required Elastic Client Configuration
 analytics.elastic.host =  ${?ELASTIC_CLIENT_HOST}


### PR DESCRIPTION
fix: necessary extra property on frontend module to achieve oauth authentication on kafka

As you can see in this PR already merged [PR](https://github.com/datahub-project/datahub/pull/13767/files#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7) kafka confluent version has been upgraded to 8.0.0. As a result, now kafka client version is 4.0.0. This version needs an extra property called _"org.apache.kafka.sasl.oauthbearer.allowed.urls"_ as you can see on the official kafka documentation [official site](https://kafka.apache.org/documentation/#upgrade_servers_400_notable)
![image](https://github.com/user-attachments/assets/c05b2914-8023-4c89-ad64-6042d0afece9)
_Since Apache Kafka 4.0.0, we have added a system property ("org.apache.kafka.sasl.oauthbearer.allowed.urls") to set the allowed URLs as SASL OAUTHBEARER token or jwks endpoints. By default, the value is an empty list. Users should explicitly set the allowed list if necessary._
The documentation provided from confluent is outdated because they did not add the new required parameter if you are using kafka client 4.0.0 version, as you can see on the  [confluent kafka documentation,](https://docs.confluent.io/cloud/current/security/authenticate/workload-identities/identity-providers/oauth/configure-clients-oauth.html#configure-a-sr-client-to-use-a-standard-oauth-authorization-server-and-protocol) they do not specify the new property configuration that you need to add, to have oauth authentication.

Copyright 2025 Santander Global Tech & Operations All rights reserved.
 
Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
 
http://www.apache.org/licenses/LICENSE-2.0
