### PR TITLE
fix(metadata_change_sync): fix unicode handling

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/metadata_change_sync/metadata_change_sync.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Optional, Set, Union, cast
 
 from pydantic import BaseModel, Field
 
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.rest_emitter import DatahubRestEmitter
 from datahub.metadata.schema_classes import (
     ChangeTypeClass,
@@ -157,7 +158,8 @@ class MetadataChangeSyncAction(Action):
             logger.info(
                 f"emitting the mcp: entityType {mcp.entityType}, changeType {mcp.changeType}, urn {mcp.entityUrn}, aspect name {mcp.aspectName}"
             )
-            self.rest_emitter.emit_mcp(mcp)
+            mcpw = MetadataChangeProposalWrapper.try_from_mcpc(mcp) or mcp
+            self.rest_emitter.emit_mcp(mcpw)
             logger.info("successfully emit the mcp")
         except Exception as ex:
             logger.error(


### PR DESCRIPTION
Fixes the handling of unicode characters that get sent across in MetadataChangeLogs. With the standard MCP, the Avro to_obj method converts unicode characters to their actual unicode form, while the MCPW to_obj() is our internal implementation that does a standard decode, preserving the format.
