### PR TITLE
fix(ingest): increase topK from 10 to 50 for ingestion stage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source_report/ingestion_stage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_report/ingestion_stage.py
@@ -1,6 +1,6 @@
 import logging
 from contextlib import AbstractContextManager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from datahub.utilities.perf_timer import PerfTimer
@@ -22,7 +22,7 @@ PROFILING = "Profiling"
 
 @dataclass
 class IngestionStageReport:
-    ingestion_stage_durations: TopKDict[str, float] = field(default_factory=TopKDict)
+    ingestion_stage_durations: TopKDict[str, float] = TopKDict(50)
 
     def new_stage(self, stage: str) -> "IngestionStageContext":
         return IngestionStageContext(stage, self)


### PR DESCRIPTION
For most of bigger deployments the default 10 samples is nowhere enough to get useful information about where the time is going on. Specifically in the case where it is death by 100 cuts. Having top 50 gives us a better chance of knowing where the time is going on.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
