### PR TITLE
fix(docs): remove ref to github_info

### DIFF
--- a/metadata-ingestion/docs/sources/looker/lookml_pre.md
+++ b/metadata-ingestion/docs/sources/looker/lookml_pre.md
@@ -110,7 +110,7 @@ jobs:
             config:
               base_folder: ${{ github.workspace }}
               parse_table_names_from_sql: true
-              github_info:
+              git_info:
                 repo: ${{ github.repository }}
                 branch: ${{ github.ref }}
               # Options

--- a/metadata-ingestion/docs/sources/looker/lookml_recipe.yml
+++ b/metadata-ingestion/docs/sources/looker/lookml_recipe.yml
@@ -2,7 +2,7 @@ source:
   type: "lookml"
   config:
     # GitHub Coordinates: Used to check out the repo locally and add github links on the dataset's entity page.
-    github_info:
+    git_info:
       repo: org/repo-name
       deploy_key_file: ${LOOKER_DEPLOY_KEY_FILE} # file containing the private ssh key for a deploy key for the looker git repo
 


### PR DESCRIPTION
github_info is deprecated in favor of git_info https://docs.datahub.com/docs/generated/ingestion/sources/looker 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
