### PR TITLE
Acr 6214 add teradata pdcr detection for query history

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -932,7 +932,6 @@ ORDER by DataBaseName, TableName;
 
         return query
 
-
     def gen_lineage_from_query(
         self,
         query: str,


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

JPMC is using Teradata PDCR Archive to archive queries > 24hrs
dbql.DBQLogTbl -> pdcrinfo.dbqlsqltbl_hst.

It is common practice in Teradata to move the query history/log/sql information to separate database pdcrinfo. For instance,  Dbc.DBQLSQLTBL would have only 24 hour data and then data would be moved to pdcrinfo.dbqlsqltbl_hst. Likely the code should be checking both dbc and pdcrinfo databases for holistic view of last 30 days

https://linear.app/acryl-data/issue/ACR-6214/add-teradata-pdcr-detection-for-query-history