### PR TITLE
openapi 3.1.0 compatibility and structuring fix for patch body

### DIFF
--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
@@ -815,6 +815,10 @@ public class OpenAPIV3Generator {
                           schema.setNullable(!isNameRequired);
                         });
                   }
+
+                  if (s.getRequired() != null && s.getRequired().isEmpty()) {
+                    s.setRequired(null);
+                  }
                   components.addSchemas(n, s);
                 } catch (Exception e) {
                   throw new RuntimeException(e);

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/OpenAPIV3GeneratorTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/OpenAPIV3GeneratorTest.java
@@ -2,8 +2,7 @@ package io.datahubproject.openapi.v3;
 
 import static io.datahubproject.test.search.SearchTestUtils.TEST_ES_SEARCH_CONFIG;
 import static io.datahubproject.test.search.SearchTestUtils.TEST_SEARCH_SERVICE_CONFIG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -126,19 +125,17 @@ public class OpenAPIV3GeneratorTest {
 
     // Assert required properties are non-nullable
     Schema customProperties = properties.get("customProperties");
-    assertFalse(requiredNames.contains("customProperties")); // not required due to default
+    assertNull(requiredNames);
     assertFalse(
         customProperties
             .getNullable()); // it is however still not optional, therefore null is not allowed
 
     // Assert non-required properties are nullable
     Schema name = properties.get("name");
-    assertFalse(requiredNames.contains("name"));
     assertTrue(name.getNullable());
 
     // Assert non-required $ref properties are nullable or object
     Schema created = properties.get("created");
-    assertFalse(requiredNames.contains("created"));
     assertEquals(Set.of("object", "null"), created.getTypes());
     assertEquals("#/components/schemas/TimeStamp", created.get$ref());
     assertTrue(created.getNullable());

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/OpenAPIV3GeneratorTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/OpenAPIV3GeneratorTest.java
@@ -4,7 +4,6 @@ import static io.datahubproject.test.search.SearchTestUtils.TEST_ES_SEARCH_CONFI
 import static io.datahubproject.test.search.SearchTestUtils.TEST_SEARCH_SERVICE_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -137,12 +136,11 @@ public class OpenAPIV3GeneratorTest {
     assertFalse(requiredNames.contains("name"));
     assertTrue(name.getNullable());
 
-    // Assert non-required $ref properties are replaced by nullable { anyOf: [ $ref ] } objects
+    // Assert non-required $ref properties are nullable or object
     Schema created = properties.get("created");
     assertFalse(requiredNames.contains("created"));
-    assertEquals("object", created.getType());
-    assertNull(created.get$ref());
-    assertEquals(List.of(new Schema().$ref("#/components/schemas/TimeStamp")), created.getAnyOf());
+    assertEquals(Set.of("object", "null"), created.getTypes());
+    assertEquals("#/components/schemas/TimeStamp", created.get$ref());
     assertTrue(created.getNullable());
 
     // Assert systemMetadata property on response schema is optional.
@@ -153,12 +151,8 @@ public class OpenAPIV3GeneratorTest {
             .get("DatasetPropertiesAspectResponse_v3")
             .getProperties();
     Schema systemMetadata = datasetPropertiesResponseSchemaProps.get("systemMetadata");
-    assertEquals("object", systemMetadata.getType());
-    assertNull(systemMetadata.get$ref());
-    assertEquals(
-        List.of(new Schema().$ref("#/components/schemas/SystemMetadata")),
-        systemMetadata.getAnyOf());
-    assertTrue(systemMetadata.getNullable());
+    assertEquals(Set.of("object", "null"), systemMetadata.getTypes());
+    assertEquals("#/components/schemas/SystemMetadata", systemMetadata.get$ref());
   }
 
   @Test


### PR DESCRIPTION
openapi version as of datahub v1.1.0 is at `3.1.0`
https://demo.datahub.com/openapi/v3/api-docs/10-openapi-v3

This change includes a few changes to make this spec more compatible with 3.1.0 standards:
1. Use types: null, object for a nullable reference instead of anyOf
2. Use a common schema for aspect patch body in order to improve openapi-generator codegen

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
