### PR TITLE
feat(cli): --streaming-batch option delete large hierarchy

### DIFF
--- a/metadata-ingestion/src/datahub/cli/delete_cli.py
+++ b/metadata-ingestion/src/datahub/cli/delete_cli.py
@@ -318,6 +318,19 @@ def undo_by_filter(
     help="Recursively delete all contained entities (only for containers and dataPlatformInstances)",
 )
 @click.option(
+    "--streaming-batch",
+    required=False,
+    is_flag=True,
+    help="Use streaming batch deletion for recursive operations. Benefit of being resumable for large hierarchies where getting all URNs at once can take a long time.",
+)
+@click.option(
+    "--streaming-batch-size",
+    required=False,
+    default=12000,
+    type=int,
+    help="Batch size for streaming batch deletion for recursive operations.",
+)
+@click.option(
     "--start-time",
     required=False,
     type=ClickDatetime(),
@@ -368,6 +381,8 @@ def by_filter(
     entity_type: Optional[str],
     query: Optional[str],
     recursive: bool,
+    streaming_batch: bool,
+    streaming_batch_size: int,
     start_time: Optional[datetime],
     end_time: Optional[datetime],
     batch_size: int,
@@ -386,6 +401,7 @@ def by_filter(
         env=env,
         query=query,
         recursive=recursive,
+        streaming_batch=streaming_batch,
     )
     soft_delete_filter = _validate_user_soft_delete_flags(
         soft=soft, aspect=aspect, only_soft_deleted=only_soft_deleted
@@ -417,26 +433,46 @@ def by_filter(
     # Determine which urns to delete.
     delete_by_urn = bool(urn) and not recursive
     if urn:
-        urns = [urn]
-
         if recursive:
-            # Add children urns to the list.
-            if guess_entity_type(urn) == "dataPlatformInstance":
-                urns.extend(
-                    graph.get_urns_by_filter(
-                        platform_instance=urn,
-                        status=soft_delete_filter,
-                        batch_size=batch_size,
-                    )
+            if streaming_batch:
+                # For recursive deletion, use streaming approach to avoid loading all URNs into memory
+                _delete_urns_streaming_recursive(
+                    graph=graph,
+                    parent_urn=urn,
+                    aspect_name=aspect,
+                    soft=soft,
+                    dry_run=dry_run,
+                    start_time=start_time,
+                    end_time=end_time,
+                    workers=workers,
+                    soft_delete_filter=soft_delete_filter,
+                    batch_size=batch_size,
+                    force=force,
+                    streaming_batch_size=streaming_batch_size,
                 )
+                return
             else:
-                urns.extend(
-                    graph.get_urns_by_filter(
-                        container=urn,
-                        status=soft_delete_filter,
-                        batch_size=batch_size,
+                # Use the old approach: collect all URNs first
+                urns = [urn]
+                # Add children urns to the list.
+                if guess_entity_type(urn) == "dataPlatformInstance":
+                    urns.extend(
+                        graph.get_urns_by_filter(
+                            platform_instance=urn,
+                            status=soft_delete_filter,
+                            batch_size=batch_size,
+                        )
                     )
-                )
+                else:
+                    urns.extend(
+                        graph.get_urns_by_filter(
+                            container=urn,
+                            status=soft_delete_filter,
+                            batch_size=batch_size,
+                        )
+                    )
+        else:
+            urns = [urn]
     elif urn_file:
         with open(urn_file, "r") as r:
             urns = []
@@ -557,6 +593,7 @@ def _validate_user_urn_and_filters(
     env: Optional[str],
     query: Optional[str],
     recursive: bool,
+    streaming_batch: bool,
 ) -> None:
     # Check urn / filters options.
     if urn:
@@ -590,6 +627,12 @@ def _validate_user_urn_and_filters(
     elif urn and guess_entity_type(urn) in _RECURSIVE_DELETE_TYPES:
         logger.warning(
             f"This will only delete {urn}. Use --recursive to delete all contained entities."
+        )
+
+    # Check streaming flag.
+    if streaming_batch and not recursive:
+        raise click.UsageError(
+            "The --streaming-batch flag can only be used with --recursive."
         )
 
 
@@ -737,4 +780,77 @@ def _delete_one_urn(
         num_records=rows_affected,
         num_timeseries_records=ts_rows_affected,
         num_referenced_entities=referenced_entities_affected,
+    )
+
+
+def _delete_urns_streaming_recursive(
+    graph: DataHubGraph,
+    parent_urn: str,
+    aspect_name: Optional[str],
+    soft: bool,
+    dry_run: bool,
+    start_time: Optional[datetime],
+    end_time: Optional[datetime],
+    workers: int,
+    soft_delete_filter: RemovedStatusFilter,
+    batch_size: int,
+    force: bool,
+    streaming_batch_size: int,
+) -> None:
+    """Streaming recursive batch deletion that processes URNs as they're discovered."""
+
+    entity_type = guess_entity_type(parent_urn)
+    click.echo(f"Starting recursive deletion of {entity_type} {parent_urn}")
+
+    if not force and not dry_run:
+        click.confirm(
+            f"This will recursively delete {parent_urn} and all its contained entities. Do you want to continue?",
+            abort=True,
+        )
+
+    urns = []
+
+    if entity_type == "dataPlatformInstance":
+        child_urns_iter = graph.get_urns_by_filter(
+            platform_instance=parent_urn,
+            status=soft_delete_filter,
+            batch_size=batch_size,
+            # Important to skip cache so we can resume from where we left off.
+            skip_cache=True,
+        )
+    else:
+        child_urns_iter = graph.get_urns_by_filter(
+            container=parent_urn,
+            status=soft_delete_filter,
+            batch_size=batch_size,
+            # Important to skip cache so we can resume from where we left off.
+            skip_cache=True,
+        )
+
+    for child_urn in child_urns_iter:
+        urns.append(child_urn)
+        if len(urns) >= streaming_batch_size:
+            _delete_urns_parallel(
+                graph=graph,
+                urns=urns,
+                aspect_name=aspect_name,
+                soft=soft,
+                dry_run=dry_run,
+                delete_by_urn=False,
+                start_time=start_time,
+                end_time=end_time,
+                workers=workers,
+            )
+            urns = []
+    urns.append(parent_urn)
+    _delete_urns_parallel(
+        graph=graph,
+        urns=urns,
+        aspect_name=aspect_name,
+        soft=soft,
+        dry_run=dry_run,
+        delete_by_urn=False,
+        start_time=start_time,
+        end_time=end_time,
+        workers=workers,
     )

--- a/metadata-ingestion/src/datahub/cli/delete_cli.py
+++ b/metadata-ingestion/src/datahub/cli/delete_cli.py
@@ -796,7 +796,7 @@ def _delete_urns_streaming_recursive(
     force: bool,
     streaming_batch_size: int,
 ) -> None:
-    """Streaming recursive batch deletion that processes URNs as they're discovered."""
+    """Streaming recursive batch deletion that processes URNs in batches."""
 
     entity_type = guess_entity_type(parent_urn)
     click.echo(f"Starting recursive deletion of {entity_type} {parent_urn}")

--- a/metadata-ingestion/src/datahub/cli/delete_cli.py
+++ b/metadata-ingestion/src/datahub/cli/delete_cli.py
@@ -452,9 +452,8 @@ def by_filter(
                 )
                 return
             else:
-                # Use the old approach: collect all URNs first
+                # Use non streaming approach in case you wish to know exact time ETA
                 urns = [urn]
-                # Add children urns to the list.
                 if guess_entity_type(urn) == "dataPlatformInstance":
                     urns.extend(
                         graph.get_urns_by_filter(

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -906,6 +906,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
         batch_size: int = 5000,
         extraFilters: Optional[List[RawSearchFilterRule]] = None,
         extra_or_filters: Optional[RawSearchFilter] = None,
+        skip_cache: bool = False,
     ) -> Iterable[str]:
         """Fetch all urns that match all of the given filters.
 
@@ -924,6 +925,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
             Note that this requires browsePathV2 aspects (added in 0.10.4+).
         :param status: Filter on the deletion status of the entity. The default is only return non-soft-deleted entities.
         :param extraFilters: Additional filters to apply. If specified, the results will match all of the filters.
+        :param skip_cache: Whether to bypass caching. Defaults to False.
 
         :return: An iterable of urns that match the filters.
         """
@@ -951,7 +953,8 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
                 $query: String!,
                 $orFilters: [AndFilterInput!],
                 $batchSize: Int!,
-                $scrollId: String) {
+                $scrollId: String,
+                $skipCache: Boolean!) {
 
                 scrollAcrossEntities(input: {
                     query: $query,
@@ -962,6 +965,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
                     searchFlags: {
                         skipHighlighting: true
                         skipAggregates: true
+                        skipCache: $skipCache
                     }
                 }) {
                     nextScrollId
@@ -980,6 +984,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
             "query": query,
             "orFilters": orFilters,
             "batchSize": batch_size,
+            "skipCache": skip_cache,
         }
 
         for entity in self._scroll_across_entities(graphql_query, variables):
@@ -1085,7 +1090,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
             "query": query,
             "orFilters": or_filters_final,
             "batchSize": batch_size,
-            "skipCache": "true" if skip_cache else "false",
+            "skipCache": skip_cache,
             "fetchExtraFields": extra_source_fields,
         }
 

--- a/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
@@ -387,5 +387,6 @@ def test_get_urns() -> None:
                 ],
                 "batchSize": unittest.mock.ANY,
                 "scrollId": None,
+                "skipCache": False,
             },
         )


### PR DESCRIPTION
Why?

While trying to soft delete a container recursively which had 650k+ entities hit upon an issue where the initial call to get list of all urns was taking too long. And then in case there was an intermittent network issue or I had to go take a break there was a chance that I will have to restart the whole thing from beginning.

What?
- Added new flag `--streaming-batch` that allows you to delete in batches of `--streaming-batch-size` number of child entities
- Fixed a `skip_cache` issue where it being passed as a string was causing it to not work and still return cached results.

Taking these 2 together can do streaming batch cleanup which works like this
```
-> % datahub delete --urn "urn:li:container:e5688443d570ff612c481a4527831235" --recursive --streaming-batch --workers 16
[2025-06-19 16:22:05,918] INFO     {datahub.cli.delete_cli:431} - Using DataHubGraph: configured to talk to https://xyz.acryl.io/gms with token: eyJh**********g29E
Starting recursive deletion of container urn:li:container:e5688443d570ff612c481a4527831235
This will recursively delete urn:li:container:e5688443d570ff612c481a4527831235 and all its contained entities. Do you want to continue? [y/N]: y
100% (12000 of 12000) |##################################################################################################################################################################################################################| Elapsed Time: 0:03:55 Time:  0:03:55
Soft deleted 12000 entities (impacts 12000 versioned rows and 0 timeseries aspect rows) in 3 minutes and 55.65 seconds.
 31% (3812 of 12000) |###################################################################                                                                                                                                                | Elapsed Time: 0:01:14 ETA:   0:02:39
```

Pros
- There is no large initial time taken to get all urns
- Can resume even if process fails in the middle

Cons
- We don't know the full time to be taken for a recursive delete

Without this doing a soft deletion of a very large schema wasn't practically possible to do unless you wanted to baby sit it the whole day.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
