### PR TITLE
feat(doc): hide repeating allow/deny things in config tables

### DIFF
--- a/metadata-ingestion/scripts/docs_config_table.py
+++ b/metadata-ingestion/scripts/docs_config_table.py
@@ -347,6 +347,16 @@ def should_hide_field(schema_field, current_source: str, schema_dict: Dict[str, 
     """Check if field should be hidden for the current source"""
     # Extract field name from the path
     field_name = schema_field.fieldPath.split('.')[-1]
+    for ends_with in [
+        "pattern.[type=array].allow",
+        "pattern.[type=array].allow.[type=string].string",
+        "pattern.[type=array].deny",
+        "pattern.[type=array].deny.[type=string].string",
+        "pattern.[type=boolean].ignoreCase"
+    ]:
+        # We don't want repeated allow/deny/ignoreCase for Allow/Deny patterns in docs
+        if schema_field.fieldPath.endswith(ends_with):
+            return True
     
     # Look in definitions for the field schema
     definitions = schema_dict.get("definitions", {})


### PR DESCRIPTION
Rather than having this

![image](https://github.com/user-attachments/assets/56bca5cf-d350-43c0-b5d9-4bf82b2fabc7)

we will just have this

![image](https://github.com/user-attachments/assets/fc357c4e-3842-471e-ba01-00add9ee10e6)

which should make searching and scrolling a bit easier on the config table.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
