### PR TITLE
ingest(snowflake): remove email_as_user_identifier support

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -154,7 +154,7 @@ class SnowflakeIdentifierConfig(
 
     email_domain: Optional[str] = pydantic.Field(
         default=None,
-        description="Email domain of your organization so users can be displayed on UI appropriately.",
+        description="Email domain of your organization so users can be displayed on UI appropriately. This is used only if we cannot infer email ID.",
     )
 
     _email_as_user_identifier = pydantic_removed_field(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -157,11 +157,9 @@ class SnowflakeIdentifierConfig(
         description="Email domain of your organization so users can be displayed on UI appropriately.",
     )
 
-    email_as_user_identifier: bool = Field(
-        default=True,
-        description="Format user urns as an email, if the snowflake user's email is set. If `email_domain` is "
-        "provided, generates email addresses for snowflake users with unset emails, based on their "
-        "username.",
+    _email_as_user_identifier = pydantic_removed_field(
+        "email_as_user_identifier",
+        print_warning="We always use email as user identifier.",
     )
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -325,15 +325,10 @@ class SnowflakeIdentifierBuilder:
         user_email: Optional[str],
     ) -> str:
         if user_email:
-            return self.snowflake_identifier(
-                user_email
-                if self.identifier_config.email_as_user_identifier is True
-                else user_email.split("@")[0]
-            )
+            return self.snowflake_identifier(user_email)
         return self.snowflake_identifier(
             f"{user_name}@{self.identifier_config.email_domain}"
-            if self.identifier_config.email_as_user_identifier is True
-            and self.identifier_config.email_domain is not None
+            if self.identifier_config.email_domain is not None
             else user_name
         )
 

--- a/metadata-ingestion/tests/integration/snowflake/test_snowflake.py
+++ b/metadata-ingestion/tests/integration/snowflake/test_snowflake.py
@@ -121,7 +121,6 @@ def test_snowflake_basic(pytestconfig, tmp_path, mock_time, mock_datahub_graph):
                         format_sql_queries=True,
                         validate_upstreams_against_patterns=False,
                         include_operational_stats=True,
-                        email_as_user_identifier=True,
                         incremental_lineage=False,
                         start_time=datetime(2022, 6, 6, 0, 0, 0, 0).replace(
                             tzinfo=timezone.utc

--- a/metadata-ingestion/tests/integration/snowflake/test_snowflake_queries.py
+++ b/metadata-ingestion/tests/integration/snowflake/test_snowflake_queries.py
@@ -36,7 +36,6 @@ def test_user_identifiers_email_as_identifier(snowflake_connect, tmp_path):
                 "username": "TST_USR",
                 "password": "TST_PWD",
             },
-            "email_as_user_identifier": True,
             "email_domain": "example.com",
         },
         PipelineContext("run-id"),
@@ -71,7 +70,6 @@ def test_user_identifiers_username_as_identifier(snowflake_connect, tmp_path):
                 "username": "TST_USR",
                 "password": "TST_PWD",
             },
-            "email_as_user_identifier": False,
         },
         PipelineContext("run-id"),
     )


### PR DESCRIPTION
There is no good reason to keep this. Removing this gets us closer to sane defaults for all cases.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
