### PR TITLE
docs: add docs on DataHub slack bot

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -364,12 +364,12 @@ module.exports = {
           Slack: [
             {
               type: "doc",
-              id: "docs/managed-datahub/slack/saas-slack-setup",
+              id: "docs/managed-datahub/slack/saas-slack-app",
               className: "saasOnly",
             },
             {
               type: "doc",
-              id: "docs/managed-datahub/slack/saas-slack-app",
+              id: "docs/managed-datahub/slack/saas-slack-setup",
               className: "saasOnly",
             },
             {

--- a/docs/managed-datahub/slack/saas-slack-app.md
+++ b/docs/managed-datahub/slack/saas-slack-app.md
@@ -98,7 +98,3 @@ As of DataHub Cloud v0.3.12, the DataHub Slack bot is in private beta. Reach out
 <p align="center">
     <img width="60%" alt="Chat experience in Slack with the @DataHub bot." src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/slack/chatbot_1.png" />
 </p>
-
-## Coming Soon
-
-We're constantly working on rolling out new features for the Slack app, stay tuned!

--- a/docs/managed-datahub/slack/saas-slack-app.md
+++ b/docs/managed-datahub/slack/saas-slack-app.md
@@ -8,11 +8,24 @@ import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
 The DataHub Slack App brings several of DataHub's key capabilities directly into your Slack experience. These include:
 
-1. Searching for Data Assets
-2. Subscribing to notifications for Data Assets
-3. Managing Data Incidents
+1. Receive notifications
+2. Searching for Data Assets
+3. Subscribing to notifications for Data Assets
+4. Managing Data Incidents
+5. Chat with the @DataHub bot
 
 _Our goal with the Slack app is to make data discovery easier and more accessible for you._
+
+Learn more about [how to set up the Slack app](./saas-slack-setup.md) or [how to troubleshoot issues](./saas-slack-troubleshoot.md).
+
+## Receive Notifications
+
+The DataHub Slack app can send notifications to Slack channels and direct messages.
+Notifications [can be configured](../subscription-and-notification.md) in the DataHub UI once the [Slack app is set up](./saas-slack-setup.md#configure-notifications).
+
+<p align="center">
+    <img width="70%" alt="Example DataHub notification in Slack." src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/slack/notification_1.png" />
+</p>
 
 ## Slack App Commands
 
@@ -62,6 +75,28 @@ If you choose to `Mark as Resolved` the message will update in-place, and you wi
 
 <p align="center">
     <img width="70%" alt="Example of search results being displayed within Slack." src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/slack/slack_incidents_2.png" />
+</p>
+
+## @DataHub Slack Bot
+
+With the DataHub Slack bot, you can mention @DataHub in any channel and ask it questions about your metadata.
+
+Key capabilities include:
+
+- Find relevant data assets.
+- Understand the impact of changes to data assets.
+- Dig into specific assets and their glossary terms, owners, and more.
+- Write first-drafts of SQL queries to answer specific questions.
+- Get notified about incidents and updates.
+
+:::info
+
+As of DataHub Cloud v0.3.12, the DataHub Slack bot is in private beta. Reach out to your DataHub Cloud representative to get access.
+
+:::
+
+<p align="center">
+    <img width="60%" alt="Chat experience in Slack with the @DataHub bot." src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/slack/chatbot_1.png" />
 </p>
 
 ## Coming Soon

--- a/docs/managed-datahub/slack/saas-slack-setup.md
+++ b/docs/managed-datahub/slack/saas-slack-setup.md
@@ -1,6 +1,6 @@
 import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
-# Configure Slack For Notifications
+# Slack App Setup
 
 <FeatureAvailability saasOnly />
 
@@ -176,7 +176,7 @@ To customize the channel where notifications are send, click the button to the r
 If provided, a custom channel will be used to route notifications of the given type. If not provided, the default channel will be used.
 That's it! You should begin to receive notifications on Slack. Note that it may take up to 1 minute for notification settings to take effect after saving.  -->
 
-## Sending Notifications
+## Configure Notifications
 
 For now, we support sending notifications to
 
@@ -186,7 +186,7 @@ For now, we support sending notifications to
 
 By default, the Slack app will be able to send notifications to public channels. If you want to send notifications to private channels or DMs, you will need to invite the Slack app to those channels.
 
-## How to find Team ID and Channel ID in Slack
+### How to find Team ID and Channel ID in Slack
 
 :::note
 We recommend just using the Slack channel name for simplicity (e.g. `#troubleshoot`).
@@ -215,7 +215,7 @@ We recommend just using the Slack channel name for simplicity (e.g. `#troublesho
 - Team ID = `TUMKD5EGJ` from above
 - Channel ID = `C029A3M079U` from above
 
-## How to find User ID in Slack
+### How to find User ID in Slack
 
 **Your User ID**
 

--- a/docs/managed-datahub/slack/saas-slack-setup.md
+++ b/docs/managed-datahub/slack/saas-slack-setup.md
@@ -186,6 +186,8 @@ For now, we support sending notifications to
 
 By default, the Slack app will be able to send notifications to public channels. If you want to send notifications to private channels or DMs, you will need to invite the Slack app to those channels.
 
+Learn more about how [subscriptions and notifications work](../subscription-and-notification.md), including what things you can be notified about and all the places you can receive notifications.
+
 ### How to find Team ID and Channel ID in Slack
 
 :::note


### PR DESCRIPTION
Also improves the structure of the Slack notification docs, particularly to add links between the various pages.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
