### PR TITLE
fix(ui/ingest): ingestion run report

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/IngestedAssets.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestedAssets.tsx
@@ -109,7 +109,6 @@ export default function IngestedAssets({ id, executionResult }: Props) {
     const countsByEntityType =
         entitiesIngestedByTypeFromReport ??
         (entityTypeFacets ? extractEntityTypeCountsFromFacets(entityRegistry, entityTypeFacets, subTypeFacets) : []);
-    console.log("countsByEntityType", countsByEntityType);
 
     // The total number of assets ingested
     const total = totalEntitiesIngested ?? data?.searchAcrossEntities?.total ?? 0;

--- a/datahub-web-react/src/app/ingestV2/source/IngestedAssets.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestedAssets.tsx
@@ -109,6 +109,7 @@ export default function IngestedAssets({ id, executionResult }: Props) {
     const countsByEntityType =
         entitiesIngestedByTypeFromReport ??
         (entityTypeFacets ? extractEntityTypeCountsFromFacets(entityRegistry, entityTypeFacets, subTypeFacets) : []);
+    console.log("countsByEntityType", countsByEntityType);
 
     // The total number of assets ingested
     const total = totalEntitiesIngested ?? data?.searchAcrossEntities?.total ?? 0;
@@ -118,7 +119,7 @@ export default function IngestedAssets({ id, executionResult }: Props) {
             {error && <Message type="error" content="" />}
             <HeaderContainer>
                 <TitleContainer>
-                    <Typography.Title level={5}>Ingested Assets</Typography.Title>
+                    <Typography.Title level={5}>Ingested Records</Typography.Title>
                     {(loading && <Typography.Text type="secondary">Loading...</Typography.Text>) || (
                         <>
                             {(total > 0 && (

--- a/datahub-web-react/src/app/ingestV2/source/IngestedAssets.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestedAssets.tsx
@@ -118,7 +118,7 @@ export default function IngestedAssets({ id, executionResult }: Props) {
             {error && <Message type="error" content="" />}
             <HeaderContainer>
                 <TitleContainer>
-                    <Typography.Title level={5}>Ingested Records</Typography.Title>
+                    <Typography.Title level={5}>Ingested Assets</Typography.Title>
                     {(loading && <Typography.Text type="secondary">Loading...</Typography.Text>) || (
                         <>
                             {(total > 0 && (

--- a/datahub-web-react/src/app/ingestV2/source/__tests__/tests_utils.test.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/__tests__/tests_utils.test.tsx
@@ -2,7 +2,7 @@ import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { SortingState } from '@components/components/Table/types';
 
-import { getEntitiesIngestedByType, getSortInput } from '@app/ingestV2/source/utils';
+import { getEntitiesIngestedByType, getSortInput, getTotalEntitiesIngested } from '@app/ingestV2/source/utils';
 
 import { ExecutionRequestResult, SortOrder } from '@types';
 
@@ -137,5 +137,104 @@ describe('getSortInput', () => {
             sortOrder: SortOrder.Descending,
             field: 'name',
         });
+    });
+});
+
+describe('getTotalEntitiesIngested', () => {
+    test('returns null when structured report is not available', () => {
+        const result = getTotalEntitiesIngested({} as Partial<ExecutionRequestResult>);
+        expect(result).toBeNull();
+    });
+
+    test('returns null when an exception occurs during processing', () => {
+        // Create a malformed structured report to trigger an exception
+        const malformedReport = {
+            source: {
+                report: {
+                    // Missing aspects property to trigger exception
+                },
+            },
+        };
+
+        const result = getTotalEntitiesIngested(mockExecutionRequestResult(malformedReport));
+        expect(result).toBeNull();
+    });
+
+    test('returns null when aspects object is empty', () => {
+        const structuredReport = {
+            source: {
+                report: {
+                    aspects: {},
+                },
+            },
+        };
+
+        const result = getTotalEntitiesIngested(mockExecutionRequestResult(structuredReport));
+        expect(result).toBeNull();
+    });
+
+    test('correctly calculates total from multiple entity types', () => {
+        const structuredReport = {
+            source: {
+                report: {
+                    aspects: {
+                        container: {
+                            containerProperties: 156,
+                            container: 117,
+                        },
+                        dataset: {
+                            status: 1505,
+                            schemaMetadata: 1505,
+                            datasetProperties: 1505,
+                            container: 1505,
+                            operation: 1521,
+                        },
+                        dashboard: {
+                            status: 42,
+                            dashboardInfo: 42,
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = getTotalEntitiesIngested(mockExecutionRequestResult(structuredReport));
+        expect(result).toBe(156 + 1505 + 42); // 1703
+    });
+
+    test('correctly calculates total from single entity type', () => {
+        const structuredReport = {
+            source: {
+                report: {
+                    aspects: {
+                        container: {
+                            containerProperties: 156,
+                            container: 117,
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = getTotalEntitiesIngested(mockExecutionRequestResult(structuredReport));
+        expect(result).toBe(156);
+    });
+
+    test('handles aspects with non-numeric values', () => {
+        const structuredReport = {
+            source: {
+                report: {
+                    aspects: {
+                        container: {
+                            containerProperties: '156',
+                            container: 117,
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = getTotalEntitiesIngested(mockExecutionRequestResult(structuredReport));
+        expect(result).toBe(156);
     });
 });

--- a/datahub-web-react/src/app/ingestV2/source/__tests__/tests_utils.test.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/__tests__/tests_utils.test.tsx
@@ -77,7 +77,7 @@ describe('getEntitiesIngestedByType', () => {
                 displayName: 'container',
             },
             {
-                count: 1521,
+                count: 1505,
                 displayName: 'dataset',
             },
         ]);

--- a/datahub-web-react/src/app/ingestV2/source/utils.ts
+++ b/datahub-web-react/src/app/ingestV2/source/utils.ts
@@ -171,21 +171,6 @@ export const getStructuredReport = (result: Partial<ExecutionRequestResult>): St
     return structuredReport;
 };
 
-/**
- * This function is used to get the total number of entities ingested from the structured report.
- *
- * @param result - The result of the execution request.
- * @returns {number | null}
- */
-export const getTotalEntitiesIngested = (result: Partial<ExecutionRequestResult>) => {
-    const entityTypeCounts = getEntitiesIngestedByType(result);
-    if (!entityTypeCounts) {
-        return null;
-    }
-
-    return entityTypeCounts.reduce((total, entityType) => total + entityType.count, 0);
-};
-
 /** *
  * This function is used to get the entities ingested by type from the structured report.
  * It returns an array of objects with the entity type and the count of entities ingested.
@@ -278,6 +263,21 @@ export const getEntitiesIngestedByType = (result: Partial<ExecutionRequestResult
         console.error(`Caught exception while parsing structured report!`, e);
         return null;
     }
+};
+
+/**
+ * This function is used to get the total number of entities ingested from the structured report.
+ *
+ * @param result - The result of the execution request.
+ * @returns {number | null}
+ */
+export const getTotalEntitiesIngested = (result: Partial<ExecutionRequestResult>) => {
+    const entityTypeCounts = getEntitiesIngestedByType(result);
+    if (!entityTypeCounts) {
+        return null;
+    }
+
+    return entityTypeCounts.reduce((total, entityType) => total + entityType.count, 0);
 };
 
 export const getIngestionSourceStatus = (result?: Partial<ExecutionRequestResult> | null) => {


### PR DESCRIPTION
Fix explain here [loom.com/share/5b6dc75310c841c89f6e7e7502971aa2](https://www.loom.com/share/5b6dc75310c841c89f6e7e7502971aa2)

Problems

In some cases our ingestion can emit more aspects than status aspect. But status aspect remains the most reliable way to tell what has been ingested
The total assets was using sink's total records which is not the same as total assets. So using some of numbers from each entity count's status to get total assets ingested.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
