### PR TITLE
log(nullpointer): when elastic doc has missing urn

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -43,10 +43,10 @@ import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewrit
 import com.linkedin.metadata.search.features.Features;
 import com.linkedin.metadata.search.utils.ESAccessControlUtil;
 import com.linkedin.metadata.search.utils.ESUtils;
+import com.linkedin.metadata.search.utils.UrnExtractionUtils;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -542,11 +542,7 @@ public class SearchRequestHandler extends BaseRequestHandler {
 
   @Nonnull
   private Urn getUrnFromSearchHit(@Nonnull SearchHit hit) {
-    try {
-      return Urn.createFromString(hit.getSourceAsMap().get("urn").toString());
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("Invalid urn in search document " + e);
-    }
+    return UrnExtractionUtils.extractUrnFromSearchHit(hit);
   }
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/UrnExtractionUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/UrnExtractionUtils.java
@@ -1,0 +1,93 @@
+package com.linkedin.metadata.search.utils;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import java.net.URISyntaxException;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.opensearch.search.SearchHit;
+
+/**
+ * Utility class for safely extracting URNs from Elasticsearch documents. Provides null checking and
+ * detailed logging for debugging purposes.
+ */
+@Slf4j
+public class UrnExtractionUtils {
+
+  private UrnExtractionUtils() {
+    // Utility class, prevent instantiation
+  }
+
+  /**
+   * Safely extracts a URN from a search hit's source map.
+   *
+   * @param hit The search hit containing the document
+   * @return The extracted URN
+   * @throws RuntimeException if the URN field is null or invalid
+   */
+  @Nonnull
+  public static Urn extractUrnFromSearchHit(@Nonnull SearchHit hit) {
+    Map<String, Object> sourceMap = hit.getSourceAsMap();
+    Object urnValue = sourceMap.get("urn");
+
+    if (urnValue == null) {
+      log.error(
+          "Found search document with null URN. Document details: index={}, id={}, source={}",
+          hit.getIndex(),
+          hit.getId(),
+          sourceMap);
+      throw new RuntimeException(
+          "Search document contains null URN. Index: " + hit.getIndex() + ", ID: " + hit.getId());
+    }
+
+    try {
+      return Urn.createFromString(urnValue.toString());
+    } catch (URISyntaxException e) {
+      log.error(
+          "Invalid URN in search document. Index: {}, ID: {}, URN value: {}, Full source: {}",
+          hit.getIndex(),
+          hit.getId(),
+          urnValue,
+          sourceMap,
+          e);
+      throw new RuntimeException("Invalid urn in search document " + e);
+    }
+  }
+
+  /**
+   * Safely extracts a URN from a nested map within a document, returning null instead of throwing.
+   *
+   * @param document The document containing the nested map
+   * @param nestedFieldName The field name containing the nested map (e.g., "source", "destination")
+   * @param context Additional context for logging (e.g., "source", "destination")
+   * @return The extracted URN, or null if extraction failed
+   */
+  @Nullable
+  public static Urn extractUrnFromNestedFieldSafely(
+      @Nonnull Map<String, Object> document,
+      @Nonnull String nestedFieldName,
+      @Nonnull String context) {
+
+    try {
+      Map<String, Object> nestedMap = (Map<String, Object>) document.get(nestedFieldName);
+      if (nestedMap == null) {
+        log.error(
+            "Found document with null {} field. Document details: {}", nestedFieldName, document);
+        return null;
+      }
+
+      Object urnValue = nestedMap.get("urn");
+      if (urnValue == null) {
+        log.error("Found document with null {} URN. Document details: {}", context, document);
+        return null;
+      }
+
+      return UrnUtils.getUrn(urnValue.toString());
+    } catch (Exception e) {
+      log.warn("Failed to extract {} URN from document: {}", context, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/UrnExtractionUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/UrnExtractionUtilsTest.java
@@ -1,0 +1,121 @@
+package com.linkedin.metadata.search.utils;
+
+import static org.mockito.Mockito.when;
+
+import com.linkedin.common.urn.Urn;
+import java.util.HashMap;
+import java.util.Map;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.search.SearchHit;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class UrnExtractionUtilsTest {
+
+  @Mock private SearchHit mockSearchHit;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  public void testExtractUrnFromSearchHit_ValidUrn() {
+    // Given
+    Map<String, Object> sourceMap = new HashMap<>();
+    sourceMap.put("urn", "urn:li:dataset:(urn:li:dataPlatform:test,test_dataset,PROD)");
+    when(mockSearchHit.getSourceAsMap()).thenReturn(sourceMap);
+
+    // When
+    Urn result = UrnExtractionUtils.extractUrnFromSearchHit(mockSearchHit);
+
+    // Then
+    Assert.assertNotNull(result);
+    Assert.assertEquals(
+        result.toString(), "urn:li:dataset:(urn:li:dataPlatform:test,test_dataset,PROD)");
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testExtractUrnFromSearchHit_NullUrn() {
+    // Given
+    Map<String, Object> sourceMap = new HashMap<>();
+    sourceMap.put("urn", null);
+    when(mockSearchHit.getSourceAsMap()).thenReturn(sourceMap);
+
+    // When/Then - should throw RuntimeException
+    UrnExtractionUtils.extractUrnFromSearchHit(mockSearchHit);
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testExtractUrnFromSearchHit_InvalidUrn() {
+    // Given
+    Map<String, Object> sourceMap = new HashMap<>();
+    sourceMap.put("urn", "invalid:urn:format");
+    when(mockSearchHit.getSourceAsMap()).thenReturn(sourceMap);
+
+    // When/Then - should throw RuntimeException
+    UrnExtractionUtils.extractUrnFromSearchHit(mockSearchHit);
+  }
+
+  @Test
+  public void testExtractUrnFromNestedFieldSafely_ValidUrn() {
+    // Given
+    Map<String, Object> document = new HashMap<>();
+    Map<String, Object> sourceMap = new HashMap<>();
+    sourceMap.put("urn", "urn:li:dataset:(urn:li:dataPlatform:test,test_dataset,PROD)");
+    document.put("source", sourceMap);
+
+    // When
+    Urn result = UrnExtractionUtils.extractUrnFromNestedFieldSafely(document, "source", "source");
+
+    // Then
+    Assert.assertNotNull(result);
+    Assert.assertEquals(
+        result.toString(), "urn:li:dataset:(urn:li:dataPlatform:test,test_dataset,PROD)");
+  }
+
+  @Test
+  public void testExtractUrnFromNestedFieldSafely_NullNestedField() {
+    // Given
+    Map<String, Object> document = new HashMap<>();
+    document.put("source", null);
+
+    // When
+    Urn result = UrnExtractionUtils.extractUrnFromNestedFieldSafely(document, "source", "source");
+
+    // Then
+    Assert.assertNull(result);
+  }
+
+  @Test
+  public void testExtractUrnFromNestedFieldSafely_NullUrn() {
+    // Given
+    Map<String, Object> document = new HashMap<>();
+    Map<String, Object> sourceMap = new HashMap<>();
+    sourceMap.put("urn", null);
+    document.put("source", sourceMap);
+
+    // When
+    Urn result = UrnExtractionUtils.extractUrnFromNestedFieldSafely(document, "source", "source");
+
+    // Then
+    Assert.assertNull(result);
+  }
+
+  @Test
+  public void testExtractUrnFromNestedFieldSafely_InvalidUrn() {
+    // Given
+    Map<String, Object> document = new HashMap<>();
+    Map<String, Object> sourceMap = new HashMap<>();
+    sourceMap.put("urn", "invalid:urn:format");
+    document.put("source", sourceMap);
+
+    // When
+    Urn result = UrnExtractionUtils.extractUrnFromNestedFieldSafely(document, "source", "source");
+
+    // Then
+    Assert.assertNull(result);
+  }
+}


### PR DESCRIPTION
When elastic index for some reason has missing urn then improving application logging to be able to debug it easier.

Have confirmed the new unit tests work locally + lint is fine.  

Most of the change has been done using Claude. So if something is wrong with the test do let me know.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
