### PR TITLE
doc(cloud): make datahub cloud docs prominent in side bar

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -312,11 +312,11 @@ module.exports = {
     {
       type: "doc",
       id: "docs/managed-datahub/managed-datahub-overview",
-      "title": "DataHub Cloud Overview",
+      title: "DataHub Cloud Overview",
     },
     {
-      "type": "doc",
-      "id": "docs/managed-datahub/welcome-acryl",
+      type: "doc",
+      id: "docs/managed-datahub/welcome-acryl",
     },
     {
       "Configure Single Sign-On": [

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -312,6 +312,7 @@ module.exports = {
     {
       type: "doc",
       id: "docs/managed-datahub/managed-datahub-overview",
+      "title": "DataHub Cloud Overview",
     },
     {
       "type": "doc",

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -315,7 +315,7 @@ module.exports = {
     },
     {
       "type": "doc",
-      "link": "docs/managed-datahub/welcome-acryl",
+      "id": "docs/managed-datahub/welcome-acryl",
     },
     {
       "Configure Single Sign-On": [

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -303,147 +303,149 @@ module.exports = {
         },
       ],
     },
+    // DataHub Cloud.
     {
-      label: "DataHub Cloud",
-      type: "category",
-      collapsed: true,
-      link: {
-        type: "doc",
-        id: "docs/managed-datahub/managed-datahub-overview",
-      },
-      items: [
-        "docs/managed-datahub/welcome-acryl",
-        {
-          "Configure Single Sign-On": [
-            {
-              type: "doc",
-              id: "docs/authentication/guides/sso/initialize-oidc",
-              className: "saasOnly",
-            },
-            {
-              type: "doc",
-              id: "docs/managed-datahub/integrations/oidc-sso-integration",
-              className: "saasOnly",
-            },
-          ],
-        },
-        {
-          "Remote Executor": [
-            {
-              type: "doc",
-              id: "docs/managed-datahub/remote-executor/about",
-              className: "saasOnly",
-            },
-            {
-              type: "doc",
-              id: "docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor",
-              className: "saasOnly",
-            },
-            {
-              type: "doc",
-              id: "docs/managed-datahub/remote-executor/monitoring",
-              className: "saasOnly",
-            },
-          ],
-        },
-        {
-          "DataHub API": [
-            {
-              type: "doc",
-              id: "docs/managed-datahub/datahub-api/entity-events-api",
-              className: "saasOnly",
-            },
-            {
-              "GraphQL API": [
-                "docs/managed-datahub/datahub-api/graphql-api/getting-started",
-              ],
-            },
-          ],
-        },
-        {
-          Slack: [
-            {
-              type: "doc",
-              id: "docs/managed-datahub/slack/saas-slack-app",
-              className: "saasOnly",
-            },
-            {
-              type: "doc",
-              id: "docs/managed-datahub/slack/saas-slack-setup",
-              className: "saasOnly",
-            },
-            {
-              type: "doc",
-              id: "docs/managed-datahub/slack/saas-slack-troubleshoot",
-              className: "saasOnly",
-            },
-          ],
-        },
-        {
-          "Operator Guides": [
-            {
-              type: "doc",
-              id: "docs/managed-datahub/operator-guide/setting-up-events-api-on-aws-eventbridge",
-              className: "saasOnly",
-            },
-            {
-              type: "doc",
-              id: "docs/managed-datahub/integrations/aws-privatelink",
-              className: "saasOnly",
-            },
-          ],
-        },
+      type: "html",
+      value: "<div>DataHub Cloud</div>",
+      defaultStyle: true,
+    },
+    {
+      type: "doc",
+      id: "docs/managed-datahub/managed-datahub-overview",
+    },
+    {
+      "type": "doc",
+      "link": "docs/managed-datahub/welcome-acryl",
+    },
+    {
+      "Configure Single Sign-On": [
         {
           type: "doc",
-          id: "docs/managed-datahub/approval-workflows",
+          id: "docs/authentication/guides/sso/initialize-oidc",
           className: "saasOnly",
         },
         {
           type: "doc",
-          id: "docs/managed-datahub/chrome-extension",
+          id: "docs/managed-datahub/integrations/oidc-sso-integration",
+          className: "saasOnly",
         },
+      ],
+    },
+    {
+      "Remote Executor": [
         {
           type: "doc",
-          id: "docs/managed-datahub/subscription-and-notification",
+          id: "docs/managed-datahub/remote-executor/about",
           className: "saasOnly",
         },
         {
-          "DataHub Cloud Release History": [
-            "docs/managed-datahub/release-notes/v_0_3_12",
-            "docs/managed-datahub/release-notes/v_0_3_11",
-            "docs/managed-datahub/release-notes/v_0_3_10",
-            "docs/managed-datahub/release-notes/v_0_3_9",
-            "docs/managed-datahub/release-notes/v_0_3_8",
-            "docs/managed-datahub/release-notes/v_0_3_7",
-            "docs/managed-datahub/release-notes/v_0_3_6",
-            "docs/managed-datahub/release-notes/v_0_3_5",
-            "docs/managed-datahub/release-notes/v_0_3_4",
-            "docs/managed-datahub/release-notes/v_0_3_3",
-            "docs/managed-datahub/release-notes/v_0_3_2",
-            "docs/managed-datahub/release-notes/v_0_3_1",
-            "docs/managed-datahub/release-notes/v_0_2_16",
-            "docs/managed-datahub/release-notes/v_0_2_15",
-            "docs/managed-datahub/release-notes/v_0_2_14",
-            "docs/managed-datahub/release-notes/v_0_2_13",
-            "docs/managed-datahub/release-notes/v_0_2_12",
-            "docs/managed-datahub/release-notes/v_0_2_11",
-            "docs/managed-datahub/release-notes/v_0_2_10",
-            "docs/managed-datahub/release-notes/v_0_2_9",
-            "docs/managed-datahub/release-notes/v_0_2_8",
-            "docs/managed-datahub/release-notes/v_0_2_7",
-            "docs/managed-datahub/release-notes/v_0_2_6",
-            "docs/managed-datahub/release-notes/v_0_2_5",
-            "docs/managed-datahub/release-notes/v_0_2_4",
-            "docs/managed-datahub/release-notes/v_0_2_3",
-            "docs/managed-datahub/release-notes/v_0_2_2",
-            "docs/managed-datahub/release-notes/v_0_2_1",
-            "docs/managed-datahub/release-notes/v_0_2_0",
-            "docs/managed-datahub/release-notes/v_0_1_73",
-            "docs/managed-datahub/release-notes/v_0_1_72",
-            "docs/managed-datahub/release-notes/v_0_1_70",
-            "docs/managed-datahub/release-notes/v_0_1_69",
+          type: "doc",
+          id: "docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor",
+          className: "saasOnly",
+        },
+        {
+          type: "doc",
+          id: "docs/managed-datahub/remote-executor/monitoring",
+          className: "saasOnly",
+        },
+      ],
+    },
+    {
+      "DataHub API": [
+        {
+          type: "doc",
+          id: "docs/managed-datahub/datahub-api/entity-events-api",
+          className: "saasOnly",
+        },
+        {
+          "GraphQL API": [
+            "docs/managed-datahub/datahub-api/graphql-api/getting-started",
           ],
         },
+      ],
+    },
+    {
+      Slack: [
+        {
+          type: "doc",
+          id: "docs/managed-datahub/slack/saas-slack-app",
+          className: "saasOnly",
+        },
+        {
+          type: "doc",
+          id: "docs/managed-datahub/slack/saas-slack-setup",
+          className: "saasOnly",
+        },
+        {
+          type: "doc",
+          id: "docs/managed-datahub/slack/saas-slack-troubleshoot",
+          className: "saasOnly",
+        },
+      ],
+    },
+    {
+      "Operator Guides": [
+        {
+          type: "doc",
+          id: "docs/managed-datahub/operator-guide/setting-up-events-api-on-aws-eventbridge",
+          className: "saasOnly",
+        },
+        {
+          type: "doc",
+          id: "docs/managed-datahub/integrations/aws-privatelink",
+          className: "saasOnly",
+        },
+      ],
+    },
+    {
+      type: "doc",
+      id: "docs/managed-datahub/approval-workflows",
+      className: "saasOnly",
+    },
+    {
+      type: "doc",
+      id: "docs/managed-datahub/chrome-extension",
+    },
+    {
+      type: "doc",
+      id: "docs/managed-datahub/subscription-and-notification",
+      className: "saasOnly",
+    },
+    {
+      "DataHub Cloud Release History": [
+        "docs/managed-datahub/release-notes/v_0_3_12",
+        "docs/managed-datahub/release-notes/v_0_3_11",
+        "docs/managed-datahub/release-notes/v_0_3_10",
+        "docs/managed-datahub/release-notes/v_0_3_9",
+        "docs/managed-datahub/release-notes/v_0_3_8",
+        "docs/managed-datahub/release-notes/v_0_3_7",
+        "docs/managed-datahub/release-notes/v_0_3_6",
+        "docs/managed-datahub/release-notes/v_0_3_5",
+        "docs/managed-datahub/release-notes/v_0_3_4",
+        "docs/managed-datahub/release-notes/v_0_3_3",
+        "docs/managed-datahub/release-notes/v_0_3_2",
+        "docs/managed-datahub/release-notes/v_0_3_1",
+        "docs/managed-datahub/release-notes/v_0_2_16",
+        "docs/managed-datahub/release-notes/v_0_2_15",
+        "docs/managed-datahub/release-notes/v_0_2_14",
+        "docs/managed-datahub/release-notes/v_0_2_13",
+        "docs/managed-datahub/release-notes/v_0_2_12",
+        "docs/managed-datahub/release-notes/v_0_2_11",
+        "docs/managed-datahub/release-notes/v_0_2_10",
+        "docs/managed-datahub/release-notes/v_0_2_9",
+        "docs/managed-datahub/release-notes/v_0_2_8",
+        "docs/managed-datahub/release-notes/v_0_2_7",
+        "docs/managed-datahub/release-notes/v_0_2_6",
+        "docs/managed-datahub/release-notes/v_0_2_5",
+        "docs/managed-datahub/release-notes/v_0_2_4",
+        "docs/managed-datahub/release-notes/v_0_2_3",
+        "docs/managed-datahub/release-notes/v_0_2_2",
+        "docs/managed-datahub/release-notes/v_0_2_1",
+        "docs/managed-datahub/release-notes/v_0_2_0",
+        "docs/managed-datahub/release-notes/v_0_1_73",
+        "docs/managed-datahub/release-notes/v_0_1_72",
+        "docs/managed-datahub/release-notes/v_0_1_70",
+        "docs/managed-datahub/release-notes/v_0_1_69",
       ],
     },
     // Integrations.

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -310,9 +310,9 @@ module.exports = {
       defaultStyle: true,
     },
     {
+      label: "DataHub Cloud Overview",
       type: "doc",
       id: "docs/managed-datahub/managed-datahub-overview",
-      title: "DataHub Cloud Overview",
     },
     {
       type: "doc",


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/13cbe8f1-c1e9-4544-b8c5-8803a155accc)

After
![image](https://github.com/user-attachments/assets/f7d870b0-7647-4a9f-a77c-bee45bc4b19c)


Without this I find myself missing this section completely.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
