### PR TITLE
fix(quickstart): limit aws_endpoint_url override only for localstack

### DIFF
--- a/docker/profiles/docker-compose.actions.yml
+++ b/docker/profiles/docker-compose.actions.yml
@@ -60,9 +60,15 @@ services:
     profiles:
       - debug
       - debug-backend
-      - debug-backend-aws
     depends_on:
       datahub-gms-debug:
+        condition: service_healthy
+  datahub-actions-debug-aws:
+    <<: *datahub-actions-service-dev
+    profiles:
+      - debug-backend-aws
+    depends_on:
+      datahub-gms-debug-aws:
         condition: service_healthy
   datahub-actions-debug-postgres:
     <<: *datahub-actions-service-dev

--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -137,10 +137,6 @@ x-datahub-gms-service-dev: &datahub-gms-service-dev
     LINEAGE_SEARCH_CACHE_ENABLED: false
     SHOW_BROWSE_V2: true
     ENTITY_VERSIONING_ENABLED: ${ENTITY_VERSIONING_ENABLED:-true}
-    AWS_ENDPOINT_URL: ${DATAHUB_AWS_ENDPOINT_URL:-http://localstack:4566}
-    AWS_ACCESS_KEY_ID: ${DATAHUB_AWS_ACCESS_KEY_ID:-test}
-    AWS_SECRET_ACCESS_KEY: ${DATAHUB_AWS_ACCESS_KEY_ID:-test}
-    AWS_REGION: ${DATAHUB_AWS_REGION:-us-east-1}
   volumes:
     - ./datahub-gms/start.sh:/datahub/datahub-gms/scripts/start.sh
     - ./monitoring/client-prometheus-config.yaml:/datahub/datahub-gms/scripts/prometheus-config.yaml
@@ -370,7 +366,19 @@ services:
     profiles:
       - debug
       - debug-backend
+    depends_on:
+      system-update-debug:
+        condition: service_completed_successfully
+  datahub-gms-debug-aws:
+    <<: *datahub-gms-service-dev
+    profiles:
       - debug-backend-aws
+    environment:
+      <<: *datahub-gms-dev-env
+      AWS_ENDPOINT_URL: ${DATAHUB_AWS_ENDPOINT_URL:-http://localstack:4566}
+      AWS_ACCESS_KEY_ID: ${DATAHUB_AWS_ACCESS_KEY_ID:-test}
+      AWS_SECRET_ACCESS_KEY: ${DATAHUB_AWS_ACCESS_KEY_ID:-test}
+      AWS_REGION: ${DATAHUB_AWS_REGION:-us-east-1}
     depends_on:
       system-update-debug:
         condition: service_completed_successfully


### PR DESCRIPTION
The use of AWS_ENDPOINT_URL in gms has made it hard to not use localstack and actually use AWS with quickstartdebug -- since AWS_ENDPOINT_URL must be set to an override -- like localstack or not defined at all. It cannot be set to a default AWS value (there isn't one default value, it is one endpoint per service). 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
