### PR TITLE
feat(docs): add subscription client docs to assertions tutorial

### DIFF
--- a/docs/api/tutorials/assertions.md
+++ b/docs/api/tutorials/assertions.md
@@ -15,7 +15,7 @@ This guide specifically covers how to use the Assertion APIs for **DataHub Cloud
 
 ## Why Would You Use Assertions APIs?
 
-The Assertions APIs allow you to create, schedule, run, and delete Assertions with DataHub Cloud.
+The Assertions APIs allow you to create, schedule, run, and delete Assertions with DataHub Cloud. Additionally, you can manage subscriptions to receive notifications when assertions change state or when other entity changes occur.
 
 ### Goal Of This Guide
 
@@ -1162,3 +1162,31 @@ urn:li:assertion:<unique-assertion-id>
 
 3. Generate the [**AssertionRunEvent**](/docs/generated/metamodel/entities/assertion.md#assertionrunevent-timeseries) timeseries aspect using the Python SDK. This aspect should contain the result of the assertion
    run at a given timestamp and will be shown on the results graph in DataHub's UI.
+
+## Create Subscription
+
+You can create subscriptions to receive notifications when assertions change state (pass, fail, or error) or when other entity changes occur. Subscriptions can be created at the dataset level (affecting all assertions on the dataset) or at the assertion level (affecting only specific assertions).
+
+<Tabs>
+<TabItem value="python" label="Python">
+
+```python
+{{ inline /metadata-ingestion/examples/library/create_subscription.py show_path_as_comment }}
+```
+
+</TabItem>
+</Tabs>
+
+## Remove Subscription
+
+You can remove existing subscriptions to stop receiving notifications. The unsubscribe method supports selective removal of specific change types or complete removal of subscriptions.
+
+<Tabs>
+<TabItem value="python" label="Python">
+
+```python
+{{ inline /metadata-ingestion/examples/library/remove_subscription.py show_path_as_comment }}
+```
+
+</TabItem>
+</Tabs>

--- a/metadata-ingestion/examples/library/create_subscription.py
+++ b/metadata-ingestion/examples/library/create_subscription.py
@@ -1,19 +1,16 @@
 import logging
 
-from acryl_datahub_cloud.sdk.subscription_client import SubscriptionClient
-
 from datahub.sdk import DataHubClient
 
 log = logging.getLogger(__name__)
 
-# Initialize the clients
+# Initialize the client
 client = DataHubClient(
     server="https://your-datahub-cloud-instance.com", token="your-token"
 )
-subscription_client = SubscriptionClient(client)
 
 # Subscribe to all assertion changes for a dataset
-subscription_client.subscribe(
+client.subscriptions.subscribe(
     urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,purchases,PROD)",
     subscriber_urn="urn:li:corpuser:john.doe",
     # entity_change_types defaults to all available change types for datasets
@@ -21,7 +18,7 @@ subscription_client.subscribe(
 log.info("Successfully subscribed to dataset notifications")
 
 # Subscribe to specific assertion changes
-subscription_client.subscribe(
+client.subscriptions.subscribe(
     urn="urn:li:assertion:your-assertion-id",
     subscriber_urn="urn:li:corpuser:john.doe",
     entity_change_types=["ASSERTION_PASSED", "ASSERTION_FAILED"],
@@ -29,7 +26,7 @@ subscription_client.subscribe(
 log.info("Successfully subscribed to specific assertion changes")
 
 # Subscribe a group to assertion changes
-subscription_client.subscribe(
+client.subscriptions.subscribe(
     urn="urn:li:assertion:your-assertion-id",
     subscriber_urn="urn:li:corpGroup:data-team",
     entity_change_types=["ASSERTION_FAILED", "ASSERTION_ERROR"],

--- a/metadata-ingestion/examples/library/create_subscription.py
+++ b/metadata-ingestion/examples/library/create_subscription.py
@@ -1,0 +1,37 @@
+import logging
+
+from acryl_datahub_cloud.sdk.subscription_client import SubscriptionClient
+
+from datahub.sdk import DataHubClient
+
+log = logging.getLogger(__name__)
+
+# Initialize the clients
+client = DataHubClient(
+    server="https://your-datahub-cloud-instance.com", token="your-token"
+)
+subscription_client = SubscriptionClient(client)
+
+# Subscribe to all assertion changes for a dataset
+subscription_client.subscribe(
+    urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,purchases,PROD)",
+    subscriber_urn="urn:li:corpuser:john.doe",
+    # entity_change_types defaults to all available change types for datasets
+)
+log.info("Successfully subscribed to dataset notifications")
+
+# Subscribe to specific assertion changes
+subscription_client.subscribe(
+    urn="urn:li:assertion:your-assertion-id",
+    subscriber_urn="urn:li:corpuser:john.doe",
+    entity_change_types=["ASSERTION_PASSED", "ASSERTION_FAILED"],
+)
+log.info("Successfully subscribed to specific assertion changes")
+
+# Subscribe a group to assertion changes
+subscription_client.subscribe(
+    urn="urn:li:assertion:your-assertion-id",
+    subscriber_urn="urn:li:corpGroup:data-team",
+    entity_change_types=["ASSERTION_FAILED", "ASSERTION_ERROR"],
+)
+log.info("Successfully subscribed group to assertion failures and errors")

--- a/metadata-ingestion/examples/library/remove_subscription.py
+++ b/metadata-ingestion/examples/library/remove_subscription.py
@@ -1,0 +1,39 @@
+import logging
+
+from acryl_datahub_cloud.sdk.subscription_client import SubscriptionClient
+
+from datahub.sdk import DataHubClient
+
+log = logging.getLogger(__name__)
+
+# Initialize the clients
+client = DataHubClient(
+    server="https://your-datahub-cloud-instance.com", token="your-token"
+)
+subscription_client = SubscriptionClient(client)
+
+# Unsubscribe from all changes for a dataset
+subscription_client.unsubscribe(
+    urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,purchases,PROD)",
+    subscriber_urn="urn:li:corpuser:john.doe",
+    # entity_change_types defaults to all existing change types
+)
+log.info("Successfully unsubscribed from all dataset notifications")
+
+# Unsubscribe from specific assertion change types
+subscription_client.unsubscribe(
+    urn="urn:li:assertion:your-assertion-id",
+    subscriber_urn="urn:li:corpuser:john.doe",
+    entity_change_types=[
+        "ASSERTION_PASSED"
+    ],  # Keep ASSERTION_FAILED and ASSERTION_ERROR
+)
+log.info("Successfully unsubscribed from specific assertion change types")
+
+# Unsubscribe a group from assertion changes
+subscription_client.unsubscribe(
+    urn="urn:li:assertion:your-assertion-id",
+    subscriber_urn="urn:li:corpGroup:data-team",
+    entity_change_types=["ASSERTION_FAILED", "ASSERTION_ERROR"],
+)
+log.info("Successfully unsubscribed group from assertion notifications")

--- a/metadata-ingestion/examples/library/remove_subscription.py
+++ b/metadata-ingestion/examples/library/remove_subscription.py
@@ -1,19 +1,16 @@
 import logging
 
-from acryl_datahub_cloud.sdk.subscription_client import SubscriptionClient
-
 from datahub.sdk import DataHubClient
 
 log = logging.getLogger(__name__)
 
-# Initialize the clients
+# Initialize the client
 client = DataHubClient(
     server="https://your-datahub-cloud-instance.com", token="your-token"
 )
-subscription_client = SubscriptionClient(client)
 
 # Unsubscribe from all changes for a dataset
-subscription_client.unsubscribe(
+client.subscriptions.unsubscribe(
     urn="urn:li:dataset:(urn:li:dataPlatform:snowflake,purchases,PROD)",
     subscriber_urn="urn:li:corpuser:john.doe",
     # entity_change_types defaults to all existing change types
@@ -21,7 +18,7 @@ subscription_client.unsubscribe(
 log.info("Successfully unsubscribed from all dataset notifications")
 
 # Unsubscribe from specific assertion change types
-subscription_client.unsubscribe(
+client.subscriptions.unsubscribe(
     urn="urn:li:assertion:your-assertion-id",
     subscriber_urn="urn:li:corpuser:john.doe",
     entity_change_types=[
@@ -31,7 +28,7 @@ subscription_client.unsubscribe(
 log.info("Successfully unsubscribed from specific assertion change types")
 
 # Unsubscribe a group from assertion changes
-subscription_client.unsubscribe(
+client.subscriptions.unsubscribe(
     urn="urn:li:assertion:your-assertion-id",
     subscriber_urn="urn:li:corpGroup:data-team",
     entity_change_types=["ASSERTION_FAILED", "ASSERTION_ERROR"],


### PR DESCRIPTION
## Summary
- Adds subscription management documentation to assertions tutorial
- Includes validated Python examples for subscribe/unsubscribe operations
- Examples demonstrate dataset-level and assertion-level subscriptions

## Changes
- Updated assertions.md with subscription sections  
- Added create_subscription.py example (inlined)
- Added remove_subscription.py example (inlined)
- All examples pass ruff/mypy validation

🤖 Generated with [Claude Code](https://claude.ai/code)