### PR TITLE
doc(cli): update for restore-indices

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -298,6 +298,14 @@ datahub container term --container-urn "urn:li:container:3f2effd1fbe154a4d60b597
 The datahub package is composed of different plugins that allow you to connect to different metadata sources and ingest metadata from them.
 The `check` command allows you to check if all plugins are loaded correctly as well as validate an individual MCE-file.
 
+#### restore-indices
+
+This command allow you to restore indices for one or more `urn`.
+
+```shell
+datahub check restore-indices --help
+```
+
 ### delete
 
 The `delete` command allows you to delete metadata from DataHub.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -300,7 +300,7 @@ The `check` command allows you to check if all plugins are loaded correctly as w
 
 #### restore-indices
 
-This command allow you to restore indices for one or more `urn`.
+This command allows you to restore indices for one or more `urn`.
 
 ```shell
 datahub check restore-indices --help

--- a/docs/how/restore-indices.md
+++ b/docs/how/restore-indices.md
@@ -179,7 +179,7 @@ For Rest.li, see [Restore Indices API](../api/restli/restore-indices.md).
 
 ### CLI
 
-The [datahub CLI](../cli.md) also supports a utility command for restoring indices. Check the `datahub check restore-indices --help` help text for more details.
+The [datahub CLI](../cli.md) also supports a utility command for restoring indices.
 
 ## Best Practices
 


### PR DESCRIPTION
Follow up of https://github.com/datahub-project/datahub/pull/13820 

Move doc for sub-command to the CLI page for easier discoverability.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
