### PR TITLE
fix(ui): Fix non-functional page size in tags page

### DIFF
--- a/datahub-web-react/src/app/tags/ManageTags.tsx
+++ b/datahub-web-react/src/app/tags/ManageTags.tsx
@@ -56,6 +56,7 @@ const ManageTags = () => {
     const isShowNavBarRedesign = useShowNavBarRedesign();
     const [searchQuery, setSearchQuery] = useState('');
     const [currentPage, setCurrentPage] = useState(1);
+    const [pageSize, setPageSize] = useState(PAGE_SIZE);
     const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('*');
     const entityRegistry = useEntityRegistry();
     const [showCreateTagModal, setShowCreateTagModal] = useState(false);
@@ -78,11 +79,11 @@ const ManageTags = () => {
         () => ({
             types: [EntityType.Tag],
             query: debouncedSearchQuery,
-            start: (currentPage - 1) * PAGE_SIZE,
-            count: PAGE_SIZE,
+            start: (currentPage - 1) * pageSize,
+            count: pageSize,
             filters: [],
         }),
-        [currentPage, debouncedSearchQuery],
+        [currentPage, debouncedSearchQuery, pageSize],
     );
 
     const {
@@ -182,10 +183,16 @@ const ManageTags = () => {
                     />
                     <Pagination
                         currentPage={currentPage}
+                        itemsPerPage={pageSize}
                         totalPages={totalTags}
                         loading={searchLoading}
-                        onPageChange={(page) => setCurrentPage(page)}
+                        onPageChange={(newPage, newPageSize) => {
+                            if (newPageSize !== pageSize) {
+                                setCurrentPage(1);
+                                setPageSize(newPageSize);
                             } else {
+                                setCurrentPage(newPage);
+                            }
                         }}
                     />
                 </>

--- a/datahub-web-react/src/app/tags/ManageTags.tsx
+++ b/datahub-web-react/src/app/tags/ManageTags.tsx
@@ -182,10 +182,11 @@ const ManageTags = () => {
                     />
                     <Pagination
                         currentPage={currentPage}
-                        itemsPerPage={PAGE_SIZE}
                         totalPages={totalTags}
                         loading={searchLoading}
                         onPageChange={(page) => setCurrentPage(page)}
+                            } else {
+                        }}
                     />
                 </>
             )}


### PR DESCRIPTION
Fixing the page size selector in Tags page by adding a state, and redirecting to page 1 when we are changing the page size. This redirecting behaviour is to keep it consistent with search page behaviour

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
