### PR TITLE
fix(change-events): fix NPE in EditableSchemaMetadataChangeEventGenerator

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
@@ -95,7 +95,9 @@ public class EditableSchemaMetadataChangeEventGenerator
             ? baseEditableSchemaMetadata.getEditableSchemaFieldInfo()
             : new EditableSchemaFieldInfoArray();
     EditableSchemaFieldInfoArray targetFieldInfos =
-        targetEditableSchemaMetadata.getEditableSchemaFieldInfo();
+        (targetEditableSchemaMetadata != null)
+            ? targetEditableSchemaMetadata.getEditableSchemaFieldInfo()
+            : new EditableSchemaFieldInfoArray();
     int baseIdx = 0;
     int targetIdx = 0;
     while (baseIdx < baseFieldInfos.size() && targetIdx < targetFieldInfos.size()) {


### PR DESCRIPTION
Handle the case where targetEditableSchemaMetadata is null by returning an empty EditableSchemaFieldInfoArray instead of throwing an NPE. This occurs when deleting the "editableSchemaMetadata" aspect.
