### PR TITLE
feat(monitoring): modernize datahub monitoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ buildscript {
   ext.springKafkaVersion = '3.3.6'
   ext.openTelemetryVersion = '1.49.0'
   ext.neo4jVersion = '5.20.0'
-  ext.neo4jTestVersion = '5.20.0'
   ext.neo4jApocVersion = '5.20.0'
   ext.testContainersVersion = '1.21.1'
   ext.elasticsearchVersion = '2.11.1' // ES 7.10, Opensearch 1.x, 2.x
@@ -64,6 +63,7 @@ buildscript {
   ext.openLineageVersion = '1.25.0'
   ext.logbackClassicJava8 = '1.2.12'
   ext.awsSdk2Version = '2.30.33'
+  ext.micrometerVersion = '1.15.1'
 
   ext.docker_registry = project.getProperties().getOrDefault("dockerRegistry", 'acryldata')
 
@@ -142,11 +142,10 @@ project.ext.externalDependency = [
     'datastaxOssNativeProtocol': 'com.datastax.oss:native-protocol:1.5.1',
     'datastaxOssCore': 'org.apache.cassandra:java-driver-core:4.19.0',
     'datastaxOssQueryBuilder': 'org.apache.cassandra:java-driver-query-builder:4.19.0',
-    'dgraph4j' : 'io.dgraph:dgraph4j:24.1.1',
-    'dgraphNetty': 'io.grpc:grpc-netty:1.71.0',
-    'dgraphShadedNetty': 'io.grpc:grpc-netty-shaded:1.71.0',
-    'dropwizardMetricsCore': 'io.dropwizard.metrics:metrics-core:4.2.3',
-    'dropwizardMetricsJmx': 'io.dropwizard.metrics:metrics-jmx:4.2.3',
+    'micrometerPrometheus': "io.micrometer:micrometer-registry-prometheus:$micrometerVersion",
+    'micrometerJmx': "io.micrometer:micrometer-registry-jmx:$micrometerVersion",
+    'micrometerObserve': "io.micrometer:micrometer-observation:$micrometerVersion",
+    'micrometerOtelBridge': "io.micrometer:micrometer-tracing-bridge-otel:1.5.1",
     'ebean': 'io.ebean:ebean:' + ebeanVersion,
     'ebeanTest': 'io.ebean:ebean-test:' + ebeanVersion,
     'ebeanAgent': 'io.ebean:ebean-agent:' + ebeanVersion,
@@ -154,8 +153,8 @@ project.ext.externalDependency = [
     'ebeanQueryBean': 'io.ebean:querybean-generator:' + ebeanVersion,
     'elasticSearchRest': 'org.opensearch.client:opensearch-rest-high-level-client:' + elasticsearchVersion,
     'findbugsAnnotations': 'com.google.code.findbugs:annotations:3.0.1',
-    'graphqlJava': 'com.graphql-java:graphql-java:21.5',
-    'graphqlJavaScalars': 'com.graphql-java:graphql-java-extended-scalars:21.0',
+    'graphqlJava': 'com.graphql-java:graphql-java:22.3',
+    'graphqlJavaScalars': 'com.graphql-java:graphql-java-extended-scalars:22.0',
     'gson': 'com.google.code.gson:gson:2.12.0',
     'guice': 'com.google.inject:guice:7.0.0',
     'guicePlay': 'com.google.inject:guice:5.0.1', // Used for frontend while still on old Play version
@@ -224,9 +223,8 @@ project.ext.externalDependency = [
     'mockServer': 'org.mock-server:mockserver-netty:5.11.2',
     'mockServerClient': 'org.mock-server:mockserver-client-java:5.11.2',
     'mysqlConnector': 'com.mysql:mysql-connector-j:8.4.0',
-    'neo4jHarness': 'org.neo4j.test:neo4j-harness:' + neo4jTestVersion,
+    'testContainersNeo4j': 'org.testcontainers:neo4j:' + testContainersVersion,
     'neo4jJavaDriver': 'org.neo4j.driver:neo4j-java-driver:' + neo4jVersion,
-    'neo4jTestJavaDriver': 'org.neo4j.driver:neo4j-java-driver:' + neo4jTestVersion,
     'neo4jApocCore': 'org.neo4j.procedure:apoc-core:' + neo4jApocVersion,
     'neo4jApocCommon': 'org.neo4j.procedure:apoc-common:' + neo4jApocVersion,
     'opentelemetryApi': 'io.opentelemetry:opentelemetry-api:' + openTelemetryVersion,

--- a/datahub-frontend/app/auth/AuthModule.java
+++ b/datahub-frontend/app/auth/AuthModule.java
@@ -18,6 +18,7 @@ import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.entity.client.SystemRestliEntityClient;
 import com.linkedin.metadata.models.registry.EmptyEntityRegistry;
 import com.linkedin.metadata.restli.DefaultRestliClientFactory;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.parseq.retry.backoff.ExponentialBackoff;
 import com.linkedin.util.Configuration;
 import config.ConfigurationProvider;
@@ -30,6 +31,15 @@ import io.datahubproject.metadata.context.OperationContextConfig;
 import io.datahubproject.metadata.context.RetrieverContext;
 import io.datahubproject.metadata.context.SearchContext;
 import io.datahubproject.metadata.context.ValidationContext;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.MeterFilterReply;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.instrument.util.HierarchicalNameMapper;
+import io.micrometer.jmx.JmxConfig;
+import io.micrometer.jmx.JmxMeterRegistry;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import javax.annotation.Nonnull;
@@ -176,6 +186,46 @@ public class AuthModule extends AbstractModule {
 
   @Provides
   @Singleton
+  protected MetricUtils metricUtils(final AnnotationConfigApplicationContext springContext) {
+    // Create the appropriate MeterRegistry based on configuration
+    MeterRegistry meterRegistry;
+
+    // Check if JMX metrics are enabled
+    org.springframework.core.env.Environment env = springContext.getEnvironment();
+    Boolean jmxEnabled = env.getProperty("management.metrics.export.jmx.enabled", Boolean.class);
+
+    if (jmxEnabled != null && jmxEnabled) {
+      // Create JMX registry with legacy hierarchical name mapper
+      HierarchicalNameMapper legacyMapper = (id, namingConvention) -> id.getName();
+      meterRegistry = new JmxMeterRegistry(JmxConfig.DEFAULT, Clock.SYSTEM, legacyMapper);
+
+      // Apply filter to only include Dropwizard metrics in JMX
+      meterRegistry
+          .config()
+          .meterFilter(
+              new MeterFilter() {
+                @Override
+                public MeterFilterReply accept(Meter.Id id) {
+                  return id.getTag(MetricUtils.DROPWIZARD_METRIC) != null
+                      ? MeterFilterReply.ACCEPT
+                      : MeterFilterReply.DENY;
+                }
+              });
+    } else {
+      // Default to simple meter registry if JMX is not enabled
+      meterRegistry = new SimpleMeterRegistry();
+    }
+
+    // Create and configure MetricUtils
+    MetricUtils metricUtils = MetricUtils.builder().registry(meterRegistry).build();
+
+    meterRegistry.config().commonTags("application", "datahub-frontend");
+
+    return metricUtils;
+  }
+
+  @Provides
+  @Singleton
   @Named("systemOperationContext")
   protected OperationContext provideOperationContext(
       final Authentication systemAuthentication,
@@ -209,17 +259,25 @@ public class AuthModule extends AbstractModule {
 
   @Provides
   @Singleton
-  protected ConfigurationProvider provideConfigurationProvider() {
+  protected ConfigurationProvider provideConfigurationProvider(
+      AnnotationConfigApplicationContext springContext) {
+    return springContext.getBean(ConfigurationProvider.class);
+  }
+
+  @Provides
+  @Singleton
+  protected AnnotationConfigApplicationContext springContext() {
     AnnotationConfigApplicationContext context =
         new AnnotationConfigApplicationContext(ConfigurationProvider.class);
-    return context.getBean(ConfigurationProvider.class);
+    return context;
   }
 
   @Provides
   @Singleton
   protected SystemEntityClient provideEntityClient(
       @Named("systemOperationContext") final OperationContext systemOperationContext,
-      final ConfigurationProvider configurationProvider) {
+      final ConfigurationProvider configurationProvider,
+      final MetricUtils metricUtils) {
 
     return new SystemRestliEntityClient(
         buildRestliClient(),
@@ -229,7 +287,8 @@ public class AuthModule extends AbstractModule {
             .batchGetV2Size(configs.getInt(ENTITY_CLIENT_RESTLI_GET_BATCH_SIZE))
             .batchGetV2Concurrency(2)
             .build(),
-        configurationProvider.getCache().getClient().getEntityClient());
+        configurationProvider.getCache().getClient().getEntityClient(),
+        metricUtils);
   }
 
   @Provides

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -307,6 +307,7 @@ import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.client.UsageStatsJavaClient;
 import com.linkedin.metadata.config.ChromeExtensionConfiguration;
 import com.linkedin.metadata.config.DataHubConfiguration;
+import com.linkedin.metadata.config.GraphQLConfiguration;
 import com.linkedin.metadata.config.HomePageConfiguration;
 import com.linkedin.metadata.config.IngestionConfiguration;
 import com.linkedin.metadata.config.SearchBarConfiguration;
@@ -336,6 +337,7 @@ import com.linkedin.metadata.service.SettingsService;
 import com.linkedin.metadata.service.ViewService;
 import com.linkedin.metadata.timeline.TimelineService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.metadata.version.GitVersion;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
@@ -473,9 +475,8 @@ public class GmsGraphQLEngine {
   private final PageTemplateType dataHubPageTemplateType;
   private final PageModuleType dataHubPageModuleType;
 
-  private final int graphQLQueryComplexityLimit;
-  private final int graphQLQueryDepthLimit;
-  private final boolean graphQLQueryIntrospectionEnabled;
+  private final GraphQLConfiguration graphQLConfiguration;
+  private final MetricUtils metricUtils;
 
   private final BusinessAttributeType businessAttributeType;
 
@@ -604,9 +605,8 @@ public class GmsGraphQLEngine {
     this.executionRequestType = new ExecutionRequestType(entityClient);
     this.dataHubPageTemplateType = new PageTemplateType(entityClient);
     this.dataHubPageModuleType = new PageModuleType(entityClient);
-    this.graphQLQueryComplexityLimit = args.graphQLQueryComplexityLimit;
-    this.graphQLQueryDepthLimit = args.graphQLQueryDepthLimit;
-    this.graphQLQueryIntrospectionEnabled = args.graphQLQueryIntrospectionEnabled;
+    this.graphQLConfiguration = args.graphQLConfiguration;
+    this.metricUtils = args.metricUtils;
 
     this.businessAttributeType = new BusinessAttributeType(entityClient);
     // Init Lists
@@ -840,9 +840,8 @@ public class GmsGraphQLEngine {
     builder
         .addDataLoaders(loaderSuppliers(loadableTypes))
         .addDataLoader("Aspect", context -> createDataLoader(aspectType, context))
-        .setGraphQLQueryComplexityLimit(graphQLQueryComplexityLimit)
-        .setGraphQLQueryDepthLimit(graphQLQueryDepthLimit)
-        .setGraphQLQueryIntrospectionEnabled(graphQLQueryIntrospectionEnabled)
+        .setGraphQLConfiguration(graphQLConfiguration)
+        .setMetricUtils(metricUtils)
         .configureRuntimeWiring(this::configureRuntimeWiring);
     return builder;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngineArgs.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngineArgs.java
@@ -15,6 +15,7 @@ import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.client.UsageStatsJavaClient;
 import com.linkedin.metadata.config.ChromeExtensionConfiguration;
 import com.linkedin.metadata.config.DataHubConfiguration;
+import com.linkedin.metadata.config.GraphQLConfiguration;
 import com.linkedin.metadata.config.HomePageConfiguration;
 import com.linkedin.metadata.config.IngestionConfiguration;
 import com.linkedin.metadata.config.SearchBarConfiguration;
@@ -42,6 +43,7 @@ import com.linkedin.metadata.service.SettingsService;
 import com.linkedin.metadata.service.ViewService;
 import com.linkedin.metadata.timeline.TimelineService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.metadata.version.GitVersion;
 import io.datahubproject.metadata.services.RestrictedService;
 import io.datahubproject.metadata.services.SecretService;
@@ -89,15 +91,15 @@ public class GmsGraphQLEngineArgs {
   ERModelRelationshipService erModelRelationshipService;
   FormService formService;
   RestrictedService restrictedService;
-  int graphQLQueryComplexityLimit;
-  int graphQLQueryDepthLimit;
-  boolean graphQLQueryIntrospectionEnabled;
+  GraphQLConfiguration graphQLConfiguration;
   BusinessAttributeService businessAttributeService;
   ChromeExtensionConfiguration chromeExtensionConfiguration;
   ConnectionService connectionService;
   AssertionService assertionService;
   EntityVersioningService entityVersioningService;
   ApplicationService applicationService;
+  boolean systemTelemetryEnabled;
+  MetricUtils metricUtils;
 
   // any fork specific args should go below this line
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/concurrency/GraphQLConcurrencyUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/concurrency/GraphQLConcurrencyUtils.java
@@ -1,7 +1,5 @@
 package com.linkedin.datahub.graphql.concurrency;
 
-import com.codahale.metrics.MetricRegistry;
-import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.opentelemetry.context.Context;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -16,16 +14,13 @@ public class GraphQLConcurrencyUtils {
     return GraphQLConcurrencyUtils.graphQLExecutorService;
   }
 
-  public static void setExecutorService(ExecutorService executorService) {
+  public static ExecutorService setExecutorService(ExecutorService executorService) {
     GraphQLConcurrencyUtils.graphQLExecutorService = Context.taskWrapping(executorService);
+    return graphQLExecutorService;
   }
 
   public static <T> CompletableFuture<T> supplyAsync(
       Supplier<T> supplier, String caller, String task) {
-    MetricUtils.counter(
-            MetricRegistry.name(
-                GraphQLConcurrencyUtils.class.getSimpleName(), "supplyAsync", caller, task))
-        .inc();
     if (GraphQLConcurrencyUtils.graphQLExecutorService == null) {
       // Hack around to force context wrapping for base executor
       return CompletableFuture.supplyAsync(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetUsageStatsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetUsageStatsResolver.java
@@ -9,7 +9,6 @@ import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.UsageQueryResult;
 import com.linkedin.datahub.graphql.types.usage.UsageQueryResultMapper;
-import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.usage.UsageClient;
 import com.linkedin.usage.UsageTimeRange;
 import graphql.schema.DataFetcher;
@@ -49,7 +48,12 @@ public class DatasetUsageStatsResolver implements DataFetcher<CompletableFuture<
             return UsageQueryResultMapper.map(context, usageQueryResult);
           } catch (Exception e) {
             log.error(String.format("Failed to load Usage Stats for resource %s", resourceUrn), e);
-            MetricUtils.counter(this.getClass(), "usage_stats_dropped").inc();
+            context
+                .getOperationContext()
+                .getMetricUtils()
+                .ifPresent(
+                    metricUtils ->
+                        metricUtils.increment(this.getClass(), "usage_stats_dropped", 1));
           }
 
           return UsageQueryResultMapper.EMPTY;

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/GraphQLEngineTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/GraphQLEngineTest.java
@@ -1,0 +1,503 @@
+package com.linkedin.datahub.graphql;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.metadata.config.GraphQLConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLConcurrencyConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLMetricsConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLQueryConfiguration;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import graphql.ExecutionResult;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.*;
+import java.util.function.Function;
+import org.dataloader.DataLoader;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class GraphQLEngineTest {
+
+  @Mock private MetricUtils mockMetricUtils;
+
+  @Mock private QueryContext mockQueryContext;
+
+  private GraphQLConfiguration graphQLConfiguration;
+  private GraphQLEngine graphQLEngine;
+
+  private static final String TEST_SCHEMA =
+      """
+        type Query {
+            hello: String
+            user(id: ID!): User
+            users: [User]
+        }
+
+        type User {
+            id: ID!
+            name: String
+            email: String
+        }
+
+        type Mutation {
+            createUser(name: String!, email: String!): User
+        }
+        """;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    // Setup real GraphQL configuration
+    graphQLConfiguration = createDefaultConfiguration();
+  }
+
+  private GraphQLConfiguration createDefaultConfiguration() {
+    GraphQLConfiguration config = new GraphQLConfiguration();
+
+    // Query configuration
+    GraphQLQueryConfiguration queryConfig = new GraphQLQueryConfiguration();
+    queryConfig.setComplexityLimit(1000);
+    queryConfig.setDepthLimit(10);
+    queryConfig.setIntrospectionEnabled(true);
+    config.setQuery(queryConfig);
+
+    // Metrics configuration
+    GraphQLMetricsConfiguration metricsConfig = new GraphQLMetricsConfiguration();
+    metricsConfig.setEnabled(false);
+    metricsConfig.setFieldLevelEnabled(false);
+    metricsConfig.setFieldLevelOperations("Query.search");
+    metricsConfig.setFieldLevelPathEnabled(false);
+    metricsConfig.setFieldLevelPaths("/search");
+    metricsConfig.setTrivialDataFetchersEnabled(false);
+    config.setMetrics(metricsConfig);
+
+    // Concurrency configuration (if needed)
+    GraphQLConcurrencyConfiguration concurrencyConfig = new GraphQLConcurrencyConfiguration();
+    config.setConcurrency(concurrencyConfig);
+
+    return config;
+  }
+
+  @Test
+  public void testBuilderWithBasicSchema() {
+    // Build GraphQL engine with basic configuration
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(graphQLConfiguration)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    assertNotNull(graphQLEngine);
+    assertNotNull(graphQLEngine.getGraphQL());
+  }
+
+  @Test
+  public void testExecuteSimpleQuery() {
+    // Setup
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(graphQLConfiguration)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    // Execute query
+    String query = "{ hello }";
+    ExecutionResult result = graphQLEngine.execute(query, null, Map.of(), mockQueryContext);
+
+    // Verify
+    assertNotNull(result);
+    assertFalse(result.getErrors().isEmpty() == false && result.getErrors().size() > 0);
+    Map<String, Object> data = result.getData();
+    assertNotNull(data);
+    assertEquals(data.get("hello"), "World");
+  }
+
+  @Test
+  public void testExecuteQueryWithVariables() {
+    // Setup
+    Map<String, User> userDatabase = new HashMap<>();
+    userDatabase.put("1", new User("1", "John Doe", "john@example.com"));
+    userDatabase.put("2", new User("2", "Jane Smith", "jane@example.com"));
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(graphQLConfiguration)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query",
+                        typeWiring ->
+                            typeWiring.dataFetcher(
+                                "user",
+                                env -> {
+                                  String id = env.getArgument("id");
+                                  return userDatabase.get(id);
+                                })))
+            .build();
+
+    // Execute query with variables
+    String query = "query getUser($userId: ID!) { user(id: $userId) { id name email } }";
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("userId", "1");
+
+    ExecutionResult result = graphQLEngine.execute(query, "getUser", variables, mockQueryContext);
+
+    // Verify
+    assertNotNull(result);
+    assertTrue(result.getErrors().isEmpty());
+    Map<String, Object> data = result.getData();
+    assertNotNull(data);
+    Map<String, Object> user = (Map<String, Object>) data.get("user");
+    assertEquals(user.get("id"), "1");
+    assertEquals(user.get("name"), "John Doe");
+    assertEquals(user.get("email"), "john@example.com");
+  }
+
+  @Test
+  public void testBuilderWithMultipleSchemas() {
+    String schema1 = "type Query { field1: String }";
+    String schema2 = "extend type Query { field2: Int }";
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(schema1)
+            .addSchema(schema2)
+            .setGraphQLConfiguration(graphQLConfiguration)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query",
+                        typeWiring ->
+                            typeWiring
+                                .dataFetcher("field1", env -> "value1")
+                                .dataFetcher("field2", env -> 42)))
+            .build();
+
+    assertNotNull(graphQLEngine);
+
+    // Test both fields
+    ExecutionResult result =
+        graphQLEngine.execute("{ field1 field2 }", null, Map.of(), mockQueryContext);
+    assertNotNull(result);
+    Map<String, Object> data = result.getData();
+    assertEquals(data.get("field1"), "value1");
+    assertEquals(data.get("field2"), 42);
+  }
+
+  @Test
+  public void testDataLoaderIntegration() {
+    // Setup data loader
+    Function<QueryContext, DataLoader<?, ?>> userLoaderSupplier =
+        context ->
+            DataLoader.newDataLoader(
+                keys -> {
+                  List<User> users = new ArrayList<>();
+                  for (Object key : keys) {
+                    users.add(new User((String) key, "User " + key, "user" + key + "@example.com"));
+                  }
+                  return java.util.concurrent.CompletableFuture.completedFuture(users);
+                });
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(graphQLConfiguration)
+            .setMetricUtils(mockMetricUtils)
+            .addDataLoader("userLoader", userLoaderSupplier)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query",
+                        typeWiring ->
+                            typeWiring.dataFetcher(
+                                "user",
+                                env -> {
+                                  String id = env.getArgument("id");
+                                  DataLoader<String, User> loader = env.getDataLoader("userLoader");
+                                  return loader.load(id);
+                                })))
+            .build();
+
+    // Execute query
+    String query = "{ user(id: \"123\") { id name } }";
+    ExecutionResult result = graphQLEngine.execute(query, null, Map.of(), mockQueryContext);
+
+    // Verify
+    assertNotNull(result);
+    assertTrue(result.getErrors().isEmpty());
+    Map<String, Object> data = result.getData();
+    Map<String, Object> user = (Map<String, Object>) data.get("user");
+    assertEquals(user.get("id"), "123");
+    assertEquals(user.get("name"), "User 123");
+  }
+
+  @Test
+  public void testBuilderWithMultipleDataLoaders() {
+    Map<String, Function<QueryContext, DataLoader<?, ?>>> loaders = new HashMap<>();
+    loaders.put(
+        "loader1",
+        ctx ->
+            DataLoader.newDataLoader(
+                keys ->
+                    java.util.concurrent.CompletableFuture.completedFuture(new ArrayList<>(keys))));
+    loaders.put(
+        "loader2",
+        ctx ->
+            DataLoader.newDataLoader(
+                keys ->
+                    java.util.concurrent.CompletableFuture.completedFuture(new ArrayList<>(keys))));
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(graphQLConfiguration)
+            .setMetricUtils(mockMetricUtils)
+            .addDataLoaders(loaders)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    assertNotNull(graphQLEngine);
+  }
+
+  @Test
+  public void testMetricsEnabled() {
+    // Setup metrics
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    when(mockMetricUtils.getRegistry()).thenReturn(Optional.of(meterRegistry));
+
+    // Enable metrics in configuration
+    GraphQLConfiguration metricsEnabledConfig = createDefaultConfiguration();
+    metricsEnabledConfig.getMetrics().setEnabled(true);
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(metricsEnabledConfig)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    // Execute query
+    ExecutionResult result = graphQLEngine.execute("{ hello }", null, Map.of(), mockQueryContext);
+
+    // Verify
+    assertNotNull(result);
+    verify(mockMetricUtils, times(1)).getRegistry();
+  }
+
+  @Test
+  public void testIntrospectionDisabled() {
+    // Setup with introspection disabled
+    GraphQLConfiguration introspectionDisabledConfig = createDefaultConfiguration();
+    introspectionDisabledConfig.getQuery().setIntrospectionEnabled(false);
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(introspectionDisabledConfig)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    assertNotNull(graphQLEngine);
+  }
+
+  @Test
+  public void testComplexityAndDepthLimits() {
+    // Setup with custom limits
+    GraphQLConfiguration customLimitsConfig = createDefaultConfiguration();
+    customLimitsConfig.getQuery().setComplexityLimit(500);
+    customLimitsConfig.getQuery().setDepthLimit(5);
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(customLimitsConfig)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    assertNotNull(graphQLEngine);
+
+    // A deeply nested query would be rejected based on depth limit
+    // This is a simple test to ensure the engine is created with limits
+    ExecutionResult result = graphQLEngine.execute("{ hello }", null, Map.of(), mockQueryContext);
+    assertNotNull(result);
+  }
+
+  @Test
+  public void testExecuteWithNullOperationName() {
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(graphQLConfiguration)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    ExecutionResult result = graphQLEngine.execute("{ hello }", null, Map.of(), mockQueryContext);
+    assertNotNull(result);
+    assertTrue(result.getErrors().isEmpty());
+  }
+
+  @Test
+  public void testExecuteWithEmptyVariables() {
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(graphQLConfiguration)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    ExecutionResult result =
+        graphQLEngine.execute("{ hello }", null, new HashMap<>(), mockQueryContext);
+    assertNotNull(result);
+    assertTrue(result.getErrors().isEmpty());
+  }
+
+  @Test
+  public void testFieldLevelMetricsConfiguration() {
+    // Setup with field level metrics enabled
+    GraphQLConfiguration fieldMetricsConfig = createDefaultConfiguration();
+    GraphQLMetricsConfiguration metrics = fieldMetricsConfig.getMetrics();
+    metrics.setEnabled(true);
+    metrics.setFieldLevelEnabled(true);
+    metrics.setFieldLevelOperations("Query.search,Query.user");
+    metrics.setFieldLevelPathEnabled(true);
+    metrics.setFieldLevelPaths("/search,/user");
+    metrics.setTrivialDataFetchersEnabled(true);
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    when(mockMetricUtils.getRegistry()).thenReturn(Optional.of(meterRegistry));
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(fieldMetricsConfig)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query",
+                        typeWiring ->
+                            typeWiring
+                                .dataFetcher("hello", env -> "World")
+                                .dataFetcher(
+                                    "user", env -> new User("1", "Test", "test@example.com"))))
+            .build();
+
+    // Execute query
+    ExecutionResult result =
+        graphQLEngine.execute("{ user(id: \"1\") { name } }", null, Map.of(), mockQueryContext);
+
+    // Verify
+    assertNotNull(result);
+    assertTrue(result.getErrors().isEmpty());
+  }
+
+  @Test
+  public void testNullMetricUtils() {
+    // Test with null MetricUtils
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(graphQLConfiguration)
+            .setMetricUtils(null)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    assertNotNull(graphQLEngine);
+
+    // Should work fine without metrics
+    ExecutionResult result = graphQLEngine.execute("{ hello }", null, Map.of(), mockQueryContext);
+    assertNotNull(result);
+    assertTrue(result.getErrors().isEmpty());
+  }
+
+  @Test
+  public void testMetricsWithEmptyRegistry() {
+    // Setup metrics with empty registry
+    when(mockMetricUtils.getRegistry()).thenReturn(Optional.empty());
+
+    GraphQLConfiguration metricsEnabledConfig = createDefaultConfiguration();
+    metricsEnabledConfig.getMetrics().setEnabled(true);
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(metricsEnabledConfig)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query", typeWiring -> typeWiring.dataFetcher("hello", env -> "World")))
+            .build();
+
+    assertNotNull(graphQLEngine);
+  }
+
+  // Helper class for testing
+  public static class User {
+    private final String id;
+    private final String name;
+    private final String email;
+
+    public User(String id, String name, String email) {
+      this.id = id;
+      this.name = name;
+      this.email = email;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+  }
+}

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/OpenTelemetryConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/OpenTelemetryConfig.java
@@ -2,7 +2,8 @@ package com.linkedin.datahub.upgrade.config;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.system_telemetry.OpenTelemetryBaseFactory;
-import io.datahubproject.metadata.context.TraceContext;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import org.apache.kafka.clients.producer.Producer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,8 +18,10 @@ public class OpenTelemetryConfig extends OpenTelemetryBaseFactory {
 
   @Bean
   @Override
-  protected TraceContext traceContext(
-      ConfigurationProvider configurationProvider, Producer<String, String> dueProducer) {
-    return super.traceContext(configurationProvider, dueProducer);
+  protected SystemTelemetryContext traceContext(
+      MetricUtils metricUtils,
+      ConfigurationProvider configurationProvider,
+      Producer<String, String> dueProducer) {
+    return super.traceContext(metricUtils, configurationProvider, dueProducer);
   }
 }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfig.java
@@ -14,6 +14,7 @@ import com.linkedin.gms.factory.kafka.schemaregistry.InternalSchemaRegistryFacto
 import com.linkedin.metadata.config.kafka.KafkaConfiguration;
 import com.linkedin.metadata.dao.producer.KafkaEventProducer;
 import com.linkedin.metadata.dao.producer.KafkaHealthChecker;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.metadata.version.GitVersion;
 import com.linkedin.mxe.TopicConvention;
 import java.util.List;
@@ -96,13 +97,14 @@ public class SystemUpdateConfig {
       @Qualifier("configurationProvider") ConfigurationProvider provider,
       KafkaProperties properties,
       @Qualifier("duheSchemaRegistryConfig")
-          KafkaConfiguration.SerDeKeyValueConfig duheSchemaRegistryConfig) {
+          KafkaConfiguration.SerDeKeyValueConfig duheSchemaRegistryConfig,
+      MetricUtils metricUtils) {
     KafkaConfiguration kafkaConfiguration = provider.getKafka();
     Producer<String, IndexedRecord> producer =
         new KafkaProducer<>(
             DataHubKafkaProducerFactory.buildProducerProperties(
                 duheSchemaRegistryConfig, kafkaConfiguration, properties));
-    return new KafkaEventProducer(producer, topicConvention, kafkaHealthChecker);
+    return new KafkaEventProducer(producer, topicConvention, kafkaHealthChecker, metricUtils);
   }
 
   /**

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/UpgradeCliApplicationTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/UpgradeCliApplicationTest.java
@@ -10,7 +10,7 @@ import com.linkedin.datahub.upgrade.system.BlockingSystemUpgrade;
 import com.linkedin.metadata.dao.throttle.NoOpSensor;
 import com.linkedin.metadata.dao.throttle.ThrottleSensor;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import javax.inject.Named;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -39,7 +39,7 @@ public class UpgradeCliApplicationTest extends AbstractTestNGSpringContextTests 
   @Autowired
   private ThrottleSensor kafkaThrottle;
 
-  @Autowired private TraceContext traceContext;
+  @Autowired private SystemTelemetryContext systemTelemetryContext;
 
   @Test
   public void testRestoreIndicesInit() {
@@ -68,6 +68,6 @@ public class UpgradeCliApplicationTest extends AbstractTestNGSpringContextTests 
 
   @Test
   public void testTraceContext() {
-    assertNotNull(traceContext);
+    assertNotNull(systemTelemetryContext);
   }
 }

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/UpgradeCliApplicationTestConfiguration.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/UpgradeCliApplicationTestConfiguration.java
@@ -9,6 +9,8 @@ import com.linkedin.metadata.registry.SchemaRegistryServiceImpl;
 import com.linkedin.metadata.search.SearchService;
 import com.linkedin.mxe.TopicConventionImpl;
 import io.ebean.Database;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
@@ -29,6 +31,11 @@ public class UpgradeCliApplicationTestConfiguration {
   @MockBean public EntityRegistry entityRegistry;
 
   @MockBean public ConfigEntityRegistry configEntityRegistry;
+
+  @Bean
+  public MeterRegistry meterRegistry() {
+    return new SimpleMeterRegistry();
+  }
 
   @Bean
   public SchemaRegistryService schemaRegistryService() {

--- a/docs/advanced/monitoring.md
+++ b/docs/advanced/monitoring.md
@@ -1,9 +1,619 @@
 # Monitoring DataHub
 
-Monitoring DataHub's system components is critical for operating and improving DataHub. This doc explains how to add
-tracing and metrics measurements in the DataHub containers.
+## Overview
 
-## Tracing
+Monitoring DataHub's system components is essential for maintaining operational excellence, troubleshooting performance issues,
+and ensuring system reliability. This comprehensive guide covers how to implement observability in DataHub through tracing and metrics,
+and how to extract valuable insights from your running instances.
+
+## Why Monitor DataHub?
+
+Effective monitoring enables you to:
+
+- Identify Performance Bottlenecks: Pinpoint slow queries or API endpoints
+- Debug Issues Faster: Trace requests across distributed components to locate failures
+- Meet SLAs: Track and alert on key performance indicators
+
+## Observability Components
+
+DataHub's observability strategy consists of two complementary approaches:
+
+1. Metrics Collection
+
+   **Purpose:** Aggregate statistical data about system behavior over time
+   **Technology:** Transitioning from DropWizard/JMX to Micrometer
+
+   **Current State:** DropWizard metrics exposed via JMX, collected by Prometheus
+   **Future Direction:** Native Micrometer integration for Spring-based metrics
+   **Compatibility:** Prometheus-compatible format with support for other metrics backends
+
+   Key Metrics Categories:
+
+   - Performance Metrics: Request latency, throughput, error rates
+   - Resource Metrics: CPU, memory utilization
+   - Application Metrics: Cache hit rates, queue depths, processing times
+   - Business Metrics: Entity counts, ingestion rates, search performance
+
+2. Distributed Tracing
+
+   **Purpose:** Track individual requests as they flow through multiple services and components
+   **Technology:** OpenTelemetry-based instrumentation
+
+   - Provides end-to-end visibility of request lifecycles
+   - Automatically instruments popular libraries (Kafka, JDBC, Elasticsearch)
+   - Supports multiple backend systems (Jaeger, Zipkin, etc.)
+   - Enables custom span creation with minimal code changes
+
+   Key Benefits:
+
+   - Visualize request flow across microservices
+   - Identify latency hotspots
+   - Understand service dependencies
+   - Debug complex distributed transactions
+
+## GraphQL Instrumentation (Micrometer)
+
+### Overview
+
+DataHub provides comprehensive instrumentation for its GraphQL API through Micrometer metrics, enabling detailed performance
+monitoring and debugging capabilities. The instrumentation system offers flexible configuration options to balance between
+observability depth and performance overhead.
+
+### Why Path-Level GraphQL Instrumentation Matters
+
+Traditional GraphQL monitoring only tells you "the search query is slow" but not **why**. Without path-level instrumentation,
+you're blind to which specific fields are causing performance bottlenecks in complex nested queries.
+
+### Real-World Example
+
+Consider this GraphQL query:
+
+```graphql
+query getSearchResults {
+  search(input: { query: "sales data" }) {
+    searchResults {
+      entity {
+        ... on Dataset {
+          name
+          owner {
+            # Path: /search/searchResults/entity/owner
+            corpUser {
+              displayName
+            }
+          }
+          lineage {
+            # Path: /search/searchResults/entity/lineage
+            upstreamCount
+            downstreamCount
+            upstreamEntities {
+              urn
+              name
+            }
+          }
+          schemaMetadata {
+            # Path: /search/searchResults/entity/schemaMetadata
+            fields {
+              fieldPath
+              description
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### What Path-Level Instrumentation Reveals
+
+With path-level metrics, you discover:
+
+- `/search/searchResults/entity/owner` - 50ms (fast, well-cached)
+- `/search/searchResults/entity/lineage` - 2500ms (SLOW! hitting graph database)
+- `/search/searchResults/entity/schemaMetadata` - 150ms (acceptable)
+
+**Without path metrics**: "Search query takes 3 seconds"  
+**With path metrics**: "Lineage resolution is the bottleneck"
+
+### Key Benefits
+
+#### 1. **Surgical Optimization**
+
+Instead of guessing, you know exactly which resolver needs optimization. Maybe lineage needs better caching or pagination.
+
+#### 2. **Smart Query Patterns**
+
+Identify expensive patterns like:
+
+```yaml
+# These paths consistently slow:
+/*/lineage/upstreamEntities/*
+/*/siblings/*/platform
+# Action: Add field-level caching or lazy loading
+```
+
+#### 3. **Client-Specific Debugging**
+
+Different clients request different fields. Path instrumentation shows:
+
+- Web UI requests are slow (requesting everything)
+- API integrations timeout (requesting deep lineage)
+
+#### 4. **N+1 Query Detection**
+
+Spot resolver patterns that indicate N+1 problems:
+
+```
+/users/0/permissions - 10ms
+/users/1/permissions - 10ms
+/users/2/permissions - 10ms
+... (100 more times)
+```
+
+### Configuration Strategy
+
+Start targeted to minimize overhead:
+
+```yaml
+# Focus on known slow operations
+fieldLevelOperations: "searchAcrossEntities,getDataset"
+
+# Target expensive resolver paths
+fieldLevelPaths: "/**/lineage/**,/**/relationships/**,/**/privileges"
+```
+
+### Architecture
+
+The GraphQL instrumentation is implemented through `GraphQLTimingInstrumentation`, which extends GraphQL Java's instrumentation framework. It provides:
+
+- **Request-level metrics**: Overall query performance and error tracking
+- **Field-level metrics**: Detailed timing for individual field resolvers
+- **Smart filtering**: Configurable targeting of specific operations or field paths
+- **Low overhead**: Minimal performance impact through efficient instrumentation
+
+### Metrics Collected
+
+#### Request-Level Metrics
+
+**Metric: `graphql.request.duration`**
+
+- **Type**: Timer with percentiles (p50, p95, p99)
+- **Tags**:
+  - `operation`: Operation name (e.g., "getSearchResultsForMultiple")
+  - `operation.type`: Query, mutation, or subscription
+  - `success`: true/false based on error presence
+  - `field.filtering`: Filtering mode applied (DISABLED, ALL_FIELDS, BY_OPERATION, BY_PATH, BY_BOTH)
+- **Use Case**: Monitor overall GraphQL performance, identify slow operations
+
+**Metric: `graphql.request.errors`**
+
+- **Type**: Counter
+- **Tags**:
+  - `operation`: Operation name
+  - `operation.type`: Query, mutation, or subscription
+- **Use Case**: Track error rates by operation
+
+#### Field-Level Metrics
+
+**Metric: `graphql.field.duration`**
+
+- **Type**: Timer with percentiles (p50, p95, p99)
+- **Tags**:
+  - `parent.type`: GraphQL parent type (e.g., "Dataset", "User")
+  - `field`: Field name being resolved
+  - `operation`: Operation name context
+  - `success`: true/false
+  - `path`: Field path (optional, controlled by `fieldLevelPathEnabled`)
+- **Use Case**: Identify slow field resolvers, optimize data fetching
+
+**Metric: `graphql.field.errors`**
+
+- **Type**: Counter
+- **Tags**: Same as field duration (minus success tag)
+- **Use Case**: Track field-specific error patterns
+
+**Metric: `graphql.fields.instrumented`**
+
+- **Type**: Counter
+- **Tags**:
+  - `operation`: Operation name
+  - `filtering.mode`: Active filtering mode
+- **Use Case**: Monitor instrumentation coverage and overhead
+
+### Configuration Guide
+
+#### Master Controls
+
+```yaml
+graphQL:
+  metrics:
+    # Master switch for all GraphQL metrics
+    enabled: ${GRAPHQL_METRICS_ENABLED:true}
+
+    # Enable field-level resolver metrics
+    fieldLevelEnabled: ${GRAPHQL_METRICS_FIELD_LEVEL_ENABLED:false}
+```
+
+#### Selective Field Instrumentation
+
+Field-level metrics can add significant overhead for complex queries. DataHub provides multiple strategies to control which fields are instrumented:
+
+##### 1. **Operation-Based Filtering**
+
+Target specific GraphQL operations known to be slow or critical:
+
+```yaml
+fieldLevelOperations: "getSearchResultsForMultiple,searchAcrossLineageStructure"
+```
+
+##### 2. **Path-Based Filtering**
+
+Use path patterns to instrument specific parts of your schema:
+
+```yaml
+fieldLevelPaths: "/search/results/**,/user/*/permissions,/**/lineage/*"
+```
+
+**Path Pattern Syntax**:
+
+- `/user` - Exact match for the user field
+- `/user/*` - Direct children of user (e.g., `/user/name`, `/user/email`)
+- `/user/**` - User field and all descendants at any depth
+- `/*/comments/*` - Comments field under any parent
+
+##### 3. **Combined Filtering**
+
+When both operation and path filters are configured, only fields matching BOTH criteria are instrumented:
+
+```yaml
+# Only instrument search results within specific operations
+fieldLevelOperations: "searchAcrossEntities"
+fieldLevelPaths: "/searchResults/**"
+```
+
+#### Advanced Options
+
+```yaml
+# Include field paths as metric tags (WARNING: high cardinality risk)
+fieldLevelPathEnabled: false
+
+# Include metrics for trivial property access
+trivialDataFetchersEnabled: false
+```
+
+### Filtering Modes Explained
+
+The instrumentation automatically determines the most efficient filtering mode:
+
+1. **DISABLED**: Field-level metrics completely disabled
+2. **ALL_FIELDS**: No filtering, all fields instrumented (highest overhead)
+3. **BY_OPERATION**: Only instrument fields within specified operations
+4. **BY_PATH**: Only instrument fields matching path patterns
+5. **BY_BOTH**: Most restrictive - both operation and path must match
+
+### Performance Considerations
+
+#### Impact Assessment
+
+Field-level instrumentation overhead varies by:
+
+- **Query complexity**: More fields = more overhead
+- **Resolver performance**: Fast resolvers have higher relative overhead
+- **Filtering effectiveness**: Better targeting = less overhead
+
+#### Best Practices
+
+1. **Start Conservative**: Begin with field-level metrics disabled
+
+   ```yaml
+   fieldLevelEnabled: false
+   ```
+
+2. **Target Known Issues**: Enable selectively for problematic operations
+
+   ```yaml
+   fieldLevelEnabled: true
+   fieldLevelOperations: "slowSearchQuery,complexLineageQuery"
+   ```
+
+3. **Use Path Patterns Wisely**: Focus on expensive resolver paths
+
+   ```yaml
+   fieldLevelPaths: "/search/**,/**/lineage/**"
+   ```
+
+4. **Avoid Path Tags in Production**: High cardinality risk
+
+   ```yaml
+   fieldLevelPathEnabled: false # Keep this false
+   ```
+
+5. **Monitor Instrumentation Overhead**: Track the `graphql.fields.instrumented` metric
+
+### Example Configurations
+
+#### Development Environment (Full Visibility)
+
+```yaml
+graphQL:
+  metrics:
+    enabled: true
+    fieldLevelEnabled: true
+    fieldLevelOperations: "" # All operations
+    fieldLevelPathEnabled: true # Include paths for debugging
+    trivialDataFetchersEnabled: true
+```
+
+#### Production - Targeted Monitoring
+
+```yaml
+graphQL:
+  metrics:
+    enabled: true
+    fieldLevelEnabled: true
+    fieldLevelOperations: "getSearchResultsForMultiple,searchAcrossLineage"
+    fieldLevelPaths: "/search/results/*,/lineage/upstream/**,/lineage/downstream/**"
+    fieldLevelPathEnabled: false
+    trivialDataFetchersEnabled: false
+```
+
+#### Production - Minimal Overhead
+
+```yaml
+graphQL:
+  metrics:
+    enabled: true
+    fieldLevelEnabled: false # Only request-level metrics
+```
+
+### Debugging Slow Queries
+
+When investigating GraphQL performance issues:
+
+1. **Enable request-level metrics first** to identify slow operations
+2. **Temporarily enable field-level metrics** for the slow operation:
+   ```yaml
+   fieldLevelOperations: "problematicQuery"
+   ```
+3. **Analyze field duration metrics** to find bottlenecks
+4. **Optionally enable path tags** (briefly) for precise identification:
+   ```yaml
+   fieldLevelPathEnabled: true # Temporary only!
+   ```
+5. **Optimize identified resolvers** and disable detailed instrumentation
+
+### Integration with Monitoring Stack
+
+The GraphQL metrics integrate seamlessly with DataHub's monitoring infrastructure:
+
+- **Prometheus**: Metrics exposed at `/actuator/prometheus`
+- **Grafana**: Create dashboards showing:
+  - Request rates and latencies by operation
+  - Error rates and types
+  - Field resolver performance heatmaps
+  - Top slow operations and fields
+
+Example Prometheus queries:
+
+```promql
+# Average request duration by operation
+rate(graphql_request_duration_seconds_sum[5m])
+/ rate(graphql_request_duration_seconds_count[5m])
+
+# Field resolver p99 latency
+histogram_quantile(0.99,
+  rate(graphql_field_duration_seconds_bucket[5m])
+)
+
+# Error rate by operation
+rate(graphql_request_errors_total[5m])
+```
+
+## Cache Monitoring (Micrometer)
+
+### Overview
+
+Micrometer provides automatic instrumentation for cache implementations, offering deep insights into cache performance
+and efficiency. This instrumentation is crucial for DataHub, where caching significantly impacts query performance and system load.
+
+### Automatic Cache Metrics
+
+When caches are registered with Micrometer, comprehensive metrics are automatically collected without code changes:
+
+#### Core Metrics
+
+- **`cache.size`** (Gauge) - Current number of entries in the cache
+- **`cache.gets`** (Counter) - Cache access attempts, tagged with:
+  - `result=hit` - Successful cache hits
+  - `result=miss` - Cache misses requiring backend fetch
+- **`cache.puts`** (Counter) - Number of entries added to cache
+- **`cache.evictions`** (Counter) - Number of entries evicted
+- **`cache.eviction.weight`** (Counter) - Total weight of evicted entries (for size-based eviction)
+
+#### Derived Metrics
+
+Calculate key performance indicators using Prometheus queries:
+
+```promql
+# Cache hit rate (should be >80% for hot caches)
+sum(rate(cache_gets_total{result="hit"}[5m])) by (cache) /
+sum(rate(cache_gets_total[5m])) by (cache)
+
+# Cache miss rate
+1 - (cache_hit_rate)
+
+# Eviction rate (indicates cache pressure)
+rate(cache_evictions_total[5m])
+```
+
+### DataHub Cache Configuration
+
+DataHub uses multiple cache layers, each automatically instrumented:
+
+#### 1. Entity Client Cache
+
+```yaml
+cache.client.entityClient:
+  enabled: true
+  maxBytes: 104857600 # 100MB
+  entityAspectTTLSeconds:
+    corpuser:
+      corpUserInfo: 20 # Short TTL for frequently changing data
+      corpUserKey: 300 # Longer TTL for stable data
+    structuredProperty:
+      propertyDefinition: 300
+      structuredPropertyKey: 86400 # 1 day for very stable data
+```
+
+#### 2. Usage Statistics Cache
+
+```yaml
+cache.client.usageClient:
+  enabled: true
+  maxBytes: 52428800 # 50MB
+  defaultTTLSeconds: 86400 # 1 day
+  # Caches expensive usage calculations
+```
+
+#### 3. Search & Lineage Cache
+
+```yaml
+cache.search.lineage:
+  ttlSeconds: 86400 # 1 day
+```
+
+### Monitoring Best Practices
+
+#### Key Indicators to Watch
+
+1. **Hit Rate by Cache Type**
+
+   ```promql
+   # Alert if hit rate drops below 70%
+   cache_hit_rate < 0.7
+   ```
+
+2. **Memory Pressure**
+   ```promql
+   # High eviction rate relative to puts
+   rate(cache_evictions_total[5m]) / rate(cache_puts_total[5m]) > 0.1
+   ```
+
+## Thread Pool Executor Monitoring (Micrometer)
+
+### Overview
+
+Micrometer automatically instruments Java `ThreadPoolExecutor` instances, providing crucial visibility into concurrency
+bottlenecks and resource utilization. For DataHub's concurrent operations, this monitoring is essential for maintaining
+performance under load.
+
+### Automatic Executor Metrics
+
+#### Pool State Metrics
+
+- **`executor.pool.size`** (Gauge) - Current number of threads in pool
+- **`executor.pool.core`** (Gauge) - Core (minimum) pool size
+- **`executor.pool.max`** (Gauge) - Maximum allowed pool size
+- **`executor.active`** (Gauge) - Threads actively executing tasks
+
+#### Queue Metrics
+
+- **`executor.queued`** (Gauge) - Tasks waiting in queue
+- **`executor.queue.remaining`** (Gauge) - Available queue capacity
+
+#### Performance Metrics
+
+- **`executor.completed`** (Counter) - Total completed tasks
+- **`executor.seconds`** (Timer) - Task execution time distribution
+- **`executor.rejected`** (Counter) - Tasks rejected due to saturation
+
+### DataHub Executor Configurations
+
+#### 1. GraphQL Query Executor
+
+```yaml
+graphQL.concurrency:
+  separateThreadPool: true
+  corePoolSize: 20 # Base threads
+  maxPoolSize: 200 # Scale under load
+  keepAlive: 60 # Seconds before idle thread removal
+  # Handles complex GraphQL query resolution
+```
+
+#### 2. Batch Processing Executors
+
+```yaml
+entityClient.restli:
+  get:
+    batchConcurrency: 2 # Parallel batch processors
+    batchQueueSize: 500 # Task buffer
+    batchThreadKeepAlive: 60
+  ingest:
+    batchConcurrency: 2
+    batchQueueSize: 500
+```
+
+#### 3. Search & Analytics Executors
+
+```yaml
+timeseriesAspectService.query:
+  concurrency: 10 # Parallel query threads
+  queueSize: 500 # Buffered queries
+```
+
+### Critical Monitoring Patterns
+
+#### Saturation Detection
+
+```promql
+# Thread pool utilization (>0.8 indicates pressure)
+executor_active / executor_pool_size > 0.8
+
+# Queue filling up (>0.7 indicates backpressure)
+executor_queued / (executor_queued + executor_queue_remaining) > 0.7
+```
+
+#### Rejection & Starvation
+
+```promql
+# Task rejections (should be zero)
+rate(executor_rejected_total[1m]) > 0
+
+# Thread starvation (all threads busy for extended period)
+avg_over_time(executor_active[5m]) >= executor_pool_core
+```
+
+#### Performance Analysis
+
+```promql
+# Average task execution time
+rate(executor_seconds_sum[5m]) / rate(executor_seconds_count[5m])
+
+# Task throughput by executor
+rate(executor_completed_total[5m])
+```
+
+### Tuning Guidelines
+
+#### Symptoms & Solutions
+
+| Symptom         | Metric Pattern           | Solution                        |
+| --------------- | ------------------------ | ------------------------------- |
+| High latency    | `executor_queued` rising | Increase pool size              |
+| Rejections      | `executor_rejected` > 0  | Increase queue size or pool max |
+| Memory pressure | Many idle threads        | Reduce `keepAlive` time         |
+| CPU waste       | Low `executor_active`    | Reduce core pool size           |
+
+#### Capacity Planning
+
+1. **Measure baseline**: Monitor under normal load
+2. **Stress test**: Identify saturation points
+3. **Set alerts**:
+   - Warning at 70% utilization
+   - Critical at 90% utilization
+4. **Auto-scale**: Consider dynamic pool sizing based on queue depth
+
+## Distributed Tracing
 
 Traces let us track the life of a request across multiple components. Each trace is consisted of multiple spans, which
 are units of work, containing various context about the work being done as well as time taken to finish the work. By
@@ -37,13 +647,144 @@ an instance of Jaeger with port 16686. The traces should be available at http://
 We recommend using either `grpc` or `http/protobuf`, configured using `OTEL_EXPORTER_OTLP_PROTOCOL`. Avoid using `http` will not work as expected due to the size of
 the generated spans.
 
-## Metrics
+## Micrometer
 
-With tracing, we can observe how a request flows through our system into the persistence layer. However, for a more
-holistic picture, we need to be able to export metrics and measure them across time. Unfortunately, OpenTelemetry's java
-metrics library is still in active development.
+DataHub is transitioning to Micrometer as its primary metrics framework, representing a significant upgrade in observability
+capabilities. Micrometer is a vendor-neutral application metrics facade that provides a simple, consistent API for the most
+popular monitoring systems, allowing you to instrument your JVM-based application code without vendor lock-in.
 
-As such, we decided to use [Dropwizard Metrics](https://metrics.dropwizard.io/4.2.0/) to export custom metrics to JMX,
+### Why Micrometer?
+
+1. Native Spring Integration
+
+   As DataHub uses Spring Boot, Micrometer provides seamless integration with:
+
+   - Auto-configuration of common metrics
+   - Built-in metrics for HTTP requests, JVM, caches, and more
+   - Spring Boot Actuator endpoints for metrics exposure
+   - Automatic instrumentation of Spring components
+
+2. Multi-Backend Support
+
+   Unlike the legacy DropWizard approach that primarily targets JMX, Micrometer natively supports:
+
+   - Prometheus (recommended for cloud-native deployments)
+   - JMX (for backward compatibility)
+   - StatsD
+   - CloudWatch
+   - Datadog
+   - New Relic
+   - And many more...
+
+3. Dimensional Metrics
+
+   Micrometer embraces modern dimensional metrics with **labels/tags**, enabling:
+
+   - Rich querying and aggregation capabilities
+   - Better cardinality control
+   - More flexible dashboards and alerts
+   - Natural integration with cloud-native monitoring systems
+
+## Micrometer Transition Plan
+
+DataHub is undertaking a strategic transition from DropWizard metrics (exposed via JMX) to Micrometer, a modern vendor-neutral metrics facade.
+This transition aims to provide better cloud-native monitoring capabilities while maintaining backward compatibility for existing
+monitoring infrastructure.
+
+### Current State
+
+What We Have Now:
+
+- Primary System: DropWizard metrics exposed through JMX
+- Collection Method: Prometheus-JMX exporter scrapes JMX metrics
+- Dashboards: Grafana dashboards consuming JMX-sourced metrics
+- Code Pattern: MetricUtils class for creating counters and timers
+- Integration: Basic Spring integration with manual metric creation
+
+<p align="center">
+  <img width="80%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/0f6ae5ae889ee4e780504ca566670867acf975ff/imgs/advanced/monitoring/monitoring_current.svg"/>
+</p>
+
+Limitations:
+
+- JMX-centric approach limits monitoring backend options
+- No unified observability (separate instrumentation for metrics and traces)
+- No support for dimensional metrics and tags
+- Manual instrumentation required for most components
+- Legacy naming conventions without proper tagging
+
+### Transition State
+
+What We're Building:
+
+- Primary System: Micrometer with native Prometheus support
+- Collection Method: Direct Prometheus scraping via /actuator/prometheus
+- Unified Telemetry: Single instrumentation point for both metrics and traces
+- Modern Patterns: Dimensional metrics with rich tagging
+- Multi-Backend: Support for Prometheus, StatsD, CloudWatch, Datadog, etc.
+- Auto-Instrumentation: Automatic metrics for Spring components
+
+<p align="center">
+  <img width="80%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/0f6ae5ae889ee4e780504ca566670867acf975ff/imgs/advanced/monitoring/monitoring_transition.svg"/>
+</p>
+
+Key Decisions and Rationale:
+
+1. Dual Registry Approach
+
+   **Decision:** Run both systems in parallel with tag-based routing
+
+   **Rationale:**
+
+   - Zero downtime or disruption
+   - Gradual migration at component level
+   - Easy rollback if issues arise
+
+2. Prometheus as Primary Target
+
+   **Decision:** Focus on Prometheus for new metrics
+
+   **Rationale:**
+
+   - Industry standard for cloud-native applications
+   - Rich query language and ecosystem
+   - Better suited for dimensional metrics
+
+3. Observation API Adoption
+
+   **Decision:** Promote Observation API for new instrumentation
+
+   **Rationale:**
+
+   - Single instrumentation for metrics + traces
+   - Reduced code complexity
+   - Consistent naming across telemetry types
+
+### Future State
+
+<p align="center">
+  <img width="80%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/0f6ae5ae889ee4e780504ca566670867acf975ff/imgs/advanced/monitoring/monitoring_future.svg"/>
+</p>
+
+Once fully adopted, Micrometer will transform DataHub's observability from a collection of separate tools into a unified platform.
+This means developers can focus on building features while getting comprehensive telemetry "for free."
+
+Intelligent and Adaptive Monitoring
+
+- Dynamic Instrumentation: Enable detailed metrics for specific entities or operations on-demand without code changes
+- Environment-Aware Metrics: Automatically route metrics to Prometheus in Kubernetes, CloudWatch in AWS, or Azure Monitor in Azure
+- Built-in SLO Tracking: Define Service Level Objectives declaratively and automatically track error budgets
+
+Developer and Operator Experience
+
+- Adding @Observed to a method automatically generates latency percentiles, error rates, and distributed trace spans
+- Every service exposes golden signals (latency, traffic, errors, saturation) out-of-the-box
+- Business metrics (entity ingestion rates, search performance) seamlessly correlate with system metrics
+- Self-documenting telemetry where metrics, traces, and logs tell a coherent operational story
+
+## DropWizard & JMX
+
+We originally decided to use [Dropwizard Metrics](https://metrics.dropwizard.io/4.2.0/) to export custom metrics to JMX,
 and then use [Prometheus-JMX exporter](https://github.com/prometheus/jmx_exporter) to export all JMX metrics to
 Prometheus. This allows our code base to be independent of the metrics collection tool, making it easy for people to use
 their tool of choice. You can enable the agent by setting env variable `ENABLE_PROMETHEUS` to `true` for GMS and MAE/MCE
@@ -64,18 +805,18 @@ central metric registry, sets up the JMX reporter, and provides convenient funct
 You can run the following to create a counter and increment.
 
 ```java
-MetricUtils.counter(this.getClass(),"metricName").increment();
+metricUtils.counter(this.getClass(),"metricName").increment();
 ```
 
 You can run the following to time a block of code.
 
 ```java
-try(Timer.Context ignored=MetricUtils.timer(this.getClass(),"timerName").timer()){
+try(Timer.Context ignored=metricUtils.timer(this.getClass(),"timerName").timer()){
     ...block of code
     }
 ```
 
-## Enable monitoring through docker-compose
+#### Enable monitoring through docker-compose
 
 We provide some example configuration for enabling monitoring in
 this [directory](https://github.com/datahub-project/datahub/tree/master/docker/monitoring). Take a look at the docker-compose

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -19,6 +19,7 @@
 
 - #13726: Removed dgraph from tests
 - #13942: Upgraded secret encryption to AES-256-GCM. Recreate tokens take advantage of the new algorithm.
+- #13898: Deprecated DropWizard metrics, enabled Micrometer & Prometheus endpoint
 
 -->
 

--- a/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/KafkaEventProducer.java
+++ b/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/KafkaEventProducer.java
@@ -5,6 +5,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.EventUtils;
 import com.linkedin.metadata.event.EventProducer;
 import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.DataHubUpgradeHistoryEvent;
 import com.linkedin.mxe.FailedMetadataChangeProposal;
 import com.linkedin.mxe.MetadataChangeLog;
@@ -38,6 +39,7 @@ public class KafkaEventProducer extends EventProducer {
   private final Producer<String, ? extends IndexedRecord> _producer;
   private final TopicConvention _topicConvention;
   private final KafkaHealthChecker _kafkaHealthChecker;
+  private final MetricUtils metricUtils;
 
   @Override
   public void flush() {
@@ -54,10 +56,12 @@ public class KafkaEventProducer extends EventProducer {
   public KafkaEventProducer(
       @Nonnull final Producer<String, ? extends IndexedRecord> producer,
       @Nonnull final TopicConvention topicConvention,
-      @Nonnull final KafkaHealthChecker kafkaHealthChecker) {
+      @Nonnull final KafkaHealthChecker kafkaHealthChecker,
+      MetricUtils metricUtils) {
     _producer = producer;
     _topicConvention = topicConvention;
     _kafkaHealthChecker = kafkaHealthChecker;
+    this.metricUtils = metricUtils;
   }
 
   @Override
@@ -81,7 +85,7 @@ public class KafkaEventProducer extends EventProducer {
     String topic = getMetadataChangeLogTopicName(aspectSpec);
     return _producer.send(
         new ProducerRecord(topic, urn.toString(), record),
-        _kafkaHealthChecker.getKafkaCallBack("MCL", urn.toString()));
+        _kafkaHealthChecker.getKafkaCallBack(metricUtils, "MCL", urn.toString()));
   }
 
   @Override
@@ -114,7 +118,7 @@ public class KafkaEventProducer extends EventProducer {
     String topic = _topicConvention.getMetadataChangeProposalTopicName();
     return _producer.send(
         new ProducerRecord(topic, urn.toString(), record),
-        _kafkaHealthChecker.getKafkaCallBack("MCP", urn.toString()));
+        _kafkaHealthChecker.getKafkaCallBack(metricUtils, "MCP", urn.toString()));
   }
 
   @Override
@@ -143,7 +147,7 @@ public class KafkaEventProducer extends EventProducer {
 
       return _producer.send(
           new ProducerRecord(topic, mcp.getEntityUrn().toString(), record),
-          _kafkaHealthChecker.getKafkaCallBack("FMCP", mcp.getEntityUrn().toString()));
+          _kafkaHealthChecker.getKafkaCallBack(metricUtils, "FMCP", mcp.getEntityUrn().toString()));
     } catch (IOException e) {
       log.error(
           "Error while sending FailedMetadataChangeProposal: Exception  - {}, FailedMetadataChangeProposal - {}",
@@ -169,7 +173,7 @@ public class KafkaEventProducer extends EventProducer {
     final String topic = _topicConvention.getPlatformEventTopicName();
     return _producer.send(
         new ProducerRecord(topic, key == null ? name : key, record),
-        _kafkaHealthChecker.getKafkaCallBack("Platform Event", name));
+        _kafkaHealthChecker.getKafkaCallBack(metricUtils, "Platform Event", name));
   }
 
   @Override
@@ -195,7 +199,7 @@ public class KafkaEventProducer extends EventProducer {
     _producer.send(
         new ProducerRecord(topic, event.getVersion(), record),
         _kafkaHealthChecker.getKafkaCallBack(
-            "History Event", "Event Version: " + event.getVersion()));
+            metricUtils, "History Event", "Event Version: " + event.getVersion()));
   }
 
   @Nonnull

--- a/metadata-ingestion/examples/library/read_lineage_execute_graphql.py
+++ b/metadata-ingestion/examples/library/read_lineage_execute_graphql.py
@@ -30,7 +30,7 @@ variables = {
                 "and": [
                     {
                         "condition": "EQUAL",
-                        "negated": "false",
+                        "negated": False,
                         "field": "degree",
                         "values": ["1", "2", "3+"],
                     }

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -32,12 +32,8 @@ dependencies {
   implementation externalDependency.guava
   implementation externalDependency.reflections
 
-  api(externalDependency.dgraph4j) {
-    exclude group: 'com.google.guava', module: 'guava'
-    exclude group: 'io.grpc', module: 'grpc-protobuf'
-  }
-  implementation externalDependency.dgraphNetty
-  implementation externalDependency.dgraphShadedNetty
+  implementation externalDependency.neo4jJavaDriver
+  implementation externalDependency.graphqlJava
   implementation externalDependency.slf4jApi
   runtimeOnly externalDependency.logbackClassic
   compileOnly externalDependency.lombok
@@ -79,13 +75,6 @@ dependencies {
   testImplementation externalDependency.testng
   testImplementation externalDependency.h2
   testImplementation externalDependency.mysqlConnector
-  testImplementation externalDependency.neo4jHarness
-  testImplementation (externalDependency.neo4jApocCore) {
-    exclude group: 'org.yaml', module: 'snakeyaml'
-  }
-  testImplementation (externalDependency.neo4jApocCommon) {
-    exclude group: 'org.yaml', module: 'snakeyaml'
-  }
   testImplementation externalDependency.mockito
   testImplementation externalDependency.mockitoInline
   testImplementation externalDependency.iStackCommons
@@ -95,6 +84,7 @@ dependencies {
   testImplementation externalDependency.testContainersElasticsearch
   testImplementation externalDependency.testContainersOpenSearch
   testImplementation externalDependency.testContainersCassandra
+  testImplementation externalDependency.testContainersNeo4j
   testImplementation externalDependency.lombok
   testFixturesApi externalDependency.springBootTest
   testImplementation spec.product.pegasus.restliServer

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
@@ -99,6 +99,7 @@ public class JavaEntityClient implements EntityClient {
   private final RollbackService rollbackService;
   private final EventProducer eventProducer;
   private final EntityClientConfig entityClientConfig;
+  private final MetricUtils metricUtils;
 
   @Override
   @Nullable
@@ -895,7 +896,8 @@ public class JavaEntityClient implements EntityClient {
       try {
         return block.get();
       } catch (Throwable ex) {
-        MetricUtils.counter(this.getClass(), buildMetricName(ex, counterPrefix)).inc();
+        if (metricUtils != null)
+          metricUtils.increment(this.getClass(), buildMetricName(ex, counterPrefix), 1);
 
         final boolean skipRetry =
             NON_RETRYABLE.contains(ex.getClass().getCanonicalName())

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/SystemJavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/SystemJavaEntityClient.java
@@ -17,6 +17,7 @@ import com.linkedin.metadata.search.SearchService;
 import com.linkedin.metadata.search.client.CachingEntitySearchService;
 import com.linkedin.metadata.service.RollbackService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
 import java.net.URISyntaxException;
@@ -44,7 +45,8 @@ public class SystemJavaEntityClient extends JavaEntityClient implements SystemEn
       RollbackService rollbackService,
       EventProducer eventProducer,
       EntityClientCacheConfig cacheConfig,
-      EntityClientConfig entityClientConfig) {
+      EntityClientConfig entityClientConfig,
+      MetricUtils metricUtils) {
     super(
         entityService,
         deleteEntityService,
@@ -55,9 +57,11 @@ public class SystemJavaEntityClient extends JavaEntityClient implements SystemEn
         timeseriesAspectService,
         rollbackService,
         eventProducer,
-        entityClientConfig);
+        entityClientConfig,
+        metricUtils);
     this.operationContextMap = CacheBuilder.newBuilder().maximumSize(500).build();
-    this.entityClientCache = buildEntityClientCache(SystemJavaEntityClient.class, cacheConfig);
+    this.entityClientCache =
+        buildEntityClientCache(metricUtils, SystemJavaEntityClient.class, cacheConfig);
   }
 
   @Nullable

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/UsageStatsJavaClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/UsageStatsJavaClient.java
@@ -6,6 +6,7 @@ import com.linkedin.common.WindowDuration;
 import com.linkedin.metadata.config.cache.client.UsageClientCacheConfig;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.timeseries.elastic.UsageServiceUtil;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.usage.UsageClient;
 import com.linkedin.usage.UsageClientCache;
@@ -23,7 +24,8 @@ public class UsageStatsJavaClient implements UsageClient {
 
   public UsageStatsJavaClient(
       @Nonnull TimeseriesAspectService timeseriesAspectService,
-      @Nonnull UsageClientCacheConfig cacheConfig) {
+      @Nonnull UsageClientCacheConfig cacheConfig,
+      MetricUtils metricUtils) {
     this.timeseriesAspectService = timeseriesAspectService;
     this.operationContextMap = Caffeine.newBuilder().maximumSize(500).build();
     this.usageClientCache =
@@ -40,7 +42,7 @@ public class UsageStatsJavaClient implements UsageClient {
                     throw new RuntimeException(e);
                   }
                 })
-            .build();
+            .build(metricUtils);
   }
 
   @Nonnull

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
@@ -271,14 +271,25 @@ public interface AspectDao {
     return runInTransactionWithRetry(block, maxTransactionRetry);
   }
 
-  default void incrementWriteMetrics(String aspectName, long count, long bytes) {
-    MetricUtils.counter(
-            this.getClass(),
-            String.join(MetricUtils.DELIMITER, List.of(ASPECT_WRITE_COUNT_METRIC_NAME, aspectName)))
-        .inc(count);
-    MetricUtils.counter(
-            this.getClass(),
-            String.join(MetricUtils.DELIMITER, List.of(ASPECT_WRITE_BYTES_METRIC_NAME, aspectName)))
-        .inc(bytes);
+  default void incrementWriteMetrics(
+      OperationContext opContext, String aspectName, long count, long bytes) {
+    opContext
+        .getMetricUtils()
+        .ifPresent(
+            metricUtils ->
+                metricUtils.increment(
+                    this.getClass(),
+                    String.join(
+                        MetricUtils.DELIMITER, List.of(ASPECT_WRITE_COUNT_METRIC_NAME, aspectName)),
+                    count));
+    opContext
+        .getMetricUtils()
+        .ifPresent(
+            metricUtils ->
+                metricUtils.increment(
+                    this.getClass(),
+                    String.join(
+                        MetricUtils.DELIMITER, List.of(ASPECT_WRITE_BYTES_METRIC_NAME, aspectName)),
+                    bytes));
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -9,9 +9,9 @@ import static com.linkedin.metadata.utils.PegasusUtils.urnToEntityName;
 import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSystemMetadata;
 import static com.linkedin.metadata.utils.metrics.ExceptionUtils.collectMetrics;
 import static com.linkedin.metadata.utils.metrics.MetricUtils.BATCH_SIZE_ATTR;
-import static io.datahubproject.metadata.context.TraceContext.EVENT_SOURCE_KEY;
-import static io.datahubproject.metadata.context.TraceContext.SOURCE_IP_KEY;
-import static io.datahubproject.metadata.context.TraceContext.TELEMETRY_TRACE_KEY;
+import static io.datahubproject.metadata.context.SystemTelemetryContext.EVENT_SOURCE_KEY;
+import static io.datahubproject.metadata.context.SystemTelemetryContext.SOURCE_IP_KEY;
+import static io.datahubproject.metadata.context.SystemTelemetryContext.TELEMETRY_TRACE_KEY;
 
 import com.datahub.util.RecordUtils;
 import com.google.common.annotations.VisibleForTesting;
@@ -92,7 +92,7 @@ import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.Span;
@@ -954,7 +954,11 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
         () -> {
           if (inputBatch.containsDuplicateAspects()) {
             log.warn("Batch contains duplicates: {}", inputBatch.duplicateAspects());
-            MetricUtils.counter(EntityServiceImpl.class, "batch_with_duplicate").inc();
+            opContext
+                .getMetricUtils()
+                .ifPresent(
+                    metricUtils ->
+                        metricUtils.increment(EntityServiceImpl.class, "batch_with_duplicate", 1));
           }
 
           return aspectDao
@@ -1039,7 +1043,11 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
 
                     // No changes, return
                     if (changeMCPs.isEmpty()) {
-                      MetricUtils.counter(EntityServiceImpl.class, "batch_empty").inc();
+                      opContext
+                          .getMetricUtils()
+                          .ifPresent(
+                              metricUtils ->
+                                  metricUtils.increment(EntityServiceImpl.class, "batch_empty", 1));
                       return TransactionResult.ingestAspectsRollback();
                     }
 
@@ -1052,17 +1060,29 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                     if (exceptions.hasFatalExceptions()) {
                       // IF this is a client request/API request we fail the `transaction batch`
                       if (opContext.getRequestContext() != null) {
-                        MetricUtils.counter(
-                                EntityServiceImpl.class, "batch_request_validation_exception")
-                            .inc();
-                        collectMetrics(exceptions);
+                        opContext
+                            .getMetricUtils()
+                            .ifPresent(
+                                metricUtils ->
+                                    metricUtils.increment(
+                                        EntityServiceImpl.class,
+                                        "batch_request_validation_exception",
+                                        1));
+                        collectMetrics(opContext.getMetricUtils().orElse(null), exceptions);
                         throw new ValidationException(exceptions);
                       }
 
-                      MetricUtils.counter(
-                              EntityServiceImpl.class, "batch_consumer_validation_exception")
-                          .inc();
-                      log.error("mce-consumer batch exceptions: {}", collectMetrics(exceptions));
+                      opContext
+                          .getMetricUtils()
+                          .ifPresent(
+                              metricUtils ->
+                                  metricUtils.increment(
+                                      EntityServiceImpl.class,
+                                      "batch_consumer_validation_exception",
+                                      1));
+                      log.error(
+                          "mce-consumer batch exceptions: {}",
+                          collectMetrics(opContext.getMetricUtils().orElse(null), exceptions));
                       failedUpsertResults =
                           exceptions
                               .streamExceptions(changeMCPs.stream())
@@ -1139,7 +1159,12 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                           if (e.getMessage() != null
                               && e.getMessage().contains("No rows updated")) {
                             log.warn("Ignoring no rows updated condition for metadata update", e);
-                            MetricUtils.counter(EntityServiceImpl.class, "no_rows_updated").inc();
+                            opContext
+                                .getMetricUtils()
+                                .ifPresent(
+                                    metricUtils ->
+                                        metricUtils.increment(
+                                            EntityServiceImpl.class, "no_rows_updated", 1));
                             return TransactionResult.rollback();
                           }
                           throw e;
@@ -1191,7 +1216,12 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                         log.warn("Retention service is missing!");
                       }
                     } else {
-                      MetricUtils.counter(EntityServiceImpl.class, "batch_empty_transaction").inc();
+                      opContext
+                          .getMetricUtils()
+                          .ifPresent(
+                              metricUtils ->
+                                  metricUtils.increment(
+                                      EntityServiceImpl.class, "batch_empty_transaction", 1));
                       // This includes no-op batches. i.e. patch removing non-existent items
                       log.debug("Empty transaction detected");
                       if (txContext != null) {
@@ -1200,8 +1230,8 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                     }
 
                     // Force flush span processing for DUE Exports
-                    Optional.ofNullable(opContext.getTraceContext())
-                        .map(TraceContext::getUsageSpanExporter)
+                    Optional.ofNullable(opContext.getSystemTelemetryContext())
+                        .map(SystemTelemetryContext::getUsageSpanExporter)
                         .ifPresent(SpanProcessor::forceFlush);
 
                     return TransactionResult.of(
@@ -2528,8 +2558,8 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
       if (future != null) {
         try {
           future.get();
-          Optional.ofNullable(opContext.getTraceContext())
-              .map(TraceContext::getUsageSpanExporter)
+          Optional.ofNullable(opContext.getSystemTelemetryContext())
+              .map(SystemTelemetryContext::getUsageSpanExporter)
               .ifPresent(SpanProcessor::forceFlush);
         } catch (InterruptedException | ExecutionException e) {
           throw new RuntimeException(e);
@@ -2623,7 +2653,8 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
         AspectsBatch.validateProposed(
             List.of(deleteItem), opContext.getRetrieverContext(), opContext);
     if (!exceptions.isEmpty()) {
-      throw new ValidationException(collectMetrics(exceptions).toString());
+      throw new ValidationException(
+          collectMetrics(opContext.getMetricUtils().orElse(null), exceptions).toString());
     }
 
     final RollbackResult result =
@@ -2638,7 +2669,12 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                     latest = aspectDao.getLatestAspect(opContext, urn, aspectName, false);
                   } catch (EntityNotFoundException e) {
                     log.debug("Delete non-existing aspect. urn {} aspect {}", urn, aspectName);
-                    MetricUtils.counter(EntityServiceImpl.class, "delete_nonexisting").inc();
+                    opContext
+                        .getMetricUtils()
+                        .ifPresent(
+                            metricUtils ->
+                                metricUtils.increment(
+                                    EntityServiceImpl.class, "delete_nonexisting", 1));
                   }
 
                   // 1.1 If no latest exists, skip this aspect
@@ -2701,7 +2737,9 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                               .collect(Collectors.toList()),
                           opContext.getRetrieverContext());
                   if (!preCommitExceptions.isEmpty()) {
-                    throw new ValidationException(collectMetrics(preCommitExceptions).toString());
+                    throw new ValidationException(
+                        collectMetrics(opContext.getMetricUtils().orElse(null), preCommitExceptions)
+                            .toString());
                   }
 
                   // 5. Apply deletes and fix up latest row
@@ -2725,6 +2763,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
 
                     // metrics
                     aspectDao.incrementWriteMetrics(
+                        opContext,
                         aspectName,
                         1,
                         survivingResult.map(r -> r.getMetadata().getBytes().length).orElse(0));
@@ -2936,6 +2975,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
 
               // metrics
               aspectDao.incrementWriteMetrics(
+                  opContext,
                   writeItem.getAspectName(),
                   1,
                   updatedAspect.getMetadata().getBytes().length

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
@@ -90,6 +90,7 @@ public class ESGraphQueryDAO {
   private final IndexConvention indexConvention;
   @Getter private final GraphServiceConfiguration graphServiceConfig;
   @Getter private final ElasticSearchConfiguration config;
+  private final MetricUtils metricUtils;
 
   static final String SOURCE = "source";
   static final String DESTINATION = "destination";
@@ -148,7 +149,8 @@ public class ESGraphQueryDAO {
         "esQuery",
         () -> {
           try {
-            MetricUtils.counter(this.getClass(), SEARCH_EXECUTIONS_METRIC).inc();
+            if (metricUtils != null)
+              metricUtils.increment(this.getClass(), SEARCH_EXECUTIONS_METRIC, 1);
             return client.search(searchRequest, RequestOptions.DEFAULT);
           } catch (Exception e) {
             log.error("Search query failed", e);
@@ -589,7 +591,7 @@ public class ESGraphQueryDAO {
    */
   SearchResponse executeSearch(@Nonnull SearchRequest searchRequest) {
     try {
-      MetricUtils.counter(this.getClass(), SEARCH_EXECUTIONS_METRIC).inc();
+      if (metricUtils != null) metricUtils.increment(this.getClass(), SEARCH_EXECUTIONS_METRIC, 1);
       return client.search(searchRequest, RequestOptions.DEFAULT);
     } catch (Exception e) {
       log.error("Search query failed", e);
@@ -1275,7 +1277,8 @@ public class ESGraphQueryDAO {
         "esQuery",
         () -> {
           try {
-            MetricUtils.counter(this.getClass(), SEARCH_EXECUTIONS_METRIC).inc();
+            if (metricUtils != null)
+              metricUtils.increment(this.getClass(), SEARCH_EXECUTIONS_METRIC, 1);
             return client.search(searchRequest, RequestOptions.DEFAULT);
           } catch (Exception e) {
             log.error("Search query failed", e);
@@ -1872,7 +1875,8 @@ public class ESGraphQueryDAO {
         "esLineageGroupByQuery",
         () -> {
           try {
-            MetricUtils.counter(this.getClass(), SEARCH_EXECUTIONS_METRIC).inc();
+            if (metricUtils != null)
+              metricUtils.increment(this.getClass(), SEARCH_EXECUTIONS_METRIC, 1);
             return client.search(request, RequestOptions.DEFAULT);
           } catch (Exception e) {
             log.error("Search query failed", e);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/cache/CacheableSearcher.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/cache/CacheableSearcher.java
@@ -108,7 +108,11 @@ public class CacheableSearcher<K> {
                 Span.current().setAttribute(CACHE_HIT_ATTR, false);
                 result = searcher.apply(batch);
                 cache.put(cacheKey, toJsonString(result));
-                MetricUtils.counter(this.getClass(), "getBatch_cache_miss_count").inc();
+                opContext
+                    .getMetricUtils()
+                    .ifPresent(
+                        metricUtils ->
+                            metricUtils.increment(this.getClass(), "getBatch_cache_miss_count", 1));
               } else {
                 Span.current().setAttribute(CACHE_HIT_ATTR, true);
               }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/client/CachingEntitySearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/client/CachingEntitySearchService.java
@@ -213,7 +213,12 @@ public class CachingEntitySearchService {
                   getRawAutoCompleteResults(opContext, entityName, input, field, filters, limit);
               cache.put(cacheKey, toJsonString(result));
               Span.current().setAttribute(CACHE_HIT_ATTR, false);
-              MetricUtils.counter(this.getClass(), "autocomplete_cache_miss_count").inc();
+              opContext
+                  .getMetricUtils()
+                  .ifPresent(
+                      metricUtils ->
+                          metricUtils.increment(
+                              this.getClass(), "autocomplete_cache_miss_count", 1));
             } else {
               Span.current().setAttribute(CACHE_HIT_ATTR, true);
             }
@@ -257,7 +262,11 @@ public class CachingEntitySearchService {
               result = getRawBrowseResults(opContext, entityName, path, filters, from, size);
               cache.put(cacheKey, toJsonString(result));
               Span.current().setAttribute(CACHE_HIT_ATTR, false);
-              MetricUtils.counter(this.getClass(), "browse_cache_miss_count").inc();
+              opContext
+                  .getMetricUtils()
+                  .ifPresent(
+                      metricUtils ->
+                          metricUtils.increment(this.getClass(), "browse_cache_miss_count", 1));
             } else {
               Span.current().setAttribute(CACHE_HIT_ATTR, true);
             }
@@ -323,7 +332,11 @@ public class CachingEntitySearchService {
                       facets);
               cache.put(cacheKey, toJsonString(result));
               Span.current().setAttribute(CACHE_HIT_ATTR, false);
-              MetricUtils.counter(this.getClass(), "scroll_cache_miss_count").inc();
+              opContext
+                  .getMetricUtils()
+                  .ifPresent(
+                      metricUtils ->
+                          metricUtils.increment(this.getClass(), "scroll_cache_miss_count", 1));
             } else {
               Span.current().setAttribute(CACHE_HIT_ATTR, true);
             }

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesService.java
@@ -26,7 +26,6 @@ import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
 import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.timeseries.transformer.TimeseriesAspectTransformer;
-import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.structured.StructuredPropertyDefinition;
@@ -333,7 +332,11 @@ public class UpdateIndicesService implements SearchIndicesService {
     } catch (Exception e) {
       log.error(
           "Error in getting documents for urn: {} from aspect: {}", urn, aspectSpec.getName(), e);
-      MetricUtils.counter(this.getClass(), DOCUMENT_TRANSFORM_FAILED_METRIC).inc();
+      opContext
+          .getMetricUtils()
+          .ifPresent(
+              metricUtils ->
+                  metricUtils.increment(this.getClass(), DOCUMENT_TRANSFORM_FAILED_METRIC, 1));
       return;
     }
 
@@ -359,7 +362,11 @@ public class UpdateIndicesService implements SearchIndicesService {
               urn,
               aspectSpec.getName(),
               e);
-          MetricUtils.counter(this.getClass(), DOCUMENT_TRANSFORM_FAILED_METRIC).inc();
+          opContext
+              .getMetricUtils()
+              .ifPresent(
+                  metricUtils ->
+                      metricUtils.increment(this.getClass(), DOCUMENT_TRANSFORM_FAILED_METRIC, 1));
         }
       }
 
@@ -370,7 +377,11 @@ public class UpdateIndicesService implements SearchIndicesService {
               "No changes detected for search document for urn: {} aspect: {}",
               urn,
               aspectSpec.getName());
-          MetricUtils.counter(this.getClass(), SEARCH_DIFF_MODE_SKIPPED_METRIC).inc();
+          opContext
+              .getMetricUtils()
+              .ifPresent(
+                  metricUtils ->
+                      metricUtils.increment(this.getClass(), SEARCH_DIFF_MODE_SKIPPED_METRIC, 1));
           return;
         }
       }

--- a/metadata-io/src/main/java/com/linkedin/metadata/system_telemetry/GraphQLTimingInstrumentation.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/system_telemetry/GraphQLTimingInstrumentation.java
@@ -1,0 +1,379 @@
+package com.linkedin.metadata.system_telemetry;
+
+import com.linkedin.metadata.config.graphql.GraphQLMetricsConfiguration;
+import graphql.ExecutionResult;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.SimpleInstrumentationContext;
+import graphql.execution.instrumentation.SimplePerformantInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLTypeUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+public class GraphQLTimingInstrumentation extends SimplePerformantInstrumentation {
+
+  private final MeterRegistry meterRegistry;
+  private final GraphQLMetricsConfiguration config;
+  private final Set<String> fieldInstrumentedOperations;
+  private final List<PathMatcher> fieldInstrumentedPaths;
+  private final double[] percentiles;
+
+  // Inner class for path matching
+  private static class PathMatcher {
+    private final String pattern;
+    private final Pattern regex;
+
+    PathMatcher(String pattern) {
+      this.pattern = pattern;
+      this.regex = Pattern.compile(convertPathToRegex(pattern));
+    }
+
+    boolean matches(String path) {
+      return regex.matcher(path).matches();
+    }
+
+    private static String convertPathToRegex(String pattern) {
+      // Convert GraphQL path patterns to regex
+      // Examples:
+      // /user -> matches exactly /user
+      // /user/* -> matches /user/name, /user/id but not /user/posts/0
+      // /user/** -> matches /user and anything under it at any depth
+      // /*/comments/* -> matches /posts/comments/text, /articles/comments/author
+      // /user/posts/*/comments -> matches /user/posts/0/comments, /user/posts/1/comments
+
+      String regex =
+          pattern
+              .replace(".", "\\.") // Escape dots
+              .replace("/**", "(/.*)?") // /** matches current and any descendants
+              .replace("/*", "/[^/]+") // /* matches exactly one segment
+              .replaceAll("/\\*\\*$", "(/.*)?"); // /** at end is optional
+
+      // For patterns ending with /**, also match the parent path
+      if (pattern.endsWith("/**")) {
+        String parentPath = pattern.substring(0, pattern.length() - 3);
+        regex = "(" + parentPath + "|" + regex + ")";
+      }
+
+      return "^" + regex + "$";
+    }
+  }
+
+  public GraphQLTimingInstrumentation(
+      MeterRegistry meterRegistry, GraphQLMetricsConfiguration config) {
+    this.meterRegistry = meterRegistry;
+    this.config = config;
+    this.fieldInstrumentedOperations = parseOperationsList(config.getFieldLevelOperations());
+    this.fieldInstrumentedPaths = parsePathPatterns(config.getFieldLevelPaths());
+    this.percentiles = parsePercentiles(config.getPercentiles());
+  }
+
+  private Set<String> parseOperationsList(String operationsList) {
+    if (operationsList == null || operationsList.trim().isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    Set<String> operations = new HashSet<>();
+    for (String operation : operationsList.split(",")) {
+      String trimmed = operation.trim();
+      if (!trimmed.isEmpty()) {
+        operations.add(trimmed);
+      }
+    }
+    return operations;
+  }
+
+  private List<PathMatcher> parsePathPatterns(String pathsList) {
+    if (pathsList == null || pathsList.trim().isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<PathMatcher> matchers = new ArrayList<>();
+    for (String path : pathsList.split(",")) {
+      String trimmed = path.trim();
+      if (!trimmed.isEmpty()) {
+        matchers.add(new PathMatcher(trimmed));
+      }
+    }
+    return matchers;
+  }
+
+  @Override
+  public InstrumentationState createState(InstrumentationCreateStateParameters parameters) {
+    return new TimingState();
+  }
+
+  @Override
+  public InstrumentationContext<ExecutionResult> beginExecution(
+      InstrumentationExecutionParameters parameters, InstrumentationState state) {
+
+    TimingState timingState = (TimingState) state;
+    timingState.startTime = System.nanoTime();
+
+    // Determine operation name and filtering mode
+    String operationName = getOperationName(parameters);
+    timingState.operationName = operationName;
+    timingState.filteringMode = determineFilteringMode(operationName);
+
+    return SimpleInstrumentationContext.whenCompleted(
+        (result, t) -> {
+          long duration = System.nanoTime() - timingState.startTime;
+
+          Timer.builder("graphql.request.duration")
+              .tag("operation", operationName)
+              .tag("operation.type", getOperationType(parameters))
+              .tag("success", String.valueOf(t == null && result.getErrors().isEmpty()))
+              .tag("field.filtering", timingState.filteringMode.toString())
+              .register(meterRegistry)
+              .record(duration, TimeUnit.NANOSECONDS);
+
+          // Record error count
+          if (t != null || !result.getErrors().isEmpty()) {
+            meterRegistry
+                .counter(
+                    "graphql.request.errors",
+                    "operation",
+                    operationName,
+                    "operation.type",
+                    getOperationType(parameters))
+                .increment();
+          }
+
+          // Record fields instrumented count
+          if (timingState.fieldsInstrumented > 0) {
+            meterRegistry
+                .counter(
+                    "graphql.fields.instrumented",
+                    "operation",
+                    operationName,
+                    "filtering.mode",
+                    timingState.filteringMode.toString())
+                .increment(timingState.fieldsInstrumented);
+          }
+        });
+  }
+
+  enum FilteringMode {
+    DISABLED, // Field-level metrics disabled globally
+    ALL_FIELDS, // No filtering, instrument all fields
+    BY_OPERATION, // Filter by operation name only
+    BY_PATH, // Filter by path pattern only
+    BY_BOTH // Filter by both operation and path
+  }
+
+  private FilteringMode determineFilteringMode(String operationName) {
+    if (!config.isFieldLevelEnabled()) {
+      return FilteringMode.DISABLED;
+    }
+
+    boolean hasOperationFilter = !fieldInstrumentedOperations.isEmpty();
+    boolean hasPathFilter = !fieldInstrumentedPaths.isEmpty();
+
+    if (!hasOperationFilter && !hasPathFilter) {
+      return FilteringMode.ALL_FIELDS;
+    } else if (hasOperationFilter && !hasPathFilter) {
+      return FilteringMode.BY_OPERATION;
+    } else if (!hasOperationFilter && hasPathFilter) {
+      return FilteringMode.BY_PATH;
+    } else {
+      return FilteringMode.BY_BOTH;
+    }
+  }
+
+  private boolean shouldInstrumentField(
+      String operationName, String fieldPath, FilteringMode mode) {
+    switch (mode) {
+      case DISABLED:
+        return false;
+
+      case ALL_FIELDS:
+        return true;
+
+      case BY_OPERATION:
+        return fieldInstrumentedOperations.contains(operationName);
+
+      case BY_PATH:
+        return matchesAnyPath(fieldPath);
+
+      case BY_BOTH:
+        // Both conditions must be met
+        return fieldInstrumentedOperations.contains(operationName) && matchesAnyPath(fieldPath);
+
+      default:
+        return false;
+    }
+  }
+
+  private boolean matchesAnyPath(String fieldPath) {
+    for (PathMatcher matcher : fieldInstrumentedPaths) {
+      if (matcher.matches(fieldPath)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public DataFetcher<?> instrumentDataFetcher(
+      DataFetcher<?> dataFetcher,
+      InstrumentationFieldFetchParameters parameters,
+      InstrumentationState state) {
+
+    TimingState timingState = (TimingState) state;
+
+    // Get the field path
+    String fieldPath = parameters.getExecutionStepInfo().getPath().toString();
+
+    // Check if we should instrument this field
+    if (!shouldInstrumentField(timingState.operationName, fieldPath, timingState.filteringMode)) {
+      return dataFetcher;
+    }
+
+    // Skip trivial data fetchers unless explicitly included
+    if (parameters.isTrivialDataFetcher() && !config.isTrivialDataFetchersEnabled()) {
+      return dataFetcher;
+    }
+
+    // Increment counter of instrumented fields
+    timingState.fieldsInstrumented++;
+
+    return environment -> {
+      GraphQLOutputType parentType = parameters.getExecutionStepInfo().getParent().getType();
+      String parentTypeName = GraphQLTypeUtil.simplePrint(parentType);
+      String fieldName = parameters.getExecutionStepInfo().getFieldDefinition().getName();
+
+      long startTime = System.nanoTime();
+      try {
+        Object result = dataFetcher.get(environment);
+
+        if (result instanceof CompletableFuture) {
+          CompletableFuture<?> cf = (CompletableFuture<?>) result;
+          return cf.whenComplete(
+              (r, t) -> {
+                long duration = System.nanoTime() - startTime;
+                recordFieldMetrics(
+                    parentTypeName,
+                    fieldName,
+                    fieldPath,
+                    duration,
+                    t == null,
+                    timingState.operationName);
+              });
+        }
+
+        long duration = System.nanoTime() - startTime;
+        recordFieldMetrics(
+            parentTypeName, fieldName, fieldPath, duration, true, timingState.operationName);
+        return result;
+
+      } catch (Exception e) {
+        long duration = System.nanoTime() - startTime;
+        recordFieldMetrics(
+            parentTypeName, fieldName, fieldPath, duration, false, timingState.operationName);
+        throw e;
+      }
+    };
+  }
+
+  private String getOperationName(InstrumentationExecutionParameters parameters) {
+    if (parameters.getOperation() != null) {
+      return parameters.getOperation();
+    }
+    if (parameters.getExecutionInput() != null
+        && parameters.getExecutionInput().getOperationName() != null) {
+      return parameters.getExecutionInput().getOperationName();
+    }
+    return "unnamed";
+  }
+
+  private String getOperationType(InstrumentationExecutionParameters parameters) {
+    if (parameters.getExecutionInput() != null) {
+      String query = parameters.getExecutionInput().getQuery();
+      if (query != null) {
+        if (query.trim().startsWith("mutation")) return "mutation";
+        if (query.trim().startsWith("subscription")) return "subscription";
+      }
+    }
+    return "query";
+  }
+
+  private void recordFieldMetrics(
+      String parentType,
+      String fieldName,
+      String fieldPath,
+      long duration,
+      boolean success,
+      String operationName) {
+    Timer.Builder timerBuilder =
+        Timer.builder("graphql.field.duration")
+            .tag("parent.type", parentType)
+            .tag("field", fieldName)
+            .tag("operation", operationName)
+            .tag("success", String.valueOf(success));
+
+    if (config.isFieldLevelPathEnabled()) {
+      timerBuilder.tag("path", truncatePath(fieldPath));
+    }
+
+    timerBuilder
+        .publishPercentiles(percentiles)
+        .register(meterRegistry)
+        .record(duration, TimeUnit.NANOSECONDS);
+
+    // Record field errors
+    if (!success) {
+      meterRegistry
+          .counter(
+              "graphql.field.errors",
+              "parent.type",
+              parentType,
+              "field",
+              fieldName,
+              "operation",
+              operationName)
+          .increment();
+    }
+  }
+
+  private String truncatePath(String path) {
+    // Truncate paths to avoid high cardinality
+    // Handle both formats:
+    // - Array indices with brackets: /searchResults[0]/entity -> /searchResults[*]/entity
+    // - Array indices with slashes: /users/0/name -> /users/*/name
+    return path.replaceAll("\\[\\d+\\]", "[*]") // Replace [0], [1], etc. with [*]
+        .replaceAll("/\\d+", "/*"); // Replace /0, /1, etc. with /*
+  }
+
+  private double[] parsePercentiles(String percentilesConfig) {
+    if (percentilesConfig == null || percentilesConfig.trim().isEmpty()) {
+      // Default percentiles
+      return new double[] {0.5, 0.95, 0.99};
+    }
+
+    String[] parts = percentilesConfig.split(",");
+    double[] result = new double[parts.length];
+    for (int i = 0; i < parts.length; i++) {
+      result[i] = Double.parseDouble(parts[i].trim());
+    }
+    return result;
+  }
+
+  static class TimingState implements InstrumentationState {
+    long startTime;
+    String operationName;
+    FilteringMode filteringMode;
+    int fieldsInstrumented = 0;
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataService.java
@@ -1,6 +1,6 @@
 package com.linkedin.metadata.systemmetadata;
 
-import static io.datahubproject.metadata.context.TraceContext.TELEMETRY_TRACE_KEY;
+import static io.datahubproject.metadata.context.SystemTelemetryContext.TELEMETRY_TRACE_KEY;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/SystemMetadataMappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/SystemMetadataMappingsBuilder.java
@@ -1,6 +1,6 @@
 package com.linkedin.metadata.systemmetadata;
 
-import static io.datahubproject.metadata.context.TraceContext.TELEMETRY_TRACE_KEY;
+import static io.datahubproject.metadata.context.SystemTelemetryContext.TELEMETRY_TRACE_KEY;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;

--- a/metadata-io/src/main/java/com/linkedin/metadata/trace/KafkaTraceReader.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/trace/KafkaTraceReader.java
@@ -1,6 +1,6 @@
 package com.linkedin.metadata.trace;
 
-import static io.datahubproject.metadata.context.TraceContext.TELEMETRY_TRACE_KEY;
+import static io.datahubproject.metadata.context.SystemTelemetryContext.TELEMETRY_TRACE_KEY;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;

--- a/metadata-io/src/main/java/com/linkedin/metadata/trace/TraceServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/trace/TraceServiceImpl.java
@@ -16,7 +16,7 @@ import com.linkedin.mxe.FailedMetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.metadata.context.TraceIdGenerator;
 import io.datahubproject.metadata.exception.TraceException;
 import io.datahubproject.openapi.v1.models.TraceStatus;
@@ -473,7 +473,7 @@ public class TraceServiceImpl implements TraceService {
   @Nullable
   private static String extractTraceId(@Nullable SystemMetadata systemMetadata) {
     if (systemMetadata != null && systemMetadata.getProperties() != null) {
-      return systemMetadata.getProperties().get(TraceContext.TELEMETRY_TRACE_KEY);
+      return systemMetadata.getProperties().get(SystemTelemetryContext.TELEMETRY_TRACE_KEY);
     }
     return null;
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtilTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/utils/DefaultAspectsUtilTest.java
@@ -33,7 +33,7 @@ public class DefaultAspectsUtilTest {
   public void testAdditionalChanges() {
     OperationContext opContext = TestOperationContexts.systemContextNoSearchAuthorization();
     Database server = EbeanTestUtils.createTestServer(DefaultAspectsUtilTest.class.getSimpleName());
-    EbeanAspectDao aspectDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault);
+    EbeanAspectDao aspectDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault, null);
     aspectDao.setConnectionValidated(true);
     EventProducer mockProducer = mock(EventProducer.class);
     PreProcessHooks preProcessHooks = new PreProcessHooks();

--- a/metadata-io/src/test/java/com/linkedin/metadata/client/JavaEntityClientTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/client/JavaEntityClientTest.java
@@ -4,7 +4,6 @@ import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
-import com.codahale.metrics.Counter;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.Status;
 import com.linkedin.common.UrnArray;
@@ -38,8 +37,6 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.List;
 import java.util.function.Supplier;
-import org.mockito.MockedStatic;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -53,9 +50,8 @@ public class JavaEntityClientTest {
   private LineageSearchService _lineageSearchService;
   private TimeseriesAspectService _timeseriesAspectService;
   private EventProducer _eventProducer;
-  private MockedStatic<MetricUtils> _metricUtils;
+  private MetricUtils _metricUtils;
   private RollbackService rollbackService;
-  private Counter _counter;
   private OperationContext opContext;
 
   @BeforeMethod
@@ -69,15 +65,8 @@ public class JavaEntityClientTest {
     _timeseriesAspectService = mock(TimeseriesAspectService.class);
     rollbackService = mock(RollbackService.class);
     _eventProducer = mock(EventProducer.class);
-    _metricUtils = mockStatic(MetricUtils.class);
-    _counter = mock(Counter.class);
-    when(MetricUtils.counter(any(), any())).thenReturn(_counter);
+    _metricUtils = mock(MetricUtils.class);
     opContext = TestOperationContexts.systemContextNoSearchAuthorization();
-  }
-
-  @AfterMethod
-  public void closeTest() {
-    _metricUtils.close();
   }
 
   private JavaEntityClient getJavaEntityClient() {
@@ -91,7 +80,8 @@ public class JavaEntityClientTest {
         _timeseriesAspectService,
         rollbackService,
         _eventProducer,
-        EntityClientConfig.builder().batchGetV2Size(1).build());
+        EntityClientConfig.builder().batchGetV2Size(1).build(),
+        _metricUtils);
   }
 
   @Test
@@ -103,7 +93,7 @@ public class JavaEntityClientTest {
 
     assertEquals(client.withRetry(mockSupplier, null), 42);
     verify(mockSupplier, times(1)).get();
-    _metricUtils.verify(() -> MetricUtils.counter(any(), any()), times(0));
+    verify(_metricUtils, times(0)).increment(any(), anyDouble());
   }
 
   @Test
@@ -116,9 +106,8 @@ public class JavaEntityClientTest {
 
     assertEquals(client.withRetry(mockSupplier, "test"), 42);
     verify(mockSupplier, times(4)).get();
-    _metricUtils.verify(
-        () -> MetricUtils.counter(client.getClass(), "test_exception_" + e.getClass().getName()),
-        times(3));
+    verify(_metricUtils, times(3))
+        .increment(eq(client.getClass()), eq("test_exception_" + e.getClass().getName()), eq(1d));
   }
 
   @Test
@@ -131,9 +120,8 @@ public class JavaEntityClientTest {
 
     assertThrows(IllegalArgumentException.class, () -> client.withRetry(mockSupplier, "test"));
     verify(mockSupplier, times(4)).get();
-    _metricUtils.verify(
-        () -> MetricUtils.counter(client.getClass(), "test_exception_" + e.getClass().getName()),
-        times(4));
+    verify(_metricUtils, times(4))
+        .increment(eq(client.getClass()), eq("test_exception_" + e.getClass().getName()), eq(1d));
   }
 
   @Test
@@ -147,9 +135,8 @@ public class JavaEntityClientTest {
     assertThrows(
         RequiredFieldNotPresentException.class, () -> client.withRetry(mockSupplier, null));
     verify(mockSupplier, times(1)).get();
-    _metricUtils.verify(
-        () -> MetricUtils.counter(client.getClass(), "exception_" + e.getClass().getName()),
-        times(1));
+    verify(_metricUtils, times(1))
+        .increment(eq(client.getClass()), eq("exception_" + e.getClass().getName()), eq(1d));
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/dao/throttle/APIThrottleTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/dao/throttle/APIThrottleTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.dao.throttle;
 import static com.linkedin.metadata.dao.throttle.ThrottleType.MANUAL;
 import static com.linkedin.metadata.dao.throttle.ThrottleType.MCL_TIMESERIES_LAG;
 import static com.linkedin.metadata.dao.throttle.ThrottleType.MCL_VERSIONED_LAG;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,7 +47,10 @@ public class APIThrottleTest {
   @BeforeMethod
   public void init() {
     mockRequestContext = mock(RequestContext.class);
-    opContext = TestOperationContexts.userContextNoSearchAuthorization(mockRequestContext);
+    RequestContext.RequestContextBuilder builder = mock(RequestContext.RequestContextBuilder.class);
+    when(builder.metricUtils(any())).thenReturn(builder);
+    when(builder.build()).thenReturn(mockRequestContext);
+    opContext = TestOperationContexts.userContextNoSearchAuthorization(builder);
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/elasticsearch/update/BulkListenerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/elasticsearch/update/BulkListenerTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.elasticsearch.update;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
@@ -8,7 +9,7 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 
 import com.linkedin.metadata.search.elasticsearch.update.BulkListener;
-import org.mockito.Mockito;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.support.WriteRequest;
 import org.testng.annotations.Test;
@@ -17,22 +18,24 @@ public class BulkListenerTest {
 
   @Test
   public void testConstructor() {
-    BulkListener test = BulkListener.getInstance();
+    BulkListener test = BulkListener.getInstance(mock(MetricUtils.class));
     assertNotNull(test);
-    assertEquals(test, BulkListener.getInstance());
-    assertNotEquals(test, BulkListener.getInstance(WriteRequest.RefreshPolicy.IMMEDIATE));
+    assertEquals(test, BulkListener.getInstance(mock(MetricUtils.class)));
+    assertNotEquals(
+        test,
+        BulkListener.getInstance(WriteRequest.RefreshPolicy.IMMEDIATE, mock(MetricUtils.class)));
   }
 
   @Test
   public void testDefaultPolicy() {
-    BulkListener test = BulkListener.getInstance();
+    BulkListener test = BulkListener.getInstance(mock(MetricUtils.class));
 
-    BulkRequest mockRequest1 = Mockito.mock(BulkRequest.class);
+    BulkRequest mockRequest1 = mock(BulkRequest.class);
     test.beforeBulk(0L, mockRequest1);
     verify(mockRequest1, times(0)).setRefreshPolicy(any(WriteRequest.RefreshPolicy.class));
 
-    BulkRequest mockRequest2 = Mockito.mock(BulkRequest.class);
-    test = BulkListener.getInstance(WriteRequest.RefreshPolicy.IMMEDIATE);
+    BulkRequest mockRequest2 = mock(BulkRequest.class);
+    test = BulkListener.getInstance(WriteRequest.RefreshPolicy.IMMEDIATE, mock(MetricUtils.class));
     test.beforeBulk(0L, mockRequest2);
     verify(mockRequest2, times(1)).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/elasticsearch/update/ESBulkProcessorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/elasticsearch/update/ESBulkProcessorTest.java
@@ -1,18 +1,358 @@
 package com.linkedin.metadata.elasticsearch.update;
 
-import static org.testng.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
 
 import com.linkedin.metadata.search.elasticsearch.update.ESBulkProcessor;
-import org.mockito.Mockito;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.client.RequestOptions;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.tasks.TaskSubmissionResponse;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.index.reindex.DeleteByQueryRequest;
+import org.opensearch.index.reindex.UpdateByQueryRequest;
+import org.opensearch.script.Script;
+import org.opensearch.script.ScriptType;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ESBulkProcessorTest {
 
+  @Mock private RestHighLevelClient mockSearchClient;
+  @Mock private MetricUtils mockMetricUtils;
+  @Mock private BulkByScrollResponse mockBulkByScrollResponse;
+  @Mock private TaskSubmissionResponse mockTaskSubmissionResponse;
+  @Mock private BulkResponse mockBulkResponse;
+
+  private AutoCloseable mocks;
+
+  @BeforeMethod
+  public void setup() {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
   @Test
   public void testESBulkProcessorBuilder() {
-    RestHighLevelClient mock = Mockito.mock(RestHighLevelClient.class);
-    ESBulkProcessor test = ESBulkProcessor.builder(mock).build();
+    ESBulkProcessor test = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
     assertNotNull(test);
+  }
+
+  @Test
+  public void testESBulkProcessorBuilderWithNullMetrics() {
+    // Test that processor works with null MetricUtils
+    ESBulkProcessor test = ESBulkProcessor.builder(mockSearchClient, null).build();
+    assertNotNull(test);
+  }
+
+  @Test
+  public void testESBulkProcessorBuilderWithCustomParameters() {
+    ESBulkProcessor test =
+        ESBulkProcessor.builder(mockSearchClient, mockMetricUtils)
+            .async(true)
+            .batchDelete(true)
+            .bulkRequestsLimit(1000)
+            .bulkFlushPeriod(5)
+            .numRetries(5)
+            .retryInterval(2L)
+            .defaultTimeout(TimeValue.timeValueMinutes(5))
+            .writeRequestRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .build();
+
+    assertNotNull(test);
+    assertEquals(test.getWriteRequestRefreshPolicy(), WriteRequest.RefreshPolicy.IMMEDIATE);
+  }
+
+  @Test
+  public void testAddRequest() {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+
+    IndexRequest indexRequest = new IndexRequest("test-index").id("1");
+    processor.add(indexRequest);
+
+    verify(mockMetricUtils, times(1))
+        .increment(eq(processor.getClass()), eq("num_elasticSearch_writes"), eq(1d));
+  }
+
+  @Test
+  public void testAddRequestWithNullMetrics() {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, null).build();
+
+    IndexRequest indexRequest = new IndexRequest("test-index").id("1");
+    // Should not throw exception even with null metrics
+    processor.add(indexRequest);
+  }
+
+  @Test
+  public void testUpdateByQuerySuccess() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+
+    when(mockBulkByScrollResponse.getTotal()).thenReturn(100L);
+    when(mockSearchClient.updateByQuery(
+            any(UpdateByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockBulkByScrollResponse);
+
+    Script script =
+        new Script(ScriptType.INLINE, "painless", "ctx._source.field = 'value'", Map.of());
+    QueryBuilder query = QueryBuilders.matchAllQuery();
+
+    Optional<BulkByScrollResponse> result = processor.updateByQuery(script, query, "test-index");
+
+    assertTrue(result.isPresent());
+    assertEquals(result.get(), mockBulkByScrollResponse);
+    verify(mockMetricUtils, times(1))
+        .increment(eq(processor.getClass()), eq("num_elasticSearch_writes"), eq(100d));
+  }
+
+  @Test
+  public void testUpdateByQueryFailure() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+
+    IOException exception = new IOException("Update failed");
+    when(mockSearchClient.updateByQuery(
+            any(UpdateByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenThrow(exception);
+
+    Script script =
+        new Script(ScriptType.INLINE, "painless", "ctx._source.field = 'value'", Map.of());
+    QueryBuilder query = QueryBuilders.matchAllQuery();
+
+    Optional<BulkByScrollResponse> result = processor.updateByQuery(script, query, "test-index");
+
+    assertFalse(result.isPresent());
+    verify(mockMetricUtils, times(1))
+        .exceptionIncrement(eq(ESBulkProcessor.class), eq("update_by_query"), eq(exception));
+  }
+
+  @Test
+  public void testUpdateByQueryWithNullMetrics() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, null).build();
+
+    when(mockBulkByScrollResponse.getTotal()).thenReturn(100L);
+    when(mockSearchClient.updateByQuery(
+            any(UpdateByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockBulkByScrollResponse);
+
+    Script script =
+        new Script(ScriptType.INLINE, "painless", "ctx._source.field = 'value'", Map.of());
+    QueryBuilder query = QueryBuilders.matchAllQuery();
+
+    // Should not throw exception even with null metrics
+    Optional<BulkByScrollResponse> result = processor.updateByQuery(script, query, "test-index");
+
+    assertTrue(result.isPresent());
+  }
+
+  @Test
+  public void testDeleteByQuerySuccess() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+
+    when(mockBulkByScrollResponse.getTotal()).thenReturn(50L);
+    when(mockSearchClient.deleteByQuery(
+            any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockBulkByScrollResponse);
+
+    QueryBuilder query = QueryBuilders.termQuery("status", "deleted");
+
+    Optional<BulkByScrollResponse> result = processor.deleteByQuery(query, "test-index");
+
+    assertTrue(result.isPresent());
+    assertEquals(result.get(), mockBulkByScrollResponse);
+    verify(mockMetricUtils, times(1))
+        .increment(eq(processor.getClass()), eq("num_elasticSearch_writes"), eq(50d));
+  }
+
+  @Test
+  public void testDeleteByQueryFailure() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+
+    IOException exception = new IOException("Delete failed");
+    when(mockSearchClient.deleteByQuery(
+            any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenThrow(exception);
+
+    QueryBuilder query = QueryBuilders.termQuery("status", "deleted");
+
+    Optional<BulkByScrollResponse> result = processor.deleteByQuery(query, "test-index");
+
+    assertFalse(result.isPresent());
+    verify(mockMetricUtils, times(1))
+        .exceptionIncrement(eq(ESBulkProcessor.class), eq("delete_by_query"), eq(exception));
+  }
+
+  @Test
+  public void testDeleteByQueryWithNullMetrics() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, null).build();
+
+    when(mockBulkByScrollResponse.getTotal()).thenReturn(50L);
+    when(mockSearchClient.deleteByQuery(
+            any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockBulkByScrollResponse);
+
+    QueryBuilder query = QueryBuilders.termQuery("status", "deleted");
+
+    // Should not throw exception even with null metrics
+    Optional<BulkByScrollResponse> result = processor.deleteByQuery(query, "test-index");
+
+    assertTrue(result.isPresent());
+  }
+
+  @Test
+  public void testDeleteByQueryWithCustomParameters() throws IOException {
+    ESBulkProcessor processor =
+        ESBulkProcessor.builder(mockSearchClient, mockMetricUtils)
+            .bulkRequestsLimit(200)
+            .numRetries(5)
+            .retryInterval(2L)
+            .build();
+
+    when(mockBulkByScrollResponse.getTotal()).thenReturn(75L);
+    when(mockSearchClient.deleteByQuery(
+            any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockBulkByScrollResponse);
+
+    QueryBuilder query = QueryBuilders.matchAllQuery();
+    TimeValue timeout = TimeValue.timeValueMinutes(10);
+
+    Optional<BulkByScrollResponse> result =
+        processor.deleteByQuery(query, false, 200, timeout, "test-index");
+
+    assertTrue(result.isPresent());
+    verify(mockSearchClient)
+        .deleteByQuery(any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT));
+  }
+
+  @Test
+  public void testDeleteByQueryAsyncSuccess() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+
+    when(mockSearchClient.submitDeleteByQueryTask(
+            any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockTaskSubmissionResponse);
+
+    QueryBuilder query = QueryBuilders.termQuery("status", "deleted");
+
+    Optional<TaskSubmissionResponse> result =
+        processor.deleteByQueryAsync(query, true, 100, null, "test-index");
+
+    assertTrue(result.isPresent());
+    assertEquals(result.get(), mockTaskSubmissionResponse);
+    verify(mockMetricUtils, times(1))
+        .increment(eq(processor.getClass()), eq("num_elasticSearch_batches_submitted"), eq(1d));
+  }
+
+  @Test
+  public void testDeleteByQueryAsyncFailure() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+
+    IOException exception = new IOException("Submit task failed");
+    when(mockSearchClient.submitDeleteByQueryTask(
+            any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenThrow(exception);
+
+    QueryBuilder query = QueryBuilders.termQuery("status", "deleted");
+
+    Optional<TaskSubmissionResponse> result =
+        processor.deleteByQueryAsync(query, true, 100, null, "test-index");
+
+    assertFalse(result.isPresent());
+    verify(mockMetricUtils, times(1))
+        .exceptionIncrement(
+            eq(ESBulkProcessor.class), eq("submit_delete_by_query_task"), eq(exception));
+  }
+
+  @Test
+  public void testDeleteByQueryAsyncWithNullMetrics() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, null).build();
+
+    when(mockSearchClient.submitDeleteByQueryTask(
+            any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockTaskSubmissionResponse);
+
+    QueryBuilder query = QueryBuilders.termQuery("status", "deleted");
+
+    // Should not throw exception even with null metrics
+    Optional<TaskSubmissionResponse> result =
+        processor.deleteByQueryAsync(query, true, 100, null, "test-index");
+
+    assertTrue(result.isPresent());
+  }
+
+  @Test
+  public void testDeleteByQueryAsyncWithTimeout() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+
+    when(mockSearchClient.submitDeleteByQueryTask(
+            any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockTaskSubmissionResponse);
+
+    QueryBuilder query = QueryBuilders.matchAllQuery();
+    TimeValue timeout = TimeValue.timeValueMinutes(30);
+
+    Optional<TaskSubmissionResponse> result =
+        processor.deleteByQueryAsync(query, false, 500, timeout, "test-index-1", "test-index-2");
+
+    assertTrue(result.isPresent());
+    verify(mockSearchClient)
+        .submitDeleteByQueryTask(any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT));
+  }
+
+  @Test
+  public void testFlush() {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+    processor.flush();
+    // Verify flush doesn't throw exception
+  }
+
+  @Test
+  public void testClose() throws IOException {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+    processor.close();
+    // Verify close doesn't throw exception
+  }
+
+  @Test
+  public void testMultipleOperationsWithMixedRequests() {
+    ESBulkProcessor processor = ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).build();
+
+    // Add various types of requests
+    processor.add(new IndexRequest("index1").id("1"));
+    processor.add(new UpdateRequest("index1", "2"));
+    processor.add(new DeleteRequest("index1", "3"));
+
+    verify(mockMetricUtils, times(3))
+        .increment(eq(processor.getClass()), eq("num_elasticSearch_writes"), eq(1d));
+  }
+
+  @Test
+  public void testBatchDeleteBehavior() throws IOException {
+    ESBulkProcessor processor =
+        ESBulkProcessor.builder(mockSearchClient, mockMetricUtils).batchDelete(true).build();
+
+    when(mockBulkByScrollResponse.getTotal()).thenReturn(25L);
+    when(mockSearchClient.deleteByQuery(
+            any(DeleteByQueryRequest.class), eq(RequestOptions.DEFAULT)))
+        .thenReturn(mockBulkByScrollResponse);
+
+    QueryBuilder query = QueryBuilders.matchAllQuery();
+
+    Optional<BulkByScrollResponse> result = processor.deleteByQuery(query, "test-index");
+
+    assertTrue(result.isPresent());
+    // With batchDelete=true, flush should not be called before delete
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/AspectDaoTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/AspectDaoTest.java
@@ -27,7 +27,7 @@ import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.ObjectMapperContext;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -61,7 +61,7 @@ public class AspectDaoTest {
 
             // Create a tracer
             Tracer tracer = openTelemetry.getTracer("test-tracer");
-            return TraceContext.builder().tracer(tracer).build();
+            return SystemTelemetryContext.builder().tracer(tracer).build();
           });
   private final EntitySpec corpUserEntitySpec =
       opContext.getEntityRegistry().getEntitySpec(CORP_USER_ENTITY_NAME);

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanAspectMigrationsDaoTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanAspectMigrationsDaoTest.java
@@ -33,7 +33,7 @@ public class EbeanAspectMigrationsDaoTest extends AspectMigrationsDaoTest<EbeanA
     Database server =
         EbeanTestUtils.createTestServer(EbeanAspectMigrationsDaoTest.class.getSimpleName());
     _mockProducer = mock(EventProducer.class);
-    EbeanAspectDao dao = new EbeanAspectDao(server, EbeanConfiguration.testDefault);
+    EbeanAspectDao dao = new EbeanAspectDao(server, EbeanConfiguration.testDefault, null);
     dao.setConnectionValidated(true);
     _mockUpdateIndicesService = mock(UpdateIndicesService.class);
     PreProcessHooks preProcessHooks = new PreProcessHooks();

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
@@ -66,7 +66,7 @@ public class EbeanEntityServiceOptimizationTest {
   public void setupTest() {
     Database server =
         EbeanTestUtils.createTestServer(EbeanEntityServiceOptimizationTest.class.getSimpleName());
-    AspectDao aspectDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault);
+    AspectDao aspectDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault, null);
     PreProcessHooks preProcessHooks = new PreProcessHooks();
     preProcessHooks.setUiEnabled(true);
     entityService =

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceTest.java
@@ -101,7 +101,7 @@ public class EbeanEntityServiceTest
 
     Database server = EbeanTestUtils.createTestServer(EbeanEntityServiceTest.class.getSimpleName());
 
-    _aspectDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault);
+    _aspectDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault, null);
 
     PreProcessHooks preProcessHooks = new PreProcessHooks();
     preProcessHooks.setUiEnabled(true);
@@ -147,7 +147,8 @@ public class EbeanEntityServiceTest
 
     // Create database and spy on aspectDao
     Database server = EbeanTestUtils.createTestServer(EbeanEntityServiceTest.class.getSimpleName());
-    EbeanAspectDao aspectDao = spy(new EbeanAspectDao(server, EbeanConfiguration.testDefault));
+    EbeanAspectDao aspectDao =
+        spy(new EbeanAspectDao(server, EbeanConfiguration.testDefault, null));
 
     // Prevent actual saves
     EntityAspect mockEntityAspect = mock(EntityAspect.class);

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
@@ -13,6 +13,7 @@ import com.linkedin.metadata.aspect.batch.AspectsBatch;
 import com.linkedin.metadata.config.EbeanConfiguration;
 import com.linkedin.metadata.entity.EntityAspectIdentifier;
 import com.linkedin.metadata.entity.TransactionResult;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.ebean.Database;
 import io.ebean.test.LoggedSql;
@@ -29,7 +30,7 @@ public class EbeanAspectDaoTest {
   @BeforeMethod
   public void setupTest() {
     Database server = EbeanTestUtils.createTestServer(EbeanAspectDaoTest.class.getSimpleName());
-    testDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault);
+    testDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault, mock(MetricUtils.class));
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAORelationshipGroupQueryTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAORelationshipGroupQueryTest.java
@@ -85,7 +85,8 @@ public class ESGraphQueryDAORelationshipGroupQueryTest {
             operationContext.getLineageRegistry(),
             operationContext.getSearchContext().getIndexConvention(),
             graphServiceConfig,
-            testESConfig);
+            testESConfig,
+            null);
   }
 
   @Test
@@ -588,7 +589,8 @@ public class ESGraphQueryDAORelationshipGroupQueryTest {
             operationContext.getLineageRegistry(),
             operationContext.getSearchContext().getIndexConvention(),
             TEST_GRAPH_SERVICE_CONFIG,
-            testESConfig);
+            testESConfig,
+            null);
 
     // Call the public method directly with exploreMultiplePaths = true
     ESGraphQueryDAO.LineageResponse resultWithMultiPaths =
@@ -621,7 +623,8 @@ public class ESGraphQueryDAORelationshipGroupQueryTest {
             operationContext.getLineageRegistry(),
             operationContext.getSearchContext().getIndexConvention(),
             TEST_GRAPH_SERVICE_CONFIG,
-            testSinglePathConfig);
+            testSinglePathConfig,
+            null);
 
     // Reset the mock and reconfigure it
     reset(mockClient);

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAOTest.java
@@ -137,7 +137,8 @@ public class ESGraphQueryDAOTest {
             operationContext.getLineageRegistry(),
             null,
             TEST_GRAPH_SERVICE_CONFIG,
-            TEST_ES_SEARCH_CONFIG);
+            TEST_ES_SEARCH_CONFIG,
+            null);
     QueryBuilder limitedBuilder = graphQueryDAO.getLineageQueryForEntityType(urns, edgeInfos);
 
     LineageGraphFilters lineageGraphFilters =
@@ -313,7 +314,8 @@ public class ESGraphQueryDAOTest {
             operationContext.getLineageRegistry(),
             operationContext.getSearchContext().getIndexConvention(),
             TEST_GRAPH_SERVICE_CONFIG,
-            TEST_ES_SEARCH_CONFIG);
+            TEST_ES_SEARCH_CONFIG,
+            null);
 
     // Mock the search response
     SearchResponse mockSearchResponse = mock(SearchResponse.class);
@@ -373,7 +375,8 @@ public class ESGraphQueryDAOTest {
             operationContext.getLineageRegistry(),
             operationContext.getSearchContext().getIndexConvention(),
             TEST_GRAPH_SERVICE_CONFIG,
-            TEST_ES_SEARCH_CONFIG);
+            TEST_ES_SEARCH_CONFIG,
+            null);
 
     // Create a map with mixed entity types for a single entity type key
     Map<String, Set<Urn>> urnsPerEntityType = new HashMap<>();
@@ -423,7 +426,8 @@ public class ESGraphQueryDAOTest {
             operationContext.getLineageRegistry(),
             operationContext.getSearchContext().getIndexConvention(),
             TEST_GRAPH_SERVICE_CONFIG,
-            TEST_ES_SEARCH_CONFIG);
+            TEST_ES_SEARCH_CONFIG,
+            null);
 
     // Create a map with empty URN sets
     Map<String, Set<Urn>> urnsPerEntityType = new HashMap<>();
@@ -490,7 +494,8 @@ public class ESGraphQueryDAOTest {
             mockLineageRegistry,
             operationContext.getSearchContext().getIndexConvention(),
             TEST_GRAPH_SERVICE_CONFIG,
-            TEST_ES_SEARCH_CONFIG);
+            TEST_ES_SEARCH_CONFIG,
+            null);
 
     // Create a map with dataset URNs
     Map<String, Set<Urn>> urnsPerEntityType = new HashMap<>();
@@ -629,7 +634,8 @@ public class ESGraphQueryDAOTest {
             operationContext.getLineageRegistry(),
             operationContext.getSearchContext().getIndexConvention(),
             testConfig,
-            TEST_ES_SEARCH_CONFIG);
+            TEST_ES_SEARCH_CONFIG,
+            null);
 
     // Create test data - requesting more than the limit
     GraphFilters graphFilters =
@@ -675,7 +681,8 @@ public class ESGraphQueryDAOTest {
             operationContext.getLineageRegistry(),
             operationContext.getSearchContext().getIndexConvention(),
             testConfig,
-            TEST_ES_SEARCH_CONFIG);
+            TEST_ES_SEARCH_CONFIG,
+            null);
 
     // Create test data
     GraphFilters graphFilters =

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/neo4j/Neo4jTestServerBuilder.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/neo4j/Neo4jTestServerBuilder.java
@@ -1,66 +1,78 @@
 package com.linkedin.metadata.graph.neo4j;
 
-import apoc.path.PathExplorer;
-import java.io.File;
 import java.net.URI;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.harness.Neo4j;
-import org.neo4j.harness.Neo4jBuilder;
-import org.neo4j.harness.internal.InProcessNeo4jBuilder;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.utility.DockerImageName;
 
+/** Neo4j test server builder using Testcontainers. */
 public class Neo4jTestServerBuilder {
 
-  private final Neo4jBuilder builder;
-  private Neo4j controls;
+  private static final String NEO4J_IMAGE = "neo4j:4.4.28-community";
+  private static final String NEO4J_PASSWORD = "testpassword";
 
-  private Neo4jTestServerBuilder(Neo4jBuilder builder) {
-    this.builder = builder;
-  }
+  private Neo4jContainer<?> container;
+  private Driver driver;
 
   public Neo4jTestServerBuilder() {
-    this(new InProcessNeo4jBuilder().withProcedure(PathExplorer.class).withDisabledServer());
+    // Initialize container with required configuration
   }
 
-  public Neo4jTestServerBuilder(File workingDirectory) {
-    this(new InProcessNeo4jBuilder(workingDirectory.toPath()).withDisabledServer());
-  }
-
-  public Neo4j newServer() {
-    if (controls == null) {
-      controls = builder.build();
+  public void start() {
+    if (container == null) {
+      container =
+          new Neo4jContainer<>(DockerImageName.parse(NEO4J_IMAGE))
+              .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+              .withPlugins("apoc")
+              .withAdminPassword(NEO4J_PASSWORD)
+              .withEnv("NEO4J_apoc_export_file_enabled", "true")
+              .withEnv("NEO4J_apoc_import_file_enabled", "true")
+              .withEnv("NEO4J_apoc_import_file_use__neo4j__config", "true")
+              .withEnv("NEO4JLABS_PLUGINS", "[\"apoc\"]");
     }
-    return controls;
+
+    if (!container.isRunning()) {
+      container.start();
+      this.driver =
+          GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", NEO4J_PASSWORD));
+    }
   }
 
   public void shutdown() {
-    if (controls != null) {
-      controls.close();
-      controls = null;
+    if (driver != null) {
+      driver.close();
+      driver = null;
+    }
+    if (container != null && container.isRunning()) {
+      container.stop();
+      container = null;
     }
   }
 
   public URI boltURI() {
-    if (controls == null) {
-      throw new IllegalStateException("Cannot access instance URI.");
-    }
-    return controls.boltURI();
+    ensureRunning();
+    return URI.create(container.getBoltUrl());
   }
 
   public URI httpURI() {
-    if (controls == null) {
-      throw new IllegalStateException("Cannot access instance URI.");
-    }
-    return controls.httpURI();
+    ensureRunning();
+    return URI.create(container.getHttpUrl());
   }
 
-  public URI httpsURI() {
-    if (controls == null) {
-      throw new IllegalStateException("Cannot access instance URI.");
-    }
-    return controls.httpURI();
+  public Driver getDriver() {
+    ensureRunning();
+    return driver;
   }
 
-  public GraphDatabaseService getGraphDatabaseService() {
-    return controls.defaultDatabaseService();
+  public String getPassword() {
+    return NEO4J_PASSWORD;
+  }
+
+  private void ensureRunning() {
+    if (container == null || !container.isRunning()) {
+      throw new IllegalStateException("Container is not running. Call start() first.");
+    }
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/search/SearchGraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/search/SearchGraphServiceTestBase.java
@@ -113,7 +113,8 @@ public abstract class SearchGraphServiceTestBase extends GraphServiceTestBase {
             lineageRegistry,
             _indexConvention,
             graphServiceConfig,
-            esSearchConfig);
+            esSearchConfig,
+            null);
     ESGraphWriteDAO writeDAO =
         new ESGraphWriteDAO(
             _indexConvention, getBulkProcessor(), 1, esSearchConfig.getSearch().getGraph());

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/client/CachingEntitySearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/client/CachingEntitySearchServiceTest.java
@@ -1,0 +1,481 @@
+package com.linkedin.metadata.search.client;
+
+import static io.datahubproject.test.search.SearchTestUtils.TEST_SEARCH_SERVICE_CONFIG;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.metadata.browse.BrowseResult;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.SearchFlags;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.SortCriterion;
+import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.ScrollResult;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import com.linkedin.metadata.search.cache.CacheableSearcher;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.SearchContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import io.opentelemetry.api.trace.Span;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CachingEntitySearchServiceTest {
+
+  @Mock private CacheManager cacheManager;
+
+  @Mock private EntitySearchService entitySearchService;
+
+  private OperationContext opContext;
+
+  @Mock private SearchContext searchContext;
+
+  @Mock private Cache searchCache;
+
+  @Mock private Cache autoCompleteCache;
+
+  @Mock private Cache browseCache;
+
+  @Mock private Cache scrollCache;
+
+  @Mock private MetricUtils metricUtils;
+
+  @Mock private Span span;
+
+  private CachingEntitySearchService cachingService;
+
+  private static final int BATCH_SIZE = 100;
+  private static final boolean ENABLE_CACHE = true;
+
+  @BeforeMethod
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+
+    opContext =
+        TestOperationContexts.Builder.builder()
+            .systemTelemetryContextSupplier(
+                () -> SystemTelemetryContext.TEST.toBuilder().metricUtils(metricUtils).build())
+            .buildSystemContext();
+
+    // Setup cache manager
+    when(cacheManager.getCache(CachingEntitySearchService.ENTITY_SEARCH_SERVICE_SEARCH_CACHE_NAME))
+        .thenReturn(searchCache);
+    when(cacheManager.getCache(
+            CachingEntitySearchService.ENTITY_SEARCH_SERVICE_AUTOCOMPLETE_CACHE_NAME))
+        .thenReturn(autoCompleteCache);
+    when(cacheManager.getCache(CachingEntitySearchService.ENTITY_SEARCH_SERVICE_BROWSE_CACHE_NAME))
+        .thenReturn(browseCache);
+    when(cacheManager.getCache(CachingEntitySearchService.ENTITY_SEARCH_SERVICE_SCROLL_CACHE_NAME))
+        .thenReturn(scrollCache);
+
+    // Setup static mocks
+    try (MockedStatic<Span> spanMock = mockStatic(Span.class)) {
+      spanMock.when(Span::current).thenReturn(span);
+    }
+
+    when(entitySearchService.getSearchServiceConfig()).thenReturn(TEST_SEARCH_SERVICE_CONFIG);
+
+    cachingService =
+        new CachingEntitySearchService(cacheManager, entitySearchService, BATCH_SIZE, ENABLE_CACHE);
+  }
+
+  @Test
+  public void testSearchWithCacheHit() {
+    // Arrange
+    List<String> entityNames = Arrays.asList("dataset", "chart");
+    String query = "test query";
+    Filter filter = new Filter();
+    List<SortCriterion> sortCriteria = Collections.emptyList();
+    int from = 0;
+    Integer size = 10;
+    List<String> facets = Arrays.asList("platform", "origin");
+
+    when(searchCache.get(any(), eq(String.class)))
+        .thenReturn("{\"entities\":[],\"metadata\":{},\"numEntities\":0}");
+
+    // Act
+    SearchResult result =
+        cachingService.search(
+            opContext, entityNames, query, filter, sortCriteria, from, size, facets);
+
+    // Assert
+    assertNotNull(result);
+    verify(entitySearchService, never())
+        .search(any(), any(), any(), any(), any(), anyInt(), any(), any());
+  }
+
+  @Test
+  public void testSearchWithCacheMiss() {
+    // Arrange
+    List<String> entityNames = Arrays.asList("dataset");
+    String query = "test query";
+    Filter filter = null;
+    List<SortCriterion> sortCriteria = Collections.emptyList();
+    int from = 0;
+    Integer size = 10;
+    List<String> facets = Collections.emptyList();
+
+    SearchResult expectedResult =
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setNumEntities(0)
+            .setPageSize(size)
+            .setMetadata(new SearchResultMetadata())
+            .setFrom(0);
+    when(searchCache.get(any(), eq(String.class))).thenReturn(null);
+    when(entitySearchService.search(any(), any(), any(), any(), any(), anyInt(), any(), any()))
+        .thenReturn(expectedResult);
+
+    // Act
+    SearchResult result =
+        cachingService.search(
+            opContext, entityNames, query, filter, sortCriteria, from, size, facets);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(result, expectedResult);
+    verify(entitySearchService)
+        .search(
+            eq(opContext),
+            eq(entityNames),
+            eq(query),
+            eq(filter),
+            eq(sortCriteria),
+            eq(from),
+            eq(100),
+            eq(facets));
+    verify(searchCache).put(any(), anyString());
+    verify(metricUtils)
+        .increment(eq(CacheableSearcher.class), eq("getBatch_cache_miss_count"), eq(1d));
+  }
+
+  @Test
+  public void testSearchWithCacheDisabled() {
+    // Arrange
+    CachingEntitySearchService serviceWithCacheDisabled =
+        new CachingEntitySearchService(cacheManager, entitySearchService, BATCH_SIZE, false);
+
+    List<String> entityNames = Arrays.asList("dataset");
+    String query = "test";
+    SearchResult expectedResult =
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setMetadata(new SearchResultMetadata())
+            .setNumEntities(0)
+            .setPageSize(10)
+            .setFrom(0);
+
+    when(entitySearchService.search(any(), any(), any(), any(), any(), anyInt(), any(), any()))
+        .thenReturn(expectedResult);
+
+    // Act
+    SearchResult result =
+        serviceWithCacheDisabled.search(
+            opContext, entityNames, query, null, null, 0, 10, Collections.emptyList());
+
+    // Assert
+    assertEquals(result, expectedResult);
+    verify(searchCache, never()).get(any(), (Class<String>) any());
+    verify(searchCache, never()).put(any(), any());
+  }
+
+  @Test
+  public void testAutoCompleteWithCacheHit() {
+    // Arrange
+    String entityName = "dataset";
+    String input = "test";
+    String field = "name";
+    Filter filter = new Filter();
+    Integer limit = 10;
+
+    AutoCompleteResult cachedResult = new AutoCompleteResult();
+    when(autoCompleteCache.get(any(), eq(String.class))).thenReturn("{\"query\":\"test\"}");
+
+    // Act
+    AutoCompleteResult result =
+        cachingService.autoComplete(opContext, entityName, input, field, filter, limit);
+
+    // Assert
+    assertNotNull(result);
+    verify(entitySearchService, never()).autoComplete(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testAutoCompleteWithCacheMiss() {
+    // Arrange
+    String entityName = "dataset";
+    String input = "test";
+    String field = null;
+    Filter filter = null;
+    Integer limit = 5;
+
+    AutoCompleteResult expectedResult = new AutoCompleteResult();
+    when(autoCompleteCache.get(any(), eq(String.class))).thenReturn(null);
+    when(entitySearchService.autoComplete(any(), any(), any(), any(), any(), any()))
+        .thenReturn(expectedResult);
+
+    // Act
+    AutoCompleteResult result =
+        cachingService.autoComplete(opContext, entityName, input, field, filter, limit);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(result, expectedResult);
+    verify(entitySearchService)
+        .autoComplete(eq(opContext), eq(entityName), eq(input), eq(field), eq(filter), eq(limit));
+    verify(autoCompleteCache).put(any(), anyString());
+    verify(metricUtils)
+        .increment(
+            eq(CachingEntitySearchService.class), eq("autocomplete_cache_miss_count"), eq(1d));
+  }
+
+  @Test
+  public void testBrowseWithCacheHit() {
+    // Arrange
+    String entityName = "dataset";
+    String path = "/prod/data";
+    Filter filter = new Filter();
+    int from = 0;
+    Integer size = 20;
+
+    BrowseResult cachedResult = new BrowseResult();
+    when(browseCache.get(any(), eq(String.class))).thenReturn("{\"entities\":[]}");
+
+    // Act
+    BrowseResult result = cachingService.browse(opContext, entityName, path, filter, from, size);
+
+    // Assert
+    assertNotNull(result);
+    verify(entitySearchService, never()).browse(any(), any(), any(), any(), anyInt(), any());
+  }
+
+  @Test
+  public void testBrowseWithCacheMiss() {
+    // Arrange
+    String entityName = "dataset";
+    String path = "/prod";
+    Filter filter = null;
+    int from = 10;
+    Integer size = 50;
+
+    BrowseResult expectedResult = new BrowseResult();
+    when(browseCache.get(any(), eq(String.class))).thenReturn(null);
+    when(entitySearchService.browse(any(), any(), any(), any(), anyInt(), any()))
+        .thenReturn(expectedResult);
+
+    // Act
+    BrowseResult result = cachingService.browse(opContext, entityName, path, filter, from, size);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(result, expectedResult);
+    verify(entitySearchService)
+        .browse(eq(opContext), eq(entityName), eq(path), eq(filter), eq(from), eq(size));
+    verify(browseCache).put(any(), anyString());
+    verify(metricUtils)
+        .increment(eq(CachingEntitySearchService.class), eq("browse_cache_miss_count"), eq(1d));
+  }
+
+  @Test
+  public void testScrollWithCacheHit() {
+    // Arrange
+    List<String> entities = Arrays.asList("dataset", "dataflow");
+    String query = "scroll test";
+    Filter filter = new Filter();
+    List<SortCriterion> sortCriteria = Collections.emptyList();
+    String scrollId = "scroll123";
+    String keepAlive = "1m";
+    Integer size = 100;
+    List<String> facets = Arrays.asList("platform");
+
+    ScrollResult cachedResult = new ScrollResult();
+    when(scrollCache.get(any(), eq(String.class))).thenReturn("{\"entities\":[]}");
+
+    // Act
+    ScrollResult result =
+        cachingService.scroll(
+            opContext, entities, query, filter, sortCriteria, scrollId, keepAlive, size, facets);
+
+    // Assert
+    assertNotNull(result);
+    verify(entitySearchService, never())
+        .fullTextScroll(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    verify(entitySearchService, never())
+        .structuredScroll(any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testScrollWithCacheMissFullText() {
+    // Arrange
+    List<String> entities = Arrays.asList("dataset");
+    String query = "test";
+    Filter filter = null;
+    List<SortCriterion> sortCriteria = null;
+    String scrollId = null;
+    String keepAlive = "5m";
+    Integer size = 50;
+    List<String> facets = Collections.emptyList();
+
+    ScrollResult expectedResult =
+        new ScrollResult().setEntities(new SearchEntityArray()).setNumEntities(0).setPageSize(size);
+    when(scrollCache.get(any(), eq(String.class))).thenReturn(null);
+    when(entitySearchService.fullTextScroll(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(expectedResult);
+
+    // Act
+    ScrollResult result =
+        cachingService.scroll(
+            opContext.withSearchFlags(flags -> flags.setFulltext(true)),
+            entities,
+            query,
+            filter,
+            sortCriteria,
+            scrollId,
+            keepAlive,
+            size,
+            facets);
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(result, expectedResult);
+    verify(entitySearchService)
+        .fullTextScroll(
+            any(OperationContext.class),
+            eq(entities),
+            eq(query),
+            eq(filter),
+            eq(sortCriteria),
+            eq(scrollId),
+            eq(keepAlive),
+            eq(size),
+            eq(facets));
+    verify(entitySearchService, never())
+        .structuredScroll(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    verify(scrollCache).put(any(), anyString());
+    verify(metricUtils)
+        .increment(eq(CachingEntitySearchService.class), eq("scroll_cache_miss_count"), eq(1d));
+  }
+
+  @Test
+  public void testScrollWithCacheMissStructured() {
+    // Arrange
+    List<String> entities = Arrays.asList("dataset");
+    String query = "test";
+    SearchFlags searchFlags = new SearchFlags();
+    searchFlags.setFulltext(false);
+    when(searchContext.getSearchFlags()).thenReturn(searchFlags);
+
+    ScrollResult expectedResult = new ScrollResult();
+    when(scrollCache.get(any(), eq(String.class))).thenReturn(null);
+    when(entitySearchService.structuredScroll(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(expectedResult);
+
+    // Act
+    ScrollResult result =
+        cachingService.scroll(
+            opContext, entities, query, null, null, null, "1m", 10, Collections.emptyList());
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(result, expectedResult);
+    verify(entitySearchService)
+        .structuredScroll(any(), any(), any(), any(), any(), any(), any(), any(), any());
+    verify(entitySearchService, never())
+        .fullTextScroll(any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testCacheSkipWithSearchFlags() {
+    // Arrange
+    String entityName = "dataset";
+    String input = "test";
+    AutoCompleteResult expectedResult = new AutoCompleteResult();
+
+    when(entitySearchService.autoComplete(any(), any(), any(), any(), any(), any()))
+        .thenReturn(expectedResult);
+
+    // Act
+    AutoCompleteResult result =
+        cachingService.autoComplete(
+            opContext.withSearchFlags(flags -> flags.setSkipCache(true)),
+            entityName,
+            input,
+            null,
+            null,
+            10);
+
+    // Assert
+    assertEquals(result, expectedResult);
+    verify(autoCompleteCache, never()).get(any(), (Class<String>) any());
+    verify(autoCompleteCache, never()).put(any(), any());
+    verify(entitySearchService).autoComplete(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testNullSearchFlags() {
+    // Arrange
+    when(searchContext.getSearchFlags()).thenReturn(null);
+
+    String entityName = "dataset";
+    String path = "/test";
+    BrowseResult expectedResult = new BrowseResult();
+
+    when(browseCache.get(any(), eq(String.class))).thenReturn(null);
+    when(entitySearchService.browse(any(), any(), any(), any(), anyInt(), any()))
+        .thenReturn(expectedResult);
+
+    // Act
+    BrowseResult result = cachingService.browse(opContext, entityName, path, null, 0, 10);
+
+    // Assert
+    assertNotNull(result);
+    verify(browseCache).get(any(), eq(String.class));
+    verify(browseCache).put(any(), anyString());
+  }
+
+  @Test
+  public void testCacheKeyGeneration() {
+    // Test that different parameters generate different cache keys
+    String query1 = "test1";
+    String query2 = "test2";
+
+    when(searchCache.get(any(), eq(String.class))).thenReturn(null);
+    SearchResult result =
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setMetadata(new SearchResultMetadata())
+            .setNumEntities(0)
+            .setPageSize(10);
+    when(entitySearchService.search(any(), any(), any(), any(), any(), anyInt(), any(), any()))
+        .thenReturn(result);
+
+    // First search
+    cachingService.search(
+        opContext, Arrays.asList("dataset"), query1, null, null, 0, 10, Collections.emptyList());
+
+    // Second search with different query
+    cachingService.search(
+        opContext, Arrays.asList("dataset"), query2, null, null, 0, 10, Collections.emptyList());
+
+    // Verify two different cache keys were used
+    verify(searchCache, times(2)).get(any(), eq(String.class));
+    verify(searchCache, times(2)).put(any(), anyString());
+    verify(entitySearchService, times(2))
+        .search(any(), any(), any(), any(), any(), anyInt(), any(), any());
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateGraphIndicesServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateGraphIndicesServiceTest.java
@@ -11,13 +11,22 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.linkedin.common.AuditStamp;
 import com.linkedin.common.Status;
+import com.linkedin.common.urn.CorpuserUrn;
+import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.container.Container;
+import com.linkedin.dataset.DatasetLineageType;
 import com.linkedin.dataset.DatasetProperties;
+import com.linkedin.dataset.Upstream;
+import com.linkedin.dataset.UpstreamArray;
+import com.linkedin.dataset.UpstreamLineage;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.models.graph.EdgeUrnType;
@@ -44,6 +53,8 @@ import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.MetadataChangeLog;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.mockito.ArgumentCaptor;
@@ -277,6 +288,217 @@ public class UpdateGraphIndicesServiceTest {
                     createRelationshipFilter(
                         new Filter().setOr(new ConjunctiveCriterionArray()),
                         RelationshipDirection.OUTGOING))));
+  }
+
+  @Test
+  public void testUpdateGraphServiceDiffWithSubtractiveDifference() throws URISyntaxException {
+    // Enable diff mode
+    test.setGraphDiffMode(true);
+
+    // Create upstream lineage with 2 upstreams initially
+    Urn upstream1 = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,upstream1,PROD)");
+    Urn upstream2 = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,upstream2,PROD)");
+
+    UpstreamArray upstreamArray = new UpstreamArray();
+    upstreamArray.add(createUpstream(upstream1));
+    upstreamArray.add(createUpstream(upstream2));
+
+    UpstreamLineage oldUpstreamLineage = new UpstreamLineage().setUpstreams(upstreamArray);
+    GenericAspect oldAspect = GenericRecordUtils.serializeAspect(oldUpstreamLineage);
+
+    // New upstream lineage with only 1 upstream (removing upstream2)
+    UpstreamArray newUpstreamArray = new UpstreamArray();
+    newUpstreamArray.add(createUpstream(upstream1));
+
+    UpstreamLineage newUpstreamLineage = new UpstreamLineage().setUpstreams(newUpstreamArray);
+    GenericAspect newAspect = GenericRecordUtils.serializeAspect(newUpstreamLineage);
+
+    test.handleChangeEvent(
+        TEST_OP_CONTEXT,
+        new MetadataChangeLog()
+            .setChangeType(ChangeType.UPSERT)
+            .setEntityType("dataset")
+            .setEntityUrn(TEST_URN)
+            .setAspectName(Constants.UPSTREAM_LINEAGE_ASPECT_NAME)
+            .setPreviousAspectValue(oldAspect)
+            .setAspect(newAspect));
+
+    // Verify that deleteDocument was called for the removed edge
+    ArgumentCaptor<String> docIdCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockWriteDAO, times(1)).deleteDocument(docIdCaptor.capture());
+
+    String docId = docIdCaptor.getValue();
+    // The doc ID should contain hash of the edge including source and destination
+    assertNotNull(docId);
+  }
+
+  @Test
+  public void testUpdateGraphServiceDiffWithAdditiveDifference() throws URISyntaxException {
+    // Enable diff mode
+    test.setGraphDiffMode(true);
+
+    Urn upstream1 = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,upstream1,PROD)");
+    Urn upstream2 = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,upstream2,PROD)");
+
+    // Old upstream lineage with 1 upstream
+    UpstreamArray oldUpstreamArray = new UpstreamArray();
+    oldUpstreamArray.add(createUpstream(upstream1));
+
+    UpstreamLineage oldUpstreamLineage = new UpstreamLineage().setUpstreams(oldUpstreamArray);
+    GenericAspect oldAspect = GenericRecordUtils.serializeAspect(oldUpstreamLineage);
+
+    // New upstream lineage with 2 upstreams (adding upstream2)
+    UpstreamArray newUpstreamArray = new UpstreamArray();
+    newUpstreamArray.add(createUpstream(upstream1));
+    newUpstreamArray.add(createUpstream(upstream2));
+
+    UpstreamLineage newUpstreamLineage = new UpstreamLineage().setUpstreams(newUpstreamArray);
+    GenericAspect newAspect = GenericRecordUtils.serializeAspect(newUpstreamLineage);
+
+    test.handleChangeEvent(
+        TEST_OP_CONTEXT,
+        new MetadataChangeLog()
+            .setChangeType(ChangeType.UPSERT)
+            .setEntityType("dataset")
+            .setEntityUrn(TEST_URN)
+            .setAspectName(Constants.UPSTREAM_LINEAGE_ASPECT_NAME)
+            .setPreviousAspectValue(oldAspect)
+            .setAspect(newAspect));
+
+    // Verify that upsertDocument was called for the new edge
+    ArgumentCaptor<String> docIdCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> documentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockWriteDAO, times(2)).upsertDocument(docIdCaptor.capture(), documentCaptor.capture());
+
+    String docId = docIdCaptor.getValue();
+    assertNotNull(docId);
+  }
+
+  @Test
+  public void testUpdateGraphServiceDiffWithMergedEdges() throws URISyntaxException {
+    // Enable diff mode
+    test.setGraphDiffMode(true);
+
+    Urn upstream1 = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,upstream1,PROD)");
+
+    // Create old upstream with one audit stamp
+    AuditStamp oldAuditStamp = new AuditStamp().setActor(new CorpuserUrn("user1")).setTime(1000L);
+
+    Upstream oldUpstream =
+        new Upstream()
+            .setDataset(DatasetUrn.createFromUrn(upstream1))
+            .setType(DatasetLineageType.TRANSFORMED)
+            .setAuditStamp(oldAuditStamp);
+
+    UpstreamArray oldUpstreamArray = new UpstreamArray();
+    oldUpstreamArray.add(oldUpstream);
+
+    UpstreamLineage oldUpstreamLineage = new UpstreamLineage().setUpstreams(oldUpstreamArray);
+    GenericAspect oldAspect = GenericRecordUtils.serializeAspect(oldUpstreamLineage);
+
+    // Create new upstream with updated audit stamp (same upstream, different properties)
+    AuditStamp newAuditStamp = new AuditStamp().setActor(new CorpuserUrn("user2")).setTime(2000L);
+
+    Upstream newUpstream =
+        new Upstream()
+            .setDataset(DatasetUrn.createFromUrn(upstream1))
+            .setType(DatasetLineageType.TRANSFORMED)
+            .setAuditStamp(newAuditStamp);
+
+    UpstreamArray newUpstreamArray = new UpstreamArray();
+    newUpstreamArray.add(newUpstream);
+
+    UpstreamLineage newUpstreamLineage = new UpstreamLineage().setUpstreams(newUpstreamArray);
+    GenericAspect newAspect = GenericRecordUtils.serializeAspect(newUpstreamLineage);
+
+    test.handleChangeEvent(
+        TEST_OP_CONTEXT,
+        new MetadataChangeLog()
+            .setChangeType(ChangeType.UPSERT)
+            .setEntityType("dataset")
+            .setEntityUrn(TEST_URN)
+            .setAspectName(Constants.UPSTREAM_LINEAGE_ASPECT_NAME)
+            .setPreviousAspectValue(oldAspect)
+            .setAspect(newAspect));
+
+    // Verify that upsertDocument was called for the updated edge
+    ArgumentCaptor<String> docIdCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> documentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockWriteDAO, times(1)).upsertDocument(docIdCaptor.capture(), documentCaptor.capture());
+
+    String document = documentCaptor.getValue();
+    // The updated document should contain the new audit stamp info
+    assertTrue(document.contains("user2"));
+    assertTrue(document.contains("2000"));
+  }
+
+  @Test
+  public void testUpdateGraphServiceDiffWithAllThreeConditions() throws URISyntaxException {
+    // Enable diff mode
+    test.setGraphDiffMode(true);
+
+    Urn upstream1 = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,upstream1,PROD)");
+    Urn upstream2 = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,upstream2,PROD)");
+    Urn upstream3 = UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,upstream3,PROD)");
+
+    // Old: upstream1 (will be updated), upstream2 (will be removed)
+    UpstreamArray oldUpstreamArray = new UpstreamArray();
+    oldUpstreamArray.add(createUpstream(upstream1));
+    oldUpstreamArray.add(createUpstream(upstream2));
+
+    UpstreamLineage oldUpstreamLineage = new UpstreamLineage().setUpstreams(oldUpstreamArray);
+    GenericAspect oldAspect = GenericRecordUtils.serializeAspect(oldUpstreamLineage);
+
+    // New: upstream1 (updated with new timestamp), upstream3 (new)
+    AuditStamp newAuditStamp =
+        new AuditStamp().setActor(new CorpuserUrn("updatedUser")).setTime(3000L);
+
+    Upstream updatedUpstream =
+        new Upstream()
+            .setDataset(DatasetUrn.createFromUrn(upstream1))
+            .setType(DatasetLineageType.TRANSFORMED)
+            .setAuditStamp(newAuditStamp);
+
+    UpstreamArray newUpstreamArray = new UpstreamArray();
+    newUpstreamArray.add(updatedUpstream);
+    newUpstreamArray.add(createUpstream(upstream3));
+
+    UpstreamLineage newUpstreamLineage = new UpstreamLineage().setUpstreams(newUpstreamArray);
+    GenericAspect newAspect = GenericRecordUtils.serializeAspect(newUpstreamLineage);
+
+    test.handleChangeEvent(
+        TEST_OP_CONTEXT,
+        new MetadataChangeLog()
+            .setChangeType(ChangeType.UPSERT)
+            .setEntityType("dataset")
+            .setEntityUrn(TEST_URN)
+            .setAspectName(Constants.UPSTREAM_LINEAGE_ASPECT_NAME)
+            .setPreviousAspectValue(oldAspect)
+            .setAspect(newAspect));
+
+    // Verify all three operations occurred
+    // 1 delete for upstream2 removal
+    verify(mockWriteDAO, times(1)).deleteDocument(any(String.class));
+
+    // 2 upserts: one for upstream1 update, one for upstream3 addition
+    ArgumentCaptor<String> documentCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockWriteDAO, times(2)).upsertDocument(any(String.class), documentCaptor.capture());
+
+    List<String> documents = documentCaptor.getAllValues();
+    // Verify that we have documents for both the update and the addition
+    assertTrue(documents.stream().anyMatch(doc -> doc.contains("updatedUser")));
+    assertTrue(documents.stream().anyMatch(doc -> doc.contains(upstream3.toString())));
+  }
+
+  // Helper method
+  private Upstream createUpstream(Urn datasetUrn) throws URISyntaxException {
+    return new Upstream()
+        .setDataset(DatasetUrn.createFromUrn(datasetUrn))
+        .setType(DatasetLineageType.TRANSFORMED)
+        .setAuditStamp(
+            new AuditStamp()
+                .setActor(new CorpuserUrn("testUser"))
+                .setTime(System.currentTimeMillis()));
   }
 
   private static Filter createUrnFilter(@Nonnull final Urn urn) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_telemetry/GraphQLTimingInstrumentationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_telemetry/GraphQLTimingInstrumentationTest.java
@@ -1,0 +1,759 @@
+package com.linkedin.metadata.system_telemetry;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.datahub.graphql.GraphQLEngine;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.metadata.config.GraphQLConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLConcurrencyConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLMetricsConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLQueryConfiguration;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.execution.ExecutionStepInfo;
+import graphql.execution.ResultPath;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class GraphQLTimingInstrumentationTest {
+
+  private MeterRegistry meterRegistry;
+  private GraphQLMetricsConfiguration config;
+  private GraphQLTimingInstrumentation instrumentation;
+  private GraphQLConfiguration graphQLConfiguration;
+  private GraphQLEngine graphQLEngine;
+
+  @Mock private InstrumentationCreateStateParameters createStateParams;
+
+  @Mock private InstrumentationExecutionParameters executionParams;
+
+  @Mock private InstrumentationFieldFetchParameters fieldFetchParams;
+
+  @Mock private ExecutionStepInfo executionStepInfo;
+
+  @Mock private ExecutionStepInfo parentStepInfo;
+
+  @Mock private GraphQLFieldDefinition fieldDefinition;
+
+  @Mock private DataFetchingEnvironment dataFetchingEnvironment;
+
+  @Mock private ExecutionInput executionInput;
+
+  @Mock private ResultPath resultPath;
+
+  @Mock private MetricUtils mockMetricUtils;
+
+  @Mock private QueryContext mockQueryContext;
+
+  private static final String TEST_SCHEMA =
+      """
+            type Query {
+                hello: String
+                user(id: ID!): User
+                users: [User]
+            }
+
+            type User {
+                id: ID!
+                name: String
+                email: String
+            }
+
+            type Mutation {
+                createUser(name: String!, email: String!): User
+            }
+            """;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    meterRegistry = new SimpleMeterRegistry();
+    config = new GraphQLMetricsConfiguration();
+    config.setFieldLevelEnabled(true);
+    instrumentation = new GraphQLTimingInstrumentation(meterRegistry, config);
+
+    // Setup real GraphQL configuration for GraphQLEngine
+    graphQLConfiguration = createDefaultConfiguration();
+    when(mockMetricUtils.getRegistry()).thenReturn(Optional.of(meterRegistry));
+  }
+
+  @Test
+  public void testCreateState() {
+    // Act
+    InstrumentationState state = instrumentation.createState(createStateParams);
+
+    // Assert
+    assertNotNull(state);
+    assertTrue(state instanceof GraphQLTimingInstrumentation.TimingState);
+  }
+
+  @Test
+  public void testBeginExecutionSuccess() {
+    // Arrange
+    when(executionParams.getOperation()).thenReturn("TestOperation");
+    when(executionParams.getExecutionInput()).thenReturn(executionInput);
+    when(executionInput.getQuery()).thenReturn("query { test }");
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+
+    // Act
+    InstrumentationContext<ExecutionResult> context =
+        instrumentation.beginExecution(executionParams, state);
+
+    // Assert
+    assertNotNull(context);
+    assertEquals(state.operationName, "TestOperation");
+    assertTrue(state.startTime > 0);
+
+    // Simulate completion
+    ExecutionResult result = mock(ExecutionResult.class);
+    when(result.getErrors()).thenReturn(Collections.emptyList());
+    context.onCompleted(result, null);
+
+    // Verify metrics
+    Timer timer =
+        meterRegistry
+            .find("graphql.request.duration")
+            .tag("operation", "TestOperation")
+            .tag("success", "true")
+            .timer();
+    assertNotNull(timer);
+    assertEquals(timer.count(), 1);
+  }
+
+  @Test
+  public void testBeginExecutionWithError() {
+    // Arrange
+    when(executionParams.getOperation()).thenReturn("ErrorOperation");
+    when(executionParams.getExecutionInput()).thenReturn(executionInput);
+    when(executionInput.getQuery()).thenReturn("query { test }");
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+
+    // Act
+    InstrumentationContext<ExecutionResult> context =
+        instrumentation.beginExecution(executionParams, state);
+    context.onCompleted(null, new RuntimeException("Test error"));
+
+    // Assert
+    Counter errorCounter =
+        meterRegistry.find("graphql.request.errors").tag("operation", "ErrorOperation").counter();
+    assertNotNull(errorCounter);
+    assertEquals(errorCounter.count(), 1.0);
+  }
+
+  @Test
+  public void testOperationTypeDetection() {
+    // Test mutation
+    when(executionParams.getOperation()).thenReturn("TestMutation");
+    when(executionParams.getExecutionInput()).thenReturn(executionInput);
+    when(executionInput.getQuery()).thenReturn("mutation { createUser }");
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+    InstrumentationContext<ExecutionResult> context =
+        instrumentation.beginExecution(executionParams, state);
+
+    // Complete the execution to record metrics
+    ExecutionResult result = mock(ExecutionResult.class);
+    when(result.getErrors()).thenReturn(Collections.emptyList());
+    context.onCompleted(result, null);
+
+    Timer timer =
+        meterRegistry.find("graphql.request.duration").tag("operation.type", "mutation").timer();
+    assertNotNull(timer);
+  }
+
+  @Test
+  public void testPathMatcherRegexConversion() {
+    // This test verifies the regex conversion logic
+    // IMPORTANT: The original code does NOT escape brackets, so they are treated as regex character
+    // classes
+
+    // Test exact match
+    assertTrue(matchesPath("/user", "/user"));
+    assertFalse(matchesPath("/user", "/users"));
+
+    // Test single wildcard - matches one segment
+    assertTrue(matchesPath("/user/*", "/user/name"));
+    assertTrue(matchesPath("/user/*", "/user/posts[0]")); // posts[0] is one segment
+    assertFalse(matchesPath("/user/*", "/user/posts[0]/comments")); // too many segments
+
+    // Test recursive wildcard
+    assertTrue(matchesPath("/user/**", "/user"));
+    assertTrue(matchesPath("/user/**", "/user/name"));
+    assertTrue(matchesPath("/user/**", "/user/posts[0]/comments"));
+
+    // Test patterns with brackets - they are treated as regex character classes!
+    assertFalse(
+        matchesPath("/user/posts[0]/*", "/user/posts[0]/comments")); // [0] is regex, not literal
+    assertTrue(
+        matchesPath("/user/posts[0]/*", "/user/posts0/comments")); // matches without brackets
+
+    // The correct way to match paths with brackets is to use wildcards
+    assertTrue(matchesPath("/user/*/comments", "/user/posts[0]/comments"));
+    assertTrue(matchesPath("/user/*/comments", "/user/posts[1]/comments"));
+
+    // Test complex patterns
+    assertTrue(matchesPath("/*/comments/*", "/posts/comments/text"));
+    assertFalse(matchesPath("/*/comments/*", "/posts/comments")); // missing last segment
+  }
+
+  private boolean matchesPath(String pattern, String path) {
+    // Exact copy of the convertPathToRegex logic from the original code
+    String regex =
+        pattern
+            .replace(".", "\\.") // Escape dots
+            .replace("/**", "(/.*)?") // /** matches current and any descendants
+            .replace("/*", "/[^/]+") // /* matches exactly one segment
+            .replaceAll("/\\*\\*$", "(/.*)?"); // /** at end is optional
+
+    // For patterns ending with /**, also match the parent path
+    if (pattern.endsWith("/**")) {
+      String parentPath = pattern.substring(0, pattern.length() - 3);
+      regex = "(" + parentPath + "|" + regex + ")";
+    }
+
+    regex = "^" + regex + "$";
+    return path.matches(regex);
+  }
+
+  @DataProvider(name = "pathMatchingData")
+  public Object[][] pathMatchingData() {
+    return new Object[][] {
+      // Pattern, Path, Should Match
+      // IMPORTANT: The original code does NOT escape brackets in patterns,
+      // so [0] in a pattern is treated as a regex character class, not literal [0]
+      {"/user", "/user", true},
+      {"/user", "/users", false},
+      {"/user/*", "/user/name", true},
+      {"/user/*", "/user/posts[0]", true}, // posts[0] is one segment, matched by *
+      {"/user/**", "/user", true},
+      {"/user/**", "/user/name", true},
+      {"/user/**", "/user/posts[0]/comments", true},
+      {"/*/comments/*", "/posts/comments/text", true},
+      {"/*/comments/*", "/articles/comments/author", true},
+      {"/*/comments/*", "/posts/comments", false},
+      // Use wildcards to match segments with brackets
+      {"/user/*/comments", "/user/posts[0]/comments", true},
+      {"/user/*/comments", "/user/posts[1]/comments", true},
+      {"/user/*/*", "/user/posts[0]/comments", true}, // Two wildcard segments
+      // These patterns with literal brackets won't work as expected:
+      // {"/user/posts[0]/*", "/user/posts[0]/comments", false}, // Would fail
+      // Instead use wildcards to match array elements
+      {"/user/posts/*", "/user/posts/0", true}, // If using numeric indices without brackets
+      {"/user/posts/*", "/user/posts/[0]", true} // The whole "[0]" is matched as one segment
+    };
+  }
+
+  @Test(dataProvider = "pathMatchingData")
+  public void testPathMatching(String pattern, String path, boolean shouldMatch) {
+    // Arrange
+    config.setFieldLevelPaths(pattern);
+    instrumentation = new GraphQLTimingInstrumentation(meterRegistry, config);
+
+    setupFieldMocks(path, "TestType", "testField");
+
+    // Create state through the proper method
+    InstrumentationState baseState = instrumentation.createState(createStateParams);
+    GraphQLTimingInstrumentation.TimingState state =
+        (GraphQLTimingInstrumentation.TimingState) baseState;
+
+    // Set up execution parameters for beginExecution
+    when(executionParams.getOperation()).thenReturn("TestOp");
+    when(executionParams.getExecutionInput()).thenReturn(executionInput);
+    when(executionInput.getQuery()).thenReturn("query { test }");
+
+    // Initialize the state properly through beginExecution
+    instrumentation.beginExecution(executionParams, state);
+
+    DataFetcher<?> originalFetcher = env -> "test";
+
+    // Act
+    DataFetcher<?> instrumentedFetcher =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state);
+
+    // Assert
+    if (shouldMatch) {
+      assertNotSame(
+          originalFetcher,
+          instrumentedFetcher,
+          String.format("Expected pattern '%s' to match path '%s', but it didn't", pattern, path));
+    } else {
+      assertSame(
+          originalFetcher,
+          instrumentedFetcher,
+          String.format("Expected pattern '%s' to NOT match path '%s', but it did", pattern, path));
+    }
+  }
+
+  @Test
+  public void testFilteringModeAllFields() {
+    // Arrange - no filters configured
+    config.setFieldLevelOperations("");
+    config.setFieldLevelPaths("");
+    instrumentation = new GraphQLTimingInstrumentation(meterRegistry, config);
+
+    setupFieldMocks("/any/path", "TestType", "testField");
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+    state.operationName = "TestOp";
+    state.filteringMode = GraphQLTimingInstrumentation.FilteringMode.ALL_FIELDS;
+
+    DataFetcher<?> originalFetcher = env -> "test";
+
+    // Act
+    DataFetcher<?> instrumentedFetcher =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state);
+
+    // Assert - should be instrumented
+    assertNotSame(originalFetcher, instrumentedFetcher);
+  }
+
+  @Test
+  public void testFilteringModeByOperation() {
+    // Arrange
+    config.setFieldLevelOperations("AllowedOp1,AllowedOp2");
+    config.setFieldLevelPaths("");
+    instrumentation = new GraphQLTimingInstrumentation(meterRegistry, config);
+
+    setupFieldMocks("/any/path", "TestType", "testField");
+
+    // Test allowed operation
+    GraphQLTimingInstrumentation.TimingState state1 =
+        new GraphQLTimingInstrumentation.TimingState();
+    state1.operationName = "AllowedOp1";
+    state1.filteringMode = GraphQLTimingInstrumentation.FilteringMode.BY_OPERATION;
+
+    DataFetcher<?> originalFetcher = env -> "test";
+    DataFetcher<?> instrumentedFetcher1 =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state1);
+
+    assertNotSame(originalFetcher, instrumentedFetcher1);
+
+    // Test disallowed operation
+    GraphQLTimingInstrumentation.TimingState state2 =
+        new GraphQLTimingInstrumentation.TimingState();
+    state2.operationName = "NotAllowedOp";
+    state2.filteringMode = GraphQLTimingInstrumentation.FilteringMode.BY_OPERATION;
+
+    DataFetcher<?> instrumentedFetcher2 =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state2);
+
+    assertSame(originalFetcher, instrumentedFetcher2);
+  }
+
+  @Test
+  public void testFilteringModeByBoth() {
+    // Arrange - both operation and path filters
+    config.setFieldLevelOperations("AllowedOp");
+    config.setFieldLevelPaths("/user/**");
+    instrumentation = new GraphQLTimingInstrumentation(meterRegistry, config);
+
+    // Test: allowed operation + matching path
+    setupFieldMocks("/user/name", "TestType", "testField");
+
+    GraphQLTimingInstrumentation.TimingState state1 =
+        new GraphQLTimingInstrumentation.TimingState();
+    state1.operationName = "AllowedOp";
+    state1.filteringMode = GraphQLTimingInstrumentation.FilteringMode.BY_BOTH;
+
+    DataFetcher<?> originalFetcher = env -> "test";
+    DataFetcher<?> instrumentedFetcher1 =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state1);
+
+    assertNotSame(originalFetcher, instrumentedFetcher1);
+
+    // Test: allowed operation + non-matching path
+    setupFieldMocks("/post/title", "TestType", "testField");
+
+    DataFetcher<?> instrumentedFetcher2 =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state1);
+
+    assertSame(originalFetcher, instrumentedFetcher2);
+  }
+
+  @Test
+  public void testCompletableFutureDataFetcher() throws Exception {
+    // Arrange
+    setupFieldMocks("/test/path", "TestType", "asyncField");
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+    state.operationName = "TestOp";
+    state.filteringMode = GraphQLTimingInstrumentation.FilteringMode.ALL_FIELDS;
+
+    CompletableFuture<String> future = new CompletableFuture<>();
+    DataFetcher<?> originalFetcher = env -> future;
+
+    // Act
+    DataFetcher<?> instrumentedFetcher =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state);
+
+    Object result = instrumentedFetcher.get(dataFetchingEnvironment);
+    assertTrue(result instanceof CompletableFuture);
+
+    // Complete the future
+    future.complete("async result");
+
+    // Wait a bit for metrics to be recorded
+    Thread.sleep(100);
+
+    // Assert
+    Timer timer =
+        meterRegistry
+            .find("graphql.field.duration")
+            .tag("parent.type", "TestType")
+            .tag("field", "asyncField")
+            .tag("success", "true")
+            .timer();
+    assertNotNull(timer);
+    assertEquals(timer.count(), 1);
+  }
+
+  @Test
+  public void testDataFetcherException() throws Exception {
+    // Arrange
+    setupFieldMocks("/test/path", "TestType", "errorField");
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+    state.operationName = "TestOp";
+    state.filteringMode = GraphQLTimingInstrumentation.FilteringMode.ALL_FIELDS;
+
+    RuntimeException testException = new RuntimeException("Test error");
+    DataFetcher<?> originalFetcher =
+        env -> {
+          throw testException;
+        };
+
+    // Act
+    DataFetcher<?> instrumentedFetcher =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state);
+
+    // Assert exception is propagated
+    try {
+      instrumentedFetcher.get(dataFetchingEnvironment);
+      fail("Expected exception to be thrown");
+    } catch (RuntimeException e) {
+      assertEquals(e, testException);
+    }
+
+    // Verify error metrics
+    Timer timer =
+        meterRegistry
+            .find("graphql.field.duration")
+            .tag("parent.type", "TestType")
+            .tag("field", "errorField")
+            .tag("success", "false")
+            .timer();
+    assertNotNull(timer);
+    assertEquals(timer.count(), 1);
+
+    Counter errorCounter =
+        meterRegistry
+            .find("graphql.field.errors")
+            .tag("parent.type", "TestType")
+            .tag("field", "errorField")
+            .counter();
+    assertNotNull(errorCounter);
+    assertEquals(errorCounter.count(), 1.0);
+  }
+
+  @Test
+  public void testTrivialDataFetcherFiltering() {
+    // Arrange
+    config.setTrivialDataFetchersEnabled(false);
+    instrumentation = new GraphQLTimingInstrumentation(meterRegistry, config);
+
+    setupFieldMocks("/test/path", "TestType", "trivialField");
+    when(fieldFetchParams.isTrivialDataFetcher()).thenReturn(true);
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+    state.operationName = "TestOp";
+    state.filteringMode = GraphQLTimingInstrumentation.FilteringMode.ALL_FIELDS;
+
+    DataFetcher<?> originalFetcher = env -> "test";
+
+    // Act
+    DataFetcher<?> instrumentedFetcher =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state);
+
+    // Assert - should not be instrumented
+    assertSame(originalFetcher, instrumentedFetcher);
+  }
+
+  @Test
+  public void testPathTruncation() throws Exception {
+    // Arrange
+    config.setFieldLevelPathEnabled(true);
+    instrumentation = new GraphQLTimingInstrumentation(meterRegistry, config);
+
+    // Test array index with brackets
+    setupFieldMocks("/searchResults[0]/entity", "TestType", "entity");
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+    state.operationName = "TestOp";
+    state.filteringMode = GraphQLTimingInstrumentation.FilteringMode.ALL_FIELDS;
+
+    DataFetcher<?> originalFetcher = env -> "test";
+    DataFetcher<?> instrumentedFetcher =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state);
+
+    instrumentedFetcher.get(dataFetchingEnvironment);
+
+    // Assert path is truncated
+    Timer timer =
+        meterRegistry
+            .find("graphql.field.duration")
+            .tag("path", "/searchResults[*]/entity")
+            .timer();
+    assertNotNull(timer);
+
+    // Test multiple array indices
+    setupFieldMocks("/users[0]/posts[1]/comments[2]", "TestType", "comments");
+
+    instrumentedFetcher =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state);
+    instrumentedFetcher.get(dataFetchingEnvironment);
+
+    timer =
+        meterRegistry
+            .find("graphql.field.duration")
+            .tag("path", "/users[*]/posts[*]/comments[*]")
+            .timer();
+    assertNotNull(timer);
+  }
+
+  @Test
+  public void testFieldsInstrumentedCounter() {
+    // Arrange
+    setupFieldMocks("/test/path1", "TestType", "field1");
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+    state.operationName = "TestOp";
+    state.filteringMode = GraphQLTimingInstrumentation.FilteringMode.ALL_FIELDS;
+
+    DataFetcher<?> originalFetcher = env -> "test";
+
+    // Act - instrument multiple fields
+    for (int i = 0; i < 5; i++) {
+      setupFieldMocks("/test/path" + i, "TestType", "field" + i);
+      instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state);
+    }
+
+    // Assert
+    assertEquals(state.fieldsInstrumented, 5);
+  }
+
+  @Test
+  public void testDisabledFieldLevelMetrics() {
+    // Arrange
+    config.setFieldLevelEnabled(false);
+    instrumentation = new GraphQLTimingInstrumentation(meterRegistry, config);
+
+    setupFieldMocks("/test/path", "TestType", "testField");
+
+    GraphQLTimingInstrumentation.TimingState state = new GraphQLTimingInstrumentation.TimingState();
+    state.operationName = "TestOp";
+    state.filteringMode = GraphQLTimingInstrumentation.FilteringMode.DISABLED;
+
+    DataFetcher<?> originalFetcher = env -> "test";
+
+    // Act
+    DataFetcher<?> instrumentedFetcher =
+        instrumentation.instrumentDataFetcher(originalFetcher, fieldFetchParams, state);
+
+    // Assert - should not be instrumented
+    assertSame(originalFetcher, instrumentedFetcher);
+  }
+
+  private void setupFieldMocks(String path, String parentTypeName, String fieldName) {
+    GraphQLObjectType parentType = mock(GraphQLObjectType.class);
+    when(parentType.getName()).thenReturn(parentTypeName);
+
+    when(fieldFetchParams.getExecutionStepInfo()).thenReturn(executionStepInfo);
+    when(executionStepInfo.getPath()).thenReturn(resultPath);
+    when(resultPath.toString()).thenReturn(path);
+    when(executionStepInfo.getParent()).thenReturn(parentStepInfo);
+    when(parentStepInfo.getType()).thenReturn(parentType);
+    when(executionStepInfo.getFieldDefinition()).thenReturn(fieldDefinition);
+    when(fieldDefinition.getName()).thenReturn(fieldName);
+    when(fieldFetchParams.isTrivialDataFetcher()).thenReturn(false);
+  }
+
+  @Test
+  public void testExecuteQueryWithResolverErrorAndMetrics() {
+    // Enable metrics in configuration
+    GraphQLConfiguration metricsEnabledConfig = createDefaultConfiguration();
+    metricsEnabledConfig.getMetrics().setFieldLevelEnabled(true);
+    metricsEnabledConfig.getMetrics().setTrivialDataFetchersEnabled(false);
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(metricsEnabledConfig)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query",
+                        typeWiring ->
+                            typeWiring
+                                .dataFetcher(
+                                    "user",
+                                    env -> {
+                                      String id = env.getArgument("id");
+                                      if ("error".equals(id)) {
+                                        throw new RuntimeException("Database connection failed");
+                                      }
+                                      return new User(id, "Test User", "test@example.com");
+                                    })
+                                .dataFetcher(
+                                    "users",
+                                    env -> {
+                                      throw new RuntimeException("Service unavailable");
+                                    })))
+            .build();
+
+    // Execute query that will throw an error
+    String query = "{ user(id: \"error\") { id name } }";
+    ExecutionResult result = graphQLEngine.execute(query, null, Map.of(), mockQueryContext);
+
+    // Verify error response
+    assertNotNull(result);
+    assertFalse(result.getErrors().isEmpty());
+
+    // Verify metrics were recorded with error
+    // The instrumentation should have recorded:
+    // 1. graphql.request.duration with success=false tag
+    // 2. graphql.request.errors counter incremented
+    // 3. graphql.field.errors for the failing field (if field-level metrics enabled)
+
+    // Check request duration was recorded with success=false
+    Timer requestTimer =
+        meterRegistry.find("graphql.request.duration").tag("success", "false").timer();
+    assertNotNull(requestTimer);
+    assertTrue(requestTimer.count() > 0);
+
+    // Check error counter was incremented
+    Counter errorCounter = meterRegistry.find("graphql.request.errors").counter();
+    assertNotNull(errorCounter);
+    assertTrue(errorCounter.count() > 0);
+  }
+
+  @Test
+  public void testFieldLevelErrorMetrics() {
+    // Setup with metrics enabled
+    GraphQLConfiguration metricsConfig = createDefaultConfiguration();
+    metricsConfig.getMetrics().setFieldLevelEnabled(true);
+
+    graphQLEngine =
+        GraphQLEngine.builder()
+            .addSchema(TEST_SCHEMA)
+            .setGraphQLConfiguration(metricsConfig)
+            .setMetricUtils(mockMetricUtils)
+            .configureRuntimeWiring(
+                wiring ->
+                    wiring.type(
+                        "Query",
+                        typeWiring ->
+                            typeWiring.dataFetcher(
+                                "user",
+                                env -> {
+                                  throw new RuntimeException("Field resolution error");
+                                })))
+            .build();
+
+    // Execute failing query
+    String query = "{ user(id: \"1\") { name } }";
+    ExecutionResult result = graphQLEngine.execute(query, null, Map.of(), mockQueryContext);
+
+    // Verify error
+    assertNotNull(result);
+    assertFalse(result.getErrors().isEmpty());
+
+    // Verify field-level error metrics
+    Counter fieldErrorCounter =
+        meterRegistry
+            .find("graphql.field.errors")
+            .tag("parent.type", "Query")
+            .tag("field", "user")
+            .counter();
+
+    if (fieldErrorCounter != null) {
+      assertTrue(fieldErrorCounter.count() > 0);
+    }
+  }
+
+  private GraphQLConfiguration createDefaultConfiguration() {
+    GraphQLConfiguration config = new GraphQLConfiguration();
+
+    // Query configuration
+    GraphQLQueryConfiguration queryConfig = new GraphQLQueryConfiguration();
+    queryConfig.setComplexityLimit(1000);
+    queryConfig.setDepthLimit(10);
+    queryConfig.setIntrospectionEnabled(true);
+    config.setQuery(queryConfig);
+
+    // Metrics configuration
+    GraphQLMetricsConfiguration metricsConfig = new GraphQLMetricsConfiguration();
+    metricsConfig.setEnabled(true);
+    metricsConfig.setFieldLevelEnabled(false);
+    metricsConfig.setFieldLevelOperations("Query.search");
+    metricsConfig.setFieldLevelPathEnabled(false);
+    metricsConfig.setFieldLevelPaths("/search");
+    metricsConfig.setTrivialDataFetchersEnabled(false);
+    config.setMetrics(metricsConfig);
+
+    // Concurrency configuration (if needed)
+    GraphQLConcurrencyConfiguration concurrencyConfig = new GraphQLConcurrencyConfiguration();
+    config.setConcurrency(concurrencyConfig);
+
+    return config;
+  }
+
+  private static class User {
+    private final String id;
+    private final String name;
+    private final String email;
+
+    public User(String id, String name, String email) {
+      this.id = id;
+      this.name = name;
+      this.email = email;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/EbeanTimelineServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/EbeanTimelineServiceTest.java
@@ -30,7 +30,7 @@ public class EbeanTimelineServiceTest extends TimelineServiceTest<EbeanAspectDao
   public void setupTest() {
     Database server =
         EbeanTestUtils.createTestServer(EbeanTimelineServiceTest.class.getSimpleName());
-    _aspectDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault);
+    _aspectDao = new EbeanAspectDao(server, EbeanConfiguration.testDefault, null);
     _aspectDao.setConnectionValidated(true);
     _entityTimelineService = new TimelineServiceImpl(_aspectDao, _testEntityRegistry);
     _mockProducer = mock(EventProducer.class);

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/search/TimeseriesAspectServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/search/TimeseriesAspectServiceTestBase.java
@@ -151,7 +151,8 @@ public abstract class TimeseriesAspectServiceTestBase extends AbstractTestNGSpri
         TEST_TIMESERIES_ASPECT_SERVICE_CONFIG,
         opContext.getEntityRegistry(),
         opContext.getSearchContext().getIndexConvention(),
-        getIndexBuilder());
+        getIndexBuilder(),
+        null);
   }
 
   /*

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/search/TimeseriesAspectServiceUnitTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/search/TimeseriesAspectServiceUnitTest.java
@@ -82,7 +82,8 @@ public class TimeseriesAspectServiceUnitTest {
           TEST_TIMESERIES_ASPECT_SERVICE_CONFIG,
           entityRegistry,
           indexConvention,
-          indexBuilder);
+          indexBuilder,
+          null);
 
   private static final String INDEX_PATTERN = "indexPattern";
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/trace/BaseKafkaTraceReaderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/trace/BaseKafkaTraceReaderTest.java
@@ -17,7 +17,7 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.openapi.v1.models.TraceStorageStatus;
 import io.datahubproject.openapi.v1.models.TraceWriteStatus;
 import java.io.IOException;
@@ -135,7 +135,7 @@ public abstract class BaseKafkaTraceReaderTest<M extends RecordTemplate> {
 
     SystemMetadata systemMetadata = new SystemMetadata();
     Map<String, String> properties = new HashMap<>();
-    properties.put(TraceContext.TELEMETRY_TRACE_KEY, TRACE_ID);
+    properties.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TRACE_ID);
     systemMetadata.setProperties(new StringMap(properties));
 
     GenericRecord genericRecord = toGenericRecord(buildMessage(systemMetadata));
@@ -178,7 +178,7 @@ public abstract class BaseKafkaTraceReaderTest<M extends RecordTemplate> {
     // Create system metadata with trace ID
     SystemMetadata systemMetadata = new SystemMetadata();
     Map<String, String> properties = new HashMap<>();
-    properties.put(TraceContext.TELEMETRY_TRACE_KEY, TRACE_ID);
+    properties.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TRACE_ID);
     systemMetadata.setProperties(new StringMap(properties));
 
     // Build message with metadata
@@ -220,7 +220,7 @@ public abstract class BaseKafkaTraceReaderTest<M extends RecordTemplate> {
     // Mock system metadata
     SystemMetadata systemMetadata = new SystemMetadata();
     Map<String, String> properties = new HashMap<>();
-    properties.put(TraceContext.TELEMETRY_TRACE_KEY, TRACE_ID);
+    properties.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TRACE_ID);
     systemMetadata.setProperties(new StringMap(properties));
     M message = buildMessage(systemMetadata);
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/trace/MCLTraceReaderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/trace/MCLTraceReaderTest.java
@@ -12,7 +12,7 @@ import com.linkedin.metadata.EventUtils;
 import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,7 +75,7 @@ public class MCLTraceReaderTest extends BaseKafkaTraceReaderTest<MetadataChangeL
 
     SystemMetadata systemMetadata = new SystemMetadata();
     Map<String, String> properties = new HashMap<>();
-    properties.put(TraceContext.TELEMETRY_TRACE_KEY, TRACE_ID);
+    properties.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TRACE_ID);
     systemMetadata.setProperties(new StringMap(properties));
 
     MetadataChangeLog mcl = buildMessage(systemMetadata);

--- a/metadata-io/src/test/java/com/linkedin/metadata/trace/MCPFailedTraceReaderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/trace/MCPFailedTraceReaderTest.java
@@ -13,7 +13,7 @@ import com.linkedin.mxe.FailedMetadataChangeProposal;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -80,7 +80,7 @@ public class MCPFailedTraceReaderTest
 
     SystemMetadata systemMetadata = new SystemMetadata();
     Map<String, String> properties = new HashMap<>();
-    properties.put(TraceContext.TELEMETRY_TRACE_KEY, TRACE_ID);
+    properties.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TRACE_ID);
     systemMetadata.setProperties(new StringMap(properties));
 
     FailedMetadataChangeProposal fmcp = buildMessage(systemMetadata);

--- a/metadata-io/src/test/java/com/linkedin/metadata/trace/MCPTraceReaderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/trace/MCPTraceReaderTest.java
@@ -12,7 +12,7 @@ import com.linkedin.metadata.EventUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,7 +75,7 @@ public final class MCPTraceReaderTest extends BaseKafkaTraceReaderTest<MetadataC
 
     SystemMetadata systemMetadata = new SystemMetadata();
     Map<String, String> properties = new HashMap<>();
-    properties.put(TraceContext.TELEMETRY_TRACE_KEY, TRACE_ID);
+    properties.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TRACE_ID);
     systemMetadata.setProperties(new StringMap(properties));
 
     MetadataChangeProposal mcp = buildMessage(systemMetadata);

--- a/metadata-io/src/test/java/com/linkedin/metadata/trace/TraceServiceImplTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/trace/TraceServiceImplTest.java
@@ -31,7 +31,7 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.metadata.context.TraceIdGenerator;
 import io.datahubproject.openapi.v1.models.TraceStatus;
 import io.datahubproject.openapi.v1.models.TraceStorageStatus;
@@ -53,8 +53,10 @@ import org.testng.annotations.Test;
 
 public class TraceServiceImplTest {
   private static final String TEST_TRACE_ID_FUTURE =
-      TraceContext.TRACE_ID_GENERATOR.generateTraceId(Instant.now().toEpochMilli() + 1000);
-  private static final String TEST_TRACE_ID = TraceContext.TRACE_ID_GENERATOR.generateTraceId();
+      SystemTelemetryContext.TRACE_ID_GENERATOR.generateTraceId(
+          Instant.now().toEpochMilli() + 1000);
+  private static final String TEST_TRACE_ID =
+      SystemTelemetryContext.TRACE_ID_GENERATOR.generateTraceId();
   protected static final String ASPECT_NAME = "status";
   protected static final String TIMESERIES_ASPECT_NAME = "datasetProfile";
   protected static final Urn TEST_URN =
@@ -96,7 +98,7 @@ public class TraceServiceImplTest {
     // Mock entityService response for primary storage
     SystemMetadata systemMetadata = new SystemMetadata();
     Map<String, String> properties = new HashMap<>();
-    properties.put(TraceContext.TELEMETRY_TRACE_KEY, TEST_TRACE_ID);
+    properties.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TEST_TRACE_ID);
     systemMetadata.setProperties(new StringMap(properties));
 
     EnvelopedAspect envelopedAspect = new EnvelopedAspect();
@@ -235,7 +237,7 @@ public class TraceServiceImplTest {
     // Mock primary storage with historic state
     SystemMetadata systemMetadata = new SystemMetadata();
     Map<String, String> properties = new HashMap<>();
-    properties.put(TraceContext.TELEMETRY_TRACE_KEY, TEST_TRACE_ID_FUTURE);
+    properties.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TEST_TRACE_ID_FUTURE);
     systemMetadata.setProperties(new StringMap(properties));
 
     EnvelopedAspect envelopedAspect = new EnvelopedAspect();
@@ -298,7 +300,7 @@ public class TraceServiceImplTest {
     // Mock the failed message in MCPFailedTraceReader
     SystemMetadata failedMetadata = new SystemMetadata();
     Map<String, String> properties = new HashMap<>();
-    properties.put(TraceContext.TELEMETRY_TRACE_KEY, TEST_TRACE_ID);
+    properties.put(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TEST_TRACE_ID);
     failedMetadata.setProperties(new StringMap(properties));
 
     FailedMetadataChangeProposal failedMCP =
@@ -358,7 +360,7 @@ public class TraceServiceImplTest {
     // Create system metadata with NO_OP state
     SystemMetadata systemMetadata = new SystemMetadata();
     systemMetadata.setProperties(
-        new StringMap(Map.of(TraceContext.TELEMETRY_TRACE_KEY, TEST_TRACE_ID)));
+        new StringMap(Map.of(SystemTelemetryContext.TELEMETRY_TRACE_KEY, TEST_TRACE_ID)));
     SystemMetadataUtils.setNoOp(systemMetadata, true); // Set NO_OP flag
 
     // Create enveloped aspect with NO_OP system metadata

--- a/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SampleDataFixtureConfiguration.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SampleDataFixtureConfiguration.java
@@ -310,6 +310,7 @@ public class SampleDataFixtureConfiguration {
         null,
         null,
         null,
-        EntityClientConfig.builder().batchGetV2Size(1).build());
+        EntityClientConfig.builder().batchGetV2Size(1).build(),
+        null);
   }
 }

--- a/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SearchFixtureUtils.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SearchFixtureUtils.java
@@ -127,7 +127,7 @@ public class SearchFixtureUtils {
   private void reindexTestFixtureData() throws IOException {
     ESBulkProcessor bulkProcessor =
         ESBulkProcessor.builder(
-                new RestHighLevelClient(SearchTestUtils.environmentRestClientBuilder()))
+                new RestHighLevelClient(SearchTestUtils.environmentRestClientBuilder()), null)
             .async(true)
             .bulkRequestsLimit(1000)
             .retryInterval(1L)

--- a/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SearchLineageFixtureConfiguration.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SearchLineageFixtureConfiguration.java
@@ -196,7 +196,8 @@ public class SearchLineageFixtureConfiguration {
                 lineageRegistry,
                 indexConvention,
                 TEST_GRAPH_SERVICE_CONFIG,
-                TEST_ES_SEARCH_CONFIG),
+                TEST_ES_SEARCH_CONFIG,
+                null),
             indexBuilder,
             indexConvention.getIdHashAlgo());
     graphService.reindexAll(Collections.emptySet());
@@ -276,6 +277,7 @@ public class SearchLineageFixtureConfiguration {
         null,
         null,
         null,
-        EntityClientConfig.builder().batchGetV2Size(1).build());
+        EntityClientConfig.builder().batchGetV2Size(1).build(),
+        null);
   }
 }

--- a/metadata-io/src/test/java/io/datahubproject/test/search/config/SearchTestContainerConfiguration.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/search/config/SearchTestContainerConfiguration.java
@@ -67,7 +67,7 @@ public class SearchTestContainerConfiguration {
   public ESBulkProcessor getBulkProcessor(
       @Qualifier("searchRestHighLevelClient") RestHighLevelClient searchClient) {
     ESBulkProcessor esBulkProcessor =
-        ESBulkProcessor.builder(searchClient)
+        ESBulkProcessor.builder(searchClient, null)
             .async(true)
             /*
              * Force a refresh as part of this request. This refresh policy does not scale for high indexing or search throughput but is useful

--- a/metadata-io/src/test/resources/testng.xml
+++ b/metadata-io/src/test/resources/testng.xml
@@ -10,6 +10,7 @@ parallel followed by everything else.
 <suite-files>
     <suite-file path="testng-search.xml"/>
     <suite-file path="testng-cassandra.xml"/>
+    <suite-file path="testng-neo4j.xml"/>
     <suite-file path="testng-other.xml"/>
     <suite-file path="testng-sql-opt.xml"/>
 </suite-files>

--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MAEOpenTelemetryConfig.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MAEOpenTelemetryConfig.java
@@ -2,7 +2,8 @@ package com.linkedin.metadata.kafka;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.system_telemetry.OpenTelemetryBaseFactory;
-import io.datahubproject.metadata.context.TraceContext;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import org.apache.kafka.clients.producer.Producer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -18,9 +19,10 @@ public class MAEOpenTelemetryConfig extends OpenTelemetryBaseFactory {
 
   @Bean
   @Override
-  protected TraceContext traceContext(
+  protected SystemTelemetryContext traceContext(
+      MetricUtils metricUtils,
       ConfigurationProvider configurationProvider,
       @Qualifier("dataHubUsageProducer") Producer<String, String> dueProducer) {
-    return super.traceContext(configurationProvider, dueProducer);
+    return super.traceContext(metricUtils, configurationProvider, dueProducer);
   }
 }

--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MaeConsumerApplication.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MaeConsumerApplication.java
@@ -35,7 +35,8 @@ import org.springframework.context.annotation.FilterType;
       "com.linkedin.gms.factory.plugins",
       "com.linkedin.gms.factory.change",
       "com.datahub.event.hook",
-      "com.linkedin.gms.factory.notifications"
+      "com.linkedin.gms.factory.notifications",
+      "com.linkedin.gms.factory.system_telemetry"
     },
     excludeFilters = {
       @ComponentScan.Filter(

--- a/metadata-jobs/mae-consumer-job/src/test/java/com/linkedin/metadata/kafka/MaeConsumerApplicationTestConfiguration.java
+++ b/metadata-jobs/mae-consumer-job/src/test/java/com/linkedin/metadata/kafka/MaeConsumerApplicationTestConfiguration.java
@@ -8,6 +8,7 @@ import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
 import com.linkedin.metadata.systemmetadata.ElasticSearchSystemMetadataService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.services.RestrictedService;
 import io.datahubproject.metadata.services.SecretService;
 import io.ebean.Database;
@@ -38,4 +39,6 @@ public class MaeConsumerApplicationTestConfiguration {
   @MockBean private ConfigEntityRegistry _configEntityRegistry;
 
   @MockBean public ElasticSearchService elasticSearchService;
+
+  @MockBean public MetricUtils metricUtils;
 }

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/DataHubUsageEventsProcessorTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/DataHubUsageEventsProcessorTest.java
@@ -1,0 +1,339 @@
+package com.linkedin.metadata.kafka;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.kafka.elasticsearch.ElasticsearchConnector;
+import com.linkedin.metadata.kafka.elasticsearch.JsonElasticEvent;
+import com.linkedin.metadata.kafka.transformer.DataHubUsageEventTransformer;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Optional;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DataHubUsageEventsProcessorTest {
+
+  private static final String TEST_INDEX_NAME = "datahub_usage_event_test";
+  private static final String TEST_TOPIC = "DataHubUsageEvent_v1";
+  private static final String TEST_KEY = "test-key";
+  private static final String TEST_EVENT_ID = "event-123";
+  private static final long TEST_OFFSET = 12345L;
+  private static final long TEST_TIMESTAMP = System.currentTimeMillis();
+
+  @Mock private ElasticsearchConnector elasticsearchConnector;
+
+  @Mock private DataHubUsageEventTransformer dataHubUsageEventTransformer;
+
+  @Mock private ConsumerRecord<String, String> mockRecord;
+
+  private OperationContext systemOperationContext;
+
+  @Mock private MetricUtils metricUtils;
+
+  private DataHubUsageEventsProcessor processor;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    systemOperationContext =
+        TestOperationContexts.Builder.builder()
+            .systemTelemetryContextSupplier(
+                () ->
+                    SystemTelemetryContext.builder()
+                        .tracer(SystemTelemetryContext.TEST.getTracer())
+                        .metricUtils(metricUtils)
+                        .build())
+            .buildSystemContext();
+
+    processor =
+        new DataHubUsageEventsProcessor(
+            elasticsearchConnector,
+            dataHubUsageEventTransformer,
+            systemOperationContext.getSearchContext().getIndexConvention(),
+            systemOperationContext);
+  }
+
+  @Test
+  public void testConsumeSuccessfulEvent() {
+    // Given
+    String eventJson = "{\"type\":\"PageViewEvent\",\"timestamp\":1234567890}";
+    String transformedDocument = "{\"transformed\":\"data\"}";
+
+    when(mockRecord.key()).thenReturn(TEST_KEY);
+    when(mockRecord.topic()).thenReturn(TEST_TOPIC);
+    when(mockRecord.partition()).thenReturn(0);
+    when(mockRecord.offset()).thenReturn(TEST_OFFSET);
+    when(mockRecord.timestamp()).thenReturn(TEST_TIMESTAMP);
+    when(mockRecord.serializedValueSize()).thenReturn(100);
+    when(mockRecord.value()).thenReturn(eventJson);
+
+    DataHubUsageEventTransformer.TransformedDocument transformedDoc =
+        new DataHubUsageEventTransformer.TransformedDocument(TEST_EVENT_ID, transformedDocument);
+
+    when(dataHubUsageEventTransformer.transformDataHubUsageEvent(eventJson))
+        .thenReturn(Optional.of(transformedDoc));
+
+    // When
+    processor.consume(mockRecord);
+
+    // Then
+    verify(metricUtils).histogram(eq(DataHubUsageEventsProcessor.class), eq("kafkaLag"), anyLong());
+
+    ArgumentCaptor<JsonElasticEvent> eventCaptor = ArgumentCaptor.forClass(JsonElasticEvent.class);
+    verify(elasticsearchConnector).feedElasticEvent(eventCaptor.capture());
+
+    JsonElasticEvent capturedEvent = eventCaptor.getValue();
+    assertEquals(capturedEvent.getIndex(), "datahub_usage_event");
+    assertEquals(capturedEvent.getActionType(), ChangeType.CREATE);
+    assertEquals(capturedEvent.getId(), "event-123_12345"); // event ID + last 5 digits of offset
+  }
+
+  @Test
+  public void testConsumeWithFailedTransformation() {
+    // Given
+    String eventJson = "{\"invalid\":\"event\"}";
+
+    when(mockRecord.key()).thenReturn(TEST_KEY);
+    when(mockRecord.topic()).thenReturn(TEST_TOPIC);
+    when(mockRecord.partition()).thenReturn(0);
+    when(mockRecord.offset()).thenReturn(TEST_OFFSET);
+    when(mockRecord.timestamp()).thenReturn(TEST_TIMESTAMP);
+    when(mockRecord.serializedValueSize()).thenReturn(50);
+    when(mockRecord.value()).thenReturn(eventJson);
+
+    when(dataHubUsageEventTransformer.transformDataHubUsageEvent(eventJson))
+        .thenReturn(Optional.empty());
+
+    // When
+    processor.consume(mockRecord);
+
+    // Then
+    verify(metricUtils).histogram(eq(DataHubUsageEventsProcessor.class), eq("kafkaLag"), anyLong());
+    verify(elasticsearchConnector, never()).feedElasticEvent(any());
+  }
+
+  @Test
+  public void testConsumeWithNoMetrics() {
+    // Given
+    systemOperationContext =
+        TestOperationContexts.Builder.builder()
+            .systemTelemetryContextSupplier(
+                () ->
+                    systemOperationContext.getSystemTelemetryContext().toBuilder()
+                        .metricUtils(null)
+                        .build())
+            .buildSystemContext();
+
+    processor =
+        new DataHubUsageEventsProcessor(
+            elasticsearchConnector,
+            dataHubUsageEventTransformer,
+            systemOperationContext.getSearchContext().getIndexConvention(),
+            systemOperationContext);
+
+    String eventJson = "{\"type\":\"SearchEvent\"}";
+    String transformedDocument = "{\"search\":\"data\"}";
+
+    when(mockRecord.key()).thenReturn(TEST_KEY);
+    when(mockRecord.topic()).thenReturn(TEST_TOPIC);
+    when(mockRecord.partition()).thenReturn(0);
+    when(mockRecord.offset()).thenReturn(TEST_OFFSET);
+    when(mockRecord.timestamp()).thenReturn(TEST_TIMESTAMP);
+    when(mockRecord.serializedValueSize()).thenReturn(75);
+    when(mockRecord.value()).thenReturn(eventJson);
+
+    DataHubUsageEventTransformer.TransformedDocument transformedDoc =
+        new DataHubUsageEventTransformer.TransformedDocument(TEST_EVENT_ID, transformedDocument);
+
+    when(dataHubUsageEventTransformer.transformDataHubUsageEvent(eventJson))
+        .thenReturn(Optional.of(transformedDoc));
+
+    // When
+    processor.consume(mockRecord);
+
+    // Then
+    verify(metricUtils, never()).histogram(any(), any(), anyLong());
+    verify(elasticsearchConnector).feedElasticEvent(any());
+  }
+
+  @Test
+  public void testDocumentIdGenerationWithLargeOffset() {
+    // Given
+    String eventJson = "{\"type\":\"Event\"}";
+    String transformedDocument = "{\"data\":\"value\"}";
+    long largeOffset = 9876543210L; // Last 5 digits should be 43210
+
+    when(mockRecord.key()).thenReturn(TEST_KEY);
+    when(mockRecord.topic()).thenReturn(TEST_TOPIC);
+    when(mockRecord.partition()).thenReturn(0);
+    when(mockRecord.offset()).thenReturn(largeOffset);
+    when(mockRecord.timestamp()).thenReturn(TEST_TIMESTAMP);
+    when(mockRecord.serializedValueSize()).thenReturn(50);
+    when(mockRecord.value()).thenReturn(eventJson);
+
+    DataHubUsageEventTransformer.TransformedDocument transformedDoc =
+        new DataHubUsageEventTransformer.TransformedDocument(TEST_EVENT_ID, transformedDocument);
+
+    when(dataHubUsageEventTransformer.transformDataHubUsageEvent(eventJson))
+        .thenReturn(Optional.of(transformedDoc));
+
+    // When
+    processor.consume(mockRecord);
+
+    // Then
+    verify(elasticsearchConnector)
+        .feedElasticEvent(argThat(event -> event.getId().equals("event-123_43210")));
+  }
+
+  @Test
+  public void testDocumentIdGenerationWithSmallOffset() {
+    // Given
+    String eventJson = "{\"type\":\"Event\"}";
+    String transformedDocument = "{\"data\":\"value\"}";
+    long smallOffset = 42L; // Should be padded to 00042
+
+    when(mockRecord.key()).thenReturn(TEST_KEY);
+    when(mockRecord.topic()).thenReturn(TEST_TOPIC);
+    when(mockRecord.partition()).thenReturn(0);
+    when(mockRecord.offset()).thenReturn(smallOffset);
+    when(mockRecord.timestamp()).thenReturn(TEST_TIMESTAMP);
+    when(mockRecord.serializedValueSize()).thenReturn(50);
+    when(mockRecord.value()).thenReturn(eventJson);
+
+    DataHubUsageEventTransformer.TransformedDocument transformedDoc =
+        new DataHubUsageEventTransformer.TransformedDocument(TEST_EVENT_ID, transformedDocument);
+
+    when(dataHubUsageEventTransformer.transformDataHubUsageEvent(eventJson))
+        .thenReturn(Optional.of(transformedDoc));
+
+    // When
+    processor.consume(mockRecord);
+
+    // Then
+    verify(elasticsearchConnector)
+        .feedElasticEvent(argThat(event -> event.getId().equals("event-123_00042")));
+  }
+
+  @Test
+  public void testDocumentIdGenerationWithSpecialCharacters() {
+    // Given
+    String eventJson = "{\"type\":\"Event\"}";
+    String transformedDocument = "{\"data\":\"value\"}";
+    String eventIdWithSpecialChars = "event/123+456";
+
+    when(mockRecord.key()).thenReturn(TEST_KEY);
+    when(mockRecord.topic()).thenReturn(TEST_TOPIC);
+    when(mockRecord.partition()).thenReturn(0);
+    when(mockRecord.offset()).thenReturn(TEST_OFFSET);
+    when(mockRecord.timestamp()).thenReturn(TEST_TIMESTAMP);
+    when(mockRecord.serializedValueSize()).thenReturn(50);
+    when(mockRecord.value()).thenReturn(eventJson);
+
+    DataHubUsageEventTransformer.TransformedDocument transformedDoc =
+        new DataHubUsageEventTransformer.TransformedDocument(
+            eventIdWithSpecialChars, transformedDocument);
+
+    when(dataHubUsageEventTransformer.transformDataHubUsageEvent(eventJson))
+        .thenReturn(Optional.of(transformedDoc));
+
+    // When
+    processor.consume(mockRecord);
+
+    // Then
+    verify(elasticsearchConnector)
+        .feedElasticEvent(argThat(event -> event.getId().equals("event%2F123%2B456_12345")));
+  }
+
+  @Test
+  public void testConsumeWithNullRecord() {
+    // Given
+    when(mockRecord.key()).thenReturn(TEST_KEY);
+    when(mockRecord.topic()).thenReturn(TEST_TOPIC);
+    when(mockRecord.partition()).thenReturn(0);
+    when(mockRecord.offset()).thenReturn(TEST_OFFSET);
+    when(mockRecord.timestamp()).thenReturn(TEST_TIMESTAMP);
+    when(mockRecord.serializedValueSize()).thenReturn(0);
+    when(mockRecord.value()).thenReturn(null);
+
+    when(dataHubUsageEventTransformer.transformDataHubUsageEvent(null))
+        .thenReturn(Optional.empty());
+
+    // When
+    processor.consume(mockRecord);
+
+    // Then
+    verify(elasticsearchConnector, never()).feedElasticEvent(any());
+  }
+
+  @Test
+  public void testConsumeVerifyElasticEventProperties() {
+    // Given
+    String eventJson = "{\"type\":\"ViewEvent\"}";
+    String transformedDocument = "{\"view\":\"data\"}";
+
+    when(mockRecord.key()).thenReturn(TEST_KEY);
+    when(mockRecord.topic()).thenReturn(TEST_TOPIC);
+    when(mockRecord.partition()).thenReturn(2); // partition 2
+    when(mockRecord.offset()).thenReturn(TEST_OFFSET);
+    when(mockRecord.timestamp()).thenReturn(TEST_TIMESTAMP);
+    when(mockRecord.serializedValueSize()).thenReturn(100); // serialized value size
+    when(mockRecord.value()).thenReturn(eventJson);
+
+    DataHubUsageEventTransformer.TransformedDocument transformedDoc =
+        new DataHubUsageEventTransformer.TransformedDocument(TEST_EVENT_ID, transformedDocument);
+
+    when(dataHubUsageEventTransformer.transformDataHubUsageEvent(eventJson))
+        .thenReturn(Optional.of(transformedDoc));
+
+    // When
+    processor.consume(mockRecord);
+
+    // Then
+    ArgumentCaptor<JsonElasticEvent> eventCaptor = ArgumentCaptor.forClass(JsonElasticEvent.class);
+    verify(elasticsearchConnector).feedElasticEvent(eventCaptor.capture());
+
+    JsonElasticEvent capturedEvent = eventCaptor.getValue();
+    assertEquals(capturedEvent.getIndex(), "datahub_usage_event");
+    assertEquals(capturedEvent.getActionType(), ChangeType.CREATE);
+  }
+
+  @Test
+  public void testKafkaLagCalculation() {
+    // Given
+    String eventJson = "{\"type\":\"Event\"}";
+    long recordTimestamp = System.currentTimeMillis() - 5000; // 5 seconds ago
+
+    when(mockRecord.key()).thenReturn(TEST_KEY);
+    when(mockRecord.topic()).thenReturn(TEST_TOPIC);
+    when(mockRecord.partition()).thenReturn(0);
+    when(mockRecord.offset()).thenReturn(TEST_OFFSET);
+    when(mockRecord.timestamp()).thenReturn(recordTimestamp);
+    when(mockRecord.serializedValueSize()).thenReturn(50);
+    when(mockRecord.value()).thenReturn(eventJson);
+
+    when(dataHubUsageEventTransformer.transformDataHubUsageEvent(eventJson))
+        .thenReturn(Optional.empty());
+
+    // When
+    processor.consume(mockRecord);
+
+    // Then
+    ArgumentCaptor<Long> lagCaptor = ArgumentCaptor.forClass(Long.class);
+    verify(metricUtils)
+        .histogram(eq(DataHubUsageEventsProcessor.class), eq("kafkaLag"), lagCaptor.capture());
+
+    Long capturedLag = lagCaptor.getValue();
+    assertTrue(capturedLag >= 5000L); // Should be at least 5 seconds
+  }
+}

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.service.FormService;
 import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.OperationContextConfig;
 import io.datahubproject.metadata.context.ServicesRegistryContext;
@@ -106,4 +107,6 @@ public class MCLSpringCommonTestConfiguration {
 
   @MockBean(name = "traceAdminClient")
   public AdminClient traceAdminClient;
+
+  @MockBean public MetricUtils metricUtils;
 }

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MCEOpenTelemetryConfig.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MCEOpenTelemetryConfig.java
@@ -2,7 +2,8 @@ package com.linkedin.metadata.kafka;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.system_telemetry.OpenTelemetryBaseFactory;
-import io.datahubproject.metadata.context.TraceContext;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import org.apache.kafka.clients.producer.Producer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -18,9 +19,10 @@ public class MCEOpenTelemetryConfig extends OpenTelemetryBaseFactory {
 
   @Bean
   @Override
-  protected TraceContext traceContext(
+  protected SystemTelemetryContext traceContext(
+      MetricUtils metricUtils,
       ConfigurationProvider configurationProvider,
       @Qualifier("dataHubUsageProducer") Producer<String, String> dueProducer) {
-    return super.traceContext(configurationProvider, dueProducer);
+    return super.traceContext(metricUtils, configurationProvider, dueProducer);
   }
 }

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceConsumerApplication.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceConsumerApplication.java
@@ -34,7 +34,8 @@ import org.springframework.context.annotation.PropertySource;
       "com.linkedin.metadata.dao.producer",
       "io.datahubproject.metadata.jobs.common.health.kafka",
       "com.linkedin.gms.factory.context",
-      "com.linkedin.gms.factory.plugins"
+      "com.linkedin.gms.factory.plugins",
+      "com.linkedin.gms.factory.system_telemetry"
     },
     excludeFilters = {
       @ComponentScan.Filter(

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/restli/EbeanServerConfig.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/restli/EbeanServerConfig.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.restli;
 
 import static com.linkedin.gms.factory.common.LocalEbeanConfigFactory.getListenerToTrackCounts;
 
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.ebean.datasource.DataSourceConfig;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +48,8 @@ public class EbeanServerConfig {
   @Primary
   public DataSourceConfig buildDataSourceConfig(
       @Value("${ebean.url}") String dataSourceUrl,
-      @Qualifier("parseqEngineThreads") int ebeanMaxConnections) {
+      @Qualifier("parseqEngineThreads") int ebeanMaxConnections,
+      MetricUtils metricUtils) {
     DataSourceConfig dataSourceConfig = new DataSourceConfig();
     dataSourceConfig.setUsername(ebeanDatasourceUsername);
     dataSourceConfig.setPassword(ebeanDatasourcePassword);
@@ -59,7 +61,7 @@ public class EbeanServerConfig {
     dataSourceConfig.setMaxAgeMinutes(ebeanMaxAgeMinutes);
     dataSourceConfig.setLeakTimeMinutes(ebeanLeakTimeMinutes);
     dataSourceConfig.setWaitTimeoutMillis(ebeanWaitTimeoutMillis);
-    dataSourceConfig.setListener(getListenerToTrackCounts("mce-consumer"));
+    dataSourceConfig.setListener(getListenerToTrackCounts(metricUtils, "mce-consumer"));
     // Adding IAM auth access for AWS Postgres
     if (postgresUseIamAuth) {
       Map<String, String> custom = new HashMap<>();

--- a/metadata-jobs/mce-consumer-job/src/test/java/com/linkedin/metadata/kafka/MceConsumerApplicationTestConfiguration.java
+++ b/metadata-jobs/mce-consumer-job/src/test/java/com/linkedin/metadata/kafka/MceConsumerApplicationTestConfiguration.java
@@ -13,6 +13,7 @@ import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.restli.DefaultRestliClientFactory;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.parseq.retry.backoff.ExponentialBackoff;
 import com.linkedin.restli.client.Client;
 import io.ebean.Database;
@@ -40,13 +41,15 @@ public class MceConsumerApplicationTestConfiguration {
   @Primary
   public SystemEntityClient systemEntityClient(
       @Qualifier("configurationProvider") final ConfigurationProvider configurationProvider,
-      final EntityClientConfig entityClientConfig) {
+      final EntityClientConfig entityClientConfig,
+      final MetricUtils metricUtils) {
     String selfUri = restTemplate.getRootUri();
     final Client restClient = DefaultRestliClientFactory.getRestLiClient(URI.create(selfUri), null);
     return new SystemRestliEntityClient(
         restClient,
         entityClientConfig,
-        configurationProvider.getCache().getClient().getEntityClient());
+        configurationProvider.getCache().getClient().getEntityClient(),
+        metricUtils);
   }
 
   @Bean

--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeEventsProcessor.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeEventsProcessor.java
@@ -2,8 +2,6 @@ package com.linkedin.metadata.kafka;
 
 import static com.linkedin.metadata.config.kafka.KafkaConfiguration.DEFAULT_EVENT_CONSUMER_NAME;
 
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.MetricRegistry;
 import com.linkedin.entity.Entity;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.gms.factory.entityclient.RestliEntityClientFactory;
@@ -46,9 +44,6 @@ public class MetadataChangeEventsProcessor {
   private final SystemEntityClient entityClient;
   private final Producer<String, IndexedRecord> kafkaProducer;
 
-  private final Histogram kafkaLagStats =
-      MetricUtils.get().histogram(MetricRegistry.name(this.getClass(), "kafkaLag"));
-
   @Value(
       "${FAILED_METADATA_CHANGE_EVENT_NAME:${KAFKA_FMCE_TOPIC_NAME:"
           + Topics.FAILED_METADATA_CHANGE_EVENT
@@ -68,7 +63,14 @@ public class MetadataChangeEventsProcessor {
     systemOperationContext.withSpan(
         "consume",
         () -> {
-          kafkaLagStats.update(System.currentTimeMillis() - consumerRecord.timestamp());
+          systemOperationContext
+              .getMetricUtils()
+              .ifPresent(
+                  metricUtils ->
+                      metricUtils.histogram(
+                          this.getClass(),
+                          "kafkaLag",
+                          System.currentTimeMillis() - consumerRecord.timestamp()));
           final GenericRecord record = consumerRecord.value();
 
           log.info(

--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeProposalsProcessor.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeProposalsProcessor.java
@@ -7,8 +7,6 @@ import static com.linkedin.metadata.Constants.MDC_ENTITY_URN;
 import static com.linkedin.metadata.config.kafka.KafkaConfiguration.MCP_EVENT_CONSUMER_NAME;
 import static com.linkedin.mxe.ConsumerGroups.MCP_CONSUMER_GROUP_ID_VALUE;
 
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.MetricRegistry;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.events.metadata.ChangeType;
@@ -60,9 +58,6 @@ public class MetadataChangeProposalsProcessor {
   private final KafkaListenerEndpointRegistry registry;
   private final ConfigurationProvider provider;
 
-  private final Histogram kafkaLagStats =
-      MetricUtils.get().histogram(MetricRegistry.name(this.getClass(), "kafkaLag"));
-
   @Value(
       "${FAILED_METADATA_CHANGE_PROPOSAL_TOPIC_NAME:"
           + Topics.FAILED_METADATA_CHANGE_PROPOSAL
@@ -84,7 +79,14 @@ public class MetadataChangeProposalsProcessor {
       autoStartup = "false")
   public void consume(final ConsumerRecord<String, GenericRecord> consumerRecord) {
     try {
-      kafkaLagStats.update(System.currentTimeMillis() - consumerRecord.timestamp());
+      systemOperationContext
+          .getMetricUtils()
+          .ifPresent(
+              metricUtils ->
+                  metricUtils.histogram(
+                      this.getClass(),
+                      "kafkaLag",
+                      System.currentTimeMillis() - consumerRecord.timestamp()));
       final GenericRecord record = consumerRecord.value();
 
       log.info(

--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/batch/BatchMetadataChangeProposalsProcessor.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/batch/BatchMetadataChangeProposalsProcessor.java
@@ -4,8 +4,6 @@ import static com.linkedin.metadata.config.kafka.KafkaConfiguration.MCP_EVENT_CO
 import static com.linkedin.metadata.utils.metrics.MetricUtils.BATCH_SIZE_ATTR;
 import static com.linkedin.mxe.ConsumerGroups.MCP_CONSUMER_GROUP_ID_VALUE;
 
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.MetricRegistry;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.entityclient.RestliEntityClientFactory;
@@ -57,9 +55,6 @@ public class BatchMetadataChangeProposalsProcessor {
   private final KafkaListenerEndpointRegistry registry;
   private final ConfigurationProvider provider;
 
-  private final Histogram kafkaLagStats =
-      MetricUtils.get().histogram(MetricRegistry.name(this.getClass(), "kafkaLag"));
-
   @Value(
       "${FAILED_METADATA_CHANGE_PROPOSAL_TOPIC_NAME:"
           + Topics.FAILED_METADATA_CHANGE_PROPOSAL
@@ -86,7 +81,14 @@ public class BatchMetadataChangeProposalsProcessor {
     String topicName = null;
 
     for (ConsumerRecord<String, GenericRecord> consumerRecord : consumerRecords) {
-      kafkaLagStats.update(System.currentTimeMillis() - consumerRecord.timestamp());
+      systemOperationContext
+          .getMetricUtils()
+          .ifPresent(
+              metricUtils ->
+                  metricUtils.histogram(
+                      this.getClass(),
+                      "kafkaLag",
+                      System.currentTimeMillis() - consumerRecord.timestamp()));
       final GenericRecord record = consumerRecord.value();
 
       if (topicName == null) {

--- a/metadata-jobs/mce-consumer/src/test/java/com/linkedin/metadata/kafka/MetadataChangeProposalsProcessorTest.java
+++ b/metadata-jobs/mce-consumer/src/test/java/com/linkedin/metadata/kafka/MetadataChangeProposalsProcessorTest.java
@@ -2,14 +2,12 @@ package com.linkedin.metadata.kafka;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.codahale.metrics.MetricRegistry;
 import com.linkedin.common.Status;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -114,7 +112,8 @@ public class MetadataChangeProposalsProcessorTest {
             mockRollbackService,
             mockKafkaProducer,
             new EntityClientCacheConfig(),
-            EntityClientConfig.builder().build());
+            EntityClientConfig.builder().build(),
+            null);
 
     // Setup the processor
     processor =
@@ -131,8 +130,6 @@ public class MetadataChangeProposalsProcessorTest {
     spanMock.when(Span::current).thenReturn(mockSpan);
 
     metricUtilsMock = mockStatic(MetricUtils.class);
-    MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
-    metricUtilsMock.when(MetricUtils::get).thenReturn(mockMetricRegistry);
     metricUtilsMock
         .when(() -> MetricUtils.name(eq(MetadataChangeProposalsProcessor.class), any()))
         .thenReturn("metricName");

--- a/metadata-jobs/pe-consumer/src/test/java/com/datahub/event/PlatformEventProcessorTest.java
+++ b/metadata-jobs/pe-consumer/src/test/java/com/datahub/event/PlatformEventProcessorTest.java
@@ -1,0 +1,400 @@
+package com.datahub.event;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.datahub.authentication.Actor;
+import com.datahub.authentication.ActorType;
+import com.datahub.authentication.Authentication;
+import com.datahub.event.hook.PlatformEventHook;
+import com.linkedin.metadata.EventUtils;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import com.linkedin.mxe.PlatformEvent;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PlatformEventProcessorTest {
+
+  private OperationContext mockOperationContext;
+  private MetricUtils mockMetricUtils;
+  private PlatformEventHook mockHook1;
+  private PlatformEventHook mockHook2;
+  private PlatformEventHook mockDisabledHook;
+  private PlatformEventProcessor processor;
+  private GenericRecord mockGenericRecord;
+  private PlatformEvent mockPlatformEvent;
+  private ConsumerRecord<String, GenericRecord> mockConsumerRecord;
+
+  @BeforeMethod
+  public void setup() {
+    // Create real operation context
+    Authentication auth =
+        new Authentication(new Actor(ActorType.USER, "testUser"), "test:credentials");
+    OperationContext realOperationContext =
+        TestOperationContexts.userContextNoSearchAuthorization(auth);
+
+    // Create a spy of the real operation context to inject mock MetricUtils
+    mockOperationContext = Mockito.spy(realOperationContext);
+
+    // Create mock MetricUtils
+    mockMetricUtils = mock(MetricUtils.class);
+    when(mockOperationContext.getMetricUtils()).thenReturn(Optional.of(mockMetricUtils));
+
+    // Create mock hooks
+    mockHook1 = mock(PlatformEventHook.class);
+    when(mockHook1.isEnabled()).thenReturn(true);
+
+    mockHook2 = mock(PlatformEventHook.class);
+    when(mockHook2.isEnabled()).thenReturn(true);
+
+    mockDisabledHook = mock(PlatformEventHook.class);
+    when(mockDisabledHook.isEnabled()).thenReturn(false);
+
+    // Create mock generic record and platform event
+    mockGenericRecord = mock(GenericRecord.class);
+    mockPlatformEvent = mock(PlatformEvent.class);
+    when(mockPlatformEvent.getName()).thenReturn("TestEvent");
+
+    // Create mock consumer record
+    mockConsumerRecord = mock(ConsumerRecord.class);
+    when(mockConsumerRecord.value()).thenReturn(mockGenericRecord);
+    when(mockConsumerRecord.key()).thenReturn("test-key");
+    when(mockConsumerRecord.topic()).thenReturn("platform_event_topic");
+    when(mockConsumerRecord.partition()).thenReturn(0);
+    when(mockConsumerRecord.offset()).thenReturn(100L);
+    when(mockConsumerRecord.timestamp()).thenReturn(1234567890L);
+    when(mockConsumerRecord.serializedValueSize()).thenReturn(1024);
+  }
+
+  @Test
+  public void testConstructorFiltersEnabledHooks() {
+    // Create processor with mixed enabled/disabled hooks
+    List<PlatformEventHook> allHooks = Arrays.asList(mockHook1, mockDisabledHook, mockHook2);
+    processor = new PlatformEventProcessor(mockOperationContext, allHooks);
+
+    // Verify only enabled hooks are kept
+    assertEquals(processor.getHooks().size(), 2);
+    assertTrue(processor.getHooks().contains(mockHook1));
+    assertTrue(processor.getHooks().contains(mockHook2));
+    assertTrue(!processor.getHooks().contains(mockDisabledHook));
+
+    // Verify init is called only on enabled hooks
+    verify(mockHook1, times(1)).init();
+    verify(mockHook2, times(1)).init();
+    verify(mockDisabledHook, never()).init();
+  }
+
+  @Test
+  public void testConstructorWithNoHooks() {
+    processor = new PlatformEventProcessor(mockOperationContext, Collections.emptyList());
+    assertEquals(processor.getHooks().size(), 0);
+  }
+
+  @Test
+  public void testConsumeSuccessful() throws Exception {
+    // Setup
+    List<PlatformEventHook> hooks = Arrays.asList(mockHook1, mockHook2);
+    processor = new PlatformEventProcessor(mockOperationContext, hooks);
+
+    try (MockedStatic<EventUtils> mockedEventUtils = Mockito.mockStatic(EventUtils.class)) {
+      mockedEventUtils
+          .when(() -> EventUtils.avroToPegasusPE(mockGenericRecord))
+          .thenReturn(mockPlatformEvent);
+
+      // Execute
+      processor.consume(mockConsumerRecord);
+
+      // Verify metrics
+      verify(mockMetricUtils, times(1))
+          .histogram(eq(PlatformEventProcessor.class), eq("kafkaLag"), anyLong());
+      verify(mockMetricUtils, times(1))
+          .increment(eq(PlatformEventProcessor.class), eq("received_pe_count"), eq(1d));
+      verify(mockMetricUtils, times(1))
+          .increment(eq(PlatformEventProcessor.class), eq("consumed_pe_count"), eq(1d));
+
+      // Verify hooks were invoked
+      verify(mockHook1, times(1)).invoke(any(OperationContext.class), eq(mockPlatformEvent));
+      verify(mockHook2, times(1)).invoke(any(OperationContext.class), eq(mockPlatformEvent));
+    }
+  }
+
+  @Test
+  public void testConsumeWithAvroConversionFailure() throws Exception {
+    // Setup
+    List<PlatformEventHook> hooks = Arrays.asList(mockHook1);
+    processor = new PlatformEventProcessor(mockOperationContext, hooks);
+
+    try (MockedStatic<EventUtils> mockedEventUtils = Mockito.mockStatic(EventUtils.class)) {
+      mockedEventUtils
+          .when(() -> EventUtils.avroToPegasusPE(mockGenericRecord))
+          .thenThrow(new RuntimeException("Conversion failed"));
+
+      // Execute
+      processor.consume(mockConsumerRecord);
+
+      // Verify metrics
+      verify(mockMetricUtils, times(1))
+          .increment(
+              eq(PlatformEventProcessor.class), eq("avro_to_pegasus_conversion_failure"), eq(1d));
+
+      // Verify hook was NOT invoked due to conversion failure
+      verify(mockHook1, never()).invoke(any(OperationContext.class), any(PlatformEvent.class));
+
+      // Verify consumed_pe_count was NOT incremented
+      verify(mockMetricUtils, never())
+          .increment(eq(PlatformEventProcessor.class), eq("consumed_pe_count"), eq(1d));
+    }
+  }
+
+  @Test
+  public void testConsumeWithHookFailure() throws Exception {
+    // Setup
+    List<PlatformEventHook> hooks = Arrays.asList(mockHook1, mockHook2);
+    processor = new PlatformEventProcessor(mockOperationContext, hooks);
+
+    // Make first hook throw exception
+    doThrow(new RuntimeException("Hook 1 failed"))
+        .when(mockHook1)
+        .invoke(any(OperationContext.class), any(PlatformEvent.class));
+
+    try (MockedStatic<EventUtils> mockedEventUtils = Mockito.mockStatic(EventUtils.class)) {
+      mockedEventUtils
+          .when(() -> EventUtils.avroToPegasusPE(mockGenericRecord))
+          .thenReturn(mockPlatformEvent);
+
+      // Execute
+      processor.consume(mockConsumerRecord);
+
+      // Verify failure metric for hook1
+      ArgumentCaptor<String> metricNameCaptor = ArgumentCaptor.forClass(String.class);
+      verify(mockMetricUtils, times(3))
+          .increment(eq(PlatformEventProcessor.class), metricNameCaptor.capture(), eq(1d));
+
+      List<String> capturedMetrics = metricNameCaptor.getAllValues();
+      assertTrue(capturedMetrics.contains("received_pe_count"));
+      assertTrue(capturedMetrics.stream().anyMatch(m -> m.contains("_failure")));
+      assertTrue(capturedMetrics.contains("consumed_pe_count"));
+
+      // Verify both hooks were invoked (failure in hook1 doesn't stop hook2)
+      verify(mockHook1, times(1)).invoke(any(OperationContext.class), eq(mockPlatformEvent));
+      verify(mockHook2, times(1)).invoke(any(OperationContext.class), eq(mockPlatformEvent));
+    }
+  }
+
+  @Test
+  public void testConsumeWithAllHooksFailing() throws Exception {
+    // Setup
+    List<PlatformEventHook> hooks = Arrays.asList(mockHook1, mockHook2);
+    processor = new PlatformEventProcessor(mockOperationContext, hooks);
+
+    // Make both hooks throw exceptions
+    doThrow(new RuntimeException("Hook 1 failed"))
+        .when(mockHook1)
+        .invoke(any(OperationContext.class), any(PlatformEvent.class));
+    doThrow(new RuntimeException("Hook 2 failed"))
+        .when(mockHook2)
+        .invoke(any(OperationContext.class), any(PlatformEvent.class));
+
+    try (MockedStatic<EventUtils> mockedEventUtils = Mockito.mockStatic(EventUtils.class)) {
+      mockedEventUtils
+          .when(() -> EventUtils.avroToPegasusPE(mockGenericRecord))
+          .thenReturn(mockPlatformEvent);
+
+      // Execute
+      processor.consume(mockConsumerRecord);
+
+      // Verify failure metrics for both hooks
+      ArgumentCaptor<String> metricNameCaptor = ArgumentCaptor.forClass(String.class);
+      verify(mockMetricUtils, times(4))
+          .increment(eq(PlatformEventProcessor.class), metricNameCaptor.capture(), eq(1d));
+
+      List<String> capturedMetrics = metricNameCaptor.getAllValues();
+      assertTrue(capturedMetrics.contains("received_pe_count"));
+      assertTrue(capturedMetrics.stream().filter(m -> m.contains("_failure")).count() == 2);
+      assertTrue(capturedMetrics.contains("consumed_pe_count"));
+
+      // Verify both hooks were still invoked
+      verify(mockHook1, times(1)).invoke(any(OperationContext.class), eq(mockPlatformEvent));
+      verify(mockHook2, times(1)).invoke(any(OperationContext.class), eq(mockPlatformEvent));
+    }
+  }
+
+  @Test
+  public void testConsumeWithNullMetricUtils() throws Exception {
+    // Setup operation context without metric utils
+    when(mockOperationContext.getMetricUtils()).thenReturn(Optional.empty());
+
+    List<PlatformEventHook> hooks = Arrays.asList(mockHook1);
+    processor = new PlatformEventProcessor(mockOperationContext, hooks);
+
+    try (MockedStatic<EventUtils> mockedEventUtils = Mockito.mockStatic(EventUtils.class)) {
+      mockedEventUtils
+          .when(() -> EventUtils.avroToPegasusPE(mockGenericRecord))
+          .thenReturn(mockPlatformEvent);
+
+      // Execute - should not throw even without metrics
+      processor.consume(mockConsumerRecord);
+
+      // Verify hook was still invoked
+      verify(mockHook1, times(1)).invoke(any(OperationContext.class), eq(mockPlatformEvent));
+    }
+  }
+
+  @Test
+  public void testConsumeVerifiesKafkaRecordDetails() throws Exception {
+    // Setup
+    List<PlatformEventHook> hooks = Arrays.asList(mockHook1);
+    processor = new PlatformEventProcessor(mockOperationContext, hooks);
+
+    // Set up specific consumer record values
+    String expectedKey = "test-key-123";
+    String expectedTopic = "platform_event_topic_v2";
+    int expectedPartition = 3;
+    long expectedOffset = 999L;
+    long expectedTimestamp = 1234567890L;
+    int expectedValueSize = 2048;
+
+    ConsumerRecord<String, GenericRecord> specificMockRecord = mock(ConsumerRecord.class);
+    when(specificMockRecord.value()).thenReturn(mockGenericRecord);
+    when(specificMockRecord.key()).thenReturn(expectedKey);
+    when(specificMockRecord.topic()).thenReturn(expectedTopic);
+    when(specificMockRecord.partition()).thenReturn(expectedPartition);
+    when(specificMockRecord.offset()).thenReturn(expectedOffset);
+    when(specificMockRecord.timestamp()).thenReturn(expectedTimestamp);
+    when(specificMockRecord.serializedValueSize()).thenReturn(expectedValueSize);
+
+    try (MockedStatic<EventUtils> mockedEventUtils = Mockito.mockStatic(EventUtils.class)) {
+      mockedEventUtils
+          .when(() -> EventUtils.avroToPegasusPE(mockGenericRecord))
+          .thenReturn(mockPlatformEvent);
+
+      // Execute
+      processor.consume(specificMockRecord);
+
+      // Verify lag calculation uses the correct timestamp
+      ArgumentCaptor<Long> lagCaptor = ArgumentCaptor.forClass(Long.class);
+      verify(mockMetricUtils)
+          .histogram(eq(PlatformEventProcessor.class), eq("kafkaLag"), lagCaptor.capture());
+
+      // Lag should be calculated as current time - record timestamp
+      long capturedLag = lagCaptor.getValue();
+      assertTrue(capturedLag >= 0, "Lag should be non-negative");
+
+      // Verify that the consumer record methods were called
+      // Note: some methods may be called multiple times (e.g., for logging and metrics)
+      verify(specificMockRecord, times(1)).key();
+      verify(specificMockRecord, times(1)).topic();
+      verify(specificMockRecord, times(1)).partition();
+      verify(specificMockRecord, times(1)).offset();
+      verify(specificMockRecord, times(2))
+          .timestamp(); // Called twice: once for lag calculation, once for logging
+      verify(specificMockRecord, times(1)).serializedValueSize();
+      verify(specificMockRecord, times(1)).value(); // Called to get the GenericRecord
+    }
+  }
+
+  @Test
+  public void testMultipleEventsProcessedSequentially() throws Exception {
+    // Setup
+    List<PlatformEventHook> hooks = Arrays.asList(mockHook1);
+    processor = new PlatformEventProcessor(mockOperationContext, hooks);
+
+    PlatformEvent event1 = mock(PlatformEvent.class);
+    when(event1.getName()).thenReturn("Event1");
+
+    PlatformEvent event2 = mock(PlatformEvent.class);
+    when(event2.getName()).thenReturn("Event2");
+
+    GenericRecord record1 = mock(GenericRecord.class);
+    GenericRecord record2 = mock(GenericRecord.class);
+
+    ConsumerRecord<String, GenericRecord> consumerRecord1 = mock(ConsumerRecord.class);
+    when(consumerRecord1.value()).thenReturn(record1);
+    when(consumerRecord1.key()).thenReturn("key1");
+    when(consumerRecord1.topic()).thenReturn("platform_event_topic");
+    when(consumerRecord1.partition()).thenReturn(0);
+    when(consumerRecord1.offset()).thenReturn(100L);
+    when(consumerRecord1.timestamp()).thenReturn(1234567890L);
+    when(consumerRecord1.serializedValueSize()).thenReturn(512);
+
+    ConsumerRecord<String, GenericRecord> consumerRecord2 = mock(ConsumerRecord.class);
+    when(consumerRecord2.value()).thenReturn(record2);
+    when(consumerRecord2.key()).thenReturn("key2");
+    when(consumerRecord2.topic()).thenReturn("platform_event_topic");
+    when(consumerRecord2.partition()).thenReturn(0);
+    when(consumerRecord2.offset()).thenReturn(101L);
+    when(consumerRecord2.timestamp()).thenReturn(1234567891L);
+    when(consumerRecord2.serializedValueSize()).thenReturn(768);
+
+    try (MockedStatic<EventUtils> mockedEventUtils = Mockito.mockStatic(EventUtils.class)) {
+      mockedEventUtils.when(() -> EventUtils.avroToPegasusPE(record1)).thenReturn(event1);
+      mockedEventUtils.when(() -> EventUtils.avroToPegasusPE(record2)).thenReturn(event2);
+
+      // Execute
+      processor.consume(consumerRecord1);
+      processor.consume(consumerRecord2);
+
+      // Verify both events were processed
+      verify(mockHook1, times(1)).invoke(any(OperationContext.class), eq(event1));
+      verify(mockHook1, times(1)).invoke(any(OperationContext.class), eq(event2));
+
+      // Verify metrics were incremented twice
+      verify(mockMetricUtils, times(2))
+          .increment(eq(PlatformEventProcessor.class), eq("received_pe_count"), eq(1d));
+      verify(mockMetricUtils, times(2))
+          .increment(eq(PlatformEventProcessor.class), eq("consumed_pe_count"), eq(1d));
+    }
+  }
+
+  @Test
+  public void testConsumeWithNullGenericRecord() throws Exception {
+    // Setup
+    List<PlatformEventHook> hooks = Arrays.asList(mockHook1);
+    processor = new PlatformEventProcessor(mockOperationContext, hooks);
+
+    ConsumerRecord<String, GenericRecord> nullValueRecord = mock(ConsumerRecord.class);
+    when(nullValueRecord.value()).thenReturn(null);
+    when(nullValueRecord.key()).thenReturn("test-key");
+    when(nullValueRecord.topic()).thenReturn("platform_event_topic");
+    when(nullValueRecord.partition()).thenReturn(0);
+    when(nullValueRecord.offset()).thenReturn(100L);
+    when(nullValueRecord.timestamp()).thenReturn(1234567890L);
+    when(nullValueRecord.serializedValueSize()).thenReturn(0);
+
+    try (MockedStatic<EventUtils> mockedEventUtils = Mockito.mockStatic(EventUtils.class)) {
+      mockedEventUtils
+          .when(() -> EventUtils.avroToPegasusPE(null))
+          .thenThrow(new NullPointerException("Record is null"));
+
+      // Execute
+      processor.consume(nullValueRecord);
+
+      // Verify conversion failure metric
+      verify(mockMetricUtils, times(1))
+          .increment(eq(PlatformEventProcessor.class), eq("null_record"), eq(1d));
+
+      // Verify hook was NOT invoked
+      verify(mockHook1, never()).invoke(any(OperationContext.class), any(PlatformEvent.class));
+    }
+  }
+}

--- a/metadata-operation-context/build.gradle
+++ b/metadata-operation-context/build.gradle
@@ -8,7 +8,8 @@ dependencies {
   api project(':metadata-auth:auth-api')
 
   // https://mvnrepository.com/artifact/nl.basjes.parse.useragent/yauaa
-  api 'nl.basjes.parse.useragent:yauaa:7.30.0'
+  // latest caffeine 3.1.8 compatible
+  api 'nl.basjes.parse.useragent:yauaa:7.29.0'
 
   implementation externalDependency.slf4jApi
   implementation externalDependency.servletApi

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.SystemMetadata;
 import io.datahubproject.metadata.exception.ActorAccessException;
 import io.datahubproject.metadata.exception.OperationContextException;
@@ -70,13 +71,13 @@ public class OperationContext implements AuthorizationSession {
   @Nonnull
   public static OperationContext asSession(
       OperationContext systemOperationContext,
-      @Nonnull RequestContext requestContext,
+      @Nonnull RequestContext.RequestContextBuilder requestContext,
       @Nonnull Authorizer authorizer,
       @Nonnull Authentication sessionAuthentication,
       boolean allowSystemAuthentication) {
     return OperationContext.asSession(
         systemOperationContext,
-        requestContext,
+        requestContext.metricUtils(systemOperationContext.getMetricUtils().orElse(null)),
         authorizer,
         sessionAuthentication,
         allowSystemAuthentication,
@@ -86,7 +87,7 @@ public class OperationContext implements AuthorizationSession {
   @Nonnull
   public static OperationContext asSession(
       OperationContext systemOperationContext,
-      @Nonnull RequestContext requestContext,
+      @Nonnull RequestContext.RequestContextBuilder requestContext,
       @Nonnull Authorizer authorizer,
       @Nonnull Authentication sessionAuthentication,
       boolean allowSystemAuthentication,
@@ -99,7 +100,10 @@ public class OperationContext implements AuthorizationSession {
                 .allowSystemAuthentication(allowSystemAuthentication)
                 .build())
         .authorizationContext(AuthorizationContext.builder().authorizer(authorizer).build())
-        .requestContext(requestContext)
+        .requestContext(
+            requestContext
+                .metricUtils(systemOperationContext.getMetricUtils().orElse(null))
+                .build())
         .validationContext(systemOperationContext.getValidationContext())
         .build(sessionAuthentication, skipCache);
   }
@@ -162,7 +166,7 @@ public class OperationContext implements AuthorizationSession {
       @Nullable IndexConvention indexConvention,
       @Nullable RetrieverContext retrieverContext,
       @Nonnull ValidationContext validationContext,
-      @Nullable TraceContext traceContext,
+      @Nullable SystemTelemetryContext systemTelemetryContext,
       boolean enforceExistenceEnabled) {
     return asSystem(
         config,
@@ -173,7 +177,7 @@ public class OperationContext implements AuthorizationSession {
         retrieverContext,
         validationContext,
         ObjectMapperContext.DEFAULT,
-        traceContext,
+        systemTelemetryContext,
         enforceExistenceEnabled);
   }
 
@@ -186,7 +190,7 @@ public class OperationContext implements AuthorizationSession {
       @Nullable RetrieverContext retrieverContext,
       @Nonnull ValidationContext validationContext,
       @Nonnull ObjectMapperContext objectMapperContext,
-      @Nullable TraceContext traceContext,
+      @Nullable SystemTelemetryContext systemTelemetryContext,
       boolean enforceExistenceEnabled) {
 
     ActorContext systemActorContext =
@@ -215,7 +219,7 @@ public class OperationContext implements AuthorizationSession {
           .retrieverContext(retrieverContext)
           .objectMapperContext(objectMapperContext)
           .validationContext(validationContext)
-          .traceContext(traceContext)
+          .systemTelemetryContext(systemTelemetryContext)
           .build(systemAuthentication, false);
     } catch (OperationContextException e) {
       throw new RuntimeException(e);
@@ -233,7 +237,7 @@ public class OperationContext implements AuthorizationSession {
   @Nonnull private final RetrieverContext retrieverContext;
   @Nonnull private final ObjectMapperContext objectMapperContext;
   @Nonnull private final ValidationContext validationContext;
-  @Nullable private final TraceContext traceContext;
+  @Nullable private final SystemTelemetryContext systemTelemetryContext;
 
   public OperationContext withSearchFlags(
       @Nonnull Function<SearchFlags, SearchFlags> flagDefaults) {
@@ -246,13 +250,13 @@ public class OperationContext implements AuthorizationSession {
   }
 
   public OperationContext asSession(
-      @Nonnull RequestContext requestContext,
+      @Nonnull RequestContext.RequestContextBuilder requestContext,
       @Nonnull Authorizer authorizer,
       @Nonnull Authentication sessionAuthentication)
       throws ActorAccessException {
     return OperationContext.asSession(
         this,
-        requestContext,
+        requestContext.metricUtils(getMetricUtils().orElse(null)),
         authorizer,
         sessionAuthentication,
         getOperationContextConfig().isAllowSystemAuthentication(),
@@ -378,16 +382,16 @@ public class OperationContext implements AuthorizationSession {
 
   @Nullable
   public SystemMetadata withTraceId(@Nullable SystemMetadata systemMetadata, boolean force) {
-    if (systemMetadata != null && traceContext != null) {
-      return traceContext.withTraceId(systemMetadata, force);
+    if (systemMetadata != null && systemTelemetryContext != null) {
+      return systemTelemetryContext.withTraceId(systemMetadata, force);
     }
     return systemMetadata;
   }
 
   public SystemMetadata withProducerTrace(
       String operationName, @Nullable SystemMetadata systemMetadata, String topicName) {
-    if (systemMetadata != null && traceContext != null) {
-      return traceContext.withProducerTrace(operationName, systemMetadata, topicName);
+    if (systemMetadata != null && systemTelemetryContext != null) {
+      return systemTelemetryContext.withProducerTrace(operationName, systemMetadata, topicName);
     }
     return systemMetadata;
   }
@@ -402,16 +406,16 @@ public class OperationContext implements AuthorizationSession {
    * @param <T> generic
    */
   public <T> T withSpan(String name, Supplier<T> operation, String... attributes) {
-    if (traceContext != null) {
-      return traceContext.withSpan(name, operation, attributes);
+    if (systemTelemetryContext != null) {
+      return systemTelemetryContext.withSpan(name, operation, attributes);
     } else {
       return operation.get();
     }
   }
 
   public void withSpan(String name, Runnable operation, String... attributes) {
-    if (traceContext != null) {
-      traceContext.withSpan(name, operation, attributes);
+    if (systemTelemetryContext != null) {
+      systemTelemetryContext.withSpan(name, operation, attributes);
     } else {
       operation.run();
     }
@@ -436,8 +440,8 @@ public class OperationContext implements AuthorizationSession {
       String topicName,
       Runnable operation,
       String... attributes) {
-    if (traceContext != null) {
-      traceContext.withQueueSpan(name, systemMetadata, topicName, operation, attributes);
+    if (systemTelemetryContext != null) {
+      systemTelemetryContext.withQueueSpan(name, systemMetadata, topicName, operation, attributes);
     } else {
       operation.run();
     }
@@ -452,6 +456,10 @@ public class OperationContext implements AuthorizationSession {
       log.error("Error creating trace.", e);
     }
     return throwables.stream().map(Throwable::getMessage).collect(Collectors.joining("\n"));
+  }
+
+  public Optional<MetricUtils> getMetricUtils() {
+    return Optional.ofNullable(systemTelemetryContext).map(SystemTelemetryContext::getMetricUtils);
   }
 
   /**
@@ -482,7 +490,10 @@ public class OperationContext implements AuthorizationSession {
             .add(getRequestContext() == null ? EmptyContext.EMPTY : getRequestContext())
             .add(getRetrieverContext())
             .add(getObjectMapperContext())
-            .add(getTraceContext() == null ? EmptyContext.EMPTY : getTraceContext())
+            .add(
+                getSystemTelemetryContext() == null
+                    ? EmptyContext.EMPTY
+                    : getSystemTelemetryContext())
             .build()
             .stream()
             .map(ContextInterface::getCacheKeyComponent)
@@ -626,7 +637,7 @@ public class OperationContext implements AuthorizationSession {
           this.retrieverContext,
           this.objectMapperContext != null ? this.objectMapperContext : ObjectMapperContext.DEFAULT,
           this.validationContext,
-          this.traceContext);
+          this.systemTelemetryContext);
     }
 
     private OperationContext build() {

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/SystemTelemetryContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/SystemTelemetryContext.java
@@ -10,6 +10,8 @@ import com.linkedin.data.template.StringMap;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.SystemMetadata;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
@@ -43,8 +45,14 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Getter
-@Builder
-public class TraceContext implements ContextInterface {
+@Builder(toBuilder = true)
+public class SystemTelemetryContext implements ContextInterface {
+  public static final SystemTelemetryContext TEST =
+      SystemTelemetryContext.builder()
+          .metricUtils(MetricUtils.builder().registry(new SimpleMeterRegistry()).build())
+          .tracer(OpenTelemetry.noop().getTracer("test"))
+          .build();
+
   // trace logging
   public static final String TRACE_HEADER = "X-Enable-Trace-Log";
   public static final String TRACE_COOKIE = "enable-trace-log";
@@ -98,6 +106,7 @@ public class TraceContext implements ContextInterface {
     logTracingEnabled.set(false);
   }
 
+  @Nullable private final MetricUtils metricUtils;
   @Getter @Nonnull private final Tracer tracer;
   @Getter @Nullable private final SpanProcessor usageSpanExporter;
 

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
@@ -35,13 +35,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class OperationContextTest {
-  private TraceContext mockTraceContext;
+  private SystemTelemetryContext mockSystemTelemetryContext;
   private SystemMetadata mockSystemMetadata;
   private ObjectMapper mockObjectMapper;
 
   @BeforeMethod
   public void setUp() {
-    mockTraceContext = mock(TraceContext.class);
+    mockSystemTelemetryContext = mock(SystemTelemetryContext.class);
     mockSystemMetadata = mock(SystemMetadata.class);
     mockObjectMapper = mock(ObjectMapper.class);
   }
@@ -106,12 +106,12 @@ public class OperationContextTest {
 
   @Test
   public void testWithTraceId_WithTraceContextAndSystemMetadata() {
-    when(mockTraceContext.withTraceId(eq(mockSystemMetadata), anyBoolean()))
+    when(mockSystemTelemetryContext.withTraceId(eq(mockSystemMetadata), anyBoolean()))
         .thenReturn(mockSystemMetadata);
 
     SystemMetadata result = buildTraceMock().withTraceId(mockSystemMetadata);
 
-    verify(mockTraceContext).withTraceId(mockSystemMetadata, false);
+    verify(mockSystemTelemetryContext).withTraceId(mockSystemMetadata, false);
     assertEquals(result, mockSystemMetadata);
   }
 
@@ -119,7 +119,7 @@ public class OperationContextTest {
   public void testWithTraceId_NullSystemMetadata() {
     SystemMetadata result = buildTraceMock().withTraceId(null);
 
-    verifyNoInteractions(mockTraceContext);
+    verifyNoInteractions(mockSystemTelemetryContext);
     assertNull(result);
   }
 
@@ -149,12 +149,12 @@ public class OperationContextTest {
               Supplier<?> capturedSupplier = invocation.getArgument(1);
               return capturedSupplier.get();
             })
-        .when(mockTraceContext)
+        .when(mockSystemTelemetryContext)
         .withSpan(eq(spanName), any(Supplier.class), eq(attributes));
 
     String result = buildTraceMock().withSpan(spanName, operation, attributes);
 
-    verify(mockTraceContext).withSpan(eq(spanName), any(Supplier.class), eq(attributes));
+    verify(mockSystemTelemetryContext).withSpan(eq(spanName), any(Supplier.class), eq(attributes));
     assertTrue(operationExecuted[0], "The operation supplier should have been executed");
     assertEquals(result, "result", "The result should match the operation's return value");
   }
@@ -180,7 +180,7 @@ public class OperationContextTest {
 
     buildTraceMock().withSpan(spanName, operation, attributes);
 
-    verify(mockTraceContext).withSpan(eq(spanName), eq(operation), eq(attributes));
+    verify(mockSystemTelemetryContext).withSpan(eq(spanName), eq(operation), eq(attributes));
     verifyNoMoreInteractions(operation);
   }
 
@@ -193,7 +193,7 @@ public class OperationContextTest {
 
     buildTraceMock().withQueueSpan(spanName, mockSystemMetadata, topicName, operation, attributes);
 
-    verify(mockTraceContext)
+    verify(mockSystemTelemetryContext)
         .withQueueSpan(
             eq(spanName),
             eq(List.of(mockSystemMetadata)),
@@ -212,7 +212,7 @@ public class OperationContextTest {
 
     buildTraceMock().withQueueSpan(spanName, systemMetadataList, topicName, operation, attributes);
 
-    verify(mockTraceContext)
+    verify(mockSystemTelemetryContext)
         .withQueueSpan(
             eq(spanName), eq(systemMetadataList), eq(topicName), eq(operation), eq(attributes));
   }
@@ -307,9 +307,9 @@ public class OperationContextTest {
     return buildTraceMock(null);
   }
 
-  private OperationContext buildTraceMock(Supplier<TraceContext> traceContextSupplier) {
+  private OperationContext buildTraceMock(Supplier<SystemTelemetryContext> traceContextSupplier) {
     return TestOperationContexts.systemContextTraceNoSearchAuthorization(
         () -> ObjectMapperContext.builder().objectMapper(mockObjectMapper).build(),
-        traceContextSupplier == null ? () -> mockTraceContext : traceContextSupplier);
+        traceContextSupplier == null ? () -> mockSystemTelemetryContext : traceContextSupplier);
   }
 }

--- a/metadata-service/auth-config/build.gradle
+++ b/metadata-service/auth-config/build.gradle
@@ -6,7 +6,7 @@ apply from: '../../gradle/coverage/java-coverage.gradle'
 
 dependencies {
   implementation project(path: ':metadata-models')
-  implementation project(path: ':metadata-auth:auth-api')
+  implementation project(path: ':metadata-auth:auth-api', configuration: 'shadow')
   implementation externalDependency.guava
   implementation externalDependency.slf4jApi
   compileOnly externalDependency.lombok

--- a/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceTestConfiguration.java
+++ b/metadata-service/auth-servlet-impl/src/test/java/com/datahub/auth/authentication/AuthServiceTestConfiguration.java
@@ -12,7 +12,7 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.entity.EntityService;
 import io.datahubproject.metadata.context.ObjectMapperContext;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.metadata.services.SecretService;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.opentelemetry.api.trace.SpanContext;
@@ -46,10 +46,11 @@ public class AuthServiceTestConfiguration {
 
   @Bean(name = "systemOperationContext")
   public OperationContext systemOperationContext(ObjectMapper objectMapper) {
-    TraceContext mockTraceContext = TraceContext.builder().tracer(mockTracer).build();
+    SystemTelemetryContext mockSystemTelemetryContext =
+        SystemTelemetryContext.builder().tracer(mockTracer).build();
     return TestOperationContexts.systemContextTraceNoSearchAuthorization(
         () -> ObjectMapperContext.builder().objectMapper(objectMapper).build(),
-        () -> mockTraceContext);
+        () -> mockSystemTelemetryContext);
   }
 
   @Bean

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/GraphQLConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/GraphQLConfiguration.java
@@ -1,9 +1,13 @@
 package com.linkedin.metadata.config;
 
+import com.linkedin.metadata.config.graphql.GraphQLConcurrencyConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLMetricsConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLQueryConfiguration;
 import lombok.Data;
 
 @Data
 public class GraphQLConfiguration {
   private GraphQLQueryConfiguration query;
   private GraphQLConcurrencyConfiguration concurrency;
+  private GraphQLMetricsConfiguration metrics;
 }

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/cache/client/ClientCacheConfig.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/cache/client/ClientCacheConfig.java
@@ -1,6 +1,8 @@
 package com.linkedin.metadata.config.cache.client;
 
 public interface ClientCacheConfig {
+  String getName();
+
   boolean isEnabled();
 
   boolean isStatsEnabled();

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/cache/client/EntityClientCacheConfig.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/cache/client/EntityClientCacheConfig.java
@@ -5,6 +5,7 @@ import lombok.Data;
 
 @Data
 public class EntityClientCacheConfig implements ClientCacheConfig {
+  private String name = "entityClient";
   private boolean enabled;
   private boolean statsEnabled;
   private int statsIntervalSeconds;

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/cache/client/UsageClientCacheConfig.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/cache/client/UsageClientCacheConfig.java
@@ -4,6 +4,7 @@ import lombok.Data;
 
 @Data
 public class UsageClientCacheConfig implements ClientCacheConfig {
+  private String name = "usageClient";
   private boolean enabled;
   private boolean statsEnabled;
   private int statsIntervalSeconds;

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/graphql/GraphQLConcurrencyConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/graphql/GraphQLConcurrencyConfiguration.java
@@ -1,4 +1,4 @@
-package com.linkedin.metadata.config;
+package com.linkedin.metadata.config.graphql;
 
 import lombok.Data;
 

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/graphql/GraphQLMetricsConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/graphql/GraphQLMetricsConfiguration.java
@@ -1,0 +1,14 @@
+package com.linkedin.metadata.config.graphql;
+
+import lombok.Data;
+
+@Data
+public class GraphQLMetricsConfiguration {
+  private boolean enabled;
+  private String percentiles;
+  private boolean fieldLevelEnabled;
+  private String fieldLevelOperations;
+  private boolean fieldLevelPathEnabled;
+  private String fieldLevelPaths;
+  private boolean trivialDataFetchersEnabled;
+}

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/graphql/GraphQLQueryConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/graphql/GraphQLQueryConfiguration.java
@@ -1,4 +1,4 @@
-package com.linkedin.metadata.config;
+package com.linkedin.metadata.config.graphql;
 
 import lombok.Data;
 

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -8,7 +8,7 @@ baseUrl: ${DATAHUB_BASE_URL:http://localhost:9002}
 authentication:
   # Enable if you want all requests to the Metadata Service to be authenticated.
   enabled: ${METADATA_SERVICE_AUTH_ENABLED:true}
-  excludedPaths: /schema-registry/*,/health,/config,/config/search/export,/public-iceberg/*
+  excludedPaths: /schema-registry/*,/health,/config,/config/search/export,/public-iceberg/*,/actuator/prometheus
 
   # Disable if you want to skip validation of deleted user's tokens
   enforceExistenceEnabled: ${METADATA_SERVICE_AUTH_ENFORCE_EXISTENCE_ENABLED:true}
@@ -405,6 +405,56 @@ spring:
   kafka:
     security:
       protocol: ${KAFKA_PROPERTIES_SECURITY_PROTOCOL:PLAINTEXT}
+  autoconfigure:
+    exclude:
+      # We don't use these
+      - org.springframework.boot.actuate.autoconfigure.cassandra.CassandraHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.cassandra.CassandraReactiveHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.elasticsearch.ElasticSearchRestHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.jdbc.DataSourceHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.jms.JmsHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.mail.MailHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.mongo.MongoHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.mongo.MongoReactiveHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.neo4j.Neo4jHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.redis.RedisHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.redis.RedisReactiveHealthContributorAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.tracing.OpenTelemetryTracingAutoConfiguration
+      # These are overridden with more complex configuration
+      - org.springframework.boot.actuate.autoconfigure.tracing.otlp.OtlpAutoConfiguration
+      - org.springframework.boot.actuate.autoconfigure.metrics.export.otlp.OtlpMetricsExportAutoConfiguration
+
+management:
+  health:
+    defaults:
+      enabled: false
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,info,healthcheck,metrics
+    jmx:
+      enabled: true
+  # Opentelemetry
+  tracing:
+    enabled: true
+    propagation:
+      type: W3C
+  otlp:
+    tracing:
+      export:
+        enabled: false
+  # Micrometer Configuration
+  metrics:
+    cache:
+      enabled: false
+    export:
+      jmx:
+        enabled: ${MANAGEMENT_METRICS_EXPORT_JMX_ENABLED:true} # Enable jmx metrics export
+      prometheus:
+        enabled: ${MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED:true} # Enable prometheus metrics export
+    tags:
+      application: ${spring.application.name}
 
 # Useful to debug low-level Spring errors such as class version mismatches
 server:
@@ -678,6 +728,46 @@ graphQL:
     complexityLimit: ${GRAPHQL_QUERY_COMPLEXITY_LIMIT:2000}
     depthLimit: ${GRAPHQL_QUERY_DEPTH_LIMIT:50}
     introspectionEnabled: ${GRAPHQL_QUERY_INTROSPECTION_ENABLED:true}
+  metrics:
+    # Master switch for all GraphQL metrics collection via Micrometer
+    # When false, no GraphQL metrics are collected (request-level or field-level)
+    enabled: ${GRAPHQL_METRICS_ENABLED:true}
+    percentiles: ${GRAPHQL_PERCENTILES:0.5,0.95,0.99,0.9995}
+
+    # Enable field-level resolver metrics collection
+    # When true, timing metrics are collected for individual GraphQL field resolvers
+    # This can add overhead for queries with many fields, so consider enabling selectively
+    # Metrics include: graphql.field.duration, graphql.field.errors
+    fieldLevelEnabled: ${GRAPHQL_METRICS_FIELD_LEVEL_ENABLED:false}
+
+    # Comma-delimited list of GraphQL operation names to instrument at field level
+    # When specified, only these operations will have field-level metrics collected
+    # Empty or unset means all operations are instrumented (if fieldLevelEnabled=true)
+    # Example: "getSearchResultsForMultiple,searchAcrossLineageStructure"
+    # Use case: Enable detailed metrics only for known slow or critical operations
+    fieldLevelOperations: ${GRAPHQL_METRICS_FIELD_LEVEL_OPERATIONS:getSearchResultsForMultiple,searchAcrossLineageStructure}
+
+    # Include the field path as a tag in field-level metrics
+    # WARNING: Can cause high cardinality if your schema has array fields
+    # Paths are truncated to replace array indices with * (e.g., /users/0/name -> /users/*/name)
+    # Only enable for debugging specific issues, not recommended for production
+    fieldLevelPathEnabled: ${GRAPHQL_METRICS_FIELD_LEVEL_PATH_ENABLED:false}
+
+    # Comma-delimited list of GraphQL field path patterns to instrument
+    # Works in conjunction with fieldLevelOperations - both conditions must match if both are set
+    # Pattern syntax:
+    #   - /user/posts/* - matches direct children of posts (e.g., /user/posts/title)
+    #   - /user/posts/** - matches posts and all descendants
+    #   - /*/comments/* - matches comments under any parent
+    # Empty or unset means all paths are instrumented (if fieldLevelEnabled=true)
+    # Example: "/user/posts/**,/search/results/*,/**/comments"
+    # Use case: Focus metrics on specific parts of your schema known to be slow
+    fieldLevelPaths: ${GRAPHQL_METRICS_FIELD_LEVEL_PATHS:}
+
+    # Include metrics for trivial data fetchers (simple property access from objects)
+    # These are usually very fast and numerous, so excluding them reduces metric volume
+    # Only enable if you suspect performance issues with object property access
+    trivialDataFetchersEnabled: ${GRAPHQL_METRICS_TRIVIAL_DATA_FETCHERS_ENABLED:false}
 
 chromeExtension:
   enabled: ${CHROME_EXTENSION_ENABLED:true}

--- a/metadata-service/factories/build.gradle
+++ b/metadata-service/factories/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   implementation externalDependency.kafkaAvroSerde
   compileOnly externalDependency.lombok
   implementation externalDependency.servletApi
+  implementation externalDependency.graphqlJava
   api externalDependency.springBeans
   implementation externalDependency.springBootAutoconfigure
   implementation externalDependency.springBootStarterCache
@@ -40,6 +41,8 @@ dependencies {
   api externalDependency.springKafka
   api externalDependency.springWeb
   api externalDependency.httpClient
+  implementation externalDependency.springActuator
+  implementation externalDependency.micrometerObserve
   implementation externalDependency.awsPostgresIamAuth
   implementation externalDependency.awsRds
   implementation(externalDependency.mixpanel) {

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticSearchGraphServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticSearchGraphServiceFactory.java
@@ -8,6 +8,7 @@ import com.linkedin.metadata.graph.elastic.ESGraphWriteDAO;
 import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.models.registry.LineageRegistry;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -34,7 +35,8 @@ public class ElasticSearchGraphServiceFactory {
   @Nonnull
   protected GraphService getInstance(
       final EntityRegistry entityRegistry,
-      @Value("${elasticsearch.idHashAlgo}") final String idHashAlgo) {
+      @Value("${elasticsearch.idHashAlgo}") final String idHashAlgo,
+      MetricUtils metricUtils) {
     LineageRegistry lineageRegistry = new LineageRegistry(entityRegistry);
     return new ElasticSearchGraphService(
         lineageRegistry,
@@ -50,7 +52,8 @@ public class ElasticSearchGraphServiceFactory {
             lineageRegistry,
             components.getIndexConvention(),
             configurationProvider.getGraphService(),
-            configurationProvider.getElasticSearch()),
+            configurationProvider.getElasticSearch(),
+            metricUtils),
         components.getIndexBuilder(),
         idHashAlgo);
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/context/SystemOperationContextFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/context/SystemOperationContextFactory.java
@@ -16,7 +16,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.OperationContextConfig;
 import io.datahubproject.metadata.context.RetrieverContext;
 import io.datahubproject.metadata.context.ServicesRegistryContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.metadata.context.ValidationContext;
 import io.datahubproject.metadata.services.RestrictedService;
 import javax.annotation.Nonnull;
@@ -48,7 +48,7 @@ public class SystemOperationContextFactory {
           BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components,
       @Nonnull final ConfigurationProvider configurationProvider,
       @Qualifier("systemEntityClient") @Nonnull final SystemEntityClient systemEntityClient,
-      @Nonnull final TraceContext traceContext) {
+      @Nonnull final SystemTelemetryContext systemTelemetryContext) {
 
     EntityServiceAspectRetriever entityServiceAspectRetriever =
         EntityServiceAspectRetriever.builder()
@@ -82,7 +82,7 @@ public class SystemOperationContextFactory {
                 .alternateValidation(
                     configurationProvider.getFeatureFlags().isAlternateMCPValidation())
                 .build(),
-            traceContext,
+            systemTelemetryContext,
             configurationProvider.getAuthentication().isEnforceExistenceEnabled());
 
     entityClientAspectRetriever.setSystemOperationContext(systemOperationContext);
@@ -113,7 +113,7 @@ public class SystemOperationContextFactory {
       @Qualifier("baseElasticSearchComponents")
           BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components,
       @Nonnull final ConfigurationProvider configurationProvider,
-      @Nonnull final TraceContext traceContext) {
+      @Nonnull final SystemTelemetryContext systemTelemetryContext) {
 
     EntityClientAspectRetriever entityClientAspectRetriever =
         EntityClientAspectRetriever.builder().entityClient(systemEntityClient).build();
@@ -140,7 +140,7 @@ public class SystemOperationContextFactory {
                 .alternateValidation(
                     configurationProvider.getFeatureFlags().isAlternateMCPValidation())
                 .build(),
-            traceContext,
+            systemTelemetryContext,
             configurationProvider.getAuthentication().isEnforceExistenceEnabled());
 
     entityClientAspectRetriever.setSystemOperationContext(systemOperationContext);

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/EntityAspectDaoFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/EntityAspectDaoFactory.java
@@ -5,6 +5,7 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.entity.AspectDao;
 import com.linkedin.metadata.entity.cassandra.CassandraAspectDao;
 import com.linkedin.metadata.entity.ebean.EbeanAspectDao;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.ebean.Database;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -21,8 +22,9 @@ public class EntityAspectDaoFactory {
   @Nonnull
   protected AspectDao createEbeanInstance(
       @Qualifier("ebeanServer") final Database server,
-      final ConfigurationProvider configurationProvider) {
-    return new EbeanAspectDao(server, configurationProvider.getEbean());
+      final ConfigurationProvider configurationProvider,
+      final MetricUtils metricUtils) {
+    return new EbeanAspectDao(server, configurationProvider.getEbean(), metricUtils);
   }
 
   @Bean(name = "entityAspectDao")

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityclient/JavaEntityClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityclient/JavaEntityClientFactory.java
@@ -15,6 +15,7 @@ import com.linkedin.metadata.search.SearchService;
 import com.linkedin.metadata.search.client.CachingEntitySearchService;
 import com.linkedin.metadata.service.RollbackService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import javax.inject.Singleton;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -39,7 +40,8 @@ public class JavaEntityClientFactory {
       final @Qualifier("relationshipSearchService") LineageSearchService _lineageSearchService,
       final @Qualifier("kafkaEventProducer") EventProducer _eventProducer,
       final RollbackService rollbackService,
-      final EntityClientConfig entityClientConfig) {
+      final EntityClientConfig entityClientConfig,
+      final MetricUtils metricUtils) {
     return new JavaEntityClient(
         _entityService,
         _deleteEntityService,
@@ -50,7 +52,8 @@ public class JavaEntityClientFactory {
         _timeseriesAspectService,
         rollbackService,
         _eventProducer,
-        entityClientConfig);
+        entityClientConfig,
+        metricUtils);
   }
 
   @Bean("systemEntityClient")
@@ -67,7 +70,8 @@ public class JavaEntityClientFactory {
       final @Qualifier("kafkaEventProducer") EventProducer _eventProducer,
       final RollbackService rollbackService,
       final EntityClientCacheConfig entityClientCacheConfig,
-      final EntityClientConfig entityClientConfig) {
+      final EntityClientConfig entityClientConfig,
+      final MetricUtils metricUtils) {
     return new SystemJavaEntityClient(
         _entityService,
         _deleteEntityService,
@@ -79,6 +83,7 @@ public class JavaEntityClientFactory {
         rollbackService,
         _eventProducer,
         entityClientCacheConfig,
-        entityClientConfig);
+        entityClientConfig,
+        metricUtils);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityclient/RestliEntityClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityclient/RestliEntityClientFactory.java
@@ -7,6 +7,7 @@ import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.entity.client.SystemRestliEntityClient;
 import com.linkedin.metadata.config.cache.client.EntityClientCacheConfig;
 import com.linkedin.metadata.restli.DefaultRestliClientFactory;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.restli.client.Client;
 import java.net.URI;
 import javax.inject.Singleton;
@@ -28,7 +29,8 @@ public class RestliEntityClientFactory {
       @Value("${datahub.gms.useSSL}") boolean gmsUseSSL,
       @Value("${datahub.gms.uri}") String gmsUri,
       @Value("${datahub.gms.sslContext.protocol}") String gmsSslProtocol,
-      final EntityClientConfig entityClientConfig) {
+      final EntityClientConfig entityClientConfig,
+      final MetricUtils metricUtils) {
     final Client restClient;
     if (gmsUri != null) {
       restClient = DefaultRestliClientFactory.getRestLiClient(URI.create(gmsUri), gmsSslProtocol);
@@ -36,7 +38,7 @@ public class RestliEntityClientFactory {
       restClient =
           DefaultRestliClientFactory.getRestLiClient(gmsHost, gmsPort, gmsUseSSL, gmsSslProtocol);
     }
-    return new RestliEntityClient(restClient, entityClientConfig);
+    return new RestliEntityClient(restClient, entityClientConfig, metricUtils);
   }
 
   @Bean("systemEntityClient")
@@ -48,7 +50,8 @@ public class RestliEntityClientFactory {
       @Value("${datahub.gms.uri}") String gmsUri,
       @Value("${datahub.gms.sslContext.protocol}") String gmsSslProtocol,
       final EntityClientCacheConfig entityClientCacheConfig,
-      final EntityClientConfig entityClientConfig) {
+      final EntityClientConfig entityClientConfig,
+      final MetricUtils metricUtils) {
 
     final Client restClient;
     if (gmsUri != null) {
@@ -57,6 +60,7 @@ public class RestliEntityClientFactory {
       restClient =
           DefaultRestliClientFactory.getRestLiClient(gmsHost, gmsPort, gmsUseSSL, gmsSslProtocol);
     }
-    return new SystemRestliEntityClient(restClient, entityClientConfig, entityClientCacheConfig);
+    return new SystemRestliEntityClient(
+        restClient, entityClientConfig, entityClientCacheConfig, metricUtils);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
@@ -24,7 +24,7 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.entityregistry.EntityRegistryFactory;
 import com.linkedin.gms.factory.recommendation.RecommendationServiceFactory;
 import com.linkedin.metadata.client.UsageStatsJavaClient;
-import com.linkedin.metadata.config.GraphQLConcurrencyConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLConcurrencyConfiguration;
 import com.linkedin.metadata.connection.ConnectionService;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.versioning.EntityVersioningService;
@@ -47,6 +47,8 @@ import com.linkedin.metadata.service.ViewService;
 import com.linkedin.metadata.timeline.TimelineService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import com.linkedin.metadata.utils.metrics.MicrometerMetricsRegistry;
 import com.linkedin.metadata.version.GitVersion;
 import io.datahubproject.metadata.services.RestrictedService;
 import io.datahubproject.metadata.services.SecretService;
@@ -212,14 +214,17 @@ public class GraphQLEngineFactory {
   protected GraphQLEngine graphQLEngine(
       @Qualifier("entityClient") final EntityClient entityClient,
       @Qualifier("systemEntityClient") final SystemEntityClient systemEntityClient,
-      final EntityVersioningService entityVersioningService) {
+      final EntityVersioningService entityVersioningService,
+      final MetricUtils metricUtils) {
     GmsGraphQLEngineArgs args = new GmsGraphQLEngineArgs();
     args.setEntityClient(entityClient);
     args.setSystemEntityClient(systemEntityClient);
     args.setGraphClient(graphClient);
     args.setUsageClient(
         new UsageStatsJavaClient(
-            timeseriesAspectService, configProvider.getCache().getClient().getUsageClient()));
+            timeseriesAspectService,
+            configProvider.getCache().getClient().getUsageClient(),
+            metricUtils));
     if (isAnalyticsEnabled) {
       args.setAnalyticsService(new AnalyticsService(elasticClient, indexConvention));
     }
@@ -259,22 +264,19 @@ public class GraphQLEngineFactory {
     args.setRestrictedService(restrictedService);
     args.setDataProductService(dataProductService);
     args.setApplicationService(applicationService);
-    args.setGraphQLQueryComplexityLimit(
-        configProvider.getGraphQL().getQuery().getComplexityLimit());
-    args.setGraphQLQueryIntrospectionEnabled(
-        configProvider.getGraphQL().getQuery().isIntrospectionEnabled());
-    args.setGraphQLQueryDepthLimit(configProvider.getGraphQL().getQuery().getDepthLimit());
+    args.setGraphQLConfiguration(configProvider.getGraphQL());
     args.setBusinessAttributeService(businessAttributeService);
     args.setChromeExtensionConfiguration(configProvider.getChromeExtension());
     args.setEntityVersioningService(entityVersioningService);
     args.setConnectionService(_connectionService);
     args.setAssertionService(assertionService);
+    args.setMetricUtils(metricUtils);
     return new GmsGraphQLEngine(args).builder().build();
   }
 
   @Bean(name = "graphQLWorkerPool")
   @ConditionalOnProperty("graphQL.concurrency.separateThreadPool")
-  protected ExecutorService graphQLWorkerPool() {
+  protected ExecutorService graphQLWorkerPool(MetricUtils metricUtils) {
     GraphQLConcurrencyConfiguration concurrencyConfig =
         configProvider.getGraphQL().getConcurrency();
     GraphQLWorkerPoolThreadFactory threadFactory =
@@ -297,7 +299,13 @@ public class GraphQLEngineFactory {
             new SynchronousQueue(),
             threadFactory,
             new ThreadPoolExecutor.CallerRunsPolicy());
-    GraphQLConcurrencyUtils.setExecutorService(graphQLWorkerPool);
+
+    ExecutorService graphqlExecutorService =
+        GraphQLConcurrencyUtils.setExecutorService(graphQLWorkerPool);
+    if (metricUtils != null) {
+      MicrometerMetricsRegistry.registerExecutorMetrics(
+          "graphql", graphqlExecutorService, metricUtils.getRegistry().orElse(null));
+    }
 
     return graphQLWorkerPool;
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaEventProducerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaEventProducerFactory.java
@@ -3,6 +3,7 @@ package com.linkedin.gms.factory.kafka;
 import com.linkedin.gms.factory.kafka.common.TopicConventionFactory;
 import com.linkedin.metadata.dao.producer.KafkaEventProducer;
 import com.linkedin.metadata.dao.producer.KafkaHealthChecker;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.TopicConvention;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.kafka.clients.producer.Producer;
@@ -25,7 +26,7 @@ public class DataHubKafkaEventProducerFactory {
   @Autowired private KafkaHealthChecker kafkaHealthChecker;
 
   @Bean(name = "kafkaEventProducer")
-  protected KafkaEventProducer createInstance() {
-    return new KafkaEventProducer(kafkaProducer, topicConvention, kafkaHealthChecker);
+  protected KafkaEventProducer createInstance(MetricUtils metricUtils) {
+    return new KafkaEventProducer(kafkaProducer, topicConvention, kafkaHealthChecker, metricUtils);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/trace/KafkaTraceReaderFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/trace/KafkaTraceReaderFactory.java
@@ -7,6 +7,8 @@ import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.trace.MCLTraceReader;
 import com.linkedin.metadata.trace.MCPFailedTraceReader;
 import com.linkedin.metadata.trace.MCPTraceReader;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import com.linkedin.metadata.utils.metrics.MicrometerMetricsRegistry;
 import com.linkedin.mxe.Topics;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.PreDestroy;
@@ -80,8 +82,12 @@ public class KafkaTraceReaderFactory {
   private ExecutorService traceExecutorService;
 
   @Bean("traceExecutorService")
-  public ExecutorService traceExecutorService() {
+  public ExecutorService traceExecutorService(MetricUtils metricUtils) {
     traceExecutorService = Executors.newFixedThreadPool(threadPoolSize);
+    if (metricUtils != null) {
+      MicrometerMetricsRegistry.registerExecutorMetrics(
+          "api-trace", this.traceExecutorService, metricUtils.getRegistry().orElse(null));
+    }
     return traceExecutorService;
   }
 

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactory.java
@@ -2,6 +2,7 @@ package com.linkedin.gms.factory.search;
 
 import com.linkedin.gms.factory.common.RestHighLevelClientFactory;
 import com.linkedin.metadata.search.elasticsearch.update.ESBulkProcessor;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.action.support.WriteRequest;
@@ -44,8 +45,8 @@ public class ElasticSearchBulkProcessorFactory {
 
   @Bean(name = "elasticSearchBulkProcessor")
   @Nonnull
-  protected ESBulkProcessor getInstance() {
-    return ESBulkProcessor.builder(searchClient)
+  protected ESBulkProcessor getInstance(MetricUtils metricUtils) {
+    return ESBulkProcessor.builder(searchClient, metricUtils)
         .async(async)
         .bulkFlushPeriod(bulkFlushPeriod)
         .bulkRequestsLimit(bulkRequestsLimit)

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/CacheInstrumentationFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/CacheInstrumentationFactory.java
@@ -1,0 +1,52 @@
+package com.linkedin.gms.factory.system_telemetry;
+
+import com.linkedin.metadata.utils.metrics.MicrometerMetricsRegistry;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Collection;
+import javax.annotation.Nonnull;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class CacheInstrumentationFactory {
+  /**
+   * Creates an instrumented CacheManager that automatically registers Micrometer metrics for all
+   * caches accessed through it.
+   *
+   * <p>This bean is marked as @Primary to ensure it's used by default throughout the application,
+   * replacing direct access to the underlying cache manager. When any cache is accessed via {@code
+   * getCache(String)}, metrics are automatically registered if not already present, enabling
+   * visibility into cache performance including hits, misses, evictions, and size.
+   *
+   * <p>The metrics registration is lazy - caches are only instrumented when first accessed,
+   * avoiding unnecessary overhead for unused caches while ensuring complete coverage for active
+   * caches.
+   *
+   * @param meterRegistry component responsible for registering cache metrics with Micrometer
+   * @return an instrumented CacheManager that delegates to the configured implementation while
+   *     automatically registering metrics for accessed caches
+   */
+  @Bean
+  @Primary
+  public CacheManager instrumentedCacheManager(CacheManager delegate, MeterRegistry meterRegistry) {
+
+    return new CacheManager() {
+
+      @Override
+      public Cache getCache(@Nonnull String name) {
+        Cache cache = delegate.getCache(name);
+        MicrometerMetricsRegistry.registerCacheMetrics(name, cache, meterRegistry);
+        return cache;
+      }
+
+      @Override
+      @Nonnull
+      public Collection<String> getCacheNames() {
+        return delegate.getCacheNames();
+      }
+    };
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/MetricUtilsFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/MetricUtilsFactory.java
@@ -1,0 +1,16 @@
+package com.linkedin.gms.factory.system_telemetry;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricUtilsFactory {
+  @Bean
+  public MetricUtils metricUtils(
+      MeterRegistry meterRegistry, ConfigurationProvider configurationProvider) {
+    return MetricUtils.builder().registry(meterRegistry).build();
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/MicrometerMetricsFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/MicrometerMetricsFactory.java
@@ -1,0 +1,211 @@
+package com.linkedin.gms.factory.system_telemetry;
+
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.MeterFilterReply;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.core.instrument.util.HierarchicalNameMapper;
+import io.micrometer.jmx.JmxConfig;
+import io.micrometer.jmx.JmxMeterRegistry;
+import io.micrometer.observation.ObservationPredicate;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+import io.micrometer.tracing.otel.bridge.OtelCurrentTraceContext;
+import io.micrometer.tracing.otel.bridge.OtelTracer;
+import io.opentelemetry.api.trace.Tracer;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.server.observation.ServerRequestObservationContext;
+
+@Slf4j
+@Configuration
+public class MicrometerMetricsFactory {
+
+  /** Preserve legacy flat names by ignoring tags */
+  @Deprecated
+  private static final HierarchicalNameMapper LEGACY_HIERARCHICAL_MAPPER =
+      new HierarchicalNameMapper() {
+        @NotNull
+        @Override
+        public String toHierarchicalName(Meter.Id id, @NotNull NamingConvention namingConvention) {
+          return id.getName();
+        }
+      };
+
+  /**
+   * Provides the default JMX configuration for exporting metrics to JMX. This bean is only created
+   * when: 1. No other JmxConfig bean exists (@ConditionalOnMissingBean) 2. JMX metrics export is
+   * explicitly enabled in application properties
+   *
+   * <p>The JMX registry exposes metrics as MBeans that can be viewed through tools like JConsole or
+   * JMX.
+   *
+   * @return Default JmxConfig that defines how metrics are exported to JMX
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  @ConditionalOnProperty(
+      prefix = "management.metrics.export.jmx",
+      name = "enabled",
+      havingValue = "true")
+  public JmxConfig customJmxConfig() {
+    return JmxConfig.DEFAULT;
+  }
+
+  /**
+   * Creates a JMX meter registry that exports metrics as JMX MBeans. This registry uses a custom
+   * hierarchical name mapper that preserves legacy flat naming by ignoring tags, ensuring backward
+   * compatibility with existing JMX metric consumers.
+   *
+   * <p>Only activated when JMX export is enabled via management.metrics.export.jmx.enabled=true
+   *
+   * @param config JMX configuration defining export behavior
+   * @param clock Clock instance for timing measurements
+   * @return JmxMeterRegistry that exposes metrics as JMX MBeans with legacy flat names
+   */
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "management.metrics.export.jmx",
+      name = "enabled",
+      havingValue = "true")
+  public JmxMeterRegistry jmxMeterRegistry(JmxConfig config, Clock clock) {
+    return new JmxMeterRegistry(config, clock, LEGACY_HIERARCHICAL_MAPPER);
+  }
+
+  /**
+   * Customizes the JMX meter registry to only expose legacy Dropwizard metrics. This filter ensures
+   * that only metrics tagged with MetricUtils.DROPWIZARD_METRIC are exported to JMX, preventing new
+   * Micrometer-native metrics from appearing in JMX.
+   *
+   * <p>This separation allows: - Legacy systems to continue consuming metrics via JMX without
+   * changes - New metrics to be exposed through modern systems like Prometheus
+   *
+   * @return MeterRegistryCustomizer that filters metrics based on DROPWIZARD_METRIC tag
+   */
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "management.metrics.export.jmx",
+      name = "enabled",
+      havingValue = "true")
+  public MeterRegistryCustomizer<JmxMeterRegistry> jmxMetricsCustomization() {
+    return registry ->
+        registry
+            .config()
+            .meterFilter(
+                new MeterFilter() {
+                  @Override
+                  public MeterFilterReply accept(Meter.Id id) {
+                    return id.getTag(MetricUtils.DROPWIZARD_METRIC) != null
+                        ? MeterFilterReply.ACCEPT
+                        : MeterFilterReply.DENY;
+                  }
+                });
+  }
+
+  /**
+   * Customizes the Prometheus meter registry to exclude legacy Dropwizard metrics. This is the
+   * inverse of the JMX filter - it only accepts metrics WITHOUT the DROPWIZARD_METRIC tag,
+   * providing a clean slate for modern metric collection.
+   *
+   * <p>This separation strategy allows: - Prometheus to collect only new, properly-tagged
+   * Micrometer metrics - Gradual migration from legacy metrics to modern metrics - Clean metric
+   * namespaces in Prometheus without legacy naming conventions
+   *
+   * @return MeterRegistryCustomizer that excludes legacy Dropwizard metrics from Prometheus
+   */
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "management.metrics.export.prometheus",
+      name = "enabled",
+      havingValue = "true")
+  public MeterRegistryCustomizer<PrometheusMeterRegistry> prometheusMetricsCustomization() {
+    return registry ->
+        registry
+            .config()
+            .meterFilter(
+                new MeterFilter() {
+                  @Override
+                  public MeterFilterReply accept(Meter.Id id) {
+                    return id.getTag(MetricUtils.DROPWIZARD_METRIC) == null
+                        ? MeterFilterReply.ACCEPT
+                        : MeterFilterReply.DENY;
+                  }
+                });
+  }
+
+  /**
+   * Creates an OtelTracer that bridges the existing OpenTelemetry Tracer with Micrometer's tracing
+   * system. This allows Micrometer's Observation API to create OpenTelemetry spans using your
+   * custom-configured tracer.
+   *
+   * @return OtelTracer that wraps your existing tracer for use with Micrometer Observation API
+   */
+  @Bean
+  @ConditionalOnProperty(prefix = "management.tracing", name = "enabled", havingValue = "true")
+  public OtelTracer otelTracer(SystemTelemetryContext telemetryContext) {
+    // Use your existing tracer
+    Tracer existingTracer = telemetryContext.getTracer();
+    return new OtelTracer(existingTracer, new OtelCurrentTraceContext(), null);
+  }
+
+  /**
+   * Creates the ObservationRegistry which is the central component of Micrometer's Observation API.
+   * This registry allows you to instrument code once and get both metrics AND traces from the same
+   * instrumentation.
+   *
+   * <p>When you use @Observed annotations or manually create observations, this registry ensures
+   * that: 1. Metrics are recorded in your MeterRegistry (timers, counters, etc.) 2. Traces/spans
+   * are created via your OpenTelemetry tracer
+   *
+   * @param meterRegistry The Micrometer registry where metrics will be recorded
+   * @param otelTracer The bridged OpenTelemetry tracer for creating spans
+   * @return ObservationRegistry configured with both metrics and tracing handlers
+   */
+  @Bean
+  @ConditionalOnBean({OtelTracer.class, MeterRegistry.class})
+  public ObservationRegistry observationRegistry(
+      MeterRegistry meterRegistry, OtelTracer otelTracer) {
+    ObservationRegistry registry = ObservationRegistry.create();
+
+    // Add Micrometer metrics handler
+    registry
+        .observationConfig()
+        .observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+
+    // Add OpenTelemetry tracing handler
+    registry
+        .observationConfig()
+        .observationHandler(new DefaultTracingObservationHandler(otelTracer));
+
+    log.info("Setup OpenTelemetry / Micrometer bridge.");
+
+    return registry;
+  }
+
+  /**
+   * Configures which HTTP requests should be observed. Excludes health checks and actuator
+   * endpoints from creating spans/metrics.
+   */
+  @Bean
+  public ObservationPredicate noActuatorObservations() {
+    return (name, context) -> {
+      if (context instanceof ServerRequestObservationContext serverContext) {
+        String path = serverContext.getCarrier().getRequestURI();
+        return !path.startsWith("/actuator") && !path.equals("/health") && !path.equals("/config");
+      }
+      return true;
+    };
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactory.java
@@ -3,7 +3,8 @@ package com.linkedin.gms.factory.system_telemetry;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.system_telemetry.usage.DataHubUsageSpanExporter;
 import com.linkedin.metadata.utils.metrics.MetricSpanExporter;
-import io.datahubproject.metadata.context.TraceContext;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -26,11 +27,15 @@ public abstract class OpenTelemetryBaseFactory {
 
   protected abstract String getApplicationComponent();
 
-  protected TraceContext traceContext(
-      ConfigurationProvider configurationProvider, Producer<String, String> dueProducer) {
+  protected SystemTelemetryContext traceContext(
+      MetricUtils metricUtils,
+      ConfigurationProvider configurationProvider,
+      Producer<String, String> dueProducer) {
+
     SpanProcessor usageSpanExporter = getUsageSpanExporter(configurationProvider, dueProducer);
-    OpenTelemetry openTelemetry = openTelemetry(usageSpanExporter);
-    return TraceContext.builder()
+    OpenTelemetry openTelemetry = openTelemetry(metricUtils, usageSpanExporter);
+    return SystemTelemetryContext.builder()
+        .metricUtils(metricUtils)
         .tracer(tracer(openTelemetry))
         .usageSpanExporter(usageSpanExporter)
         .build();
@@ -56,7 +61,7 @@ public abstract class OpenTelemetryBaseFactory {
     return openTelemetry.getTracer(getApplicationComponent());
   }
 
-  private OpenTelemetry openTelemetry(SpanProcessor usageSpanExporter) {
+  private OpenTelemetry openTelemetry(MetricUtils metricUtils, SpanProcessor usageSpanExporter) {
     return AutoConfiguredOpenTelemetrySdk.builder()
         .addPropertiesCustomizer(
             (configProperties) -> {
@@ -80,14 +85,15 @@ public abstract class OpenTelemetryBaseFactory {
             (sdkTracerProviderBuilder, configProperties) -> {
               sdkTracerProviderBuilder
                   .addSpanProcessor(
-                      TraceContext.LOG_SPAN_EXPORTER != null
-                          ? SimpleSpanProcessor.create(TraceContext.LOG_SPAN_EXPORTER)
+                      SystemTelemetryContext.LOG_SPAN_EXPORTER != null
+                          ? SimpleSpanProcessor.create(SystemTelemetryContext.LOG_SPAN_EXPORTER)
                           : SimpleSpanProcessor.create(
-                              new MetricSpanExporter())) // Fallback for exporter
-                  .addSpanProcessor(BatchSpanProcessor.builder(new MetricSpanExporter()).build())
+                              new MetricSpanExporter(metricUtils))) // Fallback for exporter
+                  .addSpanProcessor(
+                      BatchSpanProcessor.builder(new MetricSpanExporter(metricUtils)).build())
                   .setIdGenerator(
-                      TraceContext.TRACE_ID_GENERATOR != null
-                          ? TraceContext.TRACE_ID_GENERATOR
+                      SystemTelemetryContext.TRACE_ID_GENERATOR != null
+                          ? SystemTelemetryContext.TRACE_ID_GENERATOR
                           : io.opentelemetry.sdk.trace.IdGenerator
                               .random()) // Fallback for ID generator
                   .setResource(
@@ -119,7 +125,7 @@ public abstract class OpenTelemetryBaseFactory {
               return (metricsExporter == null || metricsExporter.trim().isEmpty())
                   ? (metricExporter != null
                       ? metricExporter
-                      : (MetricExporter) new MetricSpanExporter())
+                      : (MetricExporter) new MetricSpanExporter(metricUtils))
                   : metricExporter;
             })
         .build()

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/timeseries/ElasticSearchTimeseriesAspectServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/timeseries/ElasticSearchTimeseriesAspectServiceFactory.java
@@ -6,6 +6,7 @@ import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
 import com.linkedin.metadata.timeseries.elastic.ElasticSearchTimeseriesAspectService;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -28,7 +29,8 @@ public class ElasticSearchTimeseriesAspectServiceFactory {
   @Nonnull
   protected ElasticSearchTimeseriesAspectService getInstance(
       final QueryFilterRewriteChain queryFilterRewriteChain,
-      final ConfigurationProvider configurationProvider) {
+      final ConfigurationProvider configurationProvider,
+      final MetricUtils metricUtils) {
     return new ElasticSearchTimeseriesAspectService(
         components.getSearchClient(),
         components.getBulkProcessor(),
@@ -37,6 +39,7 @@ public class ElasticSearchTimeseriesAspectServiceFactory {
         configurationProvider.getTimeseriesAspectService(),
         entityRegistry,
         components.getIndexConvention(),
-        components.getIndexBuilder());
+        components.getIndexBuilder(),
+        metricUtils);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/usage/UsageClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/usage/UsageClientFactory.java
@@ -2,6 +2,7 @@ package com.linkedin.gms.factory.usage;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.restli.DefaultRestliClientFactory;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.parseq.retry.backoff.ExponentialBackoff;
 import com.linkedin.r2.transport.http.client.HttpClientFactory;
 import com.linkedin.restli.client.Client;
@@ -43,7 +44,7 @@ public class UsageClientFactory {
   private ConfigurationProvider configurationProvider;
 
   @Bean("usageClient")
-  public RestliUsageClient getUsageClient() {
+  public RestliUsageClient getUsageClient(MetricUtils metricUtils) {
     Map<String, String> params = new HashMap<>();
     params.put(HttpClientFactory.HTTP_REQUEST_TIMEOUT, String.valueOf(timeoutMs));
 
@@ -54,6 +55,7 @@ public class UsageClientFactory {
         restClient,
         new ExponentialBackoff(retryInterval),
         numRetries,
-        configurationProvider.getCache().getClient().getUsageClient());
+        configurationProvider.getCache().getClient().getUsageClient(),
+        metricUtils);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
@@ -127,7 +127,12 @@ public class DataHubUpgradeKafkaListener implements ConsumerSeekAware, Bootstrap
             }
 
           } catch (Exception e) {
-            MetricUtils.counter(this.getClass(), "avro_to_pegasus_conversion_failure").inc();
+            systemOperationContext
+                .getMetricUtils()
+                .ifPresent(
+                    metricUtils ->
+                        metricUtils.increment(
+                            this.getClass(), "avro_to_pegasus_conversion_failure", 1));
             log.error("Error deserializing message due to: ", e);
             log.error("Message: {}", record.toString());
             return;

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactoryTest.java
@@ -5,11 +5,13 @@ import static org.testng.Assert.assertNotNull;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.search.elasticsearch.update.ESBulkProcessor;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import org.opensearch.action.support.WriteRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
@@ -18,6 +20,8 @@ import org.testng.annotations.Test;
 @EnableConfigurationProperties(ConfigurationProvider.class)
 public class ElasticSearchBulkProcessorFactoryTest extends AbstractTestNGSpringContextTests {
   @Autowired ESBulkProcessor test;
+
+  @MockitoBean public MetricUtils metricUtils;
 
   @Test
   void testInjection() {

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/MicrometerMetricsFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/MicrometerMetricsFactoryTest.java
@@ -1,0 +1,387 @@
+package com.linkedin.gms.factory.system_telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
+
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.jmx.JmxConfig;
+import io.micrometer.jmx.JmxMeterRegistry;
+import io.micrometer.observation.ObservationPredicate;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.micrometer.tracing.otel.bridge.OtelTracer;
+import io.opentelemetry.api.trace.Tracer;
+import java.lang.management.ManagementFactory;
+import java.util.Set;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.http.server.observation.ServerRequestObservationContext;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@SpringBootTest
+public class MicrometerMetricsFactoryTest {
+
+  private ApplicationContextRunner contextRunner;
+  private MicrometerMetricsFactory factory;
+
+  @Mock private SystemTelemetryContext telemetryContext;
+
+  @Mock private Tracer tracer;
+
+  @Mock private Clock clock;
+
+  private AutoCloseable mockitoCloseable;
+
+  @BeforeMethod
+  public void setUp() {
+    mockitoCloseable = MockitoAnnotations.openMocks(this);
+    factory = new MicrometerMetricsFactory();
+
+    contextRunner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(MicrometerMetricsFactory.class)
+            .withBean(Clock.class, () -> clock)
+            .withBean(SystemTelemetryContext.class, () -> telemetryContext);
+
+    when(telemetryContext.getTracer()).thenReturn(tracer);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    if (mockitoCloseable != null) {
+      mockitoCloseable.close();
+    }
+  }
+
+  @Test
+  public void testJmxConfigBeanCreation() {
+    contextRunner
+        .withPropertyValues("management.metrics.export.jmx.enabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(JmxConfig.class);
+              JmxConfig jmxConfig = context.getBean(JmxConfig.class);
+              assertThat(jmxConfig).isEqualTo(JmxConfig.DEFAULT);
+            });
+  }
+
+  @Test
+  public void testJmxConfigBeanNotCreatedWhenDisabled() {
+    contextRunner
+        .withPropertyValues("management.metrics.export.jmx.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(JmxConfig.class);
+            });
+  }
+
+  @Test
+  public void testJmxMeterRegistryCreation() {
+    contextRunner
+        .withPropertyValues("management.metrics.export.jmx.enabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(JmxMeterRegistry.class);
+              JmxMeterRegistry registry = context.getBean(JmxMeterRegistry.class);
+              assertThat(registry).isNotNull();
+            });
+  }
+
+  @Test
+  public void testJmxMeterRegistryNotCreatedWhenDisabled() {
+    contextRunner
+        .withPropertyValues("management.metrics.export.jmx.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(JmxMeterRegistry.class);
+            });
+  }
+
+  @Test
+  public void testJmxMetricsCustomizationFiltersDropwizardMetrics() {
+    // Create the customizer directly
+    MeterRegistryCustomizer<JmxMeterRegistry> customizer = factory.jmxMetricsCustomization();
+
+    // Create a test registry
+    JmxMeterRegistry registry = new JmxMeterRegistry(JmxConfig.DEFAULT, Clock.SYSTEM);
+
+    // Apply the customization
+    customizer.customize(registry);
+
+    // Create test meters with different tags
+    registry.counter("test.dropwizard.metric", MetricUtils.DROPWIZARD_METRIC, "true");
+    registry.counter("test.regular.metric");
+
+    // Verify that only the dropwizard metric is registered
+    assertThat(registry.getMeters())
+        .hasSize(1)
+        .extracting(meter -> meter.getId().getName())
+        .containsOnly("test.dropwizard.metric");
+  }
+
+  @Test
+  public void testPrometheusMetricsCustomizationExcludesDropwizardMetrics() {
+    // Create the customizer directly
+    MeterRegistryCustomizer<PrometheusMeterRegistry> customizer =
+        factory.prometheusMetricsCustomization();
+
+    // Create a test registry
+    PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+
+    // Apply the customization
+    customizer.customize(registry);
+
+    // Create test meters with different tags
+    registry.counter("test.dropwizard.metric", MetricUtils.DROPWIZARD_METRIC, "true");
+    registry.counter("test.regular.metric");
+
+    // Verify that only the regular metric is registered (dropwizard metric is excluded)
+    assertThat(registry.getMeters())
+        .hasSize(1)
+        .extracting(meter -> meter.getId().getName())
+        .containsOnly("test.regular.metric");
+  }
+
+  @Test
+  public void testOtelTracerCreation() {
+    contextRunner
+        .withPropertyValues("management.tracing.enabled=true")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(OtelTracer.class);
+              OtelTracer otelTracer = context.getBean(OtelTracer.class);
+              assertThat(otelTracer).isNotNull();
+            });
+  }
+
+  @Test
+  public void testOtelTracerNotCreatedWhenDisabled() {
+    contextRunner
+        .withPropertyValues("management.tracing.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(OtelTracer.class);
+            });
+  }
+
+  @Test
+  public void testObservationRegistryNotCreatedWithoutDependencies() {
+    contextRunner
+        .withPropertyValues("management.tracing.enabled=false")
+        .run(
+            context -> {
+              assertThat(context).doesNotHaveBean(ObservationRegistry.class);
+            });
+  }
+
+  @Test
+  public void testNoActuatorObservationsPredicateFiltersActuatorPaths() {
+    ObservationPredicate predicate = factory.noActuatorObservations();
+
+    // Test actuator paths that should be excluded
+    assertThat(testPredicateWithPath(predicate, "/actuator/health")).isFalse();
+    assertThat(testPredicateWithPath(predicate, "/actuator/metrics")).isFalse();
+    assertThat(testPredicateWithPath(predicate, "/health")).isFalse();
+    assertThat(testPredicateWithPath(predicate, "/config")).isFalse();
+
+    // Test regular paths that should be included
+    assertThat(testPredicateWithPath(predicate, "/api/users")).isTrue();
+    assertThat(testPredicateWithPath(predicate, "/")).isTrue();
+    assertThat(testPredicateWithPath(predicate, "/api/actuator"))
+        .isTrue(); // Not starting with /actuator
+  }
+
+  @Test
+  public void testFullIntegrationWithAllComponentsEnabled() {
+    contextRunner
+        .withPropertyValues(
+            "management.metrics.export.jmx.enabled=true",
+            "management.metrics.export.prometheus.enabled=true",
+            "management.tracing.enabled=true")
+        .run(
+            context -> {
+              // Verify all beans are created
+              assertThat(context).hasSingleBean(JmxConfig.class);
+              assertThat(context).hasSingleBean(JmxMeterRegistry.class);
+              assertThat(context).hasSingleBean(OtelTracer.class);
+              assertThat(context).hasSingleBean(ObservationRegistry.class);
+              assertThat(context).hasSingleBean(ObservationPredicate.class);
+
+              // Verify customizers are applied
+              assertThat(context).hasBean("jmxMetricsCustomization");
+              assertThat(context).hasBean("prometheusMetricsCustomization");
+            });
+  }
+
+  @Test
+  public void testMinimalConfigurationWithEverythingDisabled() {
+    contextRunner
+        .withPropertyValues(
+            "management.metrics.export.jmx.enabled=false",
+            "management.metrics.export.prometheus.enabled=false",
+            "management.tracing.enabled=false")
+        .run(
+            context -> {
+              // Only the ObservationPredicate should be created
+              assertThat(context).hasSingleBean(ObservationPredicate.class);
+
+              // Everything else should be absent
+              assertThat(context).doesNotHaveBean(JmxConfig.class);
+              assertThat(context).doesNotHaveBean(JmxMeterRegistry.class);
+              assertThat(context).doesNotHaveBean(OtelTracer.class);
+              assertThat(context).doesNotHaveBean(ObservationRegistry.class);
+            });
+  }
+
+  @Test
+  public void testJmxMetricsWithLegacyHierarchicalNameMapper() throws Exception {
+    // Create a JMX registry using the factory method
+    JmxMeterRegistry registry = factory.jmxMeterRegistry(JmxConfig.DEFAULT, Clock.SYSTEM);
+
+    // Create a metric with tags
+    registry.counter("test.metric.name", "tag1", "value1", "tag2", "value2").increment();
+
+    // Get the MBean server
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+
+    // The legacy mapper creates a flat name with type=meters
+    ObjectName objectName = new ObjectName("metrics:name=test.metric.name,type=meters");
+
+    // Verify the MBean exists with the flat name
+    assertThat(mBeanServer.isRegistered(objectName)).isTrue();
+
+    // Verify the count value
+    Object count = mBeanServer.getAttribute(objectName, "Count");
+    assertThat(count).isEqualTo(1L);
+
+    // Verify that the name is flat (no tags in the object name)
+    String objectNameString = objectName.toString();
+    assertThat(objectNameString).doesNotContain("tag1");
+    assertThat(objectNameString).doesNotContain("value1");
+    assertThat(objectNameString).doesNotContain("tag2");
+    assertThat(objectNameString).doesNotContain("value2");
+
+    // Clean up
+    registry.close();
+  }
+
+  @Test
+  public void testJmxMetricsMultipleMetricsWithSameNameDifferentTagsThrowsException() {
+    // This test verifies that the legacy mapper causes metrics with the same name
+    // but different tags to conflict because they map to the same flat name
+    JmxMeterRegistry registry = factory.jmxMeterRegistry(JmxConfig.DEFAULT, Clock.SYSTEM);
+
+    try {
+      // Create first counter
+      registry.counter("duplicate.metric", "env", "prod").increment();
+
+      // Attempting to create a second counter with same name but different tags should fail
+      try {
+        registry.counter("duplicate.metric", "env", "dev");
+        fail("Expected IllegalArgumentException to be thrown");
+      } catch (IllegalArgumentException e) {
+        assertThat(e.getMessage()).contains("A metric named duplicate.metric already exists");
+      }
+    } finally {
+      // Clean up
+      registry.close();
+    }
+  }
+
+  @Test
+  public void testJmxMetricsLegacyMapperReturnsSameCounterForSameTags() throws Exception {
+    // This test verifies that requesting a metric with the same name and tags
+    // returns the same counter instance
+    JmxMeterRegistry registry = factory.jmxMeterRegistry(JmxConfig.DEFAULT, Clock.SYSTEM);
+
+    // Create counter with tags
+    Counter counter1 = registry.counter("shared.metric", "env", "prod", "region", "us-east");
+    counter1.increment();
+
+    // Request the same metric with the same name and tags - should return the same instance
+    Counter counter2 = registry.counter("shared.metric", "env", "prod", "region", "us-east");
+
+    // These should be the same counter instance
+    assertThat(counter1).isSameAs(counter2);
+
+    // Increment the "second" counter
+    counter2.increment();
+
+    // Both should show count of 2 since they're the same counter
+    assertThat(counter1.count()).isEqualTo(2.0);
+    assertThat(counter2.count()).isEqualTo(2.0);
+
+    // Verify in JMX
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    ObjectName objectName = new ObjectName("metrics:name=shared.metric,type=meters");
+    Object count = mBeanServer.getAttribute(objectName, "Count");
+    assertThat(count).isEqualTo(2L);
+
+    // Clean up
+    registry.close();
+  }
+
+  @Test
+  public void testJmxMetricsLegacyMapperIgnoresTagsInJmxName() throws Exception {
+    // This test verifies that the legacy mapper creates flat JMX names without tags
+    JmxMeterRegistry registry = factory.jmxMeterRegistry(JmxConfig.DEFAULT, Clock.SYSTEM);
+
+    // Create a counter with multiple tags
+    Counter counter =
+        registry.counter("tagged.metric", "env", "prod", "region", "us-east", "service", "api");
+    counter.increment(5);
+
+    // Get the MBean server
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+
+    // The JMX name should be flat without any tag information
+    ObjectName objectName = new ObjectName("metrics:name=tagged.metric,type=meters");
+    assertThat(mBeanServer.isRegistered(objectName)).isTrue();
+
+    // Verify the count
+    Object count = mBeanServer.getAttribute(objectName, "Count");
+    assertThat(count).isEqualTo(5L);
+
+    // Verify that no MBeans exist with tag information in their names
+    Set<ObjectName> allMetrics =
+        mBeanServer.queryNames(new ObjectName("metrics:name=tagged.metric,*"), null);
+    assertThat(allMetrics).hasSize(1);
+
+    // The single MBean should not contain any tag keys in its name
+    ObjectName foundName = allMetrics.iterator().next();
+    String nameString = foundName.toString();
+    assertThat(nameString).doesNotContain("env");
+    assertThat(nameString).doesNotContain("region");
+    assertThat(nameString).doesNotContain("service");
+    assertThat(nameString).doesNotContain("prod");
+    assertThat(nameString).doesNotContain("us-east");
+    assertThat(nameString).doesNotContain("api");
+
+    // Clean up
+    registry.close();
+  }
+
+  // Helper method to test predicate with a specific path
+  private boolean testPredicateWithPath(ObservationPredicate predicate, String path) {
+    ServerRequestObservationContext context = mock(ServerRequestObservationContext.class);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI(path);
+    when(context.getCarrier()).thenReturn(request);
+
+    return predicate.test("test.observation", context);
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactoryTest.java
@@ -1,0 +1,430 @@
+package com.linkedin.gms.factory.system_telemetry;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.PlatformAnalyticsConfiguration;
+import com.linkedin.metadata.config.UsageExportConfiguration;
+import com.linkedin.metadata.config.kafka.KafkaConfiguration;
+import com.linkedin.metadata.config.kafka.TopicsConfiguration;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.Producer;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.*;
+
+public class OpenTelemetryBaseFactoryTest {
+
+  // Mock TopicsConfiguration since it's not provided in the classes
+  public static class TopicsConfiguration
+      extends com.linkedin.metadata.config.kafka.TopicsConfiguration {
+    private String dataHubUsage;
+
+    public String getDataHubUsage() {
+      return dataHubUsage;
+    }
+
+    public void setDataHubUsage(String dataHubUsage) {
+      this.dataHubUsage = dataHubUsage;
+    }
+  }
+
+  // Extend KafkaConfiguration to add the missing setTopics method for testing
+  public static class TestKafkaConfiguration extends KafkaConfiguration {
+    private TopicsConfiguration topics;
+
+    public void setTopics(TopicsConfiguration topics) {
+      this.topics = topics;
+    }
+
+    @Override
+    public TopicsConfiguration getTopics() {
+      return topics;
+    }
+  }
+
+  @Mock private MetricUtils mockMetricUtils;
+
+  @Mock private ConfigurationProvider mockConfigurationProvider;
+
+  @Mock private Producer<String, String> mockProducer;
+
+  @Mock private PlatformAnalyticsConfiguration mockPlatformAnalytics;
+
+  @Mock private UsageExportConfiguration mockUsageExport;
+
+  @Mock private KafkaConfiguration mockKafka;
+
+  @Mock private TopicsConfiguration mockTopics;
+
+  private TestOpenTelemetryFactory factory;
+  private AutoCloseable mocks;
+
+  // Test implementation of the abstract class
+  private static class TestOpenTelemetryFactory extends OpenTelemetryBaseFactory {
+    private final String applicationComponent;
+
+    public TestOpenTelemetryFactory(String applicationComponent) {
+      this.applicationComponent = applicationComponent;
+    }
+
+    @Override
+    protected String getApplicationComponent() {
+      return applicationComponent;
+    }
+
+    // Expose protected method for testing
+    public SystemTelemetryContext testTraceContext(
+        MetricUtils metricUtils,
+        ConfigurationProvider configurationProvider,
+        Producer<String, String> dueProducer) {
+      return traceContext(metricUtils, configurationProvider, dueProducer);
+    }
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    factory = new TestOpenTelemetryFactory("test-component");
+
+    // Setup mock chain for ConfigurationProvider
+    when(mockConfigurationProvider.getPlatformAnalytics()).thenReturn(mockPlatformAnalytics);
+    when(mockPlatformAnalytics.getUsageExport()).thenReturn(mockUsageExport);
+    when(mockConfigurationProvider.getKafka()).thenReturn(mockKafka);
+    when(mockKafka.getTopics()).thenReturn(mockTopics);
+    when(mockTopics.getDataHubUsage()).thenReturn("test-usage-topic");
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    if (mocks != null) {
+      mocks.close();
+    }
+  }
+
+  @Test
+  public void testTraceContextWithUsageExportEnabled() {
+    // Arrange
+    when(mockPlatformAnalytics.isEnabled()).thenReturn(true);
+    when(mockUsageExport.isEnabled()).thenReturn(true);
+
+    // Act
+    SystemTelemetryContext context =
+        factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    // Assert
+    assertNotNull(context);
+    assertNotNull(context.getMetricUtils());
+    assertNotNull(context.getTracer());
+    assertNotNull(context.getUsageSpanExporter());
+    assertEquals(context.getMetricUtils(), mockMetricUtils);
+  }
+
+  @Test
+  public void testTraceContextWithUsageExportDisabled() {
+    // Arrange
+    when(mockPlatformAnalytics.isEnabled()).thenReturn(false);
+
+    // Act
+    SystemTelemetryContext context =
+        factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    // Assert
+    assertNotNull(context);
+    assertNotNull(context.getMetricUtils());
+    assertNotNull(context.getTracer());
+    assertNull(context.getUsageSpanExporter());
+  }
+
+  @Test
+  public void testTraceContextWithNullProducer() {
+    // Arrange
+    when(mockPlatformAnalytics.isEnabled()).thenReturn(true);
+    when(mockUsageExport.isEnabled()).thenReturn(true);
+
+    // Act
+    SystemTelemetryContext context =
+        factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, null);
+
+    // Assert
+    assertNotNull(context);
+    assertNull(context.getUsageSpanExporter());
+  }
+
+  @Test
+  public void testTraceContextWithPlatformAnalyticsEnabledButUsageExportDisabled() {
+    // Arrange
+    when(mockPlatformAnalytics.isEnabled()).thenReturn(true);
+    when(mockUsageExport.isEnabled()).thenReturn(false);
+
+    // Act
+    SystemTelemetryContext context =
+        factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    // Assert
+    assertNotNull(context);
+    assertNull(context.getUsageSpanExporter());
+  }
+
+  @Test
+  public void testGetUsageSpanExporterPrivateMethod() throws Exception {
+    // Use reflection to test private method
+    Method getUsageSpanExporterMethod =
+        OpenTelemetryBaseFactory.class.getDeclaredMethod(
+            "getUsageSpanExporter", ConfigurationProvider.class, Producer.class);
+    getUsageSpanExporterMethod.setAccessible(true);
+
+    // Test with all conditions met
+    when(mockPlatformAnalytics.isEnabled()).thenReturn(true);
+    when(mockUsageExport.isEnabled()).thenReturn(true);
+
+    SpanProcessor result =
+        (SpanProcessor)
+            getUsageSpanExporterMethod.invoke(factory, mockConfigurationProvider, mockProducer);
+
+    assertNotNull(result);
+    assertTrue(result instanceof BatchSpanProcessor);
+  }
+
+  @Test
+  public void testTracerCreation() throws Exception {
+    // Use reflection to test private tracer method
+    Method tracerMethod =
+        OpenTelemetryBaseFactory.class.getDeclaredMethod(
+            "tracer", io.opentelemetry.api.OpenTelemetry.class);
+    tracerMethod.setAccessible(true);
+
+    // Create a mock OpenTelemetry
+    io.opentelemetry.api.OpenTelemetry mockOpenTelemetry =
+        mock(io.opentelemetry.api.OpenTelemetry.class);
+    Tracer mockTracer = mock(Tracer.class);
+    when(mockOpenTelemetry.getTracer("test-component")).thenReturn(mockTracer);
+
+    Tracer result = (Tracer) tracerMethod.invoke(factory, mockOpenTelemetry);
+
+    assertNotNull(result);
+    assertEquals(result, mockTracer);
+    verify(mockOpenTelemetry).getTracer("test-component");
+  }
+
+  @Test
+  public void testUsageExportConfigurationProperties() {
+    // Test the full configuration chain with actual class properties
+    when(mockPlatformAnalytics.isEnabled()).thenReturn(true);
+    when(mockUsageExport.isEnabled()).thenReturn(true);
+    when(mockUsageExport.getUsageEventTypes()).thenReturn("LOGIN,LOGOUT,SEARCH");
+    when(mockUsageExport.getAspectTypes()).thenReturn("datasetProfile,datasetUsageStatistics");
+    when(mockUsageExport.getUserFilters()).thenReturn("urn:li:corpuser:datahub");
+
+    SystemTelemetryContext context =
+        factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    assertNotNull(context);
+    assertNotNull(context.getUsageSpanExporter());
+
+    // Verify that the configuration methods were called
+    verify(mockUsageExport, atLeastOnce()).isEnabled();
+    verify(mockPlatformAnalytics, atLeastOnce()).isEnabled();
+  }
+
+  @Test
+  public void testKafkaConfigurationIntegration() {
+    // Test Kafka configuration integration
+    when(mockPlatformAnalytics.isEnabled()).thenReturn(true);
+    when(mockUsageExport.isEnabled()).thenReturn(true);
+
+    // Mock Kafka configuration details
+    when(mockKafka.getBootstrapServers()).thenReturn("localhost:9092");
+
+    SystemTelemetryContext context =
+        factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    assertNotNull(context);
+    verify(mockKafka).getTopics();
+    verify(mockTopics).getDataHubUsage();
+  }
+
+  @Test
+  public void testConfigurationProviderInheritance() {
+    // Test that ConfigurationProvider properly extends DataHubAppConfiguration
+    ConfigurationProvider actualProvider = new ConfigurationProvider();
+
+    // Test that we can set and get inherited properties
+    KafkaConfiguration kafkaConfig = new KafkaConfiguration();
+    actualProvider.setKafka(kafkaConfig);
+
+    assertEquals(actualProvider.getKafka(), kafkaConfig);
+
+    // Test platform analytics configuration
+    PlatformAnalyticsConfiguration analyticsConfig = new PlatformAnalyticsConfiguration();
+    analyticsConfig.setEnabled(true);
+    actualProvider.setPlatformAnalytics(analyticsConfig);
+
+    assertTrue(actualProvider.getPlatformAnalytics().isEnabled());
+  }
+
+  @Test
+  public void testFullConfigurationChain() {
+    // Create actual configuration objects to test the full chain
+    ConfigurationProvider provider = new ConfigurationProvider();
+
+    // Setup Kafka configuration using our test extension
+    TestKafkaConfiguration kafkaConfig = new TestKafkaConfiguration();
+    TopicsConfiguration topicsConfig = new TopicsConfiguration();
+    topicsConfig.setDataHubUsage("datahub-usage-events");
+    kafkaConfig.setTopics(topicsConfig);
+    provider.setKafka(kafkaConfig);
+
+    // Setup Platform Analytics
+    PlatformAnalyticsConfiguration analyticsConfig = new PlatformAnalyticsConfiguration();
+    analyticsConfig.setEnabled(true);
+
+    UsageExportConfiguration usageExportConfig = new UsageExportConfiguration();
+    usageExportConfig.setEnabled(true);
+    usageExportConfig.setUsageEventTypes("LOGIN,SEARCH");
+    usageExportConfig.setAspectTypes("datasetProfile");
+    usageExportConfig.setUserFilters("urn:li:corpuser:test");
+
+    analyticsConfig.setUsageExport(usageExportConfig);
+    provider.setPlatformAnalytics(analyticsConfig);
+
+    // Verify the configuration chain
+    assertNotNull(provider.getKafka());
+    assertNotNull(provider.getKafka().getTopics());
+    assertNotNull(provider.getPlatformAnalytics());
+    assertNotNull(provider.getPlatformAnalytics().getUsageExport());
+    assertTrue(provider.getPlatformAnalytics().isEnabled());
+    assertTrue(provider.getPlatformAnalytics().getUsageExport().isEnabled());
+    assertEquals(
+        "LOGIN,SEARCH", provider.getPlatformAnalytics().getUsageExport().getUsageEventTypes());
+    assertEquals("datahub-usage-events", provider.getKafka().getTopics().getDataHubUsage());
+  }
+
+  @Test
+  public void testApplicationComponentNull() {
+    // Test with null application component
+    TestOpenTelemetryFactory nullComponentFactory = new TestOpenTelemetryFactory(null);
+
+    SystemTelemetryContext context =
+        nullComponentFactory.testTraceContext(
+            mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    assertNotNull(context);
+    // The service name should fall back to "default-service" when component is null
+  }
+
+  @Test
+  public void testEnvironmentVariableHandling() {
+    // This test verifies that the factory properly handles environment variables
+    // In a real test, you might want to use a library like System Rules or System Lambda
+    // to mock environment variables
+
+    Map<String, String> originalEnv = new HashMap<>();
+    originalEnv.put("OTEL_METRICS_EXPORTER", System.getenv("OTEL_METRICS_EXPORTER"));
+    originalEnv.put("OTEL_TRACES_EXPORTER", System.getenv("OTEL_TRACES_EXPORTER"));
+    originalEnv.put("OTEL_LOGS_EXPORTER", System.getenv("OTEL_LOGS_EXPORTER"));
+
+    try {
+      // Test with no environment variables set
+      SystemTelemetryContext context =
+          factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+      assertNotNull(context);
+      // The default should be "none" for exporters when env vars are not set
+    } finally {
+      // Restore original environment (in a real test, use proper env mocking)
+    }
+  }
+
+  @Test
+  public void testOpenTelemetryConfiguration() throws Exception {
+    // Test the OpenTelemetry configuration
+    Method openTelemetryMethod =
+        OpenTelemetryBaseFactory.class.getDeclaredMethod(
+            "openTelemetry", MetricUtils.class, SpanProcessor.class);
+    openTelemetryMethod.setAccessible(true);
+
+    SpanProcessor mockSpanProcessor = mock(SpanProcessor.class);
+
+    io.opentelemetry.api.OpenTelemetry result =
+        (io.opentelemetry.api.OpenTelemetry)
+            openTelemetryMethod.invoke(factory, mockMetricUtils, mockSpanProcessor);
+
+    assertNotNull(result);
+  }
+
+  @Test
+  public void testTraceContextWithNullMetricUtils() {
+    factory.testTraceContext(null, mockConfigurationProvider, mockProducer);
+    // should not throw exception
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void testTraceContextWithNullConfigurationProvider() {
+    // This should throw NPE as ConfigurationProvider is required
+    factory.testTraceContext(mockMetricUtils, null, mockProducer);
+  }
+
+  @Test
+  public void testMultipleInstancesWithDifferentComponents() {
+    // Test that multiple instances can be created with different components
+    TestOpenTelemetryFactory factory1 = new TestOpenTelemetryFactory("component1");
+    TestOpenTelemetryFactory factory2 = new TestOpenTelemetryFactory("component2");
+
+    SystemTelemetryContext context1 =
+        factory1.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+    SystemTelemetryContext context2 =
+        factory2.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    assertNotNull(context1);
+    assertNotNull(context2);
+    // Each should have its own tracer with the respective component name
+  }
+
+  @Test
+  public void testSystemTelemetryContextStaticFields() throws Exception {
+    // Test handling of static fields in SystemTelemetryContext
+    Field logSpanExporterField = SystemTelemetryContext.class.getDeclaredField("LOG_SPAN_EXPORTER");
+    logSpanExporterField.setAccessible(true);
+
+    Field traceIdGeneratorField =
+        SystemTelemetryContext.class.getDeclaredField("TRACE_ID_GENERATOR");
+    traceIdGeneratorField.setAccessible(true);
+
+    // Test with null static fields (default behavior)
+    SystemTelemetryContext context =
+        factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    assertNotNull(context);
+    // The factory should handle null static fields gracefully with fallbacks
+  }
+
+  @Test
+  public void testPropagatorCustomization() {
+    // Test that W3C trace context propagator is used when OTEL_PROPAGATORS is not set
+    SystemTelemetryContext context =
+        factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    assertNotNull(context);
+    // The W3CTraceContextPropagator should be configured
+  }
+
+  @Test
+  public void testMetricExporterCustomization() {
+    // Test metric exporter customization
+    SystemTelemetryContext context =
+        factory.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockProducer);
+
+    assertNotNull(context);
+    // Should use MetricSpanExporter when OTEL_METRICS_EXPORTER is not set
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/metadata/ingestion/validation/ExecutionIngestionAuthTestConfiguration.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/metadata/ingestion/validation/ExecutionIngestionAuthTestConfiguration.java
@@ -15,7 +15,8 @@ import com.linkedin.metadata.search.SearchService;
 import com.linkedin.metadata.search.client.CachingEntitySearchService;
 import com.linkedin.metadata.service.RollbackService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
-import org.springframework.beans.factory.annotation.Qualifier;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -41,50 +42,42 @@ public class ExecutionIngestionAuthTestConfiguration {
             .getResourceAsStream("entity-registry.yml"));
   }
 
-  @Qualifier("entityService")
-  @MockBean
+  @MockBean(name = "entityService")
   private EntityService<?> entityService;
 
-  @Qualifier("graphClient")
-  @MockBean
+  @MockBean(name = "graphClient")
   private GraphClient graphClient;
 
   @MockBean private GraphService graphService;
 
-  @Qualifier("searchService")
-  @MockBean
+  @MockBean(name = "searchService")
   private SearchService searchService;
 
-  @Qualifier("baseElasticSearchComponents")
-  @MockBean
+  @MockBean(name = "baseElasticSearchComponents")
   private BaseElasticSearchComponentsFactory.BaseElasticSearchComponents
       baseElasticSearchComponents;
 
-  @Qualifier("deleteEntityService")
-  @MockBean
+  @MockBean(name = "deleteEntityService")
   private DeleteEntityService deleteEntityService;
 
-  @Qualifier("entitySearchService")
-  @MockBean
+  @MockBean(name = "entitySearchService")
   private EntitySearchService entitySearchService;
 
-  @Qualifier("cachingEntitySearchService")
-  @MockBean
+  @MockBean(name = "cachingEntitySearchService")
   private CachingEntitySearchService cachingEntitySearchService;
 
-  @Qualifier("timeseriesAspectService")
-  @MockBean
+  @MockBean(name = "timeseriesAspectService")
   private TimeseriesAspectService timeseriesAspectService;
 
-  @Qualifier("relationshipSearchService")
-  @MockBean
+  @MockBean(name = "relationshipSearchService")
   private LineageSearchService lineageSearchService;
 
-  @Qualifier("kafkaEventProducer")
-  @MockBean
+  @MockBean(name = "kafkaEventProducer")
   private EventProducer eventProducer;
 
   @MockBean private RollbackService rollbackService;
 
-  @MockBean private io.datahubproject.metadata.context.TraceContext traceContext;
+  @MockBean private SystemTelemetryContext systemTelemetryContext;
+
+  @MockBean private MetricUtils metricUtils;
 }

--- a/metadata-service/openapi-entity-servlet/src/test/java/io/datahubproject/openapi/config/OpenAPIEntityTestConfiguration.java
+++ b/metadata-service/openapi-entity-servlet/src/test/java/io/datahubproject/openapi/config/OpenAPIEntityTestConfiguration.java
@@ -28,7 +28,7 @@ import com.linkedin.metadata.search.SearchService;
 import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeline.TimelineService;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.openapi.dto.UrnResponseMap;
 import io.datahubproject.openapi.generated.EntityResponse;
 import io.datahubproject.openapi.v1.entities.EntitiesController;
@@ -48,11 +48,12 @@ import org.springframework.http.ResponseEntity;
 
 @TestConfiguration
 public class OpenAPIEntityTestConfiguration {
-  @MockBean TraceContext traceContext;
+  @MockBean SystemTelemetryContext systemTelemetryContext;
 
   @Bean
-  public TracingInterceptor tracingInterceptor(final TraceContext traceContext) {
-    return new TracingInterceptor(traceContext);
+  public TracingInterceptor tracingInterceptor(
+      final SystemTelemetryContext systemTelemetryContext) {
+    return new TracingInterceptor(systemTelemetryContext);
   }
 
   @Bean

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/util/MappingUtil.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/util/MappingUtil.java
@@ -28,7 +28,6 @@ import com.linkedin.metadata.entity.RollbackRunResult;
 import com.linkedin.metadata.entity.ebean.batch.AspectsBatchImpl;
 import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
 import com.linkedin.metadata.entity.validation.ValidationException;
-import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
@@ -513,9 +512,17 @@ public class MappingUtil {
       throw e;
     } finally {
       if (exceptionally != null) {
-        MetricUtils.counter(MetricRegistry.name("postEntity", "failed")).inc();
+        opContext
+            .getMetricUtils()
+            .ifPresent(
+                metricUtils ->
+                    metricUtils.increment(MetricRegistry.name("postEntity", "failed"), 1));
       } else {
-        MetricUtils.counter(MetricRegistry.name("postEntity", "success")).inc();
+        opContext
+            .getMetricUtils()
+            .ifPresent(
+                metricUtils ->
+                    metricUtils.increment(MetricRegistry.name("postEntity", "success"), 1));
       }
     }
   }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/entities/EntitiesController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/entities/EntitiesController.java
@@ -71,6 +71,7 @@ public class EntitiesController {
   private final EntityService<ChangeItemImpl> _entityService;
   private final ObjectMapper _objectMapper;
   private final AuthorizerChain _authorizerChain;
+  @Nullable private final MetricUtils metricUtils;
 
   public EntitiesController(
       OperationContext systemOperationContext,
@@ -78,6 +79,7 @@ public class EntitiesController {
       ObjectMapper _objectMapper,
       AuthorizerChain _authorizerChain) {
     this.systemOperationContext = systemOperationContext;
+    this.metricUtils = systemOperationContext.getMetricUtils().orElse(null);
     this._entityService = _entityService;
     this._objectMapper = _objectMapper;
     this._authorizerChain = _authorizerChain;
@@ -161,10 +163,12 @@ public class EntitiesController {
               entityUrns, projectedAspects),
           e);
     } finally {
-      if (exceptionally != null) {
-        MetricUtils.counter(MetricRegistry.name("getEntities", "failed")).inc();
-      } else {
-        MetricUtils.counter(MetricRegistry.name("getEntities", "success")).inc();
+      if (metricUtils != null) {
+        if (exceptionally != null) {
+          metricUtils.increment(MetricRegistry.name("getEntities", "failed"), 1);
+        } else {
+          metricUtils.increment(MetricRegistry.name("getEntities", "success"), 1);
+        }
       }
     }
   }
@@ -336,10 +340,12 @@ public class EntitiesController {
       throw new RuntimeException(
           String.format("Failed to batch delete entities with urns: %s", Arrays.asList(urns)), e);
     } finally {
-      if (exceptionally != null) {
-        MetricUtils.counter(MetricRegistry.name("getEntities", "failed")).inc();
-      } else {
-        MetricUtils.counter(MetricRegistry.name("getEntities", "success")).inc();
+      if (metricUtils != null) {
+        if (exceptionally != null) {
+          metricUtils.increment(MetricRegistry.name("getEntities", "failed"), 1);
+        } else {
+          metricUtils.increment(MetricRegistry.name("getEntities", "success"), 1);
+        }
       }
     }
   }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/relationships/RelationshipsController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/relationships/RelationshipsController.java
@@ -14,7 +14,6 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.graph.RelatedEntitiesResult;
 import com.linkedin.metadata.search.utils.QueryUtils;
-import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.openapi.exception.UnauthorizedException;
@@ -198,9 +197,17 @@ public class RelationshipsController {
           e);
     } finally {
       if (exceptionally != null) {
-        MetricUtils.counter(MetricRegistry.name("getRelationships", "failed")).inc();
+        opContext
+            .getMetricUtils()
+            .ifPresent(
+                metricUtils ->
+                    metricUtils.increment(MetricRegistry.name("getRelationships", "failed"), 1));
       } else {
-        MetricUtils.counter(MetricRegistry.name("getRelationships", "success")).inc();
+        opContext
+            .getMetricUtils()
+            .ifPresent(
+                metricUtils ->
+                    metricUtils.increment(MetricRegistry.name("getRelationships", "success"), 1));
       }
     }
   }

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/elastic/ElasticsearchControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/elastic/ElasticsearchControllerTest.java
@@ -31,7 +31,7 @@ import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.timeseries.TimeseriesIndexSizeResult;
 import io.datahubproject.metadata.context.ObjectMapperContext;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.openapi.config.TracingInterceptor;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.opentelemetry.api.OpenTelemetry;
@@ -415,7 +415,7 @@ public class ElasticsearchControllerTest extends AbstractTestNGSpringContextTest
 
             // Create a tracer
             Tracer tracer = openTelemetry.getTracer("test-tracer");
-            return TraceContext.builder().tracer(tracer).build();
+            return SystemTelemetryContext.builder().tracer(tracer).build();
           });
     }
 
@@ -427,9 +427,9 @@ public class ElasticsearchControllerTest extends AbstractTestNGSpringContextTest
 
     @Bean
     @Primary
-    public TraceContext traceContext(
+    public SystemTelemetryContext traceContext(
         @Qualifier("systemOperationContext") OperationContext systemOperationContext) {
-      return systemOperationContext.getTraceContext();
+      return systemOperationContext.getSystemTelemetryContext();
     }
 
     @Bean

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/kafka/KafkaControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/kafka/KafkaControllerTest.java
@@ -20,7 +20,7 @@ import com.linkedin.metadata.trace.MCLTraceReader;
 import com.linkedin.metadata.trace.MCPTraceReader;
 import io.datahubproject.metadata.context.ObjectMapperContext;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.openapi.config.TracingInterceptor;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Collection;
@@ -402,10 +402,10 @@ public class KafkaControllerTest extends AbstractTestNGSpringContextTests {
 
     @Bean(name = "systemOperationContext")
     public OperationContext systemOperationContext(ObjectMapper objectMapper) {
-      TraceContext traceContext = mock(TraceContext.class);
+      SystemTelemetryContext systemTelemetryContext = mock(SystemTelemetryContext.class);
       return TestOperationContexts.systemContextTraceNoSearchAuthorization(
           () -> ObjectMapperContext.builder().objectMapper(objectMapper).build(),
-          () -> traceContext);
+          () -> systemTelemetryContext);
     }
 
     @Bean
@@ -416,9 +416,9 @@ public class KafkaControllerTest extends AbstractTestNGSpringContextTests {
 
     @Bean
     @Primary
-    public TraceContext traceContext(
+    public SystemTelemetryContext traceContext(
         @Qualifier("systemOperationContext") OperationContext systemOperationContext) {
-      return systemOperationContext.getTraceContext();
+      return systemOperationContext.getSystemTelemetryContext();
     }
 
     @Bean

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/v1/TraceControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/v1/TraceControllerTest.java
@@ -20,7 +20,7 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.systemmetadata.TraceService;
 import io.datahubproject.metadata.context.ObjectMapperContext;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.openapi.config.TracingInterceptor;
 import io.datahubproject.openapi.v1.models.TraceRequestV1;
 import io.datahubproject.openapi.v1.models.TraceResponseV1;
@@ -239,10 +239,10 @@ public class TraceControllerTest extends AbstractTestNGSpringContextTests {
 
     @Bean(name = "systemOperationContext")
     public OperationContext systemOperationContext(ObjectMapper objectMapper) {
-      TraceContext traceContext = mock(TraceContext.class);
+      SystemTelemetryContext systemTelemetryContext = mock(SystemTelemetryContext.class);
       return TestOperationContexts.systemContextTraceNoSearchAuthorization(
           () -> ObjectMapperContext.builder().objectMapper(objectMapper).build(),
-          () -> traceContext);
+          () -> systemTelemetryContext);
     }
 
     @Bean
@@ -253,9 +253,9 @@ public class TraceControllerTest extends AbstractTestNGSpringContextTests {
 
     @Bean
     @Primary
-    public TraceContext traceContext(
+    public SystemTelemetryContext traceContext(
         @Qualifier("systemOperationContext") OperationContext systemOperationContext) {
-      return systemOperationContext.getTraceContext();
+      return systemOperationContext.getSystemTelemetryContext();
     }
 
     @Bean

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/entities/EntitiesControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/entities/EntitiesControllerTest.java
@@ -1,0 +1,282 @@
+package io.datahubproject.openapi.v1.entities;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.codahale.metrics.MetricRegistry;
+import com.datahub.authentication.Actor;
+import com.datahub.authentication.ActorType;
+import com.datahub.authentication.Authentication;
+import com.datahub.authentication.AuthenticationContext;
+import com.datahub.authorization.AuthUtil;
+import com.datahub.authorization.AuthorizerChain;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.RollbackRunResult;
+import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
+import io.datahubproject.openapi.exception.UnauthorizedException;
+import io.datahubproject.openapi.util.MappingUtil;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class EntitiesControllerTest {
+
+  private OperationContext systemOperationContext;
+
+  @Mock private EntityService<ChangeItemImpl> entityService;
+
+  @Mock private ObjectMapper objectMapper;
+
+  @Mock private AuthorizerChain authorizerChain;
+
+  @Mock private MetricUtils metricUtils;
+
+  @Mock private HttpServletRequest request;
+
+  @Mock private Authentication authentication;
+
+  @Mock private EntityRegistry entityRegistry;
+
+  private EntitiesController controller;
+
+  private AutoCloseable mocks;
+
+  @BeforeMethod
+  public void setup() {
+    mocks = MockitoAnnotations.openMocks(this);
+
+    systemOperationContext =
+        TestOperationContexts.Builder.builder()
+            .systemTelemetryContextSupplier(
+                () -> SystemTelemetryContext.TEST.toBuilder().metricUtils(metricUtils).build())
+            .buildSystemContext();
+
+    // Create controller
+    controller =
+        new EntitiesController(
+            systemOperationContext, entityService, objectMapper, authorizerChain);
+
+    // Setup authentication
+    Actor actor = new Actor(ActorType.USER, "urn:li:corpuser:testuser");
+    when(authentication.getActor()).thenReturn(actor);
+
+    // request
+    when(request.getHeader(anyString())).thenReturn("");
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    if (mocks != null) {
+      mocks.close();
+    }
+  }
+
+  @Test
+  public void testGetEntitiesSuccess() throws Exception {
+    // Given
+    String[] urns = {"urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"};
+    String[] aspectNames = {"datasetProperties", "status"};
+
+    Set<Urn> entityUrns = new HashSet<>();
+    entityUrns.add(UrnUtils.getUrn(urns[0]));
+
+    // Mock entity responses
+    Map<Urn, EntityResponse> mockResponses = new HashMap<>();
+    EntityResponse entityResponse = new EntityResponse();
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    entityResponse.setAspects(aspectMap);
+    mockResponses.put(entityUrns.iterator().next(), entityResponse);
+
+    try (MockedStatic<AuthenticationContext> authContext =
+            Mockito.mockStatic(AuthenticationContext.class);
+        MockedStatic<OperationContext> opContext = Mockito.mockStatic(OperationContext.class);
+        MockedStatic<AuthUtil> authUtil = Mockito.mockStatic(AuthUtil.class);
+        MockedStatic<MappingUtil> mappingUtil = Mockito.mockStatic(MappingUtil.class)) {
+
+      authContext.when(AuthenticationContext::getAuthentication).thenReturn(authentication);
+
+      OperationContext mockOpContext = mock(OperationContext.class);
+      when(mockOpContext.getEntityAspectNames(anyString()))
+          .thenReturn(new HashSet<>(Arrays.asList(aspectNames)));
+
+      opContext
+          .when(() -> OperationContext.asSession(any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(mockOpContext);
+
+      authUtil.when(() -> AuthUtil.isAPIAuthorizedEntityUrns(any(), any(), any())).thenReturn(true);
+
+      when(entityService.getEntitiesV2(any(), anyString(), anySet(), anySet()))
+          .thenReturn(mockResponses);
+
+      Map<String, Object> mappedResponses = new HashMap<>();
+      mappingUtil
+          .when(() -> MappingUtil.mapServiceResponse(any(), any()))
+          .thenReturn(mappedResponses);
+
+      // When
+      ResponseEntity<?> response = controller.getEntities(request, urns, aspectNames);
+
+      // Then
+      assertEquals(response.getStatusCode(), HttpStatus.OK);
+      assertNotNull(response.getBody());
+      verify(metricUtils).increment(eq(MetricRegistry.name("getEntities", "success")), eq(1d));
+    }
+  }
+
+  @Test(expectedExceptions = UnauthorizedException.class)
+  public void testGetEntitiesUnauthorized() throws Exception {
+    // Given
+    String[] urns = {"urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"};
+
+    try (MockedStatic<AuthenticationContext> authContext =
+            Mockito.mockStatic(AuthenticationContext.class);
+        MockedStatic<OperationContext> opContext = Mockito.mockStatic(OperationContext.class);
+        MockedStatic<AuthUtil> authUtil = Mockito.mockStatic(AuthUtil.class)) {
+
+      authContext.when(AuthenticationContext::getAuthentication).thenReturn(authentication);
+
+      OperationContext mockOpContext = mock(OperationContext.class);
+      opContext
+          .when(() -> OperationContext.asSession(any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(mockOpContext);
+
+      authUtil
+          .when(() -> AuthUtil.isAPIAuthorizedEntityUrns(any(), any(), any()))
+          .thenReturn(false);
+
+      // When/Then
+      controller.getEntities(request, urns, null);
+    }
+  }
+
+  @Test
+  public void testGetEntitiesEmptyUrns() throws Exception {
+    // Given
+    String[] urns = {};
+
+    try (MockedStatic<AuthenticationContext> authContext =
+            Mockito.mockStatic(AuthenticationContext.class);
+        MockedStatic<OperationContext> opContext = Mockito.mockStatic(OperationContext.class);
+        MockedStatic<AuthUtil> authUtil = Mockito.mockStatic(AuthUtil.class)) {
+
+      authContext.when(AuthenticationContext::getAuthentication).thenReturn(authentication);
+
+      OperationContext mockOpContext = mock(OperationContext.class);
+      opContext
+          .when(() -> OperationContext.asSession(any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(mockOpContext);
+
+      authUtil.when(() -> AuthUtil.isAPIAuthorizedEntityUrns(any(), any(), any())).thenReturn(true);
+
+      // When
+      ResponseEntity<?> response = controller.getEntities(request, urns, null);
+
+      // Then
+      assertEquals(response.getStatusCode(), HttpStatus.OK);
+      assertNotNull(response.getBody());
+      verify(entityService, never()).getEntitiesV2(any(), anyString(), anySet(), anySet());
+    }
+  }
+
+  @Test
+  public void testDeleteEntitiesHardDelete() throws Exception {
+    // Given
+    String[] urns = {"urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"};
+    boolean soft = false;
+
+    try (MockedStatic<AuthenticationContext> authContext =
+            Mockito.mockStatic(AuthenticationContext.class);
+        MockedStatic<OperationContext> opContext = Mockito.mockStatic(OperationContext.class);
+        MockedStatic<AuthUtil> authUtil = Mockito.mockStatic(AuthUtil.class)) {
+
+      authContext.when(AuthenticationContext::getAuthentication).thenReturn(authentication);
+
+      OperationContext mockOpContext = mock(OperationContext.class);
+      opContext
+          .when(() -> OperationContext.asSession(any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(mockOpContext);
+
+      authUtil.when(() -> AuthUtil.isAPIAuthorizedEntityUrns(any(), any(), any())).thenReturn(true);
+
+      // Mock hard delete
+      RollbackRunResult rollbackResult = mock(RollbackRunResult.class);
+      when(entityService.deleteUrn(any(), any())).thenReturn(rollbackResult);
+
+      // When
+      ResponseEntity<?> response = controller.deleteEntities(request, urns, soft, false);
+
+      // Then
+      assertEquals(response.getStatusCode(), HttpStatus.OK);
+      assertNotNull(response.getBody());
+      verify(entityService, times(1)).deleteUrn(any(), any());
+      verify(metricUtils).increment(eq(MetricRegistry.name("getEntities", "success")), eq(1d));
+    }
+  }
+
+  @Test
+  public void testGetEntitiesWithException() throws Exception {
+    // Given
+    String[] urns = {"urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"};
+
+    try (MockedStatic<AuthenticationContext> authContext =
+            Mockito.mockStatic(AuthenticationContext.class);
+        MockedStatic<OperationContext> opContext = Mockito.mockStatic(OperationContext.class);
+        MockedStatic<AuthUtil> authUtil = Mockito.mockStatic(AuthUtil.class)) {
+
+      authContext.when(AuthenticationContext::getAuthentication).thenReturn(authentication);
+
+      OperationContext mockOpContext = mock(OperationContext.class);
+      when(mockOpContext.getEntityAspectNames(anyString())).thenReturn(new HashSet<>());
+
+      opContext
+          .when(() -> OperationContext.asSession(any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(mockOpContext);
+
+      authUtil.when(() -> AuthUtil.isAPIAuthorizedEntityUrns(any(), any(), any())).thenReturn(true);
+
+      when(entityService.getEntitiesV2(any(), anyString(), anySet(), anySet()))
+          .thenThrow(new RuntimeException("Test exception"));
+
+      // When/Then
+      try {
+        controller.getEntities(request, urns, null);
+      } catch (RuntimeException e) {
+        assertTrue(e.getMessage().contains("Failed to batch get entities"));
+        verify(metricUtils).increment(eq(MetricRegistry.name("getEntities", "failed")), eq(1d));
+      }
+    }
+  }
+}

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/event/ExternalEventsControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/event/ExternalEventsControllerTest.java
@@ -31,7 +31,7 @@ import io.datahubproject.event.ExternalEventsService;
 import io.datahubproject.event.models.v1.ExternalEvent;
 import io.datahubproject.event.models.v1.ExternalEvents;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.openapi.config.SpringWebConfig;
 import io.datahubproject.openapi.config.TracingInterceptor;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
@@ -301,6 +301,9 @@ public class ExternalEventsControllerTest extends AbstractTestNGSpringContextTes
 
   @Test
   public void testAuditEventsSearch() throws Exception {
+    when(mockAuthorizerChain.authorize(any(AuthorizationRequest.class)))
+        .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+
     LogInEvent usageEventResult =
         LogInEvent.builder()
             .eventType("LogInEvent")
@@ -339,7 +342,7 @@ public class ExternalEventsControllerTest extends AbstractTestNGSpringContextTes
   public static class ExternalEventsControllerTestConfig {
     @MockBean public ExternalEventsService eventsService;
     @MockBean public AuthorizerChain authorizerChain;
-    @MockBean public TraceContext traceContext;
+    @MockBean public SystemTelemetryContext systemTelemetryContext;
     @MockBean public DataHubUsageService dataHubUsageService;
 
     @Bean

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/relationships/RelationshipsControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/relationships/RelationshipsControllerTest.java
@@ -1,0 +1,229 @@
+package io.datahubproject.openapi.v1.relationships;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.datahub.authentication.Actor;
+import com.datahub.authentication.ActorType;
+import com.datahub.authentication.Authentication;
+import com.datahub.authentication.AuthenticationContext;
+import com.datahub.authorization.AuthUtil;
+import com.datahub.authorization.AuthorizerChain;
+import com.google.common.net.HttpHeaders;
+import com.linkedin.metadata.graph.GraphService;
+import com.linkedin.metadata.graph.RelatedEntitiesResult;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.RelationshipFilter;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.openapi.exception.UnauthorizedException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.WebDataBinder;
+import org.testng.annotations.*;
+
+public class RelationshipsControllerTest {
+
+  @Mock private GraphService graphService;
+
+  @Mock private AuthorizerChain authorizerChain;
+
+  @Mock private HttpServletRequest httpServletRequest;
+
+  @Mock private Authentication authentication;
+
+  @Mock private OperationContext mockOperationContext;
+
+  @InjectMocks private RelationshipsController relationshipsController;
+
+  private AutoCloseable mocks;
+  private MockedStatic<AuthenticationContext> authenticationContextMock;
+  private MockedStatic<AuthUtil> authUtilMock;
+  private MockedStatic<OperationContext> operationContextMock;
+
+  @BeforeMethod
+  public void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+
+    // Mock static methods
+    authenticationContextMock = mockStatic(AuthenticationContext.class);
+    authUtilMock = mockStatic(AuthUtil.class);
+    operationContextMock = mockStatic(OperationContext.class);
+
+    // Setup authentication
+    Actor actor = new Actor(ActorType.USER, "urn:li:corpuser:testuser");
+    when(authentication.getActor()).thenReturn(actor);
+    authenticationContextMock
+        .when(AuthenticationContext::getAuthentication)
+        .thenReturn(authentication);
+
+    // Setup operation context
+    operationContextMock
+        .when(
+            () ->
+                OperationContext.asSession(
+                    any(OperationContext.class),
+                    any(),
+                    any(AuthorizerChain.class),
+                    any(Authentication.class),
+                    anyBoolean()))
+        .thenReturn(mockOperationContext);
+
+    // Setup default metric utils behavior
+    when(mockOperationContext.getMetricUtils()).thenReturn(java.util.Optional.empty());
+
+    when(httpServletRequest.getHeader(eq(HttpHeaders.X_FORWARDED_FOR))).thenReturn("0.0.0.0");
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    authenticationContextMock.close();
+    authUtilMock.close();
+    operationContextMock.close();
+    if (mocks != null) {
+      mocks.close();
+    }
+  }
+
+  @Test
+  public void testInitBinder() {
+    WebDataBinder binder = mock(WebDataBinder.class);
+    relationshipsController.initBinder(binder);
+    verify(binder).registerCustomEditor(eq(String[].class), any());
+  }
+
+  @Test
+  public void testGetRelationshipsWithEncodedUrn() {
+    // Arrange
+    String encodedUrn =
+        "urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Ahive%2CSampleHiveDataset%2CPROD%29";
+    String decodedUrn = "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)";
+    String[] relationshipTypes = {"DownstreamOf"};
+    RelationshipsController.RelationshipDirection direction =
+        RelationshipsController.RelationshipDirection.OUTGOING;
+
+    RelatedEntitiesResult expectedResult = new RelatedEntitiesResult(0, 10, 0, new ArrayList<>());
+
+    authUtilMock
+        .when(() -> AuthUtil.isAPIAuthorizedUrns(any(OperationContext.class), any(), any(), any()))
+        .thenReturn(true);
+
+    when(graphService.findRelatedEntities(
+            any(OperationContext.class),
+            isNull(),
+            argThat(filter -> filter.getCriteria().get(0).getValue().toString().equals(decodedUrn)),
+            isNull(),
+            any(Filter.class),
+            any(Set.class),
+            any(RelationshipFilter.class),
+            anyInt(),
+            anyInt()))
+        .thenReturn(expectedResult);
+
+    // Act
+    ResponseEntity<RelatedEntitiesResult> response =
+        relationshipsController.getRelationships(
+            httpServletRequest, encodedUrn, relationshipTypes, direction, 0, 10);
+
+    // Assert
+    assertEquals(response.getStatusCode(), HttpStatus.OK);
+  }
+
+  @Test(expectedExceptions = UnauthorizedException.class)
+  public void testGetRelationshipsUnauthorized() {
+    // Arrange
+    String urn = "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)";
+    String[] relationshipTypes = {"DownstreamOf"};
+    RelationshipsController.RelationshipDirection direction =
+        RelationshipsController.RelationshipDirection.OUTGOING;
+
+    authUtilMock
+        .when(() -> AuthUtil.isAPIAuthorizedUrns(any(OperationContext.class), any(), any(), any()))
+        .thenReturn(false);
+
+    // Act
+    relationshipsController.getRelationships(
+        httpServletRequest, urn, relationshipTypes, direction, 0, 10);
+  }
+
+  @Test
+  public void testGetRelationshipsEmptyRelationshipTypes() {
+    // Arrange
+    String urn = "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)";
+    String[] relationshipTypes = {};
+    RelationshipsController.RelationshipDirection direction =
+        RelationshipsController.RelationshipDirection.OUTGOING;
+
+    RelatedEntitiesResult expectedResult = new RelatedEntitiesResult(0, 10, 0, new ArrayList<>());
+
+    authUtilMock
+        .when(() -> AuthUtil.isAPIAuthorizedUrns(any(OperationContext.class), any(), any(), any()))
+        .thenReturn(true);
+
+    when(graphService.findRelatedEntities(
+            any(OperationContext.class),
+            isNull(),
+            any(Filter.class),
+            isNull(),
+            any(Filter.class),
+            argThat(Set::isEmpty),
+            any(RelationshipFilter.class),
+            anyInt(),
+            anyInt()))
+        .thenReturn(expectedResult);
+
+    // Act
+    ResponseEntity<RelatedEntitiesResult> response =
+        relationshipsController.getRelationships(
+            httpServletRequest, urn, relationshipTypes, direction, 0, 10);
+
+    // Assert
+    assertEquals(response.getStatusCode(), HttpStatus.OK);
+    assertEquals(response.getBody().getTotal(), 0);
+  }
+
+  @Test
+  public void testGetRelationshipsWithMetrics() {
+    // Arrange
+    String urn = "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)";
+    String[] relationshipTypes = {"DownstreamOf"};
+    RelationshipsController.RelationshipDirection direction =
+        RelationshipsController.RelationshipDirection.OUTGOING;
+
+    RelatedEntitiesResult expectedResult = new RelatedEntitiesResult(0, 10, 1, new ArrayList<>());
+
+    authUtilMock
+        .when(() -> AuthUtil.isAPIAuthorizedUrns(any(OperationContext.class), any(), any(), any()))
+        .thenReturn(true);
+
+    when(graphService.findRelatedEntities(
+            any(OperationContext.class),
+            isNull(),
+            any(Filter.class),
+            isNull(),
+            any(Filter.class),
+            any(Set.class),
+            any(RelationshipFilter.class),
+            anyInt(),
+            anyInt()))
+        .thenReturn(expectedResult);
+
+    // Mock metric utils
+    when(mockOperationContext.getMetricUtils()).thenReturn(java.util.Optional.empty());
+
+    // Act
+    ResponseEntity<RelatedEntitiesResult> response =
+        relationshipsController.getRelationships(
+            httpServletRequest, urn, relationshipTypes, direction, 0, 10);
+
+    // Assert
+    assertEquals(response.getStatusCode(), HttpStatus.OK);
+    verify(mockOperationContext, atLeastOnce()).getMetricUtils();
+  }
+}

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/EntityControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/EntityControllerTest.java
@@ -74,7 +74,7 @@ import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.TraceContext;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.metadata.context.ValidationContext;
 import io.datahubproject.openapi.config.GlobalControllerExceptionHandler;
 import io.datahubproject.openapi.config.SpringWebConfig;
@@ -431,7 +431,7 @@ public class EntityControllerTest extends AbstractTestNGSpringContextTests {
     @MockBean public EntityServiceImpl entityService;
     @MockBean public SearchService searchService;
     @MockBean public TimeseriesAspectService timeseriesAspectService;
-    @MockBean public TraceContext traceContext;
+    @MockBean public SystemTelemetryContext systemTelemetryContext;
 
     @Bean
     public ObjectMapper objectMapper() {

--- a/metadata-service/restli-client-api/build.gradle
+++ b/metadata-service/restli-client-api/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   api project(path: ':metadata-service:restli-api', configuration: 'restClient')
   api project(':metadata-operation-context')
   implementation project(':metadata-service:configuration')
+  implementation project(':metadata-utils')
 
   implementation externalDependency.caffeine
   implementation externalDependency.slf4jApi

--- a/metadata-service/restli-client-api/src/main/java/com/linkedin/common/client/ClientCache.java
+++ b/metadata-service/restli-client-api/src/main/java/com/linkedin/common/client/ClientCache.java
@@ -1,17 +1,15 @@
 package com.linkedin.common.client;
 
-import com.codahale.metrics.Gauge;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Expiry;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.Weigher;
-import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.linkedin.metadata.config.cache.client.ClientCacheConfig;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
+import com.linkedin.metadata.utils.metrics.MicrometerMetricsRegistry;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -57,7 +55,7 @@ public class ClientCache<K, V, C extends ClientCacheConfig> {
       return null;
     }
 
-    public ClientCache<K, V, C> build(Class<?> metricClazz) {
+    public ClientCache<K, V, C> build(MetricUtils metricUtils, Class<?> metricClazz) {
       // loads data from entity client
       CacheLoader<K, V> loader =
           new CacheLoader<K, V>() {
@@ -109,35 +107,9 @@ public class ClientCache<K, V, C extends ClientCacheConfig> {
 
       LoadingCache<K, V> cache = caffeine.build(loader);
 
-      if (config.isStatsEnabled()) {
-        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
-        executor.scheduleAtFixedRate(
-            () -> {
-              CacheStats cacheStats = cache.stats();
-
-              MetricUtils.gauge(metricClazz, "hitRate", () -> (Gauge<Double>) cacheStats::hitRate);
-              MetricUtils.gauge(
-                  metricClazz,
-                  "loadFailureRate",
-                  () -> (Gauge<Double>) cacheStats::loadFailureRate);
-              MetricUtils.gauge(
-                  metricClazz, "evictionCount", () -> (Gauge<Long>) cacheStats::evictionCount);
-              MetricUtils.gauge(
-                  metricClazz,
-                  "loadFailureCount",
-                  () -> (Gauge<Long>) cacheStats::loadFailureCount);
-              MetricUtils.gauge(
-                  metricClazz,
-                  "averageLoadPenalty",
-                  () -> (Gauge<Double>) cacheStats::averageLoadPenalty);
-              MetricUtils.gauge(
-                  metricClazz, "evictionWeight", () -> (Gauge<Long>) cacheStats::evictionWeight);
-
-              log.debug(metricClazz.getSimpleName() + ": " + cacheStats);
-            },
-            0,
-            config.getStatsIntervalSeconds(),
-            TimeUnit.SECONDS);
+      if (config.isStatsEnabled() && metricUtils != null) {
+        MicrometerMetricsRegistry.registerCacheMetrics(
+            config.getName(), cache, metricUtils.getRegistry().orElse(null));
       }
 
       return new ClientCache<>(config, cache, loadFunction, weigher, ttlSecondsFunction);

--- a/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClientCache.java
+++ b/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClientCache.java
@@ -11,6 +11,7 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.metadata.config.cache.client.EntityClientCacheConfig;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Collection;
@@ -137,6 +138,7 @@ public class EntityClientCache {
 
     public EntityClientCache build(
         @Nonnull final Function<CollectionKey, Map<Urn, EntityResponse>> fetchFunction,
+        MetricUtils metricUtils,
         Class<?> metricClazz) {
 
       // estimate size
@@ -176,7 +178,7 @@ public class EntityClientCache {
               .config(this.config)
               .loadFunction(loader)
               .ttlSecondsFunction(ttlSeconds)
-              .build(metricClazz);
+              .build(metricUtils, metricClazz);
 
       return new EntityClientCache(this.config, this.cache, fetchFunction);
     }

--- a/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/SystemEntityClient.java
+++ b/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/SystemEntityClient.java
@@ -4,6 +4,7 @@ import com.google.common.cache.Cache;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.metadata.config.cache.client.EntityClientCacheConfig;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
 import java.net.URISyntaxException;
@@ -27,7 +28,7 @@ public interface SystemEntityClient extends EntityClient {
    * @return the cache
    */
   default EntityClientCache buildEntityClientCache(
-      Class<?> metricClazz, EntityClientCacheConfig cacheConfig) {
+      MetricUtils metricUtils, Class<?> metricClazz, EntityClientCacheConfig cacheConfig) {
     return EntityClientCache.builder()
         .config(cacheConfig)
         .build(
@@ -55,6 +56,7 @@ public interface SystemEntityClient extends EntityClient {
                 throw new RuntimeException(e);
               }
             },
+            metricUtils,
             metricClazz);
   }
 

--- a/metadata-service/restli-client-api/src/main/java/com/linkedin/usage/UsageClientCache.java
+++ b/metadata-service/restli-client-api/src/main/java/com/linkedin/usage/UsageClientCache.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.Weigher;
 import com.linkedin.common.client.ClientCache;
 import com.linkedin.metadata.config.cache.client.UsageClientCacheConfig;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -43,7 +44,11 @@ public class UsageClientCache {
       return this;
     }
 
-    public UsageClientCache build() {
+    private UsageClientCache build() {
+      return null;
+    }
+
+    public UsageClientCache build(MetricUtils metricUtils) {
       // estimate size
       Weigher<Key, UsageQueryResult> weighByEstimatedSize =
           (key, value) -> value.data().toString().getBytes().length;
@@ -65,7 +70,7 @@ public class UsageClientCache {
               .config(config)
               .loadFunction(loader)
               .ttlSecondsFunction(ttlSeconds)
-              .build(UsageClientCache.class);
+              .build(metricUtils, UsageClientCache.class);
 
       return new UsageClientCache(config, cache, loadFunction);
     }

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -71,6 +71,8 @@ import com.linkedin.metadata.search.LineageSearchResult;
 import com.linkedin.metadata.search.ScrollResult;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.utils.EntityKeyUtils;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import com.linkedin.metadata.utils.metrics.MicrometerMetricsRegistry;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.MetadataChangeProposalArray;
 import com.linkedin.mxe.PlatformEvent;
@@ -128,7 +130,9 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
   private final ExecutorService batchIngestPool;
 
   public RestliEntityClient(
-      @Nonnull final Client restliClient, EntityClientConfig entityClientConfig) {
+      @Nonnull final Client restliClient,
+      EntityClientConfig entityClientConfig,
+      MetricUtils metricUtils) {
     super(restliClient, entityClientConfig);
     this.batchGetV2Pool =
         new ThreadPoolExecutor(
@@ -139,6 +143,10 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             new ArrayBlockingQueue<>(
                 entityClientConfig.getBatchGetV2QueueSize()), // fixed size queue
             new ThreadPoolExecutor.CallerRunsPolicy());
+    if (metricUtils != null) {
+      MicrometerMetricsRegistry.registerExecutorMetrics(
+          "entity-client-get", this.batchGetV2Pool, metricUtils.getRegistry().orElse(null));
+    }
     this.batchIngestPool =
         new ThreadPoolExecutor(
             entityClientConfig.getBatchIngestConcurrency(), // core threads
@@ -148,6 +156,10 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             new ArrayBlockingQueue<>(
                 entityClientConfig.getBatchIngestQueueSize()), // fixed size queue
             new ThreadPoolExecutor.CallerRunsPolicy());
+    if (metricUtils != null) {
+      MicrometerMetricsRegistry.registerExecutorMetrics(
+          "entity-client-ingest", this.batchIngestPool, metricUtils.getRegistry().orElse(null));
+    }
   }
 
   @Override
@@ -165,16 +177,14 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             .aspectsParam(aspectNames)
             .id(urn.toString())
             .alwaysIncludeKeyAspectParam(alwaysIncludeKeyAspect);
-    return sendClientRequest(requestBuilder, opContext.getSessionAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   @Override
   @Nonnull
   public Entity get(@Nonnull OperationContext opContext, @Nonnull final Urn urn)
       throws RemoteInvocationException {
-    return sendClientRequest(
-            ENTITIES_REQUEST_BUILDERS.get().id(urn.toString()),
-            opContext.getSessionAuthentication())
+    return sendClientRequest(ENTITIES_REQUEST_BUILDERS.get().id(urn.toString()), opContext)
         .getEntity();
   }
 
@@ -209,7 +219,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
               .batchGet()
               .ids(urnsInBatch.stream().map(Urn::toString).collect(Collectors.toSet()));
       final Map<Urn, Entity> batchResponse =
-          sendClientRequest(batchGetRequestBuilder, opContext.getSessionAuthentication())
+          sendClientRequest(batchGetRequestBuilder, opContext)
               .getEntity()
               .getResults()
               .entrySet()
@@ -272,8 +282,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
                                             .map(Urn::toString)
                                             .collect(Collectors.toList()));
 
-                            return sendClientRequest(
-                                    requestBuilder, opContext.getSessionAuthentication())
+                            return sendClientRequest(requestBuilder, opContext)
                                 .getEntity()
                                 .getResults()
                                 .entrySet()
@@ -343,8 +352,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
                                                         versionedUrn.getVersionStamp()))
                                             .collect(Collectors.toSet()));
 
-                            return sendClientRequest(
-                                    requestBuilder, opContext.getSessionAuthentication())
+                            return sendClientRequest(requestBuilder, opContext)
                                 .getEntity()
                                 .getResults()
                                 .entrySet()
@@ -399,7 +407,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             .fieldParam(field)
             .filterParam(filterOrDefaultEmptyFilter(requestFilters))
             .limitParam(limit);
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /**
@@ -427,7 +435,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             .queryParam(query)
             .filterParam(filterOrDefaultEmptyFilter(requestFilters))
             .limitParam(limit);
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /**
@@ -460,7 +468,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     if (requestFilters != null) {
       requestBuilder.filterParam(newFilter(requestFilters));
     }
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /**
@@ -505,7 +513,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       throws RemoteInvocationException {
     EntitiesDoIngestRequestBuilder requestBuilder =
         ENTITIES_REQUEST_BUILDERS.actionIngest().entityParam(entity);
-    sendClientRequest(requestBuilder, opContext.getSessionAuthentication());
+    sendClientRequest(requestBuilder, opContext);
   }
 
   @Override
@@ -525,7 +533,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             .entityParam(entity)
             .systemMetadataParam(systemMetadata);
 
-    sendClientRequest(requestBuilder, opContext.getSessionAuthentication());
+    sendClientRequest(requestBuilder, opContext);
   }
 
   @Override
@@ -534,7 +542,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     EntitiesDoBatchIngestRequestBuilder requestBuilder =
         ENTITIES_REQUEST_BUILDERS.actionBatchIngest().entitiesParam(new EntityArray(entities));
 
-    sendClientRequest(requestBuilder, opContext.getSessionAuthentication());
+    sendClientRequest(requestBuilder, opContext);
   }
 
   /**
@@ -571,7 +579,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             .countParam(count);
     requestBuilder.searchFlagsParam(opContext.getSearchContext().getSearchFlags());
 
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /**
@@ -600,7 +608,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             .startParam(start)
             .countParam(count);
 
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /**
@@ -651,7 +659,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       }
     }
 
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /**
@@ -702,7 +710,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       requestBuilder.sortCriteriaParam(new SortCriterionArray(sortCriteria));
     }
 
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   @Override
@@ -742,7 +750,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       requestBuilder.sortCriteriaParam(new SortCriterionArray(sortCriteria));
     }
 
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   @Nonnull
@@ -790,7 +798,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
 
     requestBuilder.searchFlagsParam(opContext.getSearchContext().getSearchFlags());
 
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   @Override
@@ -841,7 +849,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
 
     requestBuilder.searchFlagsParam(opContext.getSearchContext().getSearchFlags());
 
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /**
@@ -857,7 +865,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       throws RemoteInvocationException {
     EntitiesDoGetBrowsePathsRequestBuilder requestBuilder =
         ENTITIES_REQUEST_BUILDERS.actionGetBrowsePaths().urnParam(urn);
-    return sendClientRequest(requestBuilder, opContext.getSessionAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   @Override
@@ -865,7 +873,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       throws RemoteInvocationException {
     EntitiesDoSetWritableRequestBuilder requestBuilder =
         ENTITIES_REQUEST_BUILDERS.actionSetWritable().valueParam(canWrite);
-    sendClientRequest(requestBuilder, opContext.getSessionAuthentication());
+    sendClientRequest(requestBuilder, opContext);
   }
 
   @Override
@@ -883,7 +891,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
         ENTITIES_REQUEST_BUILDERS
             .actionBatchGetTotalEntityCount()
             .entitiesParam(new StringArray(entityName));
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /** List all urns existing for a particular Entity type. */
@@ -900,7 +908,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             .entityParam(entityName)
             .startParam(start)
             .countParam(count);
-    return sendClientRequest(requestBuilder, opContext.getSessionAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /** Hard delete an entity with a particular urn. */
@@ -909,7 +917,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       throws RemoteInvocationException {
     EntitiesDoDeleteRequestBuilder requestBuilder =
         ENTITIES_REQUEST_BUILDERS.actionDelete().urnParam(urn.toString());
-    sendClientRequest(requestBuilder, opContext.getSessionAuthentication());
+    sendClientRequest(requestBuilder, opContext);
   }
 
   /** Delete all references to a particular entity. */
@@ -918,7 +926,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       throws RemoteInvocationException {
     EntitiesDoDeleteReferencesRequestBuilder requestBuilder =
         ENTITIES_REQUEST_BUILDERS.actionDeleteReferences().urnParam(urn.toString());
-    sendClientRequest(requestBuilder, opContext.getSessionAuthentication());
+    sendClientRequest(requestBuilder, opContext);
   }
 
   @Nonnull
@@ -942,7 +950,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       requestBuilder.sortParam(sortCriteria.get(0));
       requestBuilder.sortCriteriaParam(new SortCriterionArray(sortCriteria));
     }
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   @Override
@@ -960,7 +968,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             .actionExists()
             .urnParam(urn.toString())
             .includeSoftDeleteParam(includeSoftDeleted);
-    return sendClientRequest(requestBuilder, opContext.getSessionAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /**
@@ -982,7 +990,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     AspectsGetRequestBuilder requestBuilder =
         ASPECTS_REQUEST_BUILDERS.get().id(urn).aspectParam(aspect).versionParam(version);
 
-    return sendClientRequest(requestBuilder, opContext.getSessionAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 
   /**
@@ -1004,7 +1012,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     AspectsGetRequestBuilder requestBuilder =
         ASPECTS_REQUEST_BUILDERS.get().id(urn).aspectParam(aspect).versionParam(version);
     try {
-      return sendClientRequest(requestBuilder, opContext.getSessionAuthentication()).getEntity();
+      return sendClientRequest(requestBuilder, opContext).getEntity();
     } catch (RestLiResponseException e) {
       if (e.getStatus() == HttpStatus.S_404_NOT_FOUND.getCode()) {
         // Then the aspect was not found. Return null.
@@ -1067,9 +1075,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       requestBuilder.sortParam(sort);
     }
 
-    return sendClientRequest(requestBuilder, opContext.getSessionAuthentication())
-        .getEntity()
-        .getValues();
+    return sendClientRequest(requestBuilder, opContext).getEntity().getValues();
   }
 
   @Nonnull
@@ -1102,9 +1108,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
                                         new MetadataChangeProposalArray(metadataChangeProposals))
                                     .asyncParam(String.valueOf(async));
                             String result =
-                                sendClientRequest(
-                                        requestBuilder, opContext.getSessionAuthentication())
-                                    .getEntity();
+                                sendClientRequest(requestBuilder, opContext).getEntity();
 
                             if (RESTLI_SUCCESS.equals(result)) {
                               return batch.stream()
@@ -1156,8 +1160,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
         ASPECTS_REQUEST_BUILDERS.get().id(urn).aspectParam(aspect).versionParam(version);
 
     try {
-      VersionedAspect entity =
-          sendClientRequest(requestBuilder, opContext.getSessionAuthentication()).getEntity();
+      VersionedAspect entity = sendClientRequest(requestBuilder, opContext).getEntity();
       if (entity.hasAspect()) {
         DataMap rawAspect = ((DataMap) entity.data().get("aspect"));
         if (rawAspect.containsKey(aspectClass.getCanonicalName())) {
@@ -1201,7 +1204,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     if (key != null) {
       requestBuilder.keyParam(key);
     }
-    sendClientRequest(requestBuilder, opContext.getSessionAuthentication());
+    sendClientRequest(requestBuilder, opContext);
   }
 
   @Override
@@ -1210,7 +1213,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       throws Exception {
     final RunsDoRollbackRequestBuilder requestBuilder =
         RUNS_REQUEST_BUILDERS.actionRollback().runIdParam(runId).dryRunParam(false);
-    sendClientRequest(requestBuilder, opContext.getSessionAuthentication());
+    sendClientRequest(requestBuilder, opContext);
   }
 
   // TODO: Refactor QueryUtils inside of metadata-io to extract these methods into a single shared

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/SystemRestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/SystemRestliEntityClient.java
@@ -5,6 +5,7 @@ import com.google.common.cache.CacheBuilder;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.metadata.config.cache.client.EntityClientCacheConfig;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.restli.client.Client;
 import io.datahubproject.metadata.context.OperationContext;
@@ -24,10 +25,12 @@ public class SystemRestliEntityClient extends RestliEntityClient implements Syst
   public SystemRestliEntityClient(
       @Nonnull final Client restliClient,
       @Nonnull EntityClientConfig clientConfig,
-      EntityClientCacheConfig cacheConfig) {
-    super(restliClient, clientConfig);
+      EntityClientCacheConfig cacheConfig,
+      MetricUtils metricUtils) {
+    super(restliClient, clientConfig, metricUtils);
     this.operationContextMap = CacheBuilder.newBuilder().maximumSize(500).build();
-    this.entityClientCache = buildEntityClientCache(SystemRestliEntityClient.class, cacheConfig);
+    this.entityClientCache =
+        buildEntityClientCache(metricUtils, SystemRestliEntityClient.class, cacheConfig);
   }
 
   @Nullable

--- a/metadata-service/restli-client/src/main/java/com/linkedin/usage/RestliUsageClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/usage/RestliUsageClient.java
@@ -7,6 +7,7 @@ import com.linkedin.common.WindowDuration;
 import com.linkedin.common.client.BaseClient;
 import com.linkedin.entity.client.EntityClientConfig;
 import com.linkedin.metadata.config.cache.client.UsageClientCacheConfig;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.parseq.retry.backoff.BackoffPolicy;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.restli.client.Client;
@@ -26,7 +27,8 @@ public class RestliUsageClient extends BaseClient implements UsageClient {
       @Nonnull final Client restliClient,
       @Nonnull final BackoffPolicy backoffPolicy,
       int retryCount,
-      UsageClientCacheConfig cacheConfig) {
+      UsageClientCacheConfig cacheConfig,
+      MetricUtils metricUtils) {
     super(
         restliClient,
         EntityClientConfig.builder().backoffPolicy(backoffPolicy).retryCount(retryCount).build());
@@ -45,7 +47,7 @@ public class RestliUsageClient extends BaseClient implements UsageClient {
                     throw new RuntimeException(e);
                   }
                 })
-            .build();
+            .build(metricUtils);
   }
 
   /**
@@ -74,6 +76,6 @@ public class RestliUsageClient extends BaseClient implements UsageClient {
             .resourceParam(resource)
             .durationParam(WindowDuration.DAY)
             .rangeFromEndParam(range);
-    return sendClientRequest(requestBuilder, opContext.getSessionAuthentication()).getEntity();
+    return sendClientRequest(requestBuilder, opContext).getEntity();
   }
 }

--- a/metadata-service/restli-client/src/test/java/com/linkedin/common/client/BaseClientTest.java
+++ b/metadata-service/restli-client/src/test/java/com/linkedin/common/client/BaseClientTest.java
@@ -5,27 +5,101 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
 import com.datahub.authentication.Authentication;
+import com.datahub.plugins.auth.authorization.Authorizer;
+import com.linkedin.aspect.GetTimeseriesAspectValuesResponse;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.RequiredFieldNotPresentException;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.dataset.DatasetProperties;
 import com.linkedin.entity.AspectsDoIngestProposalRequestBuilder;
 import com.linkedin.entity.AspectsRequestBuilders;
+import com.linkedin.entity.Entity;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.EntityClientConfig;
 import com.linkedin.entity.client.RestliEntityClient;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.Aspect;
+import com.linkedin.metadata.aspect.EnvelopedAspect;
+import com.linkedin.metadata.aspect.EnvelopedAspectArray;
+import com.linkedin.metadata.aspect.VersionedAspect;
+import com.linkedin.metadata.browse.BrowseResult;
+import com.linkedin.metadata.graph.LineageDirection;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.ListResult;
+import com.linkedin.metadata.query.ListUrnsResult;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.SortCriterion;
+import com.linkedin.metadata.query.filter.SortOrder;
+import com.linkedin.metadata.search.LineageScrollResult;
+import com.linkedin.metadata.search.LineageSearchResult;
+import com.linkedin.metadata.search.ScrollResult;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.mxe.PlatformEvent;
+import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.parseq.retry.backoff.ExponentialBackoff;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.restli.client.ActionRequest;
 import com.linkedin.restli.client.Client;
+import com.linkedin.restli.client.Request;
+import com.linkedin.restli.client.Response;
 import com.linkedin.restli.client.ResponseFuture;
+import com.linkedin.restli.client.RestLiResponseException;
+import com.linkedin.restli.client.response.BatchKVResponse;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class BaseClientTest {
   static final Authentication AUTH =
       new Authentication(new Actor(ActorType.USER, "fake"), "foo:bar");
+  static final OperationContext opContext =
+      TestOperationContexts.userContextNoSearchAuthorization(AUTH);
+
+  private Client mockRestliClient;
+  private RestliEntityClient testClient;
+  private ResponseFuture<String> mockFuture;
+  private Response<String> mockResponse;
+  private MetricUtils mockMetricUtils;
+
+  @BeforeMethod
+  public void setup() throws RemoteInvocationException {
+    mockRestliClient = mock(Client.class);
+    mockFuture = mock(ResponseFuture.class);
+    mockResponse = mock(Response.class);
+    when(mockFuture.getResponse()).thenReturn(mockResponse);
+
+    // Setup MetricUtils mock
+    mockMetricUtils = mock(MetricUtils.class);
+    when(mockMetricUtils.getRegistry()).thenReturn(Optional.empty());
+  }
 
   @Test
   public void testZeroRetry() throws RemoteInvocationException {
@@ -45,8 +119,9 @@ public class BaseClientTest {
                 .retryCount(0)
                 .batchGetV2Size(10)
                 .batchGetV2Concurrency(2)
-                .build());
-    testClient.sendClientRequest(testRequestBuilder, AUTH);
+                .build(),
+            mockMetricUtils);
+    testClient.sendClientRequest(testRequestBuilder, opContext);
     // Expected 1 actual try and 0 retries
     verify(mockRestliClient).sendRequest(any(ActionRequest.class));
   }
@@ -71,8 +146,9 @@ public class BaseClientTest {
                 .retryCount(1)
                 .batchGetV2Size(10)
                 .batchGetV2Concurrency(2)
-                .build());
-    testClient.sendClientRequest(testRequestBuilder, AUTH);
+                .build(),
+            mockMetricUtils);
+    testClient.sendClientRequest(testRequestBuilder, opContext);
     // Expected 1 actual try and 1 retries
     verify(mockRestliClient, times(2)).sendRequest(any(ActionRequest.class));
   }
@@ -95,8 +171,1576 @@ public class BaseClientTest {
                 .retryCount(1)
                 .batchGetV2Size(10)
                 .batchGetV2Concurrency(2)
-                .build());
+                .build(),
+            mockMetricUtils);
     assertThrows(
-        RuntimeException.class, () -> testClient.sendClientRequest(testRequestBuilder, AUTH));
+        RuntimeException.class, () -> testClient.sendClientRequest(testRequestBuilder, opContext));
+  }
+
+  @Test
+  public void testBatchIngestProposalsSingleBatch()
+      throws RemoteInvocationException, InterruptedException {
+    // Create test MCPs
+    List<MetadataChangeProposal> mcps = createTestMCPs(5);
+
+    // Mock successful response
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockFuture);
+    when(mockFuture.getResponse()).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn("success");
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .batchIngestSize(10) // Batch size larger than number of MCPs
+                .batchIngestConcurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    List<String> result = testClient.batchIngestProposals(opContext, mcps, false);
+
+    // Verify only one batch request was made
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+
+    // Verify all URNs were returned
+    assertEquals(result.size(), 5);
+    for (int i = 0; i < 5; i++) {
+      assertTrue(result.contains("urn:li:dataset:(urn:li:dataPlatform:hdfs,test" + i + ",PROD)"));
+    }
+  }
+
+  @Test
+  public void testBatchIngestProposalsMultipleBatches()
+      throws RemoteInvocationException, InterruptedException {
+    // Create test MCPs - 15 total
+    List<MetadataChangeProposal> mcps = createTestMCPs(15);
+
+    // Mock successful responses for all batches
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockFuture);
+    when(mockFuture.getResponse()).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn("success");
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .batchIngestSize(5) // Batch size of 5, so we expect 3 batches
+                .batchIngestConcurrency(3)
+                .build(),
+            mockMetricUtils);
+
+    List<String> result = testClient.batchIngestProposals(opContext, mcps, true);
+
+    // Verify 3 batch requests were made (15 MCPs / 5 per batch)
+    verify(mockRestliClient, times(3)).sendRequest(any(ActionRequest.class));
+
+    // Verify all URNs were returned
+    assertEquals(result.size(), 15);
+  }
+
+  @Test
+  public void testBatchIngestProposalsWithFailure()
+      throws RemoteInvocationException, InterruptedException {
+    // Create test MCPs
+    List<MetadataChangeProposal> mcps = createTestMCPs(10);
+
+    // Mock failure response
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockFuture);
+    when(mockFuture.getResponse()).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn("failure");
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .batchIngestSize(5)
+                .batchIngestConcurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    List<String> result = testClient.batchIngestProposals(opContext, mcps, false);
+
+    // Verify 2 batch requests were made
+    verify(mockRestliClient, times(2)).sendRequest(any(ActionRequest.class));
+
+    // Verify empty result due to failure
+    assertEquals(result.size(), 0);
+  }
+
+  @Test
+  public void testBatchIngestProposalsWithException() throws RemoteInvocationException {
+    // Create test MCPs
+    List<MetadataChangeProposal> mcps = createTestMCPs(5);
+
+    // Mock exception - wrap RemoteInvocationException in RuntimeException
+    when(mockRestliClient.sendRequest(any(ActionRequest.class)))
+        .thenThrow(new RuntimeException(new RemoteInvocationException("Test exception")));
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .batchIngestSize(10)
+                .batchIngestConcurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Should throw RuntimeException wrapping the RemoteInvocationException
+    assertThrows(
+        RuntimeException.class, () -> testClient.batchIngestProposals(opContext, mcps, false));
+  }
+
+  @Test
+  public void testBatchIngestProposalsAsyncParameter()
+      throws RemoteInvocationException, InterruptedException {
+    // Create test MCPs
+    List<MetadataChangeProposal> mcps = createTestMCPs(5);
+
+    ArgumentCaptor<ActionRequest> requestCaptor = ArgumentCaptor.forClass(ActionRequest.class);
+    when(mockRestliClient.sendRequest(requestCaptor.capture())).thenReturn(mockFuture);
+    when(mockFuture.getResponse()).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn("success");
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .batchIngestSize(10)
+                .batchIngestConcurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Test with async=true
+    testClient.batchIngestProposals(opContext, mcps, true);
+
+    ActionRequest capturedRequest = requestCaptor.getValue();
+    assertTrue(capturedRequest.getInputRecord().toString().contains("async=true"));
+
+    // Test with async=false
+    testClient.batchIngestProposals(opContext, mcps, false);
+
+    capturedRequest = requestCaptor.getValue();
+    assertTrue(capturedRequest.getInputRecord().toString().contains("async=false"));
+  }
+
+  @Test
+  public void testBatchIngestProposalsEmptyList() throws RemoteInvocationException {
+    List<MetadataChangeProposal> mcps = Collections.emptyList();
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .batchIngestSize(10)
+                .batchIngestConcurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    List<String> result = testClient.batchIngestProposals(opContext, mcps, false);
+
+    // Should handle empty list gracefully
+    assertEquals(result.size(), 0);
+  }
+
+  @Test
+  public void testBatchIngestProposalsLargeBatch()
+      throws RemoteInvocationException, InterruptedException {
+    // Create a large number of MCPs to test batching behavior
+    List<MetadataChangeProposal> mcps = createTestMCPs(100);
+
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockFuture);
+    when(mockFuture.getResponse()).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn("success");
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .batchIngestSize(25) // 100 MCPs / 25 per batch = 4 batches
+                .batchIngestConcurrency(4)
+                .build(),
+            mockMetricUtils);
+
+    List<String> result = testClient.batchIngestProposals(opContext, mcps, false);
+
+    // Verify 4 batch requests were made
+    verify(mockRestliClient, times(4)).sendRequest(any(ActionRequest.class));
+
+    // Verify all URNs were returned
+    assertEquals(result.size(), 100);
+  }
+
+  @Test
+  public void testBatchIngestProposalsConcurrentExecution()
+      throws RemoteInvocationException, InterruptedException {
+    // Create test MCPs
+    List<MetadataChangeProposal> mcps = createTestMCPs(20);
+
+    // Add delay to simulate concurrent processing
+    when(mockRestliClient.sendRequest(any(ActionRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              Thread.sleep(100); // Simulate some processing time
+              return mockFuture;
+            });
+    when(mockFuture.getResponse()).thenReturn(mockResponse);
+    when(mockResponse.getEntity()).thenReturn("success");
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .batchIngestSize(5) // 20 MCPs / 5 per batch = 4 batches
+                .batchIngestConcurrency(4) // Process all 4 batches concurrently
+                .build(),
+            mockMetricUtils);
+
+    long startTime = System.currentTimeMillis();
+    List<String> result = testClient.batchIngestProposals(opContext, mcps, false);
+    long endTime = System.currentTimeMillis();
+
+    // Verify all batches were processed
+    verify(mockRestliClient, times(4)).sendRequest(any(ActionRequest.class));
+    assertEquals(result.size(), 20);
+
+    // With concurrent execution, should take ~100ms (not 400ms if sequential)
+    // Adding some buffer for test execution overhead
+    assertTrue(
+        (endTime - startTime) < 300,
+        "Concurrent execution took too long: " + (endTime - startTime) + "ms");
+  }
+
+  @Test
+  public void testGet() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    Urn testUrn = Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)");
+
+    // Create a real Entity object
+    Entity entity = new Entity(new DataMap());
+
+    // Setup mock to return Entity directly
+    setupMockClientResponse(entity);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Entity result = testClient.get(opContext, testUrn);
+
+    // Verify
+    assertNotNull(result);
+    assertEquals(result.data(), entity.data());
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testGetV2() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    Urn testUrn = Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)");
+
+    // Create test aspects
+    Map<String, RecordTemplate> aspects = new HashMap<>();
+    DatasetProperties datasetProperties = new DatasetProperties();
+    datasetProperties.setDescription("Test dataset");
+    aspects.put("datasetProperties", datasetProperties);
+
+    EntityResponse entityResponse = buildEntityResponse(aspects);
+
+    // Setup mock to return EntityResponse
+    setupMockClientResponse(entityResponse);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    EntityResponse result =
+        testClient.getV2(
+            opContext, "dataset", testUrn, Collections.singleton("datasetProperties"), true);
+
+    // Verify
+    assertNotNull(result);
+    assertEquals(result.getAspects().size(), 1);
+    assertTrue(result.getAspects().containsKey("datasetProperties"));
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testBatchGet() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    Set<Urn> urns =
+        IntStream.range(0, 30)
+            .mapToObj(
+                i -> {
+                  try {
+                    return Urn.createFromString(
+                        "urn:li:dataset:(urn:li:dataPlatform:hdfs,test" + i + ",PROD)");
+                  } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.toSet());
+
+    // Mock BatchKVResponse with the RestLi EntityResponse
+    BatchKVResponse<String, com.linkedin.restli.common.EntityResponse> batchResponse =
+        mock(BatchKVResponse.class);
+    Map<String, com.linkedin.restli.common.EntityResponse> responseMap = new HashMap<>();
+
+    for (Urn urn : urns) {
+      // Create Entity
+      Entity entity = new Entity(new DataMap());
+
+      // Create RestLi EntityResponse
+      com.linkedin.restli.common.EntityResponse entityResponse =
+          new com.linkedin.restli.common.EntityResponse(Entity.class);
+      entityResponse.setEntity(entity);
+      entityResponse.setStatus(com.linkedin.restli.common.HttpStatus.S_200_OK);
+
+      responseMap.put(urn.toString(), entityResponse);
+    }
+
+    when(batchResponse.getResults()).thenReturn(responseMap);
+
+    // Setup mock response
+    setupMockClientResponse(batchResponse);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Map<Urn, Entity> result = testClient.batchGet(opContext, urns);
+
+    // Verify - should make 2 batch requests (30 items / 25 batch size)
+    verify(mockRestliClient, times(2)).sendRequest(any(Request.class));
+    assertEquals(result.size(), 30);
+  }
+
+  @Test
+  public void testAutoCompleteWithField() throws RemoteInvocationException {
+    // Setup
+    AutoCompleteResult mockAutoCompleteResult = new AutoCompleteResult();
+    mockAutoCompleteResult.setQuery("test");
+    mockAutoCompleteResult.setSuggestions(new StringArray("test1", "test2", "test3"));
+
+    Response<AutoCompleteResult> mockAutoCompleteResponse = mock(Response.class);
+    ResponseFuture<AutoCompleteResult> mockAutoCompleteFuture = mock(ResponseFuture.class);
+
+    when(mockAutoCompleteResponse.getEntity()).thenReturn(mockAutoCompleteResult);
+    when(mockAutoCompleteFuture.getResponse()).thenReturn(mockAutoCompleteResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockAutoCompleteFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    AutoCompleteResult result =
+        testClient.autoComplete(opContext, "dataset", "test", null, 10, "name");
+
+    // Verify
+    assertEquals(result.getQuery(), "test");
+    assertEquals(result.getSuggestions().size(), 3);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testAutoComplete() throws RemoteInvocationException {
+    // Setup
+    AutoCompleteResult mockAutoCompleteResult = new AutoCompleteResult();
+    mockAutoCompleteResult.setQuery("search");
+    mockAutoCompleteResult.setSuggestions(new StringArray("searchResult1", "searchResult2"));
+
+    setupMockClientResponse(mockAutoCompleteResult);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    AutoCompleteResult result = testClient.autoComplete(opContext, "dataset", "search", null, 10);
+
+    // Verify
+    assertEquals(result.getQuery(), "search");
+    assertEquals(result.getSuggestions().size(), 2);
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testBrowse() throws RemoteInvocationException {
+    // Setup
+    BrowseResult mockBrowseResult = new BrowseResult();
+    mockBrowseResult.setFrom(0);
+    mockBrowseResult.setPageSize(10);
+    mockBrowseResult.setNumEntities(2);
+
+    Response<BrowseResult> mockBrowseResponse = mock(Response.class);
+    ResponseFuture<BrowseResult> mockBrowseFuture = mock(ResponseFuture.class);
+
+    when(mockBrowseResponse.getEntity()).thenReturn(mockBrowseResult);
+    when(mockBrowseFuture.getResponse()).thenReturn(mockBrowseResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockBrowseFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Map<String, String> filters = new HashMap<>();
+    filters.put("platform", "hdfs");
+    BrowseResult result = testClient.browse(opContext, "dataset", "/prod", filters, 0, 10);
+
+    // Verify
+    assertEquals(result.getFrom(), 0);
+    assertEquals(result.getPageSize(), 10);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testUpdate() throws RemoteInvocationException {
+    // Setup
+    Entity entity = new Entity(new DataMap());
+
+    // For void methods, we can return null or an empty response
+    setupMockClientResponse(null);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    testClient.update(opContext, entity);
+
+    // Verify
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testUpdateWithSystemMetadata() throws RemoteInvocationException {
+    // Setup - Create real Entity object instead of mock
+    Entity entity = new Entity(new DataMap());
+
+    SystemMetadata mockSystemMetadata = new SystemMetadata();
+    mockSystemMetadata.setRunId("test-run-id");
+    mockSystemMetadata.setLastObserved(System.currentTimeMillis());
+
+    when(mockRestliClient.sendRequest(any(Request.class))).thenReturn(mockFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute with system metadata
+    testClient.updateWithSystemMetadata(opContext, entity, mockSystemMetadata);
+
+    // Verify
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+    verify(mockRestliClient, times(1)).sendRequest(requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().getInputRecord().toString().contains("systemMetadata"));
+
+    // Test with null system metadata (should delegate to update())
+    testClient.updateWithSystemMetadata(opContext, entity, null);
+    verify(mockRestliClient, times(2)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testBatchUpdate() throws RemoteInvocationException {
+    // Setup - Create real Entity objects instead of mocks
+    Set<Entity> entities =
+        IntStream.range(0, 5)
+            .mapToObj(
+                i -> {
+                  Entity entity = new Entity(new DataMap());
+                  return entity;
+                })
+            .collect(Collectors.toSet());
+
+    when(mockRestliClient.sendRequest(any(Request.class))).thenReturn(mockFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    testClient.batchUpdate(opContext, entities);
+
+    // Verify
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testSearch() throws RemoteInvocationException {
+    // Setup
+    SearchResult mockSearchResult = new SearchResult();
+    mockSearchResult.setFrom(0);
+    mockSearchResult.setPageSize(10);
+    mockSearchResult.setNumEntities(100);
+
+    setupMockClientResponse(mockSearchResult);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    SearchResult result =
+        testClient.search(
+            opContext.withSearchFlags(flags -> flags.setFulltext(true)),
+            "dataset",
+            "test query",
+            new HashMap<>(),
+            0,
+            10);
+
+    // Verify
+    assertEquals(result.getFrom(), 0);
+    assertEquals(result.getPageSize(), 10);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testList() throws RemoteInvocationException {
+    // Setup
+    ListResult mockListResult = new ListResult();
+    mockListResult.setStart(0);
+    mockListResult.setCount(10);
+    mockListResult.setTotal(50);
+
+    Response<ListResult> mockListResponse = mock(Response.class);
+    ResponseFuture<ListResult> mockListFuture = mock(ResponseFuture.class);
+
+    when(mockListResponse.getEntity()).thenReturn(mockListResult);
+    when(mockListFuture.getResponse()).thenReturn(mockListResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockListFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Map<String, String> filters = new HashMap<>();
+    filters.put("platform", "hdfs");
+    ListResult result = testClient.list(opContext, "dataset", filters, 0, 10);
+
+    // Verify
+    assertEquals(result.getStart(), 0);
+    assertEquals(result.getCount(), 10);
+    assertEquals(result.getTotal(), 50);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testSearchWithSortCriteria() throws RemoteInvocationException {
+    // Setup
+    SearchResult mockSearchResult = new SearchResult();
+    mockSearchResult.setFrom(0);
+    mockSearchResult.setPageSize(10);
+
+    Response<SearchResult> mockSearchResponse = mock(Response.class);
+    ResponseFuture<SearchResult> mockSearchFuture = mock(ResponseFuture.class);
+
+    when(mockSearchResponse.getEntity()).thenReturn(mockSearchResult);
+    when(mockSearchFuture.getResponse()).thenReturn(mockSearchResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockSearchFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Filter filter = new Filter();
+    List<SortCriterion> sortCriteria =
+        Collections.singletonList(
+            new SortCriterion().setField("lastModified").setOrder(SortOrder.DESCENDING));
+
+    SearchResult result =
+        testClient.search(opContext, "dataset", "test", filter, sortCriteria, 0, 10);
+
+    // Verify
+    ArgumentCaptor<ActionRequest> requestCaptor = ArgumentCaptor.forClass(ActionRequest.class);
+    verify(mockRestliClient, times(1)).sendRequest(requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().getInputRecord().toString().contains("sort"));
+  }
+
+  @Test
+  public void testSearchAcrossEntities() throws RemoteInvocationException {
+    // Setup
+    SearchResult mockSearchResult = new SearchResult();
+    mockSearchResult.setFrom(0);
+    mockSearchResult.setPageSize(10);
+    mockSearchResult.setNumEntities(25);
+
+    Response<SearchResult> mockSearchResponse = mock(Response.class);
+    ResponseFuture<SearchResult> mockSearchFuture = mock(ResponseFuture.class);
+
+    when(mockSearchResponse.getEntity()).thenReturn(mockSearchResult);
+    when(mockSearchFuture.getResponse()).thenReturn(mockSearchResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockSearchFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    List<String> entities = Arrays.asList("dataset", "dataFlow", "dataJob");
+    Filter filter = new Filter();
+    List<SortCriterion> sortCriteria = Collections.emptyList();
+
+    SearchResult result =
+        testClient.searchAcrossEntities(
+            opContext, entities, "test query", filter, 0, 10, sortCriteria, null);
+
+    // Verify
+    assertEquals(result.getFrom(), 0);
+    assertEquals(result.getPageSize(), 10);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testScrollAcrossEntities() throws RemoteInvocationException {
+    // Setup
+    ScrollResult mockScrollResult = new ScrollResult();
+    mockScrollResult.setScrollId("scroll123");
+    mockScrollResult.setNumEntities(10);
+
+    Response<ScrollResult> mockScrollResponse = mock(Response.class);
+    ResponseFuture<ScrollResult> mockScrollFuture = mock(ResponseFuture.class);
+
+    when(mockScrollResponse.getEntity()).thenReturn(mockScrollResult);
+    when(mockScrollFuture.getResponse()).thenReturn(mockScrollResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockScrollFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    List<String> entities = Arrays.asList("dataset", "dataFlow");
+    ScrollResult result =
+        testClient.scrollAcrossEntities(
+            opContext,
+            entities,
+            "test",
+            null,
+            "scroll123",
+            "5m",
+            Collections.emptyList(),
+            10,
+            null);
+
+    // Verify
+    assertEquals(result.getScrollId(), "scroll123");
+    assertEquals(result.getNumEntities(), 10);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testSearchAcrossLineage() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    LineageSearchResult mockLineageResult = new LineageSearchResult();
+    mockLineageResult.setFrom(0);
+    mockLineageResult.setPageSize(10);
+    mockLineageResult.setNumEntities(5);
+
+    Response<LineageSearchResult> mockLineageResponse = mock(Response.class);
+    ResponseFuture<LineageSearchResult> mockLineageFuture = mock(ResponseFuture.class);
+
+    when(mockLineageResponse.getEntity()).thenReturn(mockLineageResult);
+    when(mockLineageFuture.getResponse()).thenReturn(mockLineageResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockLineageFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Urn sourceUrn = Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)");
+    List<String> entities = Arrays.asList("dataset");
+
+    LineageSearchResult result =
+        testClient.searchAcrossLineage(
+            opContext,
+            sourceUrn,
+            LineageDirection.DOWNSTREAM,
+            entities,
+            "test",
+            3,
+            null,
+            Collections.emptyList(),
+            0,
+            10);
+
+    // Verify
+    assertEquals(result.getFrom(), 0);
+    assertEquals(result.getPageSize(), 10);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testSetWritable() throws RemoteInvocationException {
+    // Setup
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute - set writable to true
+    testClient.setWritable(opContext, true);
+
+    // Verify
+    ArgumentCaptor<ActionRequest> requestCaptor = ArgumentCaptor.forClass(ActionRequest.class);
+    verify(mockRestliClient, times(1)).sendRequest(requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().getInputRecord().toString().contains("value=true"));
+
+    // Execute - set writable to false
+    testClient.setWritable(opContext, false);
+    verify(mockRestliClient, times(2)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testBatchGetTotalEntityCount() throws RemoteInvocationException {
+    // Setup
+    Map<String, Long> mockCounts = new HashMap<>();
+    mockCounts.put("dataset", 100L);
+    mockCounts.put("dataFlow", 50L);
+    mockCounts.put("dataJob", 25L);
+
+    Response<Map<String, Long>> mockCountResponse = mock(Response.class);
+    ResponseFuture<Map<String, Long>> mockCountFuture = mock(ResponseFuture.class);
+
+    when(mockCountResponse.getEntity()).thenReturn(mockCounts);
+    when(mockCountFuture.getResponse()).thenReturn(mockCountResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockCountFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    List<String> entities = Arrays.asList("dataset", "dataFlow", "dataJob");
+    Map<String, Long> result = testClient.batchGetTotalEntityCount(opContext, entities, null);
+
+    // Verify
+    assertEquals(result.get("dataset"), Long.valueOf(100L));
+    assertEquals(result.get("dataFlow"), Long.valueOf(50L));
+    assertEquals(result.get("dataJob"), Long.valueOf(25L));
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testListUrns() throws RemoteInvocationException {
+    // Setup
+    ListUrnsResult mockListUrnsResult = new ListUrnsResult();
+    mockListUrnsResult.setStart(0);
+    mockListUrnsResult.setCount(10);
+    mockListUrnsResult.setTotal(100);
+
+    Response<ListUrnsResult> mockListUrnsResponse = mock(Response.class);
+    ResponseFuture<ListUrnsResult> mockListUrnsFuture = mock(ResponseFuture.class);
+
+    when(mockListUrnsResponse.getEntity()).thenReturn(mockListUrnsResult);
+    when(mockListUrnsFuture.getResponse()).thenReturn(mockListUrnsResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockListUrnsFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    ListUrnsResult result = testClient.listUrns(opContext, "dataset", 0, 10);
+
+    // Verify
+    assertEquals(result.getStart(), 0);
+    assertEquals(result.getCount(), 10);
+    assertEquals(result.getTotal(), 100);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testDeleteEntity() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    Urn testUrn = Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)");
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    testClient.deleteEntity(opContext, testUrn);
+
+    // Verify
+    ArgumentCaptor<ActionRequest> requestCaptor = ArgumentCaptor.forClass(ActionRequest.class);
+    verify(mockRestliClient, times(1)).sendRequest(requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().getInputRecord().toString().contains(testUrn.toString()));
+  }
+
+  @Test
+  public void testDeleteEntityReferences() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    Urn testUrn = Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)");
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    testClient.deleteEntityReferences(opContext, testUrn);
+
+    // Verify
+    ArgumentCaptor<ActionRequest> requestCaptor = ArgumentCaptor.forClass(ActionRequest.class);
+    verify(mockRestliClient, times(1)).sendRequest(requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().getInputRecord().toString().contains(testUrn.toString()));
+  }
+
+  @Test
+  public void testFilter() throws RemoteInvocationException {
+    // Setup
+    SearchResult mockSearchResult = new SearchResult();
+    mockSearchResult.setFrom(0);
+    mockSearchResult.setPageSize(10);
+    mockSearchResult.setNumEntities(15);
+
+    Response<SearchResult> mockSearchResponse = mock(Response.class);
+    ResponseFuture<SearchResult> mockSearchFuture = mock(ResponseFuture.class);
+
+    when(mockSearchResponse.getEntity()).thenReturn(mockSearchResult);
+    when(mockSearchFuture.getResponse()).thenReturn(mockSearchResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockSearchFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Filter filter = new Filter();
+    filter.setOr(new ConjunctiveCriterionArray());
+    List<SortCriterion> sortCriteria = Collections.emptyList();
+
+    SearchResult result = testClient.filter(opContext, "dataset", filter, sortCriteria, 0, 10);
+
+    // Verify
+    assertEquals(result.getFrom(), 0);
+    assertEquals(result.getPageSize(), 10);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testExists() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    Urn testUrn = Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)");
+    Response<Boolean> mockBoolResponse = mock(Response.class);
+    ResponseFuture<Boolean> mockBoolFuture = mock(ResponseFuture.class);
+
+    when(mockBoolResponse.getEntity()).thenReturn(true);
+    when(mockBoolFuture.getResponse()).thenReturn(mockBoolResponse);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockBoolFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute - with default includeSoftDeleted
+    boolean result = testClient.exists(opContext, testUrn);
+
+    // Verify
+    assertTrue(result);
+    verify(mockRestliClient, times(1)).sendRequest(any(ActionRequest.class));
+
+    // Execute - with explicit includeSoftDeleted
+    when(mockBoolResponse.getEntity()).thenReturn(false);
+    boolean result2 = testClient.exists(opContext, testUrn, false);
+    assertFalse(result2);
+    verify(mockRestliClient, times(2)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testGetAspectOrNull() throws RemoteInvocationException {
+    // Setup for successful case
+    VersionedAspect mockVersionedAspect = new VersionedAspect();
+    mockVersionedAspect.setVersion(1L);
+
+    setupMockClientResponse(mockVersionedAspect);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute - successful case
+    VersionedAspect result =
+        testClient.getAspectOrNull(
+            opContext,
+            "urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)",
+            "datasetProperties",
+            1L);
+
+    // Verify
+    assertNotNull(result);
+    assertEquals(result.getVersion(), Long.valueOf(1L));
+
+    // Setup for 404 case - need to reconfigure the mock
+    RestLiResponseException notFoundException = mock(RestLiResponseException.class);
+    when(notFoundException.getStatus()).thenReturn(404);
+
+    // Create new mock future that throws the exception
+    ResponseFuture<VersionedAspect> mockFutureFor404 = mock(ResponseFuture.class);
+    when(mockFutureFor404.getResponse()).thenThrow(notFoundException);
+
+    // Reset the client mock to return the new future for the next call
+    when(mockRestliClient.sendRequest(any(Request.class))).thenReturn(mockFutureFor404);
+
+    // Execute - 404 case
+    VersionedAspect nullResult =
+        testClient.getAspectOrNull(
+            opContext,
+            "urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)",
+            "nonExistentAspect",
+            1L);
+
+    // Verify
+    assertNull(nullResult);
+  }
+
+  @Test
+  public void testGetTimeseriesAspectValues() throws RemoteInvocationException {
+    // Setup
+    EnvelopedAspectArray aspectArray = new EnvelopedAspectArray();
+    aspectArray.add(new EnvelopedAspect());
+    aspectArray.add(new EnvelopedAspect());
+
+    GetTimeseriesAspectValuesResponse response = new GetTimeseriesAspectValuesResponse();
+    response.setValues(aspectArray);
+
+    // Setup mock
+    setupMockClientResponse(response);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    List<EnvelopedAspect> result =
+        testClient.getTimeseriesAspectValues(
+            opContext,
+            "urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)",
+            "dataset",
+            "datasetProfile",
+            System.currentTimeMillis() - 86400000L, // 1 day ago
+            System.currentTimeMillis(),
+            10,
+            null,
+            null);
+
+    // Verify
+    assertEquals(result.size(), 2);
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testGetVersionedAspect() throws RemoteInvocationException {
+    // Setup
+    VersionedAspect mockVersionedAspect = new VersionedAspect();
+
+    // Create the aspect data with the correct structure
+    DataMap aspectDataMap = new DataMap();
+    DataMap datasetPropertiesData = new DataMap();
+    datasetPropertiesData.put("description", "Test dataset");
+
+    // Use DatasetProperties canonical name
+    aspectDataMap.put("com.linkedin.dataset.DatasetProperties", datasetPropertiesData);
+
+    mockVersionedAspect.setAspect(new Aspect(aspectDataMap));
+    mockVersionedAspect.setVersion(1L);
+
+    setupMockClientResponse(mockVersionedAspect);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute - use DatasetProperties.class instead of RecordTemplate.class
+    Optional<DatasetProperties> result =
+        testClient.getVersionedAspect(
+            opContext,
+            "urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)",
+            "datasetProperties",
+            1L,
+            DatasetProperties.class);
+
+    // Verify
+    assertTrue(result.isPresent());
+    assertEquals(result.get().getDescription(), "Test dataset");
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+
+    // Test 404 case
+    RestLiResponseException notFoundException = mock(RestLiResponseException.class);
+    when(notFoundException.getStatus()).thenReturn(404);
+
+    ResponseFuture<VersionedAspect> mock404Future = mock(ResponseFuture.class);
+    when(mock404Future.getResponse()).thenThrow(notFoundException);
+
+    when(mockRestliClient.sendRequest(any(Request.class))).thenReturn(mock404Future);
+
+    Optional<DatasetProperties> emptyResult =
+        testClient.getVersionedAspect(
+            opContext,
+            "urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)",
+            "nonExistent",
+            1L,
+            DatasetProperties.class);
+
+    assertFalse(emptyResult.isPresent());
+  }
+
+  @Test
+  public void testProducePlatformEvent() throws Exception {
+    // Setup
+    PlatformEvent mockEvent = new PlatformEvent();
+    mockEvent.setName("TestEvent");
+
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute with key
+    testClient.producePlatformEvent(opContext, "TestEvent", "testKey", mockEvent);
+
+    // Verify
+    ArgumentCaptor<ActionRequest> requestCaptor = ArgumentCaptor.forClass(ActionRequest.class);
+    verify(mockRestliClient, times(1)).sendRequest(requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().getInputRecord().toString().contains("TestEvent"));
+
+    // Execute without key
+    testClient.producePlatformEvent(opContext, "TestEvent", null, mockEvent);
+    verify(mockRestliClient, times(2)).sendRequest(any(ActionRequest.class));
+  }
+
+  @Test
+  public void testRollbackIngestion() throws Exception {
+    // Setup
+    Authorizer mockAuthorizer = mock(Authorizer.class);
+    when(mockRestliClient.sendRequest(any(ActionRequest.class))).thenReturn(mockFuture);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    testClient.rollbackIngestion(opContext, "test-run-id", mockAuthorizer);
+
+    // Verify
+    ArgumentCaptor<ActionRequest> requestCaptor = ArgumentCaptor.forClass(ActionRequest.class);
+    verify(mockRestliClient, times(1)).sendRequest(requestCaptor.capture());
+    assertTrue(requestCaptor.getValue().getInputRecord().toString().contains("test-run-id"));
+    assertTrue(requestCaptor.getValue().getInputRecord().toString().contains("dryRun=false"));
+  }
+
+  // Helper method to create test MCPs
+  private List<MetadataChangeProposal> createTestMCPs(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(
+            i -> {
+              MetadataChangeProposal mcp = new MetadataChangeProposal();
+              mcp.setEntityType("dataset");
+              try {
+                mcp.setEntityUrn(
+                    Urn.createFromString(
+                        "urn:li:dataset:(urn:li:dataPlatform:hdfs,test" + i + ",PROD)"));
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+              mcp.setAspectName("datasetProperties");
+              mcp.setChangeType(ChangeType.UPSERT);
+              return mcp;
+            })
+        .collect(Collectors.toList());
+  }
+
+  @Test
+  public void testGetAspect() throws RemoteInvocationException {
+    // Setup
+    VersionedAspect mockVersionedAspect = new VersionedAspect();
+    mockVersionedAspect.setVersion(1L);
+    mockVersionedAspect.setAspect(new Aspect(new DataMap()));
+
+    setupMockClientResponse(mockVersionedAspect);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    VersionedAspect result =
+        testClient.getAspect(
+            opContext,
+            "urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)",
+            "datasetProperties",
+            1L);
+
+    // Verify
+    assertNotNull(result);
+    assertEquals(result.getVersion(), Long.valueOf(1L));
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testScrollAcrossLineage() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    LineageScrollResult mockLineageScrollResult = new LineageScrollResult();
+    mockLineageScrollResult.setScrollId("lineage-scroll-123");
+    mockLineageScrollResult.setNumEntities(5);
+
+    setupMockClientResponse(mockLineageScrollResult);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Urn sourceUrn = Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)");
+    List<String> entities = Arrays.asList("dataset");
+
+    LineageScrollResult result =
+        testClient.scrollAcrossLineage(
+            opContext,
+            sourceUrn,
+            LineageDirection.DOWNSTREAM,
+            entities,
+            "test",
+            3,
+            null,
+            Collections.emptyList(),
+            "scroll123",
+            "5m",
+            10);
+
+    // Verify
+    assertEquals(result.getScrollId(), "lineage-scroll-123");
+    assertEquals(result.getNumEntities(), 5);
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testGetBrowsePaths() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    StringArray mockPaths = new StringArray();
+    mockPaths.add("/prod/data");
+    mockPaths.add("/test/data");
+
+    setupMockClientResponse(mockPaths);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Urn testUrn = Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hdfs,test,PROD)");
+    StringArray result = testClient.getBrowsePaths(opContext, testUrn);
+
+    // Verify
+    assertEquals(result.size(), 2);
+    assertTrue(result.contains("/prod/data"));
+    assertTrue(result.contains("/test/data"));
+    verify(mockRestliClient, times(1)).sendRequest(any(Request.class));
+  }
+
+  @Test
+  public void testBatchGetV2() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    Set<Urn> urns =
+        IntStream.range(0, 15)
+            .mapToObj(
+                i -> {
+                  try {
+                    return Urn.createFromString(
+                        "urn:li:dataset:(urn:li:dataPlatform:hdfs,test" + i + ",PROD)");
+                  } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.toSet());
+
+    // Create mock batch response with RestLi EntityResponse
+    BatchKVResponse<String, com.linkedin.restli.common.EntityResponse> batchResponse =
+        mock(BatchKVResponse.class);
+    Map<String, com.linkedin.restli.common.EntityResponse> responseMap = new HashMap<>();
+
+    for (Urn urn : urns) {
+      Map<String, RecordTemplate> aspects = new HashMap<>();
+      DatasetProperties props = new DatasetProperties();
+      props.setDescription("Test dataset for " + urn);
+      aspects.put("datasetProperties", props);
+
+      // Build the com.linkedin.entity.EntityResponse
+      com.linkedin.entity.EntityResponse entityResponse = buildEntityResponse(aspects);
+
+      // Wrap it in RestLi's EntityResponse
+      com.linkedin.restli.common.EntityResponse restliEntityResponse =
+          new com.linkedin.restli.common.EntityResponse(com.linkedin.entity.EntityResponse.class);
+      restliEntityResponse.setEntity(entityResponse);
+      restliEntityResponse.setStatus(com.linkedin.restli.common.HttpStatus.S_200_OK);
+
+      responseMap.put(urn.toString(), restliEntityResponse);
+    }
+
+    when(batchResponse.getResults()).thenReturn(responseMap);
+
+    // Setup mock
+    setupMockClientResponse(batchResponse);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Map<Urn, com.linkedin.entity.EntityResponse> result =
+        testClient.batchGetV2(
+            opContext, "dataset", urns, Collections.singleton("datasetProperties"), true);
+
+    // Verify - should make 2 batch requests (15 items / 10 batch size)
+    verify(mockRestliClient, times(2)).sendRequest(any(Request.class));
+    assertEquals(result.size(), 15);
+  }
+
+  @Test
+  public void testBatchGetVersionedV2() throws RemoteInvocationException, URISyntaxException {
+    // Setup
+    Set<com.linkedin.common.VersionedUrn> versionedUrns =
+        IntStream.range(0, 15)
+            .mapToObj(
+                i -> {
+                  try {
+                    Urn urn =
+                        Urn.createFromString(
+                            "urn:li:dataset:(urn:li:dataPlatform:hdfs,test" + i + ",PROD)");
+                    return new com.linkedin.common.VersionedUrn().setUrn(urn).setVersionStamp("1");
+                  } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .collect(Collectors.toSet());
+
+    // Create mock response with RestLi EntityResponse
+    BatchKVResponse<com.linkedin.common.urn.VersionedUrn, com.linkedin.restli.common.EntityResponse>
+        batchResponse = mock(BatchKVResponse.class);
+    Map<com.linkedin.common.urn.VersionedUrn, com.linkedin.restli.common.EntityResponse>
+        responseMap = new HashMap<>();
+
+    for (com.linkedin.common.VersionedUrn versionedUrn : versionedUrns) {
+      // Create the entity response using RestLi's EntityResponse
+      com.linkedin.entity.EntityResponse entityResponse = buildEntityResponse(new HashMap<>());
+
+      // Create RestLi EntityResponse wrapper
+      com.linkedin.restli.common.EntityResponse restliEntityResponse =
+          new com.linkedin.restli.common.EntityResponse(EntityResponse.class);
+      restliEntityResponse.setEntity(entityResponse);
+      restliEntityResponse.setStatus(com.linkedin.restli.common.HttpStatus.S_200_OK);
+
+      com.linkedin.common.urn.VersionedUrn key =
+          com.linkedin.common.urn.VersionedUrn.of(
+              versionedUrn.getUrn().toString(), versionedUrn.getVersionStamp());
+      responseMap.put(key, restliEntityResponse);
+    }
+
+    when(batchResponse.getResults()).thenReturn(responseMap);
+
+    // Setup mock
+    setupMockClientResponse(batchResponse);
+
+    testClient =
+        new RestliEntityClient(
+            mockRestliClient,
+            EntityClientConfig.builder()
+                .backoffPolicy(new ExponentialBackoff(1))
+                .retryCount(0)
+                .batchGetV2Size(10)
+                .batchGetV2Concurrency(2)
+                .build(),
+            mockMetricUtils);
+
+    // Execute
+    Map<Urn, com.linkedin.entity.EntityResponse> result =
+        testClient.batchGetVersionedV2(
+            opContext, "dataset", versionedUrns, Collections.singleton("datasetProperties"));
+
+    // Verify - should make 2 batch requests (15 items / 10 batch size)
+    verify(mockRestliClient, times(2)).sendRequest(any(Request.class));
+    assertEquals(result.size(), 15);
+  }
+
+  private <T> void setupMockClientResponse(T responseEntity) throws RemoteInvocationException {
+    Response<T> mockResponse = mock(Response.class);
+    ResponseFuture<T> mockFuture = mock(ResponseFuture.class);
+
+    when(mockResponse.getEntity()).thenReturn(responseEntity);
+    when(mockFuture.getResponse()).thenReturn(mockResponse);
+    when(mockRestliClient.sendRequest(any(Request.class))).thenReturn(mockFuture);
+  }
+
+  private EntityResponse buildEntityResponse(Map<String, RecordTemplate> aspects) {
+    final EntityResponse entityResponse = new EntityResponse();
+    final EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    for (Map.Entry<String, RecordTemplate> entry : aspects.entrySet()) {
+      aspectMap.put(
+          entry.getKey(),
+          new com.linkedin.entity.EnvelopedAspect()
+              .setValue(new com.linkedin.entity.Aspect(entry.getValue().data())));
+    }
+    entityResponse.setAspects(aspectMap);
+    return entityResponse;
   }
 }

--- a/metadata-service/restli-client/src/test/java/com/linkedin/entity/client/SystemRestliEntityClientTest.java
+++ b/metadata-service/restli-client/src/test/java/com/linkedin/entity/client/SystemRestliEntityClientTest.java
@@ -54,7 +54,8 @@ public class SystemRestliEntityClientTest {
                 .batchGetV2Size(1)
                 .batchGetV2Concurrency(2)
                 .build(),
-            noCacheConfig);
+            noCacheConfig,
+            null);
 
     com.linkedin.entity.EntityResponse responseStatusTrue = buildStatusResponse(true);
     com.linkedin.entity.EntityResponse responseStatusFalse = buildStatusResponse(false);
@@ -100,7 +101,8 @@ public class SystemRestliEntityClientTest {
                 .batchGetV2Size(1)
                 .batchGetV2Concurrency(2)
                 .build(),
-            cacheConfig);
+            cacheConfig,
+            null);
 
     mockResponse(mockRestliClient, responseStatusTrue);
     assertEquals(
@@ -142,7 +144,8 @@ public class SystemRestliEntityClientTest {
                 .batchGetV2Size(1)
                 .batchGetV2Concurrency(2)
                 .build(),
-            noCacheConfig);
+            noCacheConfig,
+            null);
 
     com.linkedin.entity.EntityResponse responseStatusTrue = buildStatusResponse(true);
     com.linkedin.entity.EntityResponse responseStatusFalse = buildStatusResponse(false);
@@ -188,7 +191,8 @@ public class SystemRestliEntityClientTest {
                 .batchGetV2Size(1)
                 .batchGetV2Concurrency(2)
                 .build(),
-            cacheConfig);
+            cacheConfig,
+            null);
 
     mockResponse(mockRestliClient, responseStatusTrue);
     assertEquals(
@@ -230,7 +234,8 @@ public class SystemRestliEntityClientTest {
                 .batchGetV2Size(1)
                 .batchGetV2Concurrency(2)
                 .build(),
-            noCacheConfig);
+            noCacheConfig,
+            null);
 
     com.linkedin.entity.EntityResponse responseStatusTrue = buildStatusResponse(true);
     com.linkedin.entity.EntityResponse responseStatusFalse = buildStatusResponse(false);
@@ -280,7 +285,8 @@ public class SystemRestliEntityClientTest {
                 .batchGetV2Size(1)
                 .batchGetV2Concurrency(2)
                 .build(),
-            cacheConfig);
+            cacheConfig,
+            null);
 
     mockResponse(mockRestliClient, responseStatusTrue);
     assertEquals(

--- a/metadata-service/restli-servlet-impl/build.gradle
+++ b/metadata-service/restli-servlet-impl/build.gradle
@@ -50,8 +50,6 @@ dependencies {
   implementation project(':metadata-io')
   implementation spec.product.pegasus.restliServer
   implementation externalDependency.slf4jApi
-  implementation externalDependency.dropwizardMetricsCore
-  implementation externalDependency.dropwizardMetricsJmx
 
   implementation externalDependency.lombok
   implementation externalDependency.neo4jJavaDriver

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/restli/RestliUtils.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/restli/RestliUtils.java
@@ -61,9 +61,9 @@ public class RestliUtils {
               .transform(
                       orig -> {
                         if (orig.isFailed()) {
-                          MetricUtils.counter(MetricRegistry.name(metricName, "failed")).inc();
+                          opContext.getMetricUtils().ifPresent(metricUtils -> metricUtils.increment(MetricRegistry.name(metricName, "failed"),1 ));
                         } else {
-                          MetricUtils.counter(MetricRegistry.name(metricName, "success")).inc();
+                          opContext.getMetricUtils().ifPresent(metricUtils -> metricUtils.increment(MetricRegistry.name(metricName, "success"),1 ));
                         }
                         return orig;
                       });

--- a/metadata-service/schema-registry-servlet/src/test/java/io/datahubproject/openapi/test/SchemaRegistryControllerTestConfiguration.java
+++ b/metadata-service/schema-registry-servlet/src/test/java/io/datahubproject/openapi/test/SchemaRegistryControllerTestConfiguration.java
@@ -2,6 +2,7 @@ package io.datahubproject.openapi.test;
 
 import com.linkedin.metadata.dao.producer.KafkaHealthChecker;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
@@ -14,4 +15,6 @@ public class SchemaRegistryControllerTestConfiguration {
   @MockBean KafkaHealthChecker kafkaHealthChecker;
 
   @MockBean EntityRegistry entityRegistry;
+
+  @MockBean MetricUtils metricUtils;
 }

--- a/metadata-service/servlet/src/test/java/com/datahub/gms/servlet/ConfigServletTestContext.java
+++ b/metadata-service/servlet/src/test/java/com/datahub/gms/servlet/ConfigServletTestContext.java
@@ -3,8 +3,10 @@ package com.datahub.gms.servlet;
 import com.linkedin.metadata.entity.EntityService;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
+import io.micrometer.core.instrument.Clock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +18,8 @@ import org.springframework.context.annotation.Primary;
       "com.linkedin.gms.factory.common",
       "com.linkedin.gms.factory.config",
       "com.linkedin.gms.factory.entityregistry",
-      "com.linkedin.gms.factory.plugins"
+      "com.linkedin.gms.factory.plugins",
+      "com.linkedin.gms.factory.system_telemetry"
     })
 public class ConfigServletTestContext {
 
@@ -32,4 +35,6 @@ public class ConfigServletTestContext {
   public EntityService<?> entityService() {
     return Mockito.mock(EntityService.class);
   }
+
+  @MockBean public Clock clock;
 }

--- a/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
@@ -58,6 +58,7 @@ import org.springframework.core.env.Environment;
       "com.linkedin.gms.factory.telemetry",
       "com.linkedin.gms.factory.trace",
       "com.linkedin.gms.factory.kafka.trace",
+      "com.linkedin.gms.factory.system_telemetry"
     })
 @Configuration
 @PropertySource(value = "classpath:/application.yaml", factory = YamlPropertySourceFactory.class)

--- a/metadata-service/war/src/main/java/com/linkedin/gms/factory/config/GMSOpenTelemetryConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/factory/config/GMSOpenTelemetryConfig.java
@@ -1,7 +1,8 @@
 package com.linkedin.gms.factory.config;
 
 import com.linkedin.gms.factory.system_telemetry.OpenTelemetryBaseFactory;
-import io.datahubproject.metadata.context.TraceContext;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.datahubproject.metadata.context.SystemTelemetryContext;
 import org.apache.kafka.clients.producer.Producer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -17,9 +18,10 @@ public class GMSOpenTelemetryConfig extends OpenTelemetryBaseFactory {
 
   @Bean
   @Override
-  protected TraceContext traceContext(
+  protected SystemTelemetryContext traceContext(
+      MetricUtils metricUtils,
       ConfigurationProvider configurationProvider,
       @Qualifier("dataHubUsageProducer") Producer<String, String> dueProducer) {
-    return super.traceContext(configurationProvider, dueProducer);
+    return super.traceContext(metricUtils, configurationProvider, dueProducer);
   }
 }

--- a/metadata-service/war/src/test/java/com/linkedin/gms/SpringTest.java
+++ b/metadata-service/war/src/test/java/com/linkedin/gms/SpringTest.java
@@ -8,6 +8,7 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.ebean.Database;
+import io.micrometer.core.instrument.Clock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -30,6 +31,7 @@ public class SpringTest extends AbstractTestNGSpringContextTests {
   // still testing prod config
   @MockBean private Database database;
   @MockBean private BootstrapManager bootstrapManager;
+  @MockBean private Clock clock;
 
   @Test
   public void testTelemetry() {

--- a/metadata-utils/build.gradle
+++ b/metadata-utils/build.gradle
@@ -8,13 +8,17 @@ apply from: '../gradle/coverage/java-coverage.gradle'
 dependencies {
   api externalDependency.avro
   implementation externalDependency.commonsLang
-  api externalDependency.dropwizardMetricsCore
-  implementation externalDependency.dropwizardMetricsJmx
+  api externalDependency.micrometerPrometheus
+  api externalDependency.micrometerJmx
+  api externalDependency.micrometerOtelBridge
   implementation externalDependency.opentelemetrySdk
   api externalDependency.elasticSearchRest
   implementation externalDependency.httpClient
   api externalDependency.neo4jJavaDriver
   api externalDependency.json
+  implementation (externalDependency.hazelcast) {
+    exclude group: 'org.json', module: 'json'
+  }
 
   implementation spec.product.pegasus.restliClient
   implementation spec.product.pegasus.restliCommon
@@ -37,6 +41,7 @@ dependencies {
   testImplementation externalDependency.mockito
   testImplementation externalDependency.mockitoInline
   testImplementation project(':metadata-operation-context')
+  testImplementation project(':entity-registry')
 
   constraints {
       implementation(externalDependency.log4jCore) {

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/ExceptionUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/ExceptionUtils.java
@@ -9,35 +9,36 @@ public class ExceptionUtils {
   private ExceptionUtils() {}
 
   public static ValidationExceptionCollection collectMetrics(
-      final ValidationExceptionCollection exceptions) {
-    exceptions
-        .streamAllExceptions()
-        .forEach(
-            exception -> {
-              String subTypeBaseName =
-                  String.join(
-                      DELIMITER, BASE_NAME, exception.getSubType().toString().toLowerCase());
-              // subtype count
-              MetricUtils.counter(subTypeBaseName).inc(exceptions.size());
-              // Change type count
-              MetricUtils.counter(
-                      String.join(
-                          DELIMITER,
-                          subTypeBaseName,
-                          exception.getChangeType().toString().toLowerCase()))
-                  .inc();
-              // Entity count
-              MetricUtils.counter(
-                      String.join(
-                          DELIMITER,
-                          subTypeBaseName,
-                          exception.getEntityUrn().getEntityType().toLowerCase()))
-                  .inc();
-              // Aspect count
-              MetricUtils.counter(
-                      String.join(DELIMITER, subTypeBaseName, exception.getAspectName()))
-                  .inc();
-            });
+      MetricUtils metricUtils, final ValidationExceptionCollection exceptions) {
+    if (metricUtils != null) {
+      exceptions
+          .streamAllExceptions()
+          .forEach(
+              exception -> {
+                String subTypeBaseName =
+                    String.join(
+                        DELIMITER, BASE_NAME, exception.getSubType().toString().toLowerCase());
+                // subtype count
+                metricUtils.increment(subTypeBaseName, exceptions.size());
+                // Change type count
+                metricUtils.increment(
+                    String.join(
+                        DELIMITER,
+                        subTypeBaseName,
+                        exception.getChangeType().toString().toLowerCase()),
+                    1);
+                // Entity count
+                metricUtils.increment(
+                    String.join(
+                        DELIMITER,
+                        subTypeBaseName,
+                        exception.getEntityUrn().getEntityType().toLowerCase()),
+                    1);
+                // Aspect count
+                metricUtils.increment(
+                    String.join(DELIMITER, subTypeBaseName, exception.getAspectName()), 1);
+              });
+    }
     return exceptions;
   }
 }

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricSpanExporter.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricSpanExporter.java
@@ -4,20 +4,22 @@ import static com.linkedin.metadata.utils.metrics.MetricUtils.DROPWIZARD_METRIC;
 import static com.linkedin.metadata.utils.metrics.MetricUtils.DROPWIZARD_NAME;
 
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Collection;
-import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
 
 /** Created to forward opentelemetry spans to dropwizard for backwards compatibility */
+@RequiredArgsConstructor
 public class MetricSpanExporter implements SpanExporter {
   private static final AttributeKey<String> DROPWIZARD_ATTR_KEY =
       AttributeKey.stringKey(DROPWIZARD_METRIC);
   private static final AttributeKey<String> DROPWIZARD_NAME_ATTR_KEY =
       AttributeKey.stringKey(DROPWIZARD_NAME);
+
+  private final MetricUtils metricUtils;
 
   @Override
   public CompletableResultCode export(Collection<SpanData> spans) {
@@ -42,8 +44,7 @@ public class MetricSpanExporter implements SpanExporter {
             : MetricRegistry.name(dropWizardName);
 
     // Update timer with the span duration
-    Timer timer = MetricUtils.get().timer(dropWizardMetricName);
-    timer.update(durationNanos, TimeUnit.NANOSECONDS);
+    if (metricUtils != null) metricUtils.time(dropWizardMetricName, durationNanos);
   }
 
   @Override

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
@@ -1,14 +1,25 @@
 package com.linkedin.metadata.utils.metrics;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.SharedMetricRegistries;
-import com.codahale.metrics.jmx.JmxReporter;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
+@Builder
 public class MetricUtils {
+  /* Shared OpenTelemetry & Micrometer */
   public static final String DROPWIZARD_METRIC = "dwizMetric";
   public static final String DROPWIZARD_NAME = "dwizName";
+
+  /* OpenTelemetry */
   public static final String CACHE_HIT_ATTR = "cache.hit";
   public static final String BATCH_SIZE_ATTR = "batch.size";
   public static final String QUEUE_ENQUEUED_AT_ATTR = "queue.enqueued_at";
@@ -18,54 +29,89 @@ public class MetricUtils {
   public static final String MESSAGING_DESTINATION_KIND = "messaging.destination_kind";
   public static final String MESSAGING_OPERATION = "messaging.operation";
   public static final String ERROR_TYPE = "error.type";
-
   public static final String CHANGE_TYPE = "aspect.change_type";
   public static final String ENTITY_TYPE = "aspect.entity_type";
   public static final String ASPECT_NAME = "aspect.name";
 
-  private MetricUtils() {}
+  @Deprecated public static final String DELIMITER = "_";
 
-  public static final String DELIMITER = "_";
+  private final MeterRegistry registry;
 
-  public static final String NAME = "default";
-  private static final MetricRegistry REGISTRY = SharedMetricRegistries.getOrCreate(NAME);
-
-  static {
-    final JmxReporter reporter = JmxReporter.forRegistry(REGISTRY).build();
-    reporter.start();
+  public Optional<MeterRegistry> getRegistry() {
+    return Optional.ofNullable(registry);
   }
 
-  public static MetricRegistry get() {
-    return REGISTRY;
+  @Deprecated
+  public void time(String dropWizardMetricName, long durationNanos) {
+    getRegistry()
+        .ifPresent(
+            meterRegistry ->
+                Timer.builder(dropWizardMetricName)
+                    .tags(DROPWIZARD_METRIC, "true")
+                    .publishPercentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999) // Dropwizard defaults
+                    .register(meterRegistry)
+                    .record(durationNanos, TimeUnit.NANOSECONDS));
   }
 
-  public static Counter counter(Class<?> klass, String metricName) {
-    return REGISTRY.counter(MetricRegistry.name(klass, metricName));
+  @Deprecated
+  public void increment(Class<?> klass, String metricName, double increment) {
+    String name = MetricRegistry.name(klass, metricName);
+    increment(name, increment);
   }
 
-  public static void exceptionCounter(Class<?> klass, String metricName, Throwable t) {
+  @Deprecated
+  public void exceptionIncrement(Class<?> klass, String metricName, Throwable t) {
     String[] splitClassName = t.getClass().getName().split("[.]");
     String snakeCase =
         splitClassName[splitClassName.length - 1].replaceAll("([A-Z][a-z])", DELIMITER + "$1");
 
-    counter(klass, metricName).inc();
-    counter(klass, metricName + DELIMITER + snakeCase).inc();
+    increment(klass, metricName, 1);
+    increment(klass, metricName + DELIMITER + snakeCase, 1);
   }
 
-  public static Counter counter(String metricName) {
-    return REGISTRY.counter(MetricRegistry.name(metricName));
+  @Deprecated
+  public void increment(String metricName, double increment) {
+    getRegistry()
+        .ifPresent(
+            meterRegistry ->
+                Counter.builder(MetricRegistry.name(metricName))
+                    .tag(DROPWIZARD_METRIC, "true")
+                    .register(meterRegistry)
+                    .increment(increment));
   }
 
+  @Deprecated
+  public void gauge(Class<?> clazz, String metricName, Supplier<? extends Number> valueSupplier) {
+
+    getRegistry()
+        .ifPresent(
+            meterRegistry -> {
+              String name = com.codahale.metrics.MetricRegistry.name(clazz, metricName);
+
+              Gauge.builder(name, valueSupplier, supplier -> supplier.get().doubleValue())
+                  .tag(DROPWIZARD_METRIC, "true")
+                  .register(meterRegistry);
+            });
+  }
+
+  @Deprecated
+  public void histogram(Class<?> clazz, String metricName, long value) {
+    getRegistry()
+        .ifPresent(
+            meterRegistry ->
+                DistributionSummary.builder(MetricRegistry.name(clazz, metricName))
+                    .tag(DROPWIZARD_METRIC, "true")
+                    .register(meterRegistry)
+                    .record(value));
+  }
+
+  @Deprecated
   public static String name(String name, String... names) {
     return MetricRegistry.name(name, names);
   }
 
+  @Deprecated
   public static String name(Class<?> clazz, String... names) {
     return MetricRegistry.name(clazz.getName(), names);
-  }
-
-  public static <T extends Gauge<?>> T gauge(
-      Class<?> clazz, String metricName, MetricRegistry.MetricSupplier<T> supplier) {
-    return REGISTRY.gauge(MetricRegistry.name(clazz, metricName), supplier);
   }
 }

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MicrometerMetricsRegistry.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MicrometerMetricsRegistry.java
@@ -1,0 +1,91 @@
+package com.linkedin.metadata.utils.metrics;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import io.micrometer.core.instrument.binder.cache.HazelcastCacheMetrics;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MicrometerMetricsRegistry {
+
+  static final Set<String> GLOBALLY_REGISTERED_CACHES = ConcurrentHashMap.newKeySet();
+  static final Set<String> GLOBALLY_REGISTERED_EXECUTOR_SERVICE = ConcurrentHashMap.newKeySet();
+
+  private MicrometerMetricsRegistry() {}
+
+  /**
+   * Register cache metrics if not already registered globally. This method is thread-safe and
+   * ensures each cache is only registered once.
+   */
+  public static synchronized boolean registerCacheMetrics(
+      @Nonnull String cacheName,
+      @Nonnull Object nativeCache,
+      @Nullable MeterRegistry meterRegistry) {
+
+    if (cacheName == null || nativeCache == null || meterRegistry == null) {
+      return false;
+    }
+
+    if (!GLOBALLY_REGISTERED_CACHES.add(cacheName)) {
+      return false;
+    }
+
+    try {
+      if (nativeCache instanceof Cache) {
+        Cache<?, ?> caffeineCache = (Cache<?, ?>) nativeCache;
+        CaffeineCacheMetrics.monitor(meterRegistry, caffeineCache, cacheName, "name", cacheName);
+        log.debug("Registered Caffeine cache metrics for: {}", cacheName);
+      } else if (nativeCache instanceof com.hazelcast.map.IMap) {
+        com.hazelcast.map.IMap<?, ?> hazelcastMap = (com.hazelcast.map.IMap<?, ?>) nativeCache;
+        HazelcastCacheMetrics.monitor(meterRegistry, hazelcastMap, "name", cacheName);
+        log.debug("Registered Hazelcast cache metrics for: {}", cacheName);
+      }
+      return true;
+    } catch (Exception e) {
+      // Remove from set if registration failed
+      GLOBALLY_REGISTERED_CACHES.remove(cacheName);
+      log.error(
+          "Failed to register metrics for cache: {}. Error: {}", cacheName, e.getMessage(), e);
+      return false;
+    }
+  }
+
+  /**
+   * Register executor service metrics if not already registered globally. This method is
+   * thread-safe and ensures each cache is only registered once.
+   */
+  public static synchronized boolean registerExecutorMetrics(
+      @Nonnull String executorName,
+      @Nonnull ExecutorService executorService,
+      @Nullable MeterRegistry meterRegistry) {
+
+    if (executorName == null || executorService == null || meterRegistry == null) {
+      return false;
+    }
+
+    if (!GLOBALLY_REGISTERED_EXECUTOR_SERVICE.add(executorName)) {
+      return false;
+    }
+
+    try {
+      ExecutorServiceMetrics.monitor(meterRegistry, executorService, executorName);
+      return true;
+    } catch (Exception e) {
+      // Remove from set if registration failed
+      GLOBALLY_REGISTERED_EXECUTOR_SERVICE.remove(executorName);
+      log.error(
+          "Failed to register metrics for executor: {}. Error: {}",
+          executorName,
+          e.getMessage(),
+          e);
+      return false;
+    }
+  }
+}

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/metrics/ExceptionUtilsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/metrics/ExceptionUtilsTest.java
@@ -1,0 +1,356 @@
+package com.linkedin.metadata.utils.metrics;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.batch.BatchItem;
+import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
+import com.linkedin.metadata.aspect.plugins.validation.ValidationExceptionCollection;
+import com.linkedin.metadata.aspect.plugins.validation.ValidationSubType;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.EntitySpec;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Arrays;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ExceptionUtilsTest {
+
+  @Mock private MetricUtils mockMetricUtils;
+
+  @Mock private EntitySpec mockEntitySpec;
+
+  @Mock private AspectSpec mockAspectSpec;
+
+  private OperationContext testOperationContext;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    testOperationContext = TestOperationContexts.systemContextNoSearchAuthorization();
+  }
+
+  @Test
+  public void testCollectMetrics_WithEmptyExceptionCollection() {
+    // Given
+    ValidationExceptionCollection emptyExceptions = ValidationExceptionCollection.newCollection();
+
+    // When
+    ValidationExceptionCollection result =
+        ExceptionUtils.collectMetrics(mockMetricUtils, emptyExceptions);
+
+    // Then
+    assertNotNull(result);
+    assertEquals(result, emptyExceptions);
+    verifyNoInteractions(mockMetricUtils);
+  }
+
+  @Test
+  public void testCollectMetrics_WithNullMetricUtils() throws Exception {
+    // Given
+    ValidationExceptionCollection exceptions = createExceptionCollection();
+
+    // When
+    ValidationExceptionCollection result = ExceptionUtils.collectMetrics(null, exceptions);
+
+    // Then
+    assertNotNull(result);
+    assertEquals(result, exceptions);
+    // No NPE should be thrown
+  }
+
+  @Test
+  public void testCollectMetrics_WithSingleValidationException() throws Exception {
+    // Given
+    Urn entityUrn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleDataset,PROD)");
+    BatchItem batchItem = createMockBatchItem(entityUrn, "datasetProperties", ChangeType.UPSERT);
+
+    AspectValidationException exception =
+        AspectValidationException.forItem(batchItem, "Test validation error");
+
+    ValidationExceptionCollection exceptions = ValidationExceptionCollection.newCollection();
+    exceptions.addException(exception);
+
+    // When
+    ValidationExceptionCollection result =
+        ExceptionUtils.collectMetrics(mockMetricUtils, exceptions);
+
+    // Then
+    assertNotNull(result);
+    assertEquals(result, exceptions);
+
+    // Verify metric increments
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.upsert", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.dataset", 1);
+    verify(mockMetricUtils)
+        .increment("metadata.validation.exception.validation.datasetProperties", 1);
+  }
+
+  @Test
+  public void testCollectMetrics_WithMultipleExceptions() throws Exception {
+    // Given
+    Urn datasetUrn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleDataset,PROD)");
+    Urn chartUrn = Urn.createFromString("urn:li:chart:(looker,dashboard.1)");
+
+    BatchItem datasetItem1 =
+        createMockBatchItem(datasetUrn, "datasetProperties", ChangeType.CREATE);
+    BatchItem chartItem = createMockBatchItem(chartUrn, "chartInfo", ChangeType.DELETE);
+    BatchItem datasetItem2 = createMockBatchItem(datasetUrn, "schemaMetadata", ChangeType.UPSERT);
+
+    AspectValidationException exception1 =
+        AspectValidationException.forPrecondition(datasetItem1, "Precondition failed");
+
+    AspectValidationException exception2 =
+        AspectValidationException.forAuth(chartItem, "Authorization failed");
+
+    AspectValidationException exception3 =
+        AspectValidationException.forItem(datasetItem2, "Validation failed");
+
+    ValidationExceptionCollection exceptions = ValidationExceptionCollection.newCollection();
+    exceptions.addException(exception1);
+    exceptions.addException(exception2);
+    exceptions.addException(exception3);
+
+    // When
+    ValidationExceptionCollection result =
+        ExceptionUtils.collectMetrics(mockMetricUtils, exceptions);
+
+    // Then
+    assertNotNull(result);
+    assertEquals(result, exceptions);
+
+    // Verify metrics for exception1 (PRECONDITION)
+    verify(mockMetricUtils).increment("metadata.validation.exception.precondition", 3);
+    verify(mockMetricUtils).increment("metadata.validation.exception.precondition.create", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.precondition.dataset", 1);
+    verify(mockMetricUtils)
+        .increment("metadata.validation.exception.precondition.datasetProperties", 1);
+
+    // Verify metrics for exception2 (AUTHORIZATION)
+    verify(mockMetricUtils).increment("metadata.validation.exception.authorization", 3);
+    verify(mockMetricUtils).increment("metadata.validation.exception.authorization.delete", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.authorization.chart", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.authorization.chartInfo", 1);
+
+    // Verify metrics for exception3 (VALIDATION)
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation", 3);
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.upsert", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.dataset", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.schemaMetadata", 1);
+  }
+
+  @Test
+  public void testCollectMetrics_WithAllChangeTypes() throws Exception {
+    // Given
+    Urn entityUrn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleDataset,PROD)");
+
+    Arrays.asList(
+            ChangeType.CREATE,
+            ChangeType.UPSERT,
+            ChangeType.DELETE,
+            ChangeType.PATCH,
+            ChangeType.RESTATE)
+        .forEach(
+            changeType -> {
+              BatchItem batchItem = createMockBatchItem(entityUrn, "testAspect", changeType);
+              AspectValidationException exception =
+                  AspectValidationException.forItem(batchItem, "Test error for " + changeType);
+
+              ValidationExceptionCollection exceptions =
+                  ValidationExceptionCollection.newCollection();
+              exceptions.addException(exception);
+
+              // When
+              ExceptionUtils.collectMetrics(mockMetricUtils, exceptions);
+
+              // Then
+              verify(mockMetricUtils)
+                  .increment(
+                      "metadata.validation.exception.validation."
+                          + changeType.toString().toLowerCase(),
+                      1);
+            });
+  }
+
+  @Test
+  public void testCollectMetrics_WithAllValidationSubTypes() throws Exception {
+    // Given
+    Urn entityUrn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleDataset,PROD)");
+
+    // Create different batch items to ensure they map to different keys in the collection
+    BatchItem batchItem1 = createMockBatchItem(entityUrn, "testAspect1", ChangeType.UPSERT);
+    BatchItem batchItem2 = createMockBatchItem(entityUrn, "testAspect2", ChangeType.UPSERT);
+    BatchItem batchItem3 = createMockBatchItem(entityUrn, "testAspect3", ChangeType.UPSERT);
+    BatchItem batchItem4 = createMockBatchItem(entityUrn, "testAspect4", ChangeType.UPSERT);
+
+    ValidationExceptionCollection exceptions = ValidationExceptionCollection.newCollection();
+
+    // Add VALIDATION exception
+    exceptions.addException(AspectValidationException.forItem(batchItem1, "Validation error"));
+
+    // Add PRECONDITION exception
+    exceptions.addException(
+        AspectValidationException.forPrecondition(batchItem2, "Precondition error"));
+
+    // Add FILTER exception
+    exceptions.addException(AspectValidationException.forFilter(batchItem3, "Filter error"));
+
+    // Add AUTHORIZATION exception
+    exceptions.addException(AspectValidationException.forAuth(batchItem4, "Auth error"));
+
+    // When
+    ExceptionUtils.collectMetrics(mockMetricUtils, exceptions);
+
+    // Then
+    // The ValidationExceptionCollection extends HashMap, so exceptions.size() returns the number of
+    // unique Pair<Urn,String> keys
+    // Since all 4 exceptions have different aspects, there are 4 unique keys, so exceptions.size()
+    // = 4
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation", 4);
+    verify(mockMetricUtils).increment("metadata.validation.exception.precondition", 4);
+    verify(mockMetricUtils).increment("metadata.validation.exception.filter", 4);
+    verify(mockMetricUtils).increment("metadata.validation.exception.authorization", 4);
+
+    // Each exception also increments its own changeType metric
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.upsert", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.precondition.upsert", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.filter.upsert", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.authorization.upsert", 1);
+
+    // Each exception also increments its own entityType metric
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.dataset", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.precondition.dataset", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.filter.dataset", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.authorization.dataset", 1);
+
+    // Each exception also increments its own aspectName metric
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.testAspect1", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.precondition.testAspect2", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.filter.testAspect3", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.authorization.testAspect4", 1);
+  }
+
+  @Test
+  public void testCollectMetrics_WithSpecialCharactersInAspectName() throws Exception {
+    // Given
+    Urn entityUrn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleDataset,PROD)");
+    String aspectNameWithSpecialChars = "aspect_name-with.special$chars";
+    BatchItem batchItem =
+        createMockBatchItem(entityUrn, aspectNameWithSpecialChars, ChangeType.UPSERT);
+
+    AspectValidationException exception =
+        AspectValidationException.forItem(batchItem, "Test error");
+
+    ValidationExceptionCollection exceptions = ValidationExceptionCollection.newCollection();
+    exceptions.addException(exception);
+
+    // When
+    ValidationExceptionCollection result =
+        ExceptionUtils.collectMetrics(mockMetricUtils, exceptions);
+
+    // Then
+    assertNotNull(result);
+    verify(mockMetricUtils)
+        .increment("metadata.validation.exception.validation." + aspectNameWithSpecialChars, 1);
+  }
+
+  @Test
+  public void testCollectMetrics_VerifyExceptionCollectionUnmodified() throws Exception {
+    // Given
+    Urn entityUrn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleDataset,PROD)");
+    BatchItem batchItem = createMockBatchItem(entityUrn, "datasetProperties", ChangeType.UPSERT);
+
+    AspectValidationException exception =
+        AspectValidationException.forItem(batchItem, "Test error");
+
+    ValidationExceptionCollection originalExceptions =
+        ValidationExceptionCollection.newCollection();
+    originalExceptions.addException(exception);
+    long originalSize = originalExceptions.streamAllExceptions().count();
+
+    // When
+    ValidationExceptionCollection result =
+        ExceptionUtils.collectMetrics(mockMetricUtils, originalExceptions);
+
+    // Then
+    assertSame(result, originalExceptions);
+    assertEquals(originalExceptions.streamAllExceptions().count(), originalSize);
+    assertTrue(originalExceptions.hasFatalExceptions());
+    assertEquals(originalExceptions.getSubTypes().size(), 1);
+    assertTrue(originalExceptions.getSubTypes().contains(ValidationSubType.VALIDATION));
+  }
+
+  @Test
+  public void testCollectMetrics_WithDifferentEntityTypes() throws Exception {
+    // Given
+    Urn datasetUrn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleDataset,PROD)");
+    Urn chartUrn = Urn.createFromString("urn:li:chart:(looker,dashboard.1)");
+    Urn dashboardUrn = Urn.createFromString("urn:li:dashboard:(looker,dashboards.1)");
+    Urn dataFlowUrn = Urn.createFromString("urn:li:dataFlow:(airflow,dag_abc,PROD)");
+
+    ValidationExceptionCollection exceptions = ValidationExceptionCollection.newCollection();
+
+    // Add exceptions for different entity types
+    exceptions.addException(
+        AspectValidationException.forItem(
+            createMockBatchItem(datasetUrn, "datasetProperties", ChangeType.UPSERT),
+            "Dataset error"));
+    exceptions.addException(
+        AspectValidationException.forItem(
+            createMockBatchItem(chartUrn, "chartInfo", ChangeType.UPSERT), "Chart error"));
+    exceptions.addException(
+        AspectValidationException.forItem(
+            createMockBatchItem(dashboardUrn, "dashboardInfo", ChangeType.UPSERT),
+            "Dashboard error"));
+    exceptions.addException(
+        AspectValidationException.forItem(
+            createMockBatchItem(dataFlowUrn, "dataFlowInfo", ChangeType.UPSERT), "DataFlow error"));
+
+    // When
+    ExceptionUtils.collectMetrics(mockMetricUtils, exceptions);
+
+    // Then
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.dataset", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.chart", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.dashboard", 1);
+    verify(mockMetricUtils).increment("metadata.validation.exception.validation.dataflow", 1);
+  }
+
+  // Helper method to create a mock BatchItem
+  private BatchItem createMockBatchItem(Urn urn, String aspectName, ChangeType changeType) {
+    BatchItem mockItem = mock(BatchItem.class);
+    when(mockItem.getUrn()).thenReturn(urn);
+    when(mockItem.getAspectName()).thenReturn(aspectName);
+    when(mockItem.getChangeType()).thenReturn(changeType);
+    when(mockItem.getEntitySpec()).thenReturn(mockEntitySpec);
+    when(mockItem.getAspectSpec()).thenReturn(mockAspectSpec);
+    return mockItem;
+  }
+
+  // Helper method to create a sample exception collection
+  private ValidationExceptionCollection createExceptionCollection() throws Exception {
+    Urn entityUrn =
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleDataset,PROD)");
+    BatchItem batchItem = createMockBatchItem(entityUrn, "datasetProperties", ChangeType.UPSERT);
+
+    AspectValidationException exception =
+        AspectValidationException.forItem(batchItem, "Sample error");
+
+    ValidationExceptionCollection exceptions = ValidationExceptionCollection.newCollection();
+    exceptions.addException(exception);
+    return exceptions;
+  }
+}

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/metrics/MetricUtilsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/metrics/MetricUtilsTest.java
@@ -1,0 +1,267 @@
+package com.linkedin.metadata.utils.metrics;
+
+import static org.testng.Assert.*;
+
+import com.codahale.metrics.MetricRegistry;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MetricUtilsTest {
+
+  private SimpleMeterRegistry meterRegistry;
+  private MetricUtils metricUtils;
+  private AutoCloseable mockitoCloseable;
+
+  @Mock private MeterRegistry mockMeterRegistry;
+
+  @BeforeMethod
+  public void setUp() {
+    mockitoCloseable = MockitoAnnotations.openMocks(this);
+    meterRegistry = new SimpleMeterRegistry();
+    metricUtils = MetricUtils.builder().registry(meterRegistry).build();
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    if (mockitoCloseable != null) {
+      mockitoCloseable.close();
+    }
+    meterRegistry.clear();
+    meterRegistry.close();
+  }
+
+  @Test
+  public void testGetRegistryReturnsOptionalWithRegistry() {
+    Optional<MeterRegistry> registry = metricUtils.getRegistry();
+    assertTrue(registry.isPresent());
+    assertSame(registry.get(), meterRegistry);
+  }
+
+  @Test
+  public void testGetRegistryReturnsEmptyOptionalWhenNull() {
+    MetricUtils utilsWithNullRegistry = MetricUtils.builder().registry(null).build();
+
+    Optional<MeterRegistry> registry = utilsWithNullRegistry.getRegistry();
+    assertFalse(registry.isPresent());
+  }
+
+  @Test
+  public void testTimeRecordsTimerWithDropwizardTag() {
+    String metricName = "test.timer";
+    long durationNanos = TimeUnit.MILLISECONDS.toNanos(100);
+
+    metricUtils.time(metricName, durationNanos);
+
+    Timer timer = meterRegistry.timer(metricName, MetricUtils.DROPWIZARD_METRIC, "true");
+    assertNotNull(timer);
+    assertEquals(timer.count(), 1);
+    assertEquals(timer.totalTime(TimeUnit.NANOSECONDS), (double) durationNanos);
+  }
+
+  @Test
+  public void testTimeWithNullRegistryDoesNothing() {
+    MetricUtils utilsWithNullRegistry = MetricUtils.builder().registry(null).build();
+
+    // Should not throw exception
+    utilsWithNullRegistry.time("test.timer", 1000);
+  }
+
+  @Test
+  public void testIncrementWithClassAndMetricName() {
+    Class<?> testClass = this.getClass();
+    String metricName = "test.counter";
+    double incrementValue = 5.0;
+
+    metricUtils.increment(testClass, metricName, incrementValue);
+
+    String expectedName = MetricRegistry.name(testClass, metricName);
+    Counter counter = meterRegistry.counter(expectedName, MetricUtils.DROPWIZARD_METRIC, "true");
+    assertNotNull(counter);
+    assertEquals(counter.count(), incrementValue);
+  }
+
+  @Test
+  public void testIncrementWithMetricNameOnly() {
+    String metricName = "simple.counter";
+    double incrementValue = 3.0;
+
+    metricUtils.increment(metricName, incrementValue);
+
+    Counter counter = meterRegistry.counter(metricName, MetricUtils.DROPWIZARD_METRIC, "true");
+    assertNotNull(counter);
+    assertEquals(counter.count(), incrementValue);
+  }
+
+  @Test
+  public void testExceptionIncrementCreatesMultipleCounters() {
+    Class<?> testClass = this.getClass();
+    String baseMetricName = "error.counter";
+    RuntimeException exception = new RuntimeException("Test exception");
+
+    metricUtils.exceptionIncrement(testClass, baseMetricName, exception);
+
+    // Check base counter
+    String baseName = MetricRegistry.name(testClass, baseMetricName);
+    Counter baseCounter = meterRegistry.counter(baseName, MetricUtils.DROPWIZARD_METRIC, "true");
+    assertNotNull(baseCounter);
+    assertEquals(baseCounter.count(), 1.0);
+
+    // The snake case conversion in the code is: "RuntimeException" -> "_Runtime_Exception"
+    String exceptionName =
+        MetricRegistry.name(testClass, baseMetricName + "_" + "_Runtime_Exception");
+    Counter exceptionCounter =
+        meterRegistry.counter(exceptionName, MetricUtils.DROPWIZARD_METRIC, "true");
+    assertNotNull(exceptionCounter);
+    assertEquals(exceptionCounter.count(), 1.0);
+  }
+
+  @Test
+  public void testExceptionIncrementWithComplexExceptionName() {
+    Class<?> testClass = this.getClass();
+    String baseMetricName = "error.counter";
+    IllegalArgumentException exception = new IllegalArgumentException("Test");
+
+    metricUtils.exceptionIncrement(testClass, baseMetricName, exception);
+
+    // The snake case conversion in the code is: "IllegalArgumentException" ->
+    // "_Illegal_Argument_Exception"
+    String exceptionName =
+        MetricRegistry.name(testClass, baseMetricName + "_" + "_Illegal_Argument_Exception");
+    Counter exceptionCounter =
+        meterRegistry.counter(exceptionName, MetricUtils.DROPWIZARD_METRIC, "true");
+    assertNotNull(exceptionCounter);
+    assertEquals(exceptionCounter.count(), 1.0);
+  }
+
+  @Test
+  public void testGaugeRegistersSupplierBasedGauge() {
+    Class<?> testClass = this.getClass();
+    String metricName = "test.gauge";
+    Supplier<Number> valueSupplier = () -> 42.5;
+
+    metricUtils.gauge(testClass, metricName, valueSupplier);
+
+    String expectedName = MetricRegistry.name(testClass, metricName);
+    Gauge gauge =
+        meterRegistry.find(expectedName).tag(MetricUtils.DROPWIZARD_METRIC, "true").gauge();
+
+    assertNotNull(gauge);
+    assertEquals(gauge.value(), 42.5);
+  }
+
+  @Test
+  public void testGaugeWithChangingValue() {
+    Class<?> testClass = this.getClass();
+    String metricName = "dynamic.gauge";
+
+    // Use a mutable value
+    final double[] value = {10.0};
+    Supplier<Number> valueSupplier = () -> value[0];
+
+    metricUtils.gauge(testClass, metricName, valueSupplier);
+
+    String expectedName = MetricRegistry.name(testClass, metricName);
+    Gauge gauge =
+        meterRegistry.find(expectedName).tag(MetricUtils.DROPWIZARD_METRIC, "true").gauge();
+
+    assertEquals(gauge.value(), 10.0);
+
+    // Change the value
+    value[0] = 20.0;
+    assertEquals(gauge.value(), 20.0);
+  }
+
+  @Test
+  public void testHistogramRecordsDistributionSummary() {
+    Class<?> testClass = this.getClass();
+    String metricName = "test.histogram";
+    long value = 100L;
+
+    metricUtils.histogram(testClass, metricName, value);
+
+    String expectedName = MetricRegistry.name(testClass, metricName);
+    DistributionSummary summary =
+        meterRegistry.summary(expectedName, MetricUtils.DROPWIZARD_METRIC, "true");
+
+    assertNotNull(summary);
+    assertEquals(summary.count(), 1);
+    assertEquals(summary.totalAmount(), (double) value);
+  }
+
+  @Test
+  public void testHistogramMultipleValues() {
+    Class<?> testClass = this.getClass();
+    String metricName = "multi.histogram";
+
+    metricUtils.histogram(testClass, metricName, 10);
+    metricUtils.histogram(testClass, metricName, 20);
+    metricUtils.histogram(testClass, metricName, 30);
+
+    String expectedName = MetricRegistry.name(testClass, metricName);
+    DistributionSummary summary =
+        meterRegistry.summary(expectedName, MetricUtils.DROPWIZARD_METRIC, "true");
+
+    assertEquals(summary.count(), 3);
+    assertEquals(summary.totalAmount(), 60.0);
+    assertEquals(summary.mean(), 20.0);
+  }
+
+  @Test
+  public void testNameWithStringParameters() {
+    String result = MetricUtils.name("base", "part1", "part2", "part3");
+    assertEquals(result, "base.part1.part2.part3");
+  }
+
+  @Test
+  public void testNameWithClassAndStringParameters() {
+    Class<?> testClass = this.getClass();
+    String result = MetricUtils.name(testClass, "method", "metric");
+    assertEquals(result, testClass.getName() + ".method.metric");
+  }
+
+  @Test
+  public void testNameWithEmptyParameters() {
+    String result = MetricUtils.name("base");
+    assertEquals(result, "base");
+  }
+
+  @Test
+  public void testAllMethodsWithNullRegistry() {
+    MetricUtils utilsWithNullRegistry = MetricUtils.builder().registry(null).build();
+
+    // None of these should throw exceptions
+    utilsWithNullRegistry.time("timer", 1000);
+    utilsWithNullRegistry.increment(this.getClass(), "counter", 1);
+    utilsWithNullRegistry.increment("counter", 1);
+    utilsWithNullRegistry.exceptionIncrement(this.getClass(), "error", new RuntimeException());
+    utilsWithNullRegistry.gauge(this.getClass(), "gauge", () -> 42);
+    utilsWithNullRegistry.histogram(this.getClass(), "histogram", 100);
+  }
+
+  @Test
+  public void testAllMetricsHaveDropwizardTag() {
+    // Test that all metric types are properly tagged
+    metricUtils.time("timer.metric", 1000);
+    metricUtils.increment("counter.metric", 1);
+    metricUtils.gauge(this.getClass(), "gauge.metric", () -> 42);
+    metricUtils.histogram(this.getClass(), "histogram.metric", 100);
+
+    // Verify all metrics have the dropwizard tag
+    for (Meter meter : meterRegistry.getMeters()) {
+      assertEquals(meter.getId().getTag(MetricUtils.DROPWIZARD_METRIC), "true");
+    }
+  }
+}

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/metrics/MicrometerMetricsRegistryTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/metrics/MicrometerMetricsRegistryTest.java
@@ -1,0 +1,802 @@
+package com.linkedin.metadata.utils.metrics;
+
+import static com.linkedin.metadata.utils.metrics.MicrometerMetricsRegistry.GLOBALLY_REGISTERED_CACHES;
+import static com.linkedin.metadata.utils.metrics.MicrometerMetricsRegistry.GLOBALLY_REGISTERED_EXECUTOR_SERVICE;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.hazelcast.map.IMap;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.reflect.Field;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MicrometerMetricsRegistryTest {
+
+  @Mock private IMap<Object, Object> hazelcastMap;
+  @Mock private ExecutorService mockExecutorService;
+
+  private MeterRegistry meterRegistry;
+  private ExecutorService realExecutorService;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    meterRegistry = new SimpleMeterRegistry();
+
+    // Clear the global registry before each
+    clearGlobalRegistry();
+
+    // Create a real executor service for some tests
+    realExecutorService = Executors.newFixedThreadPool(2);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    // Shutdown the real executor service
+    if (realExecutorService != null && !realExecutorService.isShutdown()) {
+      realExecutorService.shutdown();
+      realExecutorService.awaitTermination(5, TimeUnit.SECONDS);
+    }
+  }
+
+  private void clearGlobalRegistry() throws Exception {
+    GLOBALLY_REGISTERED_CACHES.clear();
+    GLOBALLY_REGISTERED_EXECUTOR_SERVICE.clear();
+  }
+
+  @Test
+  public void testRegisterCaffeineCache() {
+    // Given
+    String cacheName = "testCaffeineCache";
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, meterRegistry);
+
+    // Then
+    assertTrue(result);
+
+    // Verify that metrics are registered
+    assertFalse(meterRegistry.getMeters().isEmpty());
+    assertTrue(
+        meterRegistry.getMeters().stream()
+            .anyMatch(meter -> meter.getId().getName().startsWith("cache")));
+  }
+
+  @Test
+  public void testRegisterHazelcastCache() {
+    // Given
+    String cacheName = "testHazelcastCache";
+    when(hazelcastMap.getName()).thenReturn(cacheName);
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, hazelcastMap, meterRegistry);
+
+    // Then
+    assertTrue(result);
+
+    // Verify that metrics are registered
+    assertFalse(meterRegistry.getMeters().isEmpty());
+    assertTrue(
+        meterRegistry.getMeters().stream()
+            .anyMatch(meter -> meter.getId().getName().startsWith("cache")));
+  }
+
+  @Test
+  public void testRegisterCacheOnlyOnce() {
+    // Given
+    String cacheName = "testCache";
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+
+    // When - register the same cache twice
+    boolean firstResult =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, meterRegistry);
+    boolean secondResult =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, meterRegistry);
+
+    // Then
+    assertTrue(firstResult);
+    assertFalse(secondResult); // Second registration should return false
+  }
+
+  @Test
+  public void testRegisterMultipleCaches() {
+    // Given
+    String cacheName1 = "cache1";
+    String cacheName2 = "cache2";
+    Cache<Object, Object> caffeineCache1 =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+    Cache<Object, Object> caffeineCache2 =
+        Caffeine.newBuilder().maximumSize(200).recordStats().build();
+
+    // When
+    boolean result1 =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName1, caffeineCache1, meterRegistry);
+    boolean result2 =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName2, caffeineCache2, meterRegistry);
+
+    // Then
+    assertTrue(result1);
+    assertTrue(result2);
+
+    // Verify that metrics are registered for both caches
+    assertFalse(meterRegistry.getMeters().isEmpty());
+    assertTrue(meterRegistry.getMeters().size() > 1);
+  }
+
+  @Test
+  public void testRegisterCacheWithNullMeterRegistry() {
+    // Given
+    String cacheName = "testCache";
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+
+    // When
+    boolean result = MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void testRegisterCacheWithNullNativeCache() {
+    // Given
+    String cacheName = "testCache";
+
+    // When
+    boolean result = MicrometerMetricsRegistry.registerCacheMetrics(cacheName, null, meterRegistry);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void testRegisterCacheWithNullCacheName() {
+    // Given
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerCacheMetrics(null, caffeineCache, meterRegistry);
+
+    // Then
+    assertFalse(result); // Should return false for null cache name
+  }
+
+  @Test
+  public void testRegisterCacheWithUnsupportedCacheType() {
+    // Given
+    String cacheName = "unsupportedCache";
+    Object unsupportedCache = new Object(); // Not a Caffeine or Hazelcast cache
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, unsupportedCache, meterRegistry);
+
+    // Then
+    assertTrue(result); // Should return true but not register any metrics
+
+    // No metrics should be registered for unsupported cache type
+    assertTrue(meterRegistry.getMeters().isEmpty());
+  }
+
+  @Test
+  public void testConcurrentRegistration() throws InterruptedException {
+    // Given
+    String cacheName = "concurrentCache";
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+
+    // When - simulate concurrent registration attempts
+    Thread[] threads = new Thread[3];
+    boolean[] results = new boolean[3];
+
+    for (int i = 0; i < 3; i++) {
+      final int index = i;
+      threads[i] =
+          new Thread(
+              () -> {
+                results[index] =
+                    MicrometerMetricsRegistry.registerCacheMetrics(
+                        cacheName, caffeineCache, meterRegistry);
+              });
+      threads[i].start();
+    }
+
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    // Then - only one thread should have successfully registered
+    int successCount = 0;
+    for (boolean result : results) {
+      if (result) successCount++;
+    }
+    assertEquals(successCount, 1);
+  }
+
+  @Test
+  public void testMetricsTagsForCaffeineCache() {
+    // Given
+    String cacheName = "taggedCaffeineCache";
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, meterRegistry);
+
+    // Then
+    assertTrue(result);
+    assertFalse(meterRegistry.getMeters().isEmpty());
+
+    // Check for cache.size metric which is always present
+    // CaffeineCacheMetrics uses "cache" as the tag name, not "name"
+    assertTrue(
+        meterRegistry.getMeters().stream()
+            .anyMatch(
+                meter ->
+                    meter.getId().getName().equals("cache.size")
+                        && meter.getId().getTag("cache") != null
+                        && meter.getId().getTag("cache").equals(cacheName)));
+  }
+
+  @Test
+  public void testMetricsTagsForHazelcastCache() {
+    // Given
+    String cacheName = "taggedHazelcastCache";
+    when(hazelcastMap.getName()).thenReturn(cacheName);
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, hazelcastMap, meterRegistry);
+
+    // Then
+    assertTrue(result);
+    assertFalse(meterRegistry.getMeters().isEmpty());
+
+    // Verify at least one metric exists with the cache prefix
+    assertTrue(
+        meterRegistry.getMeters().stream()
+            .anyMatch(meter -> meter.getId().getName().startsWith("cache")));
+
+    // Verify the name tag is present on at least one metric
+    assertTrue(
+        meterRegistry.getMeters().stream()
+            .anyMatch(meter -> cacheName.equals(meter.getId().getTag("name"))));
+  }
+
+  @Test
+  public void testRegisterSameCacheWithDifferentRegistries() {
+    // Given
+    String cacheName = "multiRegistryCache";
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+    MeterRegistry secondRegistry = new SimpleMeterRegistry();
+
+    // When
+    boolean result1 =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, meterRegistry);
+    boolean result2 =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, secondRegistry);
+
+    // Then - second should fail since we're using cache name only as the key
+    assertTrue(result1);
+    assertFalse(result2); // This will fail because the cache name is already registered
+
+    // Only first registry should have metrics
+    assertFalse(meterRegistry.getMeters().isEmpty());
+    assertTrue(secondRegistry.getMeters().isEmpty());
+  }
+
+  @Test
+  public void testExceptionHandlingDuringRegistration() {
+    // Given
+    String cacheName = "exceptionCache";
+    // Create a mock cache that will cause an exception during metric registration
+    Cache<Object, Object> problematicCache = mock(Cache.class);
+    when(problematicCache.estimatedSize()).thenThrow(new RuntimeException("Test exception"));
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, problematicCache, meterRegistry);
+
+    // Then - should return false and not crash
+    assertFalse(result);
+
+    // Attempting to register again should succeed since it was removed from the set
+    Cache<Object, Object> goodCache = Caffeine.newBuilder().maximumSize(100).recordStats().build();
+    boolean retryResult =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, goodCache, meterRegistry);
+    assertTrue(retryResult);
+  }
+
+  @Test
+  public void testRegistryKeyFormat() throws Exception {
+    // Given
+    String cacheName = "testCache";
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+
+    // Register with first registry
+    boolean result1 =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, meterRegistry);
+    assertTrue(result1);
+
+    // Get the global cache set to verify the key format
+    Field field = MicrometerMetricsRegistry.class.getDeclaredField("GLOBALLY_REGISTERED_CACHES");
+    field.setAccessible(true);
+    Set<String> registeredCaches = (Set<String>) field.get(null);
+
+    // Verify the key is just the cache name (no registry hash)
+    assertEquals(registeredCaches.size(), 1);
+    String registeredKey = registeredCaches.iterator().next();
+    assertEquals(registeredKey, cacheName);
+  }
+
+  @Test
+  public void testAllNullParameters() {
+    // When
+    boolean result = MicrometerMetricsRegistry.registerCacheMetrics(null, null, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void testNullCheckOrder() {
+    // Test various combinations of null parameters
+
+    // Null cache name
+    Cache<Object, Object> caffeineCache = Caffeine.newBuilder().maximumSize(100).build();
+    assertFalse(MicrometerMetricsRegistry.registerCacheMetrics(null, caffeineCache, meterRegistry));
+
+    // Null native cache
+    assertFalse(MicrometerMetricsRegistry.registerCacheMetrics("test", null, meterRegistry));
+
+    // Null meter registry
+    assertFalse(MicrometerMetricsRegistry.registerCacheMetrics("test", caffeineCache, null));
+  }
+
+  @Test
+  public void testSuccessfulRegistrationDoesNotThrowOnSubsequentAttempts() {
+    // Given
+    String cacheName = "testCache";
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+
+    // When - register successfully
+    boolean firstResult =
+        MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, meterRegistry);
+    assertTrue(firstResult);
+
+    // Then - subsequent attempts should return false but not throw
+    for (int i = 0; i < 5; i++) {
+      boolean result =
+          MicrometerMetricsRegistry.registerCacheMetrics(cacheName, caffeineCache, meterRegistry);
+      assertFalse(result);
+    }
+  }
+
+  @Test
+  public void testConsistentTagsBetweenCaffeineAndHazelcast() {
+    // Given
+    String caffeineCacheName = "caffeineCache";
+    String hazelcastCacheName = "hazelcastCache";
+
+    Cache<Object, Object> caffeineCache =
+        Caffeine.newBuilder().maximumSize(100).recordStats().build();
+    when(hazelcastMap.getName()).thenReturn(hazelcastCacheName);
+
+    // When
+    boolean caffeineResult =
+        MicrometerMetricsRegistry.registerCacheMetrics(
+            caffeineCacheName, caffeineCache, meterRegistry);
+    boolean hazelcastResult =
+        MicrometerMetricsRegistry.registerCacheMetrics(
+            hazelcastCacheName, hazelcastMap, meterRegistry);
+
+    // Then
+    assertTrue(caffeineResult);
+    assertTrue(hazelcastResult);
+
+    // Collect all unique tag keys from Caffeine metrics
+    Set<String> caffeineTagKeys =
+        meterRegistry.getMeters().stream()
+            .filter(meter -> meter.getId().getName().startsWith("cache"))
+            .filter(meter -> caffeineCacheName.equals(meter.getId().getTag("cache")))
+            .flatMap(meter -> meter.getId().getTags().stream())
+            .map(Tag::getKey)
+            .collect(java.util.stream.Collectors.toSet());
+
+    // Collect all unique tag keys from Hazelcast metrics
+    Set<String> hazelcastTagKeys =
+        meterRegistry.getMeters().stream()
+            .filter(meter -> meter.getId().getName().startsWith("cache"))
+            .filter(meter -> hazelcastCacheName.equals(meter.getId().getTag("cache")))
+            .flatMap(meter -> meter.getId().getTags().stream())
+            .map(Tag::getKey)
+            .collect(java.util.stream.Collectors.toSet());
+
+    // Hazelcast has an additional "ownership" tag that Caffeine doesn't have
+    // Remove it for comparison of common tags
+    Set<String> hazelcastCommonTags = new java.util.HashSet<>(hazelcastTagKeys);
+    hazelcastCommonTags.remove("ownership");
+
+    // Verify that the common tags are the same
+    assertEquals(
+        caffeineTagKeys,
+        hazelcastCommonTags,
+        "Common tag keys should be identical between Caffeine and Hazelcast metrics");
+
+    // Verify Hazelcast has the ownership tag
+    assertTrue(
+        hazelcastTagKeys.contains("ownership"), "Hazelcast metrics should have 'ownership' tag");
+  }
+
+  @Test
+  public void testRegisterExecutorService() {
+    // Given
+    String executorName = "testExecutor";
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            executorName, realExecutorService, meterRegistry);
+
+    // Then
+    assertTrue(result);
+
+    // Verify that metrics are registered
+    assertFalse(meterRegistry.getMeters().isEmpty());
+    assertTrue(
+        meterRegistry.getMeters().stream()
+            .anyMatch(meter -> meter.getId().getName().startsWith("executor")));
+  }
+
+  @Test
+  public void testRegisterExecutorServiceOnlyOnce() {
+    // Given
+    String executorName = "testExecutor";
+
+    // When - register the same executor twice
+    boolean firstResult =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            executorName, realExecutorService, meterRegistry);
+    boolean secondResult =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            executorName, realExecutorService, meterRegistry);
+
+    // Then
+    assertTrue(firstResult);
+    assertFalse(secondResult); // Second registration should return false
+  }
+
+  @Test
+  public void testRegisterMultipleExecutors() {
+    // Given
+    String executorName1 = "executor1";
+    String executorName2 = "executor2";
+    ExecutorService executorService2 = Executors.newCachedThreadPool();
+
+    try {
+      // When
+      boolean result1 =
+          MicrometerMetricsRegistry.registerExecutorMetrics(
+              executorName1, realExecutorService, meterRegistry);
+      boolean result2 =
+          MicrometerMetricsRegistry.registerExecutorMetrics(
+              executorName2, executorService2, meterRegistry);
+
+      // Then
+      assertTrue(result1);
+      assertTrue(result2);
+
+      // Verify that metrics are registered for both executors
+      assertFalse(meterRegistry.getMeters().isEmpty());
+      assertTrue(meterRegistry.getMeters().size() > 1);
+    } finally {
+      executorService2.shutdown();
+    }
+  }
+
+  @Test
+  public void testRegisterExecutorWithNullMeterRegistry() {
+    // Given
+    String executorName = "testExecutor";
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerExecutorMetrics(executorName, realExecutorService, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void testRegisterExecutorWithNullExecutorService() {
+    // Given
+    String executorName = "testExecutor";
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerExecutorMetrics(executorName, null, meterRegistry);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void testRegisterExecutorWithNullExecutorName() {
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerExecutorMetrics(null, realExecutorService, meterRegistry);
+
+    // Then
+    assertFalse(result); // Should return false for null executor name
+  }
+
+  @Test
+  public void testConcurrentExecutorRegistration() throws InterruptedException {
+    // Given
+    String executorName = "concurrentExecutor";
+
+    // When - simulate concurrent registration attempts
+    Thread[] threads = new Thread[3];
+    boolean[] results = new boolean[3];
+
+    for (int i = 0; i < 3; i++) {
+      final int index = i;
+      threads[i] =
+          new Thread(
+              () -> {
+                results[index] =
+                    MicrometerMetricsRegistry.registerExecutorMetrics(
+                        executorName, realExecutorService, meterRegistry);
+              });
+      threads[i].start();
+    }
+
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    // Then - only one thread should have successfully registered
+    int successCount = 0;
+    for (boolean result : results) {
+      if (result) successCount++;
+    }
+    assertEquals(successCount, 1);
+  }
+
+  @Test
+  public void testExecutorMetricsTags() {
+    // Given
+    String executorName = "taggedExecutor";
+
+    // When
+    boolean result =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            executorName, realExecutorService, meterRegistry);
+
+    // Then
+    assertTrue(result);
+    assertFalse(meterRegistry.getMeters().isEmpty());
+
+    // Check for executor metrics with proper tags
+    assertTrue(
+        meterRegistry.getMeters().stream()
+            .anyMatch(
+                meter ->
+                    meter.getId().getName().startsWith("executor")
+                        && meter.getId().getTag("name") != null
+                        && meter.getId().getTag("name").equals(executorName)));
+  }
+
+  @Test
+  public void testRegisterSameExecutorWithDifferentRegistries() {
+    // Given
+    String executorName = "multiRegistryExecutor";
+    MeterRegistry secondRegistry = new SimpleMeterRegistry();
+
+    // When
+    boolean result1 =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            executorName, realExecutorService, meterRegistry);
+    boolean result2 =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            executorName, realExecutorService, secondRegistry);
+
+    // Then - second should fail since we're using executor name only as the key
+    assertTrue(result1);
+    assertFalse(result2); // This will fail because the executor name is already registered
+
+    // Only first registry should have metrics
+    assertFalse(meterRegistry.getMeters().isEmpty());
+    assertTrue(secondRegistry.getMeters().isEmpty());
+  }
+
+  @Test
+  public void testExecutorRegistryKeyFormat() throws Exception {
+    // Given
+    String executorName = "testExecutor";
+
+    // Register with first registry
+    boolean result1 =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            executorName, realExecutorService, meterRegistry);
+    assertTrue(result1);
+
+    // Get the global executor set to verify the key format
+    Field field =
+        MicrometerMetricsRegistry.class.getDeclaredField("GLOBALLY_REGISTERED_EXECUTOR_SERVICE");
+    field.setAccessible(true);
+    Set<String> registeredExecutors = (Set<String>) field.get(null);
+
+    // Verify the key is just the executor name (no registry hash)
+    assertEquals(registeredExecutors.size(), 1);
+    String registeredKey = registeredExecutors.iterator().next();
+    assertEquals(registeredKey, executorName);
+  }
+
+  @Test
+  public void testAllNullParametersForExecutor() {
+    // When
+    boolean result = MicrometerMetricsRegistry.registerExecutorMetrics(null, null, null);
+
+    // Then
+    assertFalse(result);
+  }
+
+  @Test
+  public void testExecutorNullCheckOrder() {
+    // Test various combinations of null parameters
+
+    // Null executor name
+    assertFalse(
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            null, realExecutorService, meterRegistry));
+
+    // Null executor service
+    assertFalse(MicrometerMetricsRegistry.registerExecutorMetrics("test", null, meterRegistry));
+
+    // Null meter registry
+    assertFalse(
+        MicrometerMetricsRegistry.registerExecutorMetrics("test", realExecutorService, null));
+  }
+
+  @Test
+  public void testSuccessfulExecutorRegistrationDoesNotThrowOnSubsequentAttempts() {
+    // Given
+    String executorName = "testExecutor";
+
+    // When - register successfully
+    boolean firstResult =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            executorName, realExecutorService, meterRegistry);
+    assertTrue(firstResult);
+
+    // Then - subsequent attempts should return false but not throw
+    for (int i = 0; i < 5; i++) {
+      boolean result =
+          MicrometerMetricsRegistry.registerExecutorMetrics(
+              executorName, realExecutorService, meterRegistry);
+      assertFalse(result);
+    }
+  }
+
+  @Test
+  public void testDifferentExecutorTypes() {
+    // Test with different executor implementations
+    String fixedPoolName = "fixedPool";
+    String cachedPoolName = "cachedPool";
+    String singleThreadName = "singleThread";
+
+    ExecutorService cachedPool = Executors.newCachedThreadPool();
+    ExecutorService singleThread = Executors.newSingleThreadExecutor();
+
+    try {
+      // When
+      boolean fixedResult =
+          MicrometerMetricsRegistry.registerExecutorMetrics(
+              fixedPoolName, realExecutorService, meterRegistry);
+      boolean cachedResult =
+          MicrometerMetricsRegistry.registerExecutorMetrics(
+              cachedPoolName, cachedPool, meterRegistry);
+      boolean singleResult =
+          MicrometerMetricsRegistry.registerExecutorMetrics(
+              singleThreadName, singleThread, meterRegistry);
+
+      // Then
+      assertTrue(fixedResult);
+      assertTrue(cachedResult);
+      assertTrue(singleResult);
+
+      // Verify metrics are present for all executor types
+      assertTrue(
+          meterRegistry.getMeters().stream()
+              .anyMatch(meter -> fixedPoolName.equals(meter.getId().getTag("name"))));
+      assertTrue(
+          meterRegistry.getMeters().stream()
+              .anyMatch(meter -> cachedPoolName.equals(meter.getId().getTag("name"))));
+      assertTrue(
+          meterRegistry.getMeters().stream()
+              .anyMatch(meter -> singleThreadName.equals(meter.getId().getTag("name"))));
+    } finally {
+      cachedPool.shutdown();
+      singleThread.shutdown();
+    }
+  }
+
+  @Test
+  public void testThreadPoolExecutorSpecificMetrics() {
+    // Given
+    String executorName = "threadPoolExecutor";
+    ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(4);
+
+    try {
+      // When
+      boolean result =
+          MicrometerMetricsRegistry.registerExecutorMetrics(
+              executorName, threadPoolExecutor, meterRegistry);
+
+      // Then
+      assertTrue(result);
+
+      // Verify ThreadPoolExecutor specific metrics are present
+      // ExecutorServiceMetrics should register metrics like pool.size, active, queued, etc.
+      assertTrue(
+          meterRegistry.getMeters().stream()
+              .anyMatch(
+                  meter ->
+                      meter.getId().getName().contains("executor.pool.size")
+                          && executorName.equals(meter.getId().getTag("name"))));
+    } finally {
+      threadPoolExecutor.shutdown();
+    }
+  }
+
+  @Test
+  public void testExecutorMetricsAfterShutdown() throws InterruptedException {
+    // Given
+    String executorName = "shutdownExecutor";
+    ExecutorService executorToShutdown = Executors.newSingleThreadExecutor();
+
+    // Register metrics before shutdown
+    boolean result =
+        MicrometerMetricsRegistry.registerExecutorMetrics(
+            executorName, executorToShutdown, meterRegistry);
+    assertTrue(result);
+
+    // When - shutdown the executor
+    executorToShutdown.shutdown();
+    executorToShutdown.awaitTermination(5, TimeUnit.SECONDS);
+
+    // Then - metrics should still be present (they might show terminated state)
+    assertFalse(meterRegistry.getMeters().isEmpty());
+    assertTrue(
+        meterRegistry.getMeters().stream()
+            .anyMatch(
+                meter ->
+                    meter.getId().getName().startsWith("executor")
+                        && executorName.equals(meter.getId().getTag("name"))));
+  }
+}

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -734,8 +734,8 @@ def test_list_users(auth_session):
         }""",
         "variables": {
             "input": {
-                "start": "0",
-                "count": "2",
+                "start": 0,
+                "count": 2,
             }
         },
     }
@@ -774,8 +774,8 @@ def test_list_groups(auth_session):
         }""",
         "variables": {
             "input": {
-                "start": "0",
-                "count": "2",
+                "start": 0,
+                "count": 2,
             }
         },
     }

--- a/smoke-test/tests/domains/domains_test.py
+++ b/smoke-test/tests/domains/domains_test.py
@@ -60,7 +60,7 @@ def test_create_list_get_domain(auth_session):
               }\n
             }\n
         }""",
-        "variables": {"input": {"start": "0", "count": "20"}},
+        "variables": {"input": {"start": 0, "count": 20}},
     }
 
     response = auth_session.post(

--- a/smoke-test/tests/managed_ingestion/managed_ingestion_test.py
+++ b/smoke-test/tests/managed_ingestion/managed_ingestion_test.py
@@ -20,7 +20,7 @@ def _get_ingestionSources(auth_session):
               }\n
             }\n
         }""",
-        "variables": {"input": {"start": "0", "count": "20"}},
+        "variables": {"input": {"start": 0, "count": 20}},
     }
 
     response = auth_session.post(
@@ -62,7 +62,7 @@ def _ensure_secret_increased(auth_session, before_count):
               }\n
             }\n
         }""",
-        "variables": {"input": {"start": "0", "count": "20"}},
+        "variables": {"input": {"start": 0, "count": 20}},
     }
 
     response = auth_session.post(
@@ -205,7 +205,7 @@ def test_create_list_get_remove_secret(auth_session):
               }\n
             }\n
         }""",
-        "variables": {"input": {"start": "0", "count": "20"}},
+        "variables": {"input": {"start": 0, "count": 20}},
     }
 
     response = auth_session.post(

--- a/smoke-test/tests/policies/test_policies.py
+++ b/smoke-test/tests/policies/test_policies.py
@@ -196,8 +196,8 @@ def listPolicies(auth_session):
         }""",
         "variables": {
             "input": {
-                "start": "0",
-                "count": "20",
+                "start": 0,
+                "count": 20,
             }
         },
     }

--- a/smoke-test/tests/structured_properties/test_structured_properties.py
+++ b/smoke-test/tests/structured_properties/test_structured_properties.py
@@ -408,7 +408,7 @@ def test_structured_property_search(
             extraFilters=[
                 {
                     "field": to_es_filter_name(dataset_property_name),
-                    "negated": "false",
+                    "negated": False,
                     "condition": "EXISTS",
                 }
             ]
@@ -439,7 +439,7 @@ def test_structured_property_search(
                     "field": to_es_filter_name(
                         field_property_name, namespace="io.datahubproject.test"
                     ),
-                    "negated": "false",
+                    "negated": False,
                     "condition": "EXISTS",
                 }
             ],
@@ -454,7 +454,7 @@ def test_structured_property_search(
             extraFilters=[
                 {
                     "field": to_es_filter_name(dataset_property_name),
-                    "negated": "false",
+                    "negated": False,
                     "condition": "EXISTS",
                 }
             ],
@@ -641,7 +641,7 @@ def test_dataset_structured_property_soft_delete_search_filter_validation(
             extraFilters=[
                 {
                     "field": to_es_filter_name(property_name=dataset_property_name),
-                    "negated": "false",
+                    "negated": False,
                     "condition": "EXISTS",
                 }
             ]
@@ -663,7 +663,7 @@ def test_dataset_structured_property_soft_delete_search_filter_validation(
                 extraFilters=[
                     {
                         "field": to_es_filter_name(property_name=dataset_property_name),
-                        "negated": "false",
+                        "negated": False,
                         "condition": "EXISTS",
                     }
                 ]
@@ -724,7 +724,7 @@ def test_dataset_structured_property_delete(ingest_cleanup_data, graph_client, c
                 extraFilters=[
                     {
                         "field": to_es_filter_name(qualified_name=qualified_name),
-                        "negated": "false",
+                        "negated": False,
                         "condition": "EXISTS",
                     }
                 ]

--- a/smoke-test/tests/tests/tests_test.py
+++ b/smoke-test/tests/tests/tests_test.py
@@ -242,7 +242,7 @@ def test_list_tests_retries(auth_session):
             }\n
           }\n
       }""",
-        "variables": {"input": {"start": "0", "count": "20"}},
+        "variables": {"input": {"start": 0, "count": 20}},
     }
 
     response = auth_session.post(

--- a/smoke-test/tests/tokens/token_utils.py
+++ b/smoke-test/tests/tokens/token_utils.py
@@ -28,8 +28,8 @@ def removeUser(session, urn):
 
 def listUsers(session):
     input = {
-        "start": "0",
-        "count": "20",
+        "start": 0,
+        "count": 20,
     }
 
     # list users

--- a/smoke-test/tests/views/views_test.py
+++ b/smoke-test/tests/views/views_test.py
@@ -79,7 +79,7 @@ def test_create_list_delete_global_view(auth_session):
               }\n
             }\n
         }""",
-        "variables": {"input": {"start": "0", "count": "20"}},
+        "variables": {"input": {"start": 0, "count": 20}},
     }
 
     response = auth_session.post(
@@ -200,7 +200,7 @@ def test_create_list_delete_personal_view(auth_session):
               }\n
             }\n
         }""",
-        "variables": {"input": {"start": "0", "count": "20"}},
+        "variables": {"input": {"start": 0, "count": 20}},
     }
 
     response = auth_session.post(


### PR DESCRIPTION
# Comprehensive Monitoring Enhancements for DataHub

[Documentation Link](https://github.com/datahub-project/datahub/blob/9f9a71602f4769297eec39e08f8adb1c1f7cc4bd/docs/advanced/monitoring.md)

## 🎯 Overview

This PR introduces significant improvements to DataHub's observability infrastructure, including the migration from DropWizard/JMX metrics to Micrometer, enhanced GraphQL instrumentation, and comprehensive documentation updates. These changes enable better performance monitoring, debugging capabilities, and cloud-native metric collection while maintaining backward compatibility.

## 🔄 Key Changes

### 1. Metrics Framework Migration
- ✅ **Deprecated Prometheus JMX agent** for Spring components in favor of native Micrometer support
- ✅ **Introduced Micrometer** as the primary metrics facade, enabling support for multiple metrics backends (Prometheus, StatsD, CloudWatch, Datadog, etc.)
- ✅ **Deprecated DropWizard metrics** instrumentation - legacy metrics routed to JMX only during transition
- ✅ Implemented dual-registry strategy for zero-downtime migration
- ✅ Integrated OpenTelemetry bridge for unified observability (metrics + traces from single instrumentation point)

### 2. GraphQL Engine Upgrade & Instrumentation
- ✅ **Upgraded GraphQL Java engine to 22.x** with enhanced instrumentation capabilities
- ✅ Implemented fine-grained GraphQL instrumentation (`GraphQLTimingInstrumentation`)
- ✅ Added request-level metrics: `graphql.request.duration`, `graphql.request.errors`
- ✅ Added configurable field-level resolver metrics with smart filtering
- ✅ Implemented path-based and operation-based targeting to minimize overhead
- ✅ Included cardinality protection through path truncation and configurable tag inclusion

### 3. Automatic Resource Instrumentation
- ✅ **Cache instrumentation** - Automatic metrics for all cache implementations (hit rates, evictions, size)
- ✅ **Thread pool executor instrumentation** - Automatic metrics for all executors (queue depth, active threads, rejections)
- ✅ Zero-code instrumentation leveraging Micrometer's auto-configuration

### 4. Configuration Updates (`application.yml`)
- ✅ Added comprehensive GraphQL metrics configuration options
- ✅ Enabled native Prometheus endpoint (`/actuator/prometheus`) replacing JMX agent requirement
- ✅ Configured Micrometer tags and export settings for multi-backend support
- ✅ Set production-safe defaults (field-level metrics disabled by default)

### 5. Documentation Enhancements
- ✅ Enhanced monitoring overview with architecture diagrams
- ✅ Added detailed Micrometer benefits and integration guide
- ✅ Created GraphQL instrumentation guide with performance best practices
- ✅ Documented cache and executor monitoring capabilities
- ✅ Provided migration roadmap from DropWizard to Micrometer
- ✅ Added future vision section outlining planned capabilities

## 📊 Metrics Summary

### New Metrics Available
```
# GraphQL Metrics
- graphql.request.duration (timer with p50, p95, p99)
- graphql.request.errors (counter)
- graphql.fields.instrumented (counter)
- graphql.field.duration (timer - when enabled)
- graphql.field.errors (counter - when enabled)

# Cache Metrics (automatic)
- cache.size (gauge)
- cache.gets (counter - hit/miss)
- cache.puts (counter)
- cache.evictions (counter)

# Executor Metrics (automatic)
- executor.pool.size (gauge)
- executor.active (gauge)
- executor.queued (gauge)
- executor.completed (counter)
- executor.rejected (counter)
```

### Migration Impact
- ❌ Prometheus JMX agent no longer required for Spring components
- ✅ Direct Prometheus endpoint at `/actuator/prometheus`
- ✅ Legacy DropWizard metrics continue to JMX only
- ✅ Existing JMX-based dashboards remain functional

## 🚀 Performance Impact

- **Minimal overhead** for default configuration (request-level only)
- **Smart filtering** reduces field-level instrumentation cost
- **Configurable targeting** allows precise control over monitoring overhead
- **Production-focus** defaults prevent high-cardinality issues

## 🔧 Configuration Examples

```yaml
# Production - Minimal overhead
graphQL.metrics.enabled: true
graphQL.metrics.fieldLevelEnabled: false

# Production - Targeted monitoring  
graphQL.metrics.fieldLevelEnabled: true
graphQL.metrics.fieldLevelOperations: "slowQuery1,slowQuery2"

# Development - Full visibility
graphQL.metrics.fieldLevelEnabled: true
graphQL.metrics.fieldLevelPathEnabled: true
```

---

**Breaking Changes**: None - Full backward compatibility maintained

**Dependencies**: 
- Micrometer (already included in Spring Boot)
- GraphQL Java 22.x (upgrade from previous version)

**Deprecations**:
- Prometheus JMX agent for Spring components
- DropWizard metrics instrumentation (migration path provided)

**Documentation**: Comprehensive updates included in this PR

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
