### PR TITLE
refactor(search): use getEntityDocumentId for URN conversion in deleteSearchData

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesService.java
@@ -33,8 +33,6 @@ import com.linkedin.structured.StructuredPropertyDefinition;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -443,13 +441,7 @@ public class UpdateIndicesService implements SearchIndicesService {
       @Nullable RecordTemplate aspect,
       Boolean isKeyAspect,
       AuditStamp auditStamp) {
-    String docId;
-    try {
-      docId = URLEncoder.encode(urn.toString(), "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      log.error("Failed to encode the urn with error: {}", e.toString());
-      return;
-    }
+    final String docId = elasticSearchService.getIndexConvention().getEntityDocumentId(urn);
 
     if (isKeyAspect) {
       elasticSearchService.deleteDocument(opContext, entityName, docId);

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesServiceTest.java
@@ -5,6 +5,7 @@ import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -18,6 +19,7 @@ import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.metadata.utils.SystemMetadataUtils;
+import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
 import com.linkedin.mxe.MetadataChangeLog;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
@@ -40,6 +42,9 @@ public class UpdateIndicesServiceTest {
   @BeforeMethod
   public void setup() {
     MockitoAnnotations.openMocks(this);
+    when(entitySearchService.getIndexConvention())
+        .thenReturn(
+            new IndexConventionImpl(IndexConventionImpl.IndexConventionConfig.builder().build()));
     operationContext = TestOperationContexts.systemContextNoSearchAuthorization();
     updateIndicesService =
         new UpdateIndicesService(


### PR DESCRIPTION
Currently, deleting StructuredProperties aspects for schemaField doesn't work as expected. While this change doesn’t directly fix that issue, it refactors the deleteSearchData method to use getEntityDocumentId(urn) instead of manual URL encoding, improving consistency when schemaFieldDocIdHashEnabled is true.