### PR TITLE
chore: aggregator_generate_timer for snowflake

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
@@ -127,6 +127,8 @@ class SnowflakeQueriesExtractorReport(Report):
     users_fetch_timer: PerfTimer = dataclasses.field(default_factory=PerfTimer)
 
     audit_log_load_timer: PerfTimer = dataclasses.field(default_factory=PerfTimer)
+    aggregator_generate_timer: PerfTimer = dataclasses.field(default_factory=PerfTimer)
+
     sql_aggregator: Optional[SqlAggregatorReport] = None
 
     num_ddl_queries_dropped: int = 0
@@ -282,7 +284,8 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
 
                 self.aggregator.add(query)
 
-        yield from auto_workunit(self.aggregator.gen_metadata())
+        with self.report.aggregator_generate_timer:
+            yield from auto_workunit(self.aggregator.gen_metadata())
 
     def fetch_users(self) -> UsersMapping:
         users: UsersMapping = dict()


### PR DESCRIPTION
Tested locally

```
 'queries_extractor': {'copy_history_fetch_timer': '7.289 seconds',
                       'query_log_fetch_timer': '6.535 seconds',
                       'users_fetch_timer': '3.868 seconds',
                       'audit_log_load_timer': '0.006 seconds',
                       'aggregator_generate_timer': '0.036 seconds',
                       'sql_aggregator': {'num_observed_queries': 1,
```