### PR TITLE
feat(ingest): add source aspect number in telemetry

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -339,6 +339,13 @@ class SourceReport(Report):
             "infos": Report.to_pure_python_obj(self.infos),
         }
 
+    def get_aspects_dict(self) -> Dict[str, Dict[str, int]]:
+        """Convert the nested defaultdict aspects to a regular dict for serialization."""
+        result = {}
+        for entity_type, aspect_counts in self.aspects.items():
+            result[entity_type] = dict(aspect_counts)
+        return result
+
     def compute_stats(self) -> None:
         super().compute_stats()
 

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -578,7 +578,7 @@ class Pipeline:
         sink_failures = len(self.sink.get_report().failures)
         sink_warnings = len(self.sink.get_report().warnings)
         global_warnings = len(get_global_warnings())
-        source_aspects = self.source.get_report().aspects
+        source_aspects = self.source.get_report().get_aspects_dict()
 
         telemetry_instance.ping(
             "ingest_stats",

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -579,6 +579,10 @@ class Pipeline:
         sink_warnings = len(self.sink.get_report().warnings)
         global_warnings = len(get_global_warnings())
         source_aspects = self.source.get_report().get_aspects_dict()
+        for _, aspect_dict in source_aspects.items():
+            aspect_dict: Dict[str, int]
+            for aspect_name, aspect_count in aspect_dict.items():
+                aspect_dict[aspect_name] = stats.discretize(aspect_count)
 
         telemetry_instance.ping(
             "ingest_stats",

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -578,11 +578,13 @@ class Pipeline:
         sink_failures = len(self.sink.get_report().failures)
         sink_warnings = len(self.sink.get_report().warnings)
         global_warnings = len(get_global_warnings())
+        source_aspects = self.source.get_report().aspects
 
         telemetry_instance.ping(
             "ingest_stats",
             {
                 "source_type": self.source_type,
+                "source_aspects": source_aspects,
                 "sink_type": self.sink_type,
                 "transformer_types": [
                     transformer.type for transformer in self.config.transformers or []

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -579,10 +579,10 @@ class Pipeline:
         sink_warnings = len(self.sink.get_report().warnings)
         global_warnings = len(get_global_warnings())
         source_aspects = self.source.get_report().get_aspects_dict()
-        for _, aspect_dict in source_aspects.items():
-            aspect_dict: Dict[str, int]
-            for aspect_name, aspect_count in aspect_dict.items():
-                aspect_dict[aspect_name] = stats.discretize(aspect_count)
+        entity_dict: Dict[str, int]
+        for _, entity_dict in source_aspects.items():
+            for aspect_name, aspect_count in entity_dict.items():
+                entity_dict[aspect_name] = stats.discretize(aspect_count)
 
         telemetry_instance.ping(
             "ingest_stats",


### PR DESCRIPTION
Adding a print in telemetry confirmed the properties being passed after pipeline success is this
```
{'source_type': 'datahub-mock-data', 'source_aspects': {'dataset': {'status': 2, 'subTypes': 2, 'upstreamLineage': 2}}, 'sink_type': 'datahub-rest', 'transformer_types': [], 'records_written': 8, 'source_failures': 0, 'source_warnings': 0, 'sink_failures': 0, 'sink_warnings': 0, 'global_warnings': 0, 'failures': 0, 'warnings': 0, 'has_pipeline_name': False}
```
or
```
{'source_type': 'datahub-mock-data', 'source_aspects': {'dataset': {'status': 2, 'subTypes': 2, 'upstreamLineage': 1}}, 'sink_type': 'datahub-rest', 'transformer_types': [], 'records_written': 4, 'source_failures': 0, 'source_warnings': 0, 'sink_failures': 0, 'sink_warnings': 0, 'global_warnings': 0, 'failures': 0, 'warnings': 0, 'has_pipeline_name': False}
```

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
