### PR TITLE
fix(customHomePage): fix position of the views popover

### DIFF
--- a/datahub-web-react/src/app/entityV2/view/select/ViewSelect.tsx
+++ b/datahub-web-react/src/app/entityV2/view/select/ViewSelect.tsx
@@ -124,6 +124,7 @@ const getOverlayStyle = (isShowNavBarRedesign?: boolean) => {
             zIndex: 13,
             paddingTop: '5px',
             'transform-origin': '0',
+            width: '100%',
         };
 
     return overlayStyle;


### PR DESCRIPTION
This PR fixes position of the views popover on the first opening

![image](https://github.com/user-attachments/assets/0b280590-7b0e-43e4-9d79-a5097bf98817)



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
