### PR TITLE
fix(ingestion/snowflake): Address diamond lineage problem + performance improvements

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sql_parsing_aggregator.py
@@ -1577,16 +1577,20 @@ class SqlParsingAggregator(Closeable):
 
         @dataclasses.dataclass
         class QueryLineageInfo:
-            upstreams: List[UrnStr]  # this is direct upstreams, with *no temp tables*
-            column_lineage: List[ColumnLineageInfo]
+            upstreams: OrderedSet[
+                UrnStr
+            ]  # this is direct upstreams, with *no temp tables*
+            column_lineage: OrderedSet[ColumnLineageInfo]
             confidence_score: float
 
             def _merge_lineage_from(self, other_query: "QueryLineageInfo") -> None:
-                self.upstreams += other_query.upstreams
-                self.column_lineage += other_query.column_lineage
+                self.upstreams.update(other_query.upstreams)
+                self.column_lineage.update(other_query.column_lineage)
                 self.confidence_score = min(
                     self.confidence_score, other_query.confidence_score
                 )
+
+        cache: Dict[str, QueryLineageInfo] = {}
 
         def _recurse_into_query(
             query: QueryMetadata, recursion_path: List[QueryId]
@@ -1594,10 +1598,12 @@ class SqlParsingAggregator(Closeable):
             if query.query_id in recursion_path:
                 # This is a cycle, so we just return the query as-is.
                 return QueryLineageInfo(
-                    upstreams=query.upstreams,
-                    column_lineage=query.column_lineage,
+                    upstreams=OrderedSet(query.upstreams),
+                    column_lineage=OrderedSet(query.column_lineage),
                     confidence_score=query.confidence_score,
                 )
+            if query.query_id in cache:
+                return cache[query.query_id]
             recursion_path = [*recursion_path, query.query_id]
             composed_of_queries.add(query.query_id)
 
@@ -1612,7 +1618,7 @@ class SqlParsingAggregator(Closeable):
                         upstream_query = self._query_map.get(upstream_query_id)
                         if (
                             upstream_query
-                            and upstream_query.query_id not in composed_of_queries
+                            and upstream_query.query_id not in recursion_path
                         ):
                             temp_query_lineage_info = _recurse_into_query(
                                 upstream_query, recursion_path
@@ -1672,11 +1678,14 @@ class SqlParsingAggregator(Closeable):
                 ]
             )
 
-            return QueryLineageInfo(
-                upstreams=list(new_upstreams),
-                column_lineage=new_cll,
+            ret = QueryLineageInfo(
+                upstreams=new_upstreams,
+                column_lineage=OrderedSet(new_cll),
                 confidence_score=new_confidence_score,
             )
+            cache[query.query_id] = ret
+
+            return ret
 
         resolved_lineage_info = _recurse_into_query(base_query, [])
 
@@ -1716,8 +1725,8 @@ class SqlParsingAggregator(Closeable):
             base_query,
             query_id=composite_query_id,
             formatted_query_string=merged_query_text,
-            upstreams=resolved_lineage_info.upstreams,
-            column_lineage=resolved_lineage_info.column_lineage,
+            upstreams=list(resolved_lineage_info.upstreams),
+            column_lineage=list(resolved_lineage_info.column_lineage),
             confidence_score=resolved_lineage_info.confidence_score,
         )
 

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -116,6 +116,9 @@ class ColumnRef(_FrozenModel):
     table: Urn
     column: str
 
+    def __hash__(self) -> int:
+        return hash((self.table, self.column))
+
 
 class _DownstreamColumnRef(_ParserBaseModel):
     table: Optional[_TableName] = None
@@ -139,10 +142,16 @@ class DownstreamColumnRef(_ParserBaseModel):
             return v
         return SchemaFieldDataTypeClass.from_obj(v)
 
+    def __hash__(self) -> int:
+        return hash((self.table, self.column, self.native_column_type))
+
 
 class ColumnTransformation(_ParserBaseModel):
     is_direct_copy: bool
     column_logic: str
+
+    def __hash__(self) -> int:
+        return hash((self.is_direct_copy, self.column_logic))
 
 
 class _ColumnLineageInfo(_ParserBaseModel):
@@ -157,6 +166,9 @@ class ColumnLineageInfo(_ParserBaseModel):
     upstreams: List[ColumnRef]
 
     logic: Optional[ColumnTransformation] = pydantic.Field(default=None)
+
+    def __hash__(self) -> int:
+        return hash((self.downstream, tuple(self.upstreams), self.logic))
 
 
 class _JoinInfo(_ParserBaseModel):


### PR DESCRIPTION
This change introduces a fix to snowflake query lineage processing which can be easily recreated with diamond structure of temporary tables dependencies, such as:

```
create schema if not exists diamond_problem;
create TABLE diamond_source1 (col_a int, col_b int, col_c int);
CREATE TEMPORARY TABLE t1 as select * from diamond_source1;
CREATE TEMPORARY TABLE t2 as select * from t1;
CREATE TEMPORARY TABLE t3 as select * from t1;
CREATE TEMPORARY TABLE t4 as select t2.col_a, t3.col_b, t2.col_c from t2 join t3 on t2.col_a = t3.col_a;
CREATE TABLE diamond_destination as select * from t4;
```

Below screenshot shows results before the fix:
<img width="1536" alt="Screenshot 2025-07-01 at 16 04 35" src="https://github.com/user-attachments/assets/c3342ec4-e6bb-49a5-8e62-d3d238588ca7" />

While after the fix we should see proper lineage:
<img width="1496" alt="Screenshot 2025-07-01 at 16 07 18" src="https://github.com/user-attachments/assets/635aa5b3-3ec6-4748-aa27-1a15f111e4db" />

Since this fix makes whole procedure process more queries, some performance improvements were added to the procedure as well:
* storing upstreams in `QueryLineageInfo` as sets instead of lists (huge performance improvements, since we avoid growing them out of proportions
* caching results returned by recurrent function (to avoid reprocessing same dependencies)
