### PR TITLE
feat(graphql) Add GraphQL Objects, Type classes, and Mappers for Templates and Modules

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
@@ -30,6 +30,8 @@ public class Constants {
   public static final String CONNECTIONS_SCHEMA_FILE = "connection.graphql";
   public static final String VERSION_SCHEMA_FILE = "versioning.graphql";
   public static final String QUERY_SCHEMA_FILE = "query.graphql";
+  public static final String TEMPLATE_SCHEMA_FILE = "template.graphql";
+  public static final String MODULE_SCHEMA_FILE = "module.graphql";
   public static final String BROWSE_PATH_DELIMITER = "/";
   public static final String BROWSE_PATH_V2_DELIMITER = "␟";
   public static final String VERSION_STAMP_FIELD_NAME = "versionStamp";

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -813,7 +813,9 @@ public class GmsGraphQLEngine {
         .addSchema(fileBasedSchema(CONTRACTS_SCHEMA_FILE))
         .addSchema(fileBasedSchema(COMMON_SCHEMA_FILE))
         .addSchema(fileBasedSchema(VERSION_SCHEMA_FILE))
-        .addSchema(fileBasedSchema(QUERY_SCHEMA_FILE));
+        .addSchema(fileBasedSchema(QUERY_SCHEMA_FILE))
+        .addSchema(fileBasedSchema(TEMPLATE_SCHEMA_FILE))
+        .addSchema(fileBasedSchema(MODULE_SCHEMA_FILE));
 
     for (GmsGraphQLPlugin plugin : this.graphQLPlugins) {
       List<String> pluginSchemaFiles = plugin.getSchemaFiles();

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -285,6 +285,7 @@ import com.linkedin.datahub.graphql.types.mlmodel.MLFeatureType;
 import com.linkedin.datahub.graphql.types.mlmodel.MLModelGroupType;
 import com.linkedin.datahub.graphql.types.mlmodel.MLModelType;
 import com.linkedin.datahub.graphql.types.mlmodel.MLPrimaryKeyType;
+import com.linkedin.datahub.graphql.types.module.PageModuleType;
 import com.linkedin.datahub.graphql.types.notebook.NotebookType;
 import com.linkedin.datahub.graphql.types.ownership.OwnershipType;
 import com.linkedin.datahub.graphql.types.policy.DataHubPolicyType;
@@ -296,6 +297,7 @@ import com.linkedin.datahub.graphql.types.rolemetadata.RoleType;
 import com.linkedin.datahub.graphql.types.schemafield.SchemaFieldType;
 import com.linkedin.datahub.graphql.types.structuredproperty.StructuredPropertyType;
 import com.linkedin.datahub.graphql.types.tag.TagType;
+import com.linkedin.datahub.graphql.types.template.PageTemplateType;
 import com.linkedin.datahub.graphql.types.test.TestType;
 import com.linkedin.datahub.graphql.types.versioning.VersionSetType;
 import com.linkedin.datahub.graphql.types.view.DataHubViewType;
@@ -467,6 +469,8 @@ public class GmsGraphQLEngine {
   private final VersionSetType versionSetType;
   private final IngestionSourceType ingestionSourceType;
   private final ExecutionRequestType executionRequestType;
+  private final PageTemplateType dataHubPageTemplateType;
+  private final PageModuleType dataHubPageModuleType;
 
   private final int graphQLQueryComplexityLimit;
   private final int graphQLQueryDepthLimit;
@@ -597,6 +601,8 @@ public class GmsGraphQLEngine {
     this.versionSetType = new VersionSetType(entityClient);
     this.ingestionSourceType = new IngestionSourceType(entityClient);
     this.executionRequestType = new ExecutionRequestType(entityClient);
+    this.dataHubPageTemplateType = new PageTemplateType(entityClient);
+    this.dataHubPageModuleType = new PageModuleType(entityClient);
     this.graphQLQueryComplexityLimit = args.graphQLQueryComplexityLimit;
     this.graphQLQueryDepthLimit = args.graphQLQueryDepthLimit;
     this.graphQLQueryIntrospectionEnabled = args.graphQLQueryIntrospectionEnabled;
@@ -651,7 +657,9 @@ public class GmsGraphQLEngine {
                 businessAttributeType,
                 dataProcessInstanceType,
                 applicationType,
-                executionRequestType));
+                executionRequestType,
+                dataHubPageTemplateType,
+                dataHubPageModuleType));
     this.loadableTypes = new ArrayList<>(entityTypes);
     this.loadableTypes.add(ingestionSourceType);
     // Extend loadable types with types from the plugins

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
@@ -13,6 +13,8 @@ import com.linkedin.datahub.graphql.generated.CorpGroup;
 import com.linkedin.datahub.graphql.generated.CorpUser;
 import com.linkedin.datahub.graphql.generated.Dashboard;
 import com.linkedin.datahub.graphql.generated.DataFlow;
+import com.linkedin.datahub.graphql.generated.DataHubPageModule;
+import com.linkedin.datahub.graphql.generated.DataHubPageTemplate;
 import com.linkedin.datahub.graphql.generated.DataHubPolicy;
 import com.linkedin.datahub.graphql.generated.DataHubRole;
 import com.linkedin.datahub.graphql.generated.DataHubView;
@@ -254,6 +256,16 @@ public class UrnToEntityMapper implements ModelMapper<com.linkedin.common.urn.Ur
       partialEntity = new Application();
       ((Application) partialEntity).setUrn(input.toString());
       ((Application) partialEntity).setType(EntityType.APPLICATION);
+    }
+    if (input.getEntityType().equals(DATAHUB_PAGE_TEMPLATE_ENTITY_NAME)) {
+      partialEntity = new DataHubPageTemplate();
+      ((DataHubPageTemplate) partialEntity).setUrn(input.toString());
+      ((DataHubPageTemplate) partialEntity).setType(EntityType.DATAHUB_PAGE_TEMPLATE);
+    }
+    if (input.getEntityType().equals(DATAHUB_PAGE_MODULE_ENTITY_NAME)) {
+      partialEntity = new DataHubPageModule();
+      ((DataHubPageModule) partialEntity).setUrn(input.toString());
+      ((DataHubPageModule) partialEntity).setType(EntityType.DATAHUB_PAGE_MODULE);
     }
     return partialEntity;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleMapper.java
@@ -1,0 +1,90 @@
+package com.linkedin.datahub.graphql.types.module;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.canView;
+import static com.linkedin.metadata.Constants.DATAHUB_PAGE_MODULE_PROPERTIES_ASPECT_NAME;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.DataMap;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.generated.DataHubPageModule;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
+import com.linkedin.datahub.graphql.types.mappers.MapperUtils;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.module.DataHubPageModuleProperties;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class PageModuleMapper implements ModelMapper<EntityResponse, DataHubPageModule> {
+
+  public static final PageModuleMapper INSTANCE = new PageModuleMapper();
+
+  public static DataHubPageModule map(
+      @Nullable final QueryContext context, @Nonnull final EntityResponse entityResponse) {
+    return INSTANCE.apply(context, entityResponse);
+  }
+
+  @Override
+  public DataHubPageModule apply(
+      @Nullable final QueryContext context, @Nonnull final EntityResponse entityResponse) {
+    final DataHubPageModule result = new DataHubPageModule();
+    Urn entityUrn = entityResponse.getUrn();
+
+    result.setUrn(entityResponse.getUrn().toString());
+    result.setType(EntityType.DATAHUB_PAGE_MODULE);
+
+    EnvelopedAspectMap aspectMap = entityResponse.getAspects();
+    MappingHelper<DataHubPageModule> mappingHelper = new MappingHelper<>(aspectMap, result);
+    mappingHelper.mapToResult(
+        DATAHUB_PAGE_MODULE_PROPERTIES_ASPECT_NAME,
+        (module, dataMap) -> mapProperties(module, dataMap));
+
+    if (context != null && !canView(context.getOperationContext(), entityUrn)) {
+      return AuthorizationUtils.restrictEntity(result, DataHubPageModule.class);
+    } else {
+      return result;
+    }
+  }
+
+  private void mapProperties(@Nonnull DataHubPageModule module, @Nonnull DataMap dataMap) {
+    DataHubPageModuleProperties gmsModuleProperties = new DataHubPageModuleProperties(dataMap);
+    com.linkedin.datahub.graphql.generated.DataHubPageModuleProperties properties =
+        new com.linkedin.datahub.graphql.generated.DataHubPageModuleProperties();
+
+    // Map name
+    if (gmsModuleProperties.hasName()) {
+      properties.setName(gmsModuleProperties.getName());
+    }
+
+    // Map type
+    if (gmsModuleProperties.hasType()) {
+      properties.setType(PageModuleTypeMapper.map(gmsModuleProperties.getType()));
+    }
+
+    // Map visibility
+    if (gmsModuleProperties.hasVisibility()) {
+      properties.setVisibility(PageModuleVisibilityMapper.map(gmsModuleProperties.getVisibility()));
+    }
+
+    // Map params
+    if (gmsModuleProperties.hasParams()) {
+      properties.setParams(PageModuleParamsMapper.map(gmsModuleProperties.getParams()));
+    }
+
+    // Map created audit stamp
+    if (gmsModuleProperties.hasCreated()) {
+      properties.setCreated(MapperUtils.createResolvedAuditStamp(gmsModuleProperties.getCreated()));
+    }
+
+    // Map last modified audit stamp
+    if (gmsModuleProperties.hasLastModified()) {
+      properties.setLastModified(
+          MapperUtils.createResolvedAuditStamp(gmsModuleProperties.getLastModified()));
+    }
+
+    module.setProperties(properties);
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleMapper.java
@@ -54,32 +54,26 @@ public class PageModuleMapper implements ModelMapper<EntityResponse, DataHubPage
     com.linkedin.datahub.graphql.generated.DataHubPageModuleProperties properties =
         new com.linkedin.datahub.graphql.generated.DataHubPageModuleProperties();
 
-    // Map name
     if (gmsModuleProperties.hasName()) {
       properties.setName(gmsModuleProperties.getName());
     }
 
-    // Map type
     if (gmsModuleProperties.hasType()) {
       properties.setType(PageModuleTypeMapper.map(gmsModuleProperties.getType()));
     }
 
-    // Map visibility
     if (gmsModuleProperties.hasVisibility()) {
       properties.setVisibility(PageModuleVisibilityMapper.map(gmsModuleProperties.getVisibility()));
     }
 
-    // Map params
     if (gmsModuleProperties.hasParams()) {
       properties.setParams(PageModuleParamsMapper.map(gmsModuleProperties.getParams()));
     }
 
-    // Map created audit stamp
     if (gmsModuleProperties.hasCreated()) {
       properties.setCreated(MapperUtils.createResolvedAuditStamp(gmsModuleProperties.getCreated()));
     }
 
-    // Map last modified audit stamp
     if (gmsModuleProperties.hasLastModified()) {
       properties.setLastModified(
           MapperUtils.createResolvedAuditStamp(gmsModuleProperties.getLastModified()));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleParamsMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleParamsMapper.java
@@ -28,10 +28,7 @@ public class PageModuleParamsMapper
         new com.linkedin.datahub.graphql.generated.DataHubPageModuleParams();
 
     // Map link params if present
-    if (params.hasLinkParams()
-        && params.getLinkParams() != null
-        && params.getLinkParams().hasLinkUrn()
-        && params.getLinkParams().getLinkUrn() != null) {
+    if (params.getLinkParams() != null && params.getLinkParams().getLinkUrn() != null) {
       LinkModuleParams linkModuleParams = new LinkModuleParams();
       Post link = new Post();
       link.setUrn(params.getLinkParams().getLinkUrn().toString());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleParamsMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleParamsMapper.java
@@ -1,0 +1,52 @@
+package com.linkedin.datahub.graphql.types.module;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.LinkModuleParams;
+import com.linkedin.datahub.graphql.generated.Post;
+import com.linkedin.datahub.graphql.generated.RichTextModuleParams;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import com.linkedin.module.DataHubPageModuleParams;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class PageModuleParamsMapper
+    implements ModelMapper<
+        DataHubPageModuleParams, com.linkedin.datahub.graphql.generated.DataHubPageModuleParams> {
+
+  public static final PageModuleParamsMapper INSTANCE = new PageModuleParamsMapper();
+
+  public static com.linkedin.datahub.graphql.generated.DataHubPageModuleParams map(
+      @Nonnull final DataHubPageModuleParams params) {
+    return INSTANCE.apply(null, params);
+  }
+
+  @Override
+  public com.linkedin.datahub.graphql.generated.DataHubPageModuleParams apply(
+      @Nullable final QueryContext context, @Nonnull final DataHubPageModuleParams params) {
+    final com.linkedin.datahub.graphql.generated.DataHubPageModuleParams result =
+        new com.linkedin.datahub.graphql.generated.DataHubPageModuleParams();
+
+    // Map link params if present
+    if (params.hasLinkParams()
+        && params.getLinkParams() != null
+        && params.getLinkParams().hasLinkUrn()
+        && params.getLinkParams().getLinkUrn() != null) {
+      LinkModuleParams linkModuleParams = new LinkModuleParams();
+      Post link = new Post();
+      link.setUrn(params.getLinkParams().getLinkUrn().toString());
+      link.setType(EntityType.POST);
+      linkModuleParams.setLink(link);
+      result.setLinkParams(linkModuleParams);
+    }
+
+    // Map rich text params if present
+    if (params.hasRichTextParams()) {
+      RichTextModuleParams richTextParams = new RichTextModuleParams();
+      richTextParams.setContent(params.getRichTextParams().getContent());
+      result.setRichTextParams(richTextParams);
+    }
+
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleType.java
@@ -1,0 +1,78 @@
+package com.linkedin.datahub.graphql.types.module;
+
+import static com.linkedin.metadata.Constants.DATAHUB_PAGE_MODULE_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATAHUB_PAGE_MODULE_PROPERTIES_ASPECT_NAME;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.DataHubPageModule;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import graphql.execution.DataFetcherResult;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PageModuleType
+    implements com.linkedin.datahub.graphql.types.EntityType<DataHubPageModule, String> {
+  public static final Set<String> ASPECTS_TO_FETCH =
+      ImmutableSet.of(DATAHUB_PAGE_MODULE_PROPERTIES_ASPECT_NAME);
+  private final EntityClient _entityClient;
+
+  @Override
+  public EntityType type() {
+    return EntityType.DATAHUB_PAGE_MODULE;
+  }
+
+  @Override
+  public Function<Entity, String> getKeyProvider() {
+    return Entity::getUrn;
+  }
+
+  @Override
+  public Class<DataHubPageModule> objectClass() {
+    return DataHubPageModule.class;
+  }
+
+  @Override
+  public List<DataFetcherResult<DataHubPageModule>> batchLoad(
+      @Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+    final List<Urn> moduleUrns = urns.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
+
+    try {
+      final Map<Urn, EntityResponse> entities =
+          _entityClient.batchGetV2(
+              context.getOperationContext(),
+              DATAHUB_PAGE_MODULE_ENTITY_NAME,
+              new HashSet<>(moduleUrns),
+              ASPECTS_TO_FETCH);
+
+      final List<EntityResponse> gmsResults = new ArrayList<>(urns.size());
+      for (Urn urn : moduleUrns) {
+        gmsResults.add(entities.getOrDefault(urn, null));
+      }
+      return gmsResults.stream()
+          .map(
+              gmsResult ->
+                  gmsResult == null
+                      ? null
+                      : DataFetcherResult.<DataHubPageModule>newResult()
+                          .data(PageModuleMapper.map(context, gmsResult))
+                          .build())
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to batch load Page Modules", e);
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleTypeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleTypeMapper.java
@@ -1,0 +1,25 @@
+package com.linkedin.datahub.graphql.types.module;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import com.linkedin.module.DataHubPageModuleType;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class PageModuleTypeMapper
+    implements ModelMapper<
+        DataHubPageModuleType, com.linkedin.datahub.graphql.generated.DataHubPageModuleType> {
+
+  public static final PageModuleTypeMapper INSTANCE = new PageModuleTypeMapper();
+
+  public static com.linkedin.datahub.graphql.generated.DataHubPageModuleType map(
+      @Nonnull final DataHubPageModuleType type) {
+    return INSTANCE.apply(null, type);
+  }
+
+  @Override
+  public com.linkedin.datahub.graphql.generated.DataHubPageModuleType apply(
+      @Nullable final QueryContext context, @Nonnull final DataHubPageModuleType type) {
+    return com.linkedin.datahub.graphql.generated.DataHubPageModuleType.valueOf(type.toString());
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleVisibilityMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/module/PageModuleVisibilityMapper.java
@@ -1,0 +1,34 @@
+package com.linkedin.datahub.graphql.types.module;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.PageModuleScope;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import com.linkedin.module.DataHubPageModuleVisibility;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class PageModuleVisibilityMapper
+    implements ModelMapper<
+        DataHubPageModuleVisibility,
+        com.linkedin.datahub.graphql.generated.DataHubPageModuleVisibility> {
+
+  public static final PageModuleVisibilityMapper INSTANCE = new PageModuleVisibilityMapper();
+
+  public static com.linkedin.datahub.graphql.generated.DataHubPageModuleVisibility map(
+      @Nonnull final DataHubPageModuleVisibility visibility) {
+    return INSTANCE.apply(null, visibility);
+  }
+
+  @Override
+  public com.linkedin.datahub.graphql.generated.DataHubPageModuleVisibility apply(
+      @Nullable final QueryContext context, @Nonnull final DataHubPageModuleVisibility visibility) {
+    final com.linkedin.datahub.graphql.generated.DataHubPageModuleVisibility result =
+        new com.linkedin.datahub.graphql.generated.DataHubPageModuleVisibility();
+
+    if (visibility.hasScope()) {
+      result.setScope(PageModuleScope.valueOf(visibility.getScope().toString()));
+    }
+
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/template/PageTemplateMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/template/PageTemplateMapper.java
@@ -1,0 +1,103 @@
+package com.linkedin.datahub.graphql.types.template;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.canView;
+import static com.linkedin.metadata.Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.DataMap;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.generated.DataHubPageModule;
+import com.linkedin.datahub.graphql.generated.DataHubPageTemplate;
+import com.linkedin.datahub.graphql.generated.DataHubPageTemplateRow;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
+import com.linkedin.datahub.graphql.types.mappers.MapperUtils;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.template.DataHubPageTemplateProperties;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class PageTemplateMapper implements ModelMapper<EntityResponse, DataHubPageTemplate> {
+
+  public static final PageTemplateMapper INSTANCE = new PageTemplateMapper();
+
+  public static DataHubPageTemplate map(
+      @Nullable final QueryContext context, @Nonnull final EntityResponse entityResponse) {
+    return INSTANCE.apply(context, entityResponse);
+  }
+
+  @Override
+  public DataHubPageTemplate apply(
+      @Nullable final QueryContext context, @Nonnull final EntityResponse entityResponse) {
+    final DataHubPageTemplate result = new DataHubPageTemplate();
+    Urn entityUrn = entityResponse.getUrn();
+
+    result.setUrn(entityResponse.getUrn().toString());
+    result.setType(EntityType.DATAHUB_PAGE_TEMPLATE);
+
+    EnvelopedAspectMap aspectMap = entityResponse.getAspects();
+    MappingHelper<DataHubPageTemplate> mappingHelper = new MappingHelper<>(aspectMap, result);
+    mappingHelper.mapToResult(
+        DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME,
+        (application, dataMap) -> mapProperties(application, dataMap));
+
+    if (context != null && !canView(context.getOperationContext(), entityUrn)) {
+      return AuthorizationUtils.restrictEntity(result, DataHubPageTemplate.class);
+    } else {
+      return result;
+    }
+  }
+
+  private void mapProperties(@Nonnull DataHubPageTemplate template, @Nonnull DataMap dataMap) {
+    DataHubPageTemplateProperties gmsTemplateProperties =
+        new DataHubPageTemplateProperties(dataMap);
+    com.linkedin.datahub.graphql.generated.DataHubPageTemplateProperties properties =
+        new com.linkedin.datahub.graphql.generated.DataHubPageTemplateProperties();
+
+    List<DataHubPageTemplateRow> rows = new ArrayList<>();
+    gmsTemplateProperties
+        .getRows()
+        .forEach(
+            row -> {
+              DataHubPageTemplateRow templateRow = new DataHubPageTemplateRow();
+              List<DataHubPageModule> modules = new ArrayList<>();
+              row.getModules()
+                  .forEach(
+                      moduleUrn -> {
+                        DataHubPageModule module = new DataHubPageModule();
+                        module.setUrn(moduleUrn.toString());
+                        module.setType(EntityType.DATAHUB_PAGE_MODULE);
+                        modules.add(module);
+                      });
+              templateRow.setModules(modules);
+              rows.add(templateRow);
+            });
+    properties.setRows(rows);
+
+    if (gmsTemplateProperties.hasSurface()) {
+      properties.setSurface(PageTemplateSurfaceMapper.map(gmsTemplateProperties.getSurface()));
+    }
+
+    if (gmsTemplateProperties.hasVisibility()) {
+      properties.setVisibility(
+          PageTemplateVisibilityMapper.map(gmsTemplateProperties.getVisibility()));
+    }
+
+    if (gmsTemplateProperties.hasCreated()) {
+      properties.setCreated(
+          MapperUtils.createResolvedAuditStamp(gmsTemplateProperties.getCreated()));
+    }
+
+    if (gmsTemplateProperties.hasLastModified()) {
+      properties.setLastModified(
+          MapperUtils.createResolvedAuditStamp(gmsTemplateProperties.getLastModified()));
+    }
+
+    template.setProperties(properties);
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/template/PageTemplateSurfaceMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/template/PageTemplateSurfaceMapper.java
@@ -1,0 +1,34 @@
+package com.linkedin.datahub.graphql.types.template;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.PageTemplateSurfaceType;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import com.linkedin.template.DataHubPageTemplateSurface;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class PageTemplateSurfaceMapper
+    implements ModelMapper<
+        DataHubPageTemplateSurface,
+        com.linkedin.datahub.graphql.generated.DataHubPageTemplateSurface> {
+
+  public static final PageTemplateSurfaceMapper INSTANCE = new PageTemplateSurfaceMapper();
+
+  public static com.linkedin.datahub.graphql.generated.DataHubPageTemplateSurface map(
+      @Nonnull final DataHubPageTemplateSurface surface) {
+    return INSTANCE.apply(null, surface);
+  }
+
+  @Override
+  public com.linkedin.datahub.graphql.generated.DataHubPageTemplateSurface apply(
+      @Nullable final QueryContext context, @Nonnull final DataHubPageTemplateSurface surface) {
+    final com.linkedin.datahub.graphql.generated.DataHubPageTemplateSurface result =
+        new com.linkedin.datahub.graphql.generated.DataHubPageTemplateSurface();
+
+    if (surface.hasSurfaceType()) {
+      result.setSurfaceType(PageTemplateSurfaceType.valueOf(surface.getSurfaceType().toString()));
+    }
+
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/template/PageTemplateType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/template/PageTemplateType.java
@@ -1,0 +1,79 @@
+package com.linkedin.datahub.graphql.types.template;
+
+import static com.linkedin.metadata.Constants.DATAHUB_PAGE_TEMPLATE_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.DataHubPageTemplate;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import graphql.execution.DataFetcherResult;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PageTemplateType
+    implements com.linkedin.datahub.graphql.types.EntityType<DataHubPageTemplate, String> {
+  public static final Set<String> ASPECTS_TO_FETCH =
+      ImmutableSet.of(DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME);
+  private final EntityClient _entityClient;
+
+  @Override
+  public EntityType type() {
+    return EntityType.DATAHUB_PAGE_TEMPLATE;
+  }
+
+  @Override
+  public Function<Entity, String> getKeyProvider() {
+    return Entity::getUrn;
+  }
+
+  @Override
+  public Class<DataHubPageTemplate> objectClass() {
+    return DataHubPageTemplate.class;
+  }
+
+  @Override
+  public List<DataFetcherResult<DataHubPageTemplate>> batchLoad(
+      @Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+    final List<Urn> applicationUrns =
+        urns.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
+
+    try {
+      final Map<Urn, EntityResponse> entities =
+          _entityClient.batchGetV2(
+              context.getOperationContext(),
+              DATAHUB_PAGE_TEMPLATE_ENTITY_NAME,
+              new HashSet<>(applicationUrns),
+              ASPECTS_TO_FETCH);
+
+      final List<EntityResponse> gmsResults = new ArrayList<>(urns.size());
+      for (Urn urn : applicationUrns) {
+        gmsResults.add(entities.getOrDefault(urn, null));
+      }
+      return gmsResults.stream()
+          .map(
+              gmsResult ->
+                  gmsResult == null
+                      ? null
+                      : DataFetcherResult.<DataHubPageTemplate>newResult()
+                          .data(PageTemplateMapper.map(context, gmsResult))
+                          .build())
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to batch load Applications", e);
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/template/PageTemplateVisibilityMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/template/PageTemplateVisibilityMapper.java
@@ -1,0 +1,35 @@
+package com.linkedin.datahub.graphql.types.template;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.PageTemplateScope;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import com.linkedin.template.DataHubPageTemplateVisibility;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class PageTemplateVisibilityMapper
+    implements ModelMapper<
+        DataHubPageTemplateVisibility,
+        com.linkedin.datahub.graphql.generated.DataHubPageTemplateVisibility> {
+
+  public static final PageTemplateVisibilityMapper INSTANCE = new PageTemplateVisibilityMapper();
+
+  public static com.linkedin.datahub.graphql.generated.DataHubPageTemplateVisibility map(
+      @Nonnull final DataHubPageTemplateVisibility visibility) {
+    return INSTANCE.apply(null, visibility);
+  }
+
+  @Override
+  public com.linkedin.datahub.graphql.generated.DataHubPageTemplateVisibility apply(
+      @Nullable final QueryContext context,
+      @Nonnull final DataHubPageTemplateVisibility visibility) {
+    final com.linkedin.datahub.graphql.generated.DataHubPageTemplateVisibility result =
+        new com.linkedin.datahub.graphql.generated.DataHubPageTemplateVisibility();
+
+    if (visibility.hasScope()) {
+      result.setScope(PageTemplateScope.valueOf(visibility.getScope().toString()));
+    }
+
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -22,6 +22,11 @@ extend type Query {
   Fetch the global settings related to the docs propagation feature.
   """
   docPropagationSettings: DocPropagationSettings
+
+  """
+  Global settings related to the home page for an instance
+  """
+  globalHomePageSettings: GlobalHomePageSettings
 }
 
 extend type Mutation {
@@ -788,4 +793,14 @@ type ThemeConfig {
   The optional custom theme ID to determine which theme config we use in the frontend
   """
   themeId: String
+}
+
+"""
+Global settings related to the home page for an instance
+"""
+type GlobalHomePageSettings {
+  """
+  The default page template for the home page for this instance
+  """
+  defaultTemplate: DataHubPageTemplate
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1302,6 +1302,11 @@ enum EntityType {
   An DataHub Page Template
   """
   DATAHUB_PAGE_TEMPLATE
+
+  """
+  An DataHub Page Module
+  """
+  DATAHUB_PAGE_MODULE
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1297,6 +1297,11 @@ enum EntityType {
   An application
   """
   APPLICATION
+
+  """
+  An DataHub Page Template
+  """
+  DATAHUB_PAGE_TEMPLATE
 }
 
 """
@@ -4188,6 +4193,11 @@ type CorpUserSettings {
   Settings related to the DataHub Views feature
   """
   views: CorpUserViewsSettings
+
+  """
+  Settings related to the home page for a user
+  """
+  homePage: CorpUserHomePageSettings
 }
 
 """
@@ -4214,6 +4224,16 @@ type CorpUserViewsSettings {
   The default view for the User.
   """
   defaultView: DataHubView
+}
+
+"""
+Settings related to the home page for a user
+"""
+type CorpUserHomePageSettings {
+  """
+  The default page template for the User.
+  """
+  defaultTemplate: DataHubPageTemplate
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -4238,7 +4238,7 @@ type CorpUserHomePageSettings {
   """
   The default page template for the User.
   """
-  defaultTemplate: DataHubPageTemplate
+  pageTemplate: DataHubPageTemplate
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/module.graphql
+++ b/datahub-graphql-core/src/main/resources/module.graphql
@@ -1,0 +1,152 @@
+"""
+A Page Module used for rendering custom or default layouts in the UI
+"""
+type DataHubPageModule implements Entity {
+  """
+  A primary key associated with the Page Module
+  """
+  urn: String!
+
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
+
+  """
+  The main properties of a DataHub page module
+  """
+  properties: DataHubPageModuleProperties!
+
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
+}
+
+"""
+The main properties of a DataHub page module
+"""
+type DataHubPageModuleProperties {
+  """
+  The display name of this module
+  """
+  name: String!
+
+  """
+  Info about the surface area of the product that this module is deployed in
+  """
+  type: DataHubPageModuleType!
+
+  """
+  Info about the visibility of this module
+  """
+  visibility: DataHubPageModuleVisibility!
+
+  """
+  The specific parameters stored for this module
+  """
+  params: DataHubPageModuleParams!
+
+  """
+  Audit stamp for when and by whom this module was created
+  """
+  created: ResolvedAuditStamp!
+
+  """
+  Audit stamp for when and by whom this module was last updated
+  """
+  lastModified: ResolvedAuditStamp!
+}
+
+"""
+Enum containing the types of page modules that there are
+"""
+enum DataHubPageModuleType {
+  """
+  Link type module
+  """
+  LINK
+  """
+  Module containing rich text to be rendered
+  """
+  RICH_TEXT
+  """
+  A module with a collection of assets
+  """
+  ASSET_COLLECTION
+  """
+  A module displaying a hierarchy to navigate
+  """
+  HIERARCHY
+  """
+  Module displaying assets owned by a user
+  """
+  OWNED_ASSETS
+  """
+  Module displaying assets subscribed to by a given user
+  """
+  SUBSCRIBED_ASSETS
+  """
+  Module displaying the top domains
+  """
+  TOP_DOMAINS
+}
+
+"""
+Info about the visibility of this module
+"""
+type DataHubPageModuleVisibility {
+  """
+  The scope of this module and who can use/see it
+  """
+  scope: PageModuleScope
+}
+
+"""
+Different scopes for where this module is relevant
+"""
+enum PageModuleScope {
+  """
+  This module is used for individual use only
+  """
+  PERSONAL
+  """
+  This module is used across users
+  """
+  GLOBAL
+}
+
+"""
+The specific parameters stored for a module
+"""
+type DataHubPageModuleParams {
+  """
+  The params required if the module is type LINK
+  """
+  linkParams: LinkParams
+
+  """
+  The params required if the module is type RICH_TEXT
+  """
+  richTextParams: RichTextModuleParams
+}
+
+"""
+The params required if the module is type LINK
+"""
+type LinkModuleParams {
+  """
+  The Post entity containing the link
+  """
+  link: Post!
+}
+
+"""
+The params required if the module is type RICH_TEXT
+"""
+type RichTextModuleParams {
+  """
+  The content of the rich text module
+  """
+  content: String!
+}

--- a/datahub-graphql-core/src/main/resources/module.graphql
+++ b/datahub-graphql-core/src/main/resources/module.graphql
@@ -89,7 +89,7 @@ enum DataHubPageModuleType {
   """
   Module displaying the top domains
   """
-  TOP_DOMAINS
+  DOMAINS
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/module.graphql
+++ b/datahub-graphql-core/src/main/resources/module.graphql
@@ -123,7 +123,7 @@ type DataHubPageModuleParams {
   """
   The params required if the module is type LINK
   """
-  linkParams: LinkParams
+  linkParams: LinkModuleParams
 
   """
   The params required if the module is type RICH_TEXT

--- a/datahub-graphql-core/src/main/resources/template.graphql
+++ b/datahub-graphql-core/src/main/resources/template.graphql
@@ -1,0 +1,108 @@
+"""
+A Page Template used for rendering custom or default layouts in the UI
+"""
+type DataHubPageTemplate implements Entity {
+  """
+  A primary key associated with the Page Template
+  """
+  urn: String!
+
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
+
+  """
+  The main properties of a DataHub page template
+  """
+  properties: DataHubPageTemplateProperties!
+
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
+}
+
+"""
+The main properties of a DataHub page template
+"""
+type DataHubPageTemplateProperties {
+  """
+  The rows of modules contained in this template
+  """
+  rows: [DataHubPageTemplateRow!]!
+
+  """
+  Info about the surface area of the product that this template is deployed in
+  """
+  surface: DataHubPageTemplateSurface!
+
+  """
+  Info about the visibility of this template
+  """
+  visibility: DataHubPageTemplateVisibility!
+
+  """
+  Audit stamp for when and by whom this template was created
+  """
+  created: ResolvedAuditStamp!
+
+  """
+  Audit stamp for when and by whom this template was last updated
+  """
+  lastModified: ResolvedAuditStamp!
+}
+
+"""
+A row of modules contained in a template
+"""
+type DataHubPageTemplateRow {
+  """
+  The modules that exist in this template row
+  """
+  modules: [DataHubPageModule!]!
+}
+
+"""
+Info about the surface area of the product that this template is deployed in
+"""
+type DataHubPageTemplateSurface {
+  """
+  Where exactly is this template bing used
+  """
+  surfaceType: PageTemplateSurfaceType
+}
+
+"""
+Different surface areas for a page template
+"""
+enum PageTemplateSurfaceType {
+  """
+  This template applies to what to display on the home page for users.
+  """
+  HOME_PAGE
+}
+
+"""
+Info about the visibility of this template
+"""
+type DataHubPageTemplateVisibility {
+  """
+  The scope of this template and who can use/see it
+  """
+  scope: PageTemplateScope
+}
+
+"""
+Different scopes for where this template is relevant
+"""
+enum PageTemplateScope {
+  """
+  This template is used for individual use only
+  """
+  PERSONAL
+  """
+  This template is used across users
+  """
+  GLOBAL
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/module/PageModuleMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/module/PageModuleMapperTest.java
@@ -1,0 +1,102 @@
+package com.linkedin.datahub.graphql.types.module;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.generated.DataHubPageModule;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.module.DataHubPageModuleParams;
+import com.linkedin.module.DataHubPageModuleProperties;
+import com.linkedin.module.DataHubPageModuleType;
+import com.linkedin.module.DataHubPageModuleVisibility;
+import com.linkedin.module.PageModuleScope;
+import org.testng.annotations.Test;
+
+public class PageModuleMapperTest {
+
+  @Test
+  public void testPageModuleMapper() throws Exception {
+    // Create test data
+    Urn moduleUrn = UrnUtils.getUrn("urn:li:dataHubPageModule:test-module");
+
+    // Create GMS properties
+    DataHubPageModuleProperties gmsProperties = new DataHubPageModuleProperties();
+    gmsProperties.setName("Test Module");
+    gmsProperties.setType(DataHubPageModuleType.LINK);
+
+    // Create visibility
+    DataHubPageModuleVisibility visibility = new DataHubPageModuleVisibility();
+    visibility.setScope(PageModuleScope.GLOBAL);
+    gmsProperties.setVisibility(visibility);
+
+    // Create params
+    DataHubPageModuleParams params = new DataHubPageModuleParams();
+    // Note: We're not setting linkParams due to the schema inconsistency
+    gmsProperties.setParams(params);
+
+    // Create audit stamps
+    AuditStamp created = new AuditStamp();
+    created.setTime(System.currentTimeMillis());
+    created.setActor(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+    gmsProperties.setCreated(created);
+
+    AuditStamp lastModified = new AuditStamp();
+    lastModified.setTime(System.currentTimeMillis());
+    lastModified.setActor(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+    gmsProperties.setLastModified(lastModified);
+
+    // Create entity response
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(moduleUrn);
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new com.linkedin.entity.Aspect(gmsProperties.data()));
+    aspectMap.put("dataHubPageModuleProperties", aspect);
+    entityResponse.setAspects(aspectMap);
+
+    // Test mapping
+    DataHubPageModule result = PageModuleMapper.map(null, entityResponse);
+
+    // Verify basic fields
+    assertEquals(result.getUrn(), moduleUrn.toString());
+    assertEquals(result.getType(), EntityType.DATAHUB_PAGE_MODULE);
+
+    // Verify properties
+    assertNotNull(result.getProperties());
+    assertEquals(result.getProperties().getName(), "Test Module");
+    assertEquals(
+        result.getProperties().getType(),
+        com.linkedin.datahub.graphql.generated.DataHubPageModuleType.LINK);
+
+    // Verify visibility
+    assertNotNull(result.getProperties().getVisibility());
+    assertEquals(
+        result.getProperties().getVisibility().getScope(),
+        com.linkedin.datahub.graphql.generated.PageModuleScope.GLOBAL);
+
+    // Verify params (should be null due to schema inconsistency)
+    assertNotNull(result.getProperties().getParams());
+    assertNull(result.getProperties().getParams().getLinkParams());
+    assertNull(result.getProperties().getParams().getRichTextParams());
+
+    // Verify audit stamps
+    assertNotNull(result.getProperties().getCreated());
+    assertEquals(result.getProperties().getCreated().getTime(), created.getTime());
+    assertNotNull(result.getProperties().getCreated().getActor());
+    assertEquals(
+        result.getProperties().getCreated().getActor().getUrn(), created.getActor().toString());
+
+    assertNotNull(result.getProperties().getLastModified());
+    assertEquals(result.getProperties().getLastModified().getTime(), lastModified.getTime());
+    assertNotNull(result.getProperties().getLastModified().getActor());
+    assertEquals(
+        result.getProperties().getLastModified().getActor().getUrn(),
+        lastModified.getActor().toString());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/module/PageModuleTypeTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/module/PageModuleTypeTest.java
@@ -1,0 +1,232 @@
+package com.linkedin.datahub.graphql.types.module;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.DataHubPageModule;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.module.DataHubPageModuleProperties;
+import com.linkedin.module.DataHubPageModuleType;
+import com.linkedin.module.DataHubPageModuleVisibility;
+import com.linkedin.module.PageModuleScope;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.execution.DataFetcherResult;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PageModuleTypeTest {
+
+  private PageModuleType pageModuleType;
+  private EntityClient mockEntityClient;
+  private QueryContext mockQueryContext;
+
+  @BeforeMethod
+  public void setUp() {
+    mockEntityClient = mock(EntityClient.class);
+    mockQueryContext = mock(QueryContext.class);
+    pageModuleType = new PageModuleType(mockEntityClient);
+    // Mock getOperationContext to avoid NPE
+    OperationContext dummyOpContext = mock(OperationContext.class);
+    when(mockQueryContext.getOperationContext()).thenReturn(dummyOpContext);
+  }
+
+  @Test
+  public void testType() {
+    assertEquals(pageModuleType.type(), EntityType.DATAHUB_PAGE_MODULE);
+  }
+
+  @Test
+  public void testObjectClass() {
+    assertEquals(pageModuleType.objectClass(), DataHubPageModule.class);
+  }
+
+  @Test
+  public void testGetKeyProvider() {
+    // Create a mock entity
+    DataHubPageModule mockEntity = new DataHubPageModule();
+    mockEntity.setUrn("urn:li:dataHubPageModule:test");
+
+    String result = pageModuleType.getKeyProvider().apply(mockEntity);
+    assertEquals(result, "urn:li:dataHubPageModule:test");
+  }
+
+  @Test
+  public void testBatchLoadSuccess() throws Exception {
+    // Create test URNs
+    String urn1 = "urn:li:dataHubPageModule:test-module-1";
+    String urn2 = "urn:li:dataHubPageModule:test-module-2";
+    List<String> urns = Arrays.asList(urn1, urn2);
+
+    // Create mock entity responses
+    EntityResponse response1 = createMockEntityResponse(urn1, "Test Module 1");
+    EntityResponse response2 = createMockEntityResponse(urn2, "Test Module 2");
+
+    Map<Urn, EntityResponse> entityMap = new HashMap<>();
+    entityMap.put(UrnUtils.getUrn(urn1), response1);
+    entityMap.put(UrnUtils.getUrn(urn2), response2);
+
+    // Mock the entity client response
+    when(mockEntityClient.batchGetV2(
+            any(), eq("dataHubPageModule"), any(), eq(PageModuleType.ASPECTS_TO_FETCH)))
+        .thenReturn(entityMap);
+
+    // Execute batch load
+    QueryContext mockContext = getMockAllowContext();
+    List<DataFetcherResult<DataHubPageModule>> results =
+        pageModuleType.batchLoad(urns, mockContext);
+
+    // Verify results
+    assertEquals(results.size(), 2);
+
+    DataFetcherResult<DataHubPageModule> result1 = results.get(0);
+    assertNotNull(result1);
+    assertNotNull(result1.getData());
+    assertEquals(result1.getData().getUrn(), urn1);
+    assertEquals(result1.getData().getType(), EntityType.DATAHUB_PAGE_MODULE);
+    assertEquals(result1.getData().getProperties().getName(), "Test Module 1");
+
+    DataFetcherResult<DataHubPageModule> result2 = results.get(1);
+    assertNotNull(result2);
+    assertNotNull(result2.getData());
+    assertEquals(result2.getData().getUrn(), urn2);
+    assertEquals(result2.getData().getType(), EntityType.DATAHUB_PAGE_MODULE);
+    assertEquals(result2.getData().getProperties().getName(), "Test Module 2");
+  }
+
+  @Test
+  public void testBatchLoadWithMissingEntities() throws Exception {
+    // Create test URNs
+    String urn1 = "urn:li:dataHubPageModule:test-module-1";
+    String urn2 = "urn:li:dataHubPageModule:test-module-2";
+    List<String> urns = Arrays.asList(urn1, urn2);
+
+    // Create mock entity response for only one entity
+    EntityResponse response1 = createMockEntityResponse(urn1, "Test Module 1");
+
+    Map<Urn, EntityResponse> entityMap = new HashMap<>();
+    entityMap.put(UrnUtils.getUrn(urn1), response1);
+    // Note: urn2 is missing from the map
+
+    // Mock the entity client response
+    when(mockEntityClient.batchGetV2(
+            any(), eq("dataHubPageModule"), any(), eq(PageModuleType.ASPECTS_TO_FETCH)))
+        .thenReturn(entityMap);
+
+    // Execute batch load
+    QueryContext mockContext = getMockAllowContext();
+    List<DataFetcherResult<DataHubPageModule>> results =
+        pageModuleType.batchLoad(urns, mockContext);
+
+    // Verify results
+    assertEquals(results.size(), 2);
+
+    DataFetcherResult<DataHubPageModule> result1 = results.get(0);
+    assertNotNull(result1);
+    assertNotNull(result1.getData());
+    assertEquals(result1.getData().getUrn(), urn1);
+
+    DataFetcherResult<DataHubPageModule> result2 = results.get(1);
+    assertNull(result2); // Missing entity should return null
+  }
+
+  @Test
+  public void testBatchLoadEmptyList() throws Exception {
+    List<String> urns = Collections.emptyList();
+
+    // Mock the entity client response
+    when(mockEntityClient.batchGetV2(
+            any(), eq("dataHubPageModule"), any(), eq(PageModuleType.ASPECTS_TO_FETCH)))
+        .thenReturn(Collections.emptyMap());
+
+    // Execute batch load
+    QueryContext mockContext = getMockAllowContext();
+    List<DataFetcherResult<DataHubPageModule>> results =
+        pageModuleType.batchLoad(urns, mockContext);
+
+    // Verify results
+    assertEquals(results.size(), 0);
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testBatchLoadException() throws Exception {
+    // Create test URNs
+    String urn1 = "urn:li:dataHubPageModule:test-module-1";
+    List<String> urns = Arrays.asList(urn1);
+
+    // Mock the entity client to throw an exception
+    when(mockEntityClient.batchGetV2(
+            any(), eq("dataHubPageModule"), any(), eq(PageModuleType.ASPECTS_TO_FETCH)))
+        .thenThrow(new RemoteInvocationException("Test exception"));
+
+    // Execute batch load - should throw RuntimeException
+    QueryContext mockContext = getMockAllowContext();
+    pageModuleType.batchLoad(urns, mockContext);
+  }
+
+  @Test
+  public void testAspectsToFetch() {
+    assertEquals(PageModuleType.ASPECTS_TO_FETCH.size(), 1);
+    assertTrue(PageModuleType.ASPECTS_TO_FETCH.contains("dataHubPageModuleProperties"));
+  }
+
+  private EntityResponse createMockEntityResponse(String urn, String name) {
+    // Create GMS properties
+    DataHubPageModuleProperties gmsProperties = new DataHubPageModuleProperties();
+    gmsProperties.setName(name);
+    gmsProperties.setType(DataHubPageModuleType.LINK);
+
+    // Create visibility
+    DataHubPageModuleVisibility visibility = new DataHubPageModuleVisibility();
+    visibility.setScope(PageModuleScope.GLOBAL);
+    gmsProperties.setVisibility(visibility);
+
+    // Create params with linkUrn
+    com.linkedin.module.DataHubPageModuleParams params =
+        new com.linkedin.module.DataHubPageModuleParams();
+    com.linkedin.module.LinkModuleParams linkParams = new com.linkedin.module.LinkModuleParams();
+    linkParams.setLinkUrn(UrnUtils.getUrn("urn:li:post:test-post"));
+    params.setLinkParams(linkParams);
+    gmsProperties.setParams(params);
+
+    // Create audit stamps
+    AuditStamp created = new AuditStamp();
+    created.setTime(System.currentTimeMillis());
+    created.setActor(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+    gmsProperties.setCreated(created);
+
+    AuditStamp lastModified = new AuditStamp();
+    lastModified.setTime(System.currentTimeMillis());
+    lastModified.setActor(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+    gmsProperties.setLastModified(lastModified);
+
+    // Create entity response
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(UrnUtils.getUrn(urn));
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new com.linkedin.entity.Aspect(gmsProperties.data()));
+    aspectMap.put("dataHubPageModuleProperties", aspect);
+    entityResponse.setAspects(aspectMap);
+
+    return entityResponse;
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/template/PageTemplateMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/template/PageTemplateMapperTest.java
@@ -1,0 +1,116 @@
+package com.linkedin.datahub.graphql.types.template;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.generated.DataHubPageModule;
+import com.linkedin.datahub.graphql.generated.DataHubPageTemplate;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.template.DataHubPageTemplateProperties;
+import com.linkedin.template.DataHubPageTemplateRow;
+import com.linkedin.template.DataHubPageTemplateRowArray;
+import com.linkedin.template.DataHubPageTemplateSurface;
+import com.linkedin.template.DataHubPageTemplateVisibility;
+import org.testng.annotations.Test;
+
+public class PageTemplateMapperTest {
+
+  @Test
+  public void testPageTemplateMapper() {
+    // Create test data
+    Urn templateUrn = UrnUtils.getUrn("urn:li:dataHubPageTemplate:test-template");
+    Urn moduleUrn = UrnUtils.getUrn("urn:li:dataHubPageModule:test-module");
+
+    // Create GMS template properties
+    DataHubPageTemplateProperties gmsProperties = new DataHubPageTemplateProperties();
+
+    // Create rows with modules
+    DataHubPageTemplateRow row = new DataHubPageTemplateRow();
+    row.setModules(new UrnArray(moduleUrn));
+    gmsProperties.setRows(new DataHubPageTemplateRowArray(row));
+
+    // Create surface
+    DataHubPageTemplateSurface surface = new DataHubPageTemplateSurface();
+    surface.setSurfaceType(com.linkedin.template.PageTemplateSurfaceType.HOME_PAGE);
+    gmsProperties.setSurface(surface);
+
+    // Create visibility
+    DataHubPageTemplateVisibility visibility = new DataHubPageTemplateVisibility();
+    visibility.setScope(com.linkedin.template.PageTemplateScope.GLOBAL);
+    gmsProperties.setVisibility(visibility);
+
+    // Create audit stamps
+    AuditStamp created = new AuditStamp();
+    created.setTime(System.currentTimeMillis());
+    created.setActor(UrnUtils.getUrn("urn:li:corpuser:testuser"));
+    gmsProperties.setCreated(created);
+
+    AuditStamp lastModified = new AuditStamp();
+    lastModified.setTime(System.currentTimeMillis());
+    lastModified.setActor(UrnUtils.getUrn("urn:li:corpuser:testuser"));
+    gmsProperties.setLastModified(lastModified);
+
+    // Create EntityResponse
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(templateUrn);
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new com.linkedin.entity.Aspect(gmsProperties.data()));
+    aspectMap.put("dataHubPageTemplateProperties", aspect);
+    entityResponse.setAspects(aspectMap);
+
+    // Test mapping
+    DataHubPageTemplate result = PageTemplateMapper.map(null, entityResponse);
+
+    // Verify results
+    assertNotNull(result);
+    assertEquals(result.getUrn(), templateUrn.toString());
+    assertEquals(result.getType(), EntityType.DATAHUB_PAGE_TEMPLATE);
+
+    assertNotNull(result.getProperties());
+    assertNotNull(result.getProperties().getRows());
+    assertEquals(result.getProperties().getRows().size(), 1);
+
+    com.linkedin.datahub.graphql.generated.DataHubPageTemplateRow resultRow =
+        result.getProperties().getRows().get(0);
+    assertNotNull(resultRow.getModules());
+    assertEquals(resultRow.getModules().size(), 1);
+
+    DataHubPageModule resultModule = resultRow.getModules().get(0);
+    assertEquals(resultModule.getUrn(), moduleUrn.toString());
+    assertEquals(resultModule.getType(), EntityType.DATAHUB_PAGE_MODULE);
+
+    // Verify surface
+    assertNotNull(result.getProperties().getSurface());
+    assertEquals(
+        result.getProperties().getSurface().getSurfaceType(),
+        com.linkedin.datahub.graphql.generated.PageTemplateSurfaceType.HOME_PAGE);
+
+    // Verify visibility
+    assertNotNull(result.getProperties().getVisibility());
+    assertEquals(
+        result.getProperties().getVisibility().getScope(),
+        com.linkedin.datahub.graphql.generated.PageTemplateScope.GLOBAL);
+
+    // Verify audit stamps
+    assertNotNull(result.getProperties().getCreated());
+    assertEquals(result.getProperties().getCreated().getTime(), created.getTime());
+    assertNotNull(result.getProperties().getCreated().getActor());
+    assertEquals(
+        result.getProperties().getCreated().getActor().getUrn(), created.getActor().toString());
+
+    assertNotNull(result.getProperties().getLastModified());
+    assertEquals(result.getProperties().getLastModified().getTime(), lastModified.getTime());
+    assertNotNull(result.getProperties().getLastModified().getActor());
+    assertEquals(
+        result.getProperties().getLastModified().getActor().getUrn(),
+        lastModified.getActor().toString());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/template/PageTemplateTypeTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/template/PageTemplateTypeTest.java
@@ -1,0 +1,337 @@
+package com.linkedin.datahub.graphql.types.template;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.DataHubPageTemplate;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.template.DataHubPageTemplateProperties;
+import com.linkedin.template.DataHubPageTemplateRow;
+import com.linkedin.template.DataHubPageTemplateRowArray;
+import com.linkedin.template.DataHubPageTemplateSurface;
+import com.linkedin.template.DataHubPageTemplateVisibility;
+import com.linkedin.template.PageTemplateScope;
+import com.linkedin.template.PageTemplateSurfaceType;
+import graphql.execution.DataFetcherResult;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class PageTemplateTypeTest {
+
+  private PageTemplateType pageTemplateType;
+  private EntityClient mockEntityClient;
+  private QueryContext mockQueryContext;
+
+  @BeforeMethod
+  public void setUp() {
+    mockEntityClient = mock(EntityClient.class);
+    mockQueryContext = getMockAllowContext();
+    pageTemplateType = new PageTemplateType(mockEntityClient);
+  }
+
+  @Test
+  public void testType() {
+    assertEquals(pageTemplateType.type(), EntityType.DATAHUB_PAGE_TEMPLATE);
+  }
+
+  @Test
+  public void testObjectClass() {
+    assertEquals(pageTemplateType.objectClass(), DataHubPageTemplate.class);
+  }
+
+  @Test
+  public void testGetKeyProvider() {
+    // Create a mock entity
+    DataHubPageTemplate mockEntity = new DataHubPageTemplate();
+    mockEntity.setUrn("urn:li:dataHubPageTemplate:test");
+
+    String result = pageTemplateType.getKeyProvider().apply(mockEntity);
+    assertEquals(result, "urn:li:dataHubPageTemplate:test");
+  }
+
+  @Test
+  public void testBatchLoadSuccess() throws Exception {
+    // Create test URNs
+    String urn1 = "urn:li:dataHubPageTemplate:test-template-1";
+    String urn2 = "urn:li:dataHubPageTemplate:test-template-2";
+    List<String> urns = Arrays.asList(urn1, urn2);
+
+    // Create mock entity responses
+    EntityResponse response1 = createMockEntityResponse(urn1, "Test Template 1");
+    EntityResponse response2 = createMockEntityResponse(urn2, "Test Template 2");
+
+    Map<Urn, EntityResponse> entityMap = new HashMap<>();
+    entityMap.put(UrnUtils.getUrn(urn1), response1);
+    entityMap.put(UrnUtils.getUrn(urn2), response2);
+
+    // Mock the entity client response
+    when(mockEntityClient.batchGetV2(
+            any(), eq("dataHubPageTemplate"), any(), eq(PageTemplateType.ASPECTS_TO_FETCH)))
+        .thenReturn(entityMap);
+
+    // Execute batch load
+    List<DataFetcherResult<DataHubPageTemplate>> results =
+        pageTemplateType.batchLoad(urns, mockQueryContext);
+
+    // Verify results
+    assertEquals(results.size(), 2);
+
+    DataFetcherResult<DataHubPageTemplate> result1 = results.get(0);
+    assertNotNull(result1);
+    assertNotNull(result1.getData());
+    assertEquals(result1.getData().getUrn(), urn1);
+    assertEquals(result1.getData().getType(), EntityType.DATAHUB_PAGE_TEMPLATE);
+    assertEquals(result1.getData().getProperties().getRows().size(), 1);
+
+    DataFetcherResult<DataHubPageTemplate> result2 = results.get(1);
+    assertNotNull(result2);
+    assertNotNull(result2.getData());
+    assertEquals(result2.getData().getUrn(), urn2);
+    assertEquals(result2.getData().getType(), EntityType.DATAHUB_PAGE_TEMPLATE);
+    assertEquals(result2.getData().getProperties().getRows().size(), 1);
+  }
+
+  @Test
+  public void testBatchLoadWithMissingEntities() throws Exception {
+    // Create test URNs
+    String urn1 = "urn:li:dataHubPageTemplate:test-template-1";
+    String urn2 = "urn:li:dataHubPageTemplate:test-template-2";
+    List<String> urns = Arrays.asList(urn1, urn2);
+
+    // Create mock entity response for only one entity
+    EntityResponse response1 = createMockEntityResponse(urn1, "Test Template 1");
+
+    Map<Urn, EntityResponse> entityMap = new HashMap<>();
+    entityMap.put(UrnUtils.getUrn(urn1), response1);
+    // Note: urn2 is missing from the map
+
+    // Mock the entity client response
+    when(mockEntityClient.batchGetV2(
+            any(), eq("dataHubPageTemplate"), any(), eq(PageTemplateType.ASPECTS_TO_FETCH)))
+        .thenReturn(entityMap);
+
+    // Execute batch load
+    List<DataFetcherResult<DataHubPageTemplate>> results =
+        pageTemplateType.batchLoad(urns, mockQueryContext);
+
+    // Verify results
+    assertEquals(results.size(), 2);
+
+    DataFetcherResult<DataHubPageTemplate> result1 = results.get(0);
+    assertNotNull(result1);
+    assertNotNull(result1.getData());
+    assertEquals(result1.getData().getUrn(), urn1);
+
+    DataFetcherResult<DataHubPageTemplate> result2 = results.get(1);
+    assertNull(result2); // Missing entity should return null
+  }
+
+  @Test
+  public void testBatchLoadEmptyList() throws Exception {
+    List<String> urns = Collections.emptyList();
+
+    // Mock the entity client response
+    when(mockEntityClient.batchGetV2(
+            any(), eq("dataHubPageTemplate"), any(), eq(PageTemplateType.ASPECTS_TO_FETCH)))
+        .thenReturn(Collections.emptyMap());
+
+    // Execute batch load
+    List<DataFetcherResult<DataHubPageTemplate>> results =
+        pageTemplateType.batchLoad(urns, mockQueryContext);
+
+    // Verify results
+    assertEquals(results.size(), 0);
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testBatchLoadException() throws Exception {
+    // Create test URNs
+    String urn1 = "urn:li:dataHubPageTemplate:test-template-1";
+    List<String> urns = Arrays.asList(urn1);
+
+    // Mock the entity client to throw an exception
+    when(mockEntityClient.batchGetV2(
+            any(), eq("dataHubPageTemplate"), any(), eq(PageTemplateType.ASPECTS_TO_FETCH)))
+        .thenThrow(new RemoteInvocationException("Test exception"));
+
+    // Execute batch load - should throw RuntimeException
+    pageTemplateType.batchLoad(urns, mockQueryContext);
+  }
+
+  @Test
+  public void testAspectsToFetch() {
+    assertEquals(PageTemplateType.ASPECTS_TO_FETCH.size(), 1);
+    assertTrue(PageTemplateType.ASPECTS_TO_FETCH.contains("dataHubPageTemplateProperties"));
+  }
+
+  @Test
+  public void testBatchLoadWithComplexTemplate() throws Exception {
+    // Create test URNs
+    String urn1 = "urn:li:dataHubPageTemplate:complex-template";
+    List<String> urns = Arrays.asList(urn1);
+
+    // Create mock entity response with complex template data
+    EntityResponse response1 = createComplexMockEntityResponse(urn1);
+
+    Map<Urn, EntityResponse> entityMap = new HashMap<>();
+    entityMap.put(UrnUtils.getUrn(urn1), response1);
+
+    // Mock the entity client response
+    when(mockEntityClient.batchGetV2(
+            any(), eq("dataHubPageTemplate"), any(), eq(PageTemplateType.ASPECTS_TO_FETCH)))
+        .thenReturn(entityMap);
+
+    // Execute batch load
+    List<DataFetcherResult<DataHubPageTemplate>> results =
+        pageTemplateType.batchLoad(urns, mockQueryContext);
+
+    // Verify results
+    assertEquals(results.size(), 1);
+
+    DataFetcherResult<DataHubPageTemplate> result1 = results.get(0);
+    assertNotNull(result1);
+    assertNotNull(result1.getData());
+    assertEquals(result1.getData().getUrn(), urn1);
+    assertEquals(result1.getData().getType(), EntityType.DATAHUB_PAGE_TEMPLATE);
+
+    // Verify complex properties
+    assertNotNull(result1.getData().getProperties().getSurface());
+    assertEquals(
+        result1.getData().getProperties().getSurface().getSurfaceType(),
+        com.linkedin.datahub.graphql.generated.PageTemplateSurfaceType.HOME_PAGE);
+
+    assertNotNull(result1.getData().getProperties().getVisibility());
+    assertEquals(
+        result1.getData().getProperties().getVisibility().getScope(),
+        com.linkedin.datahub.graphql.generated.PageTemplateScope.GLOBAL);
+
+    assertNotNull(result1.getData().getProperties().getCreated());
+    assertNotNull(result1.getData().getProperties().getLastModified());
+  }
+
+  private EntityResponse createMockEntityResponse(String urn, String name) {
+    // Create GMS properties
+    DataHubPageTemplateProperties gmsProperties = new DataHubPageTemplateProperties();
+
+    // Create rows with modules
+    DataHubPageTemplateRow row = new DataHubPageTemplateRow();
+    Urn moduleUrn = UrnUtils.getUrn("urn:li:dataHubPageModule:test-module");
+    UrnArray moduleUrns = new UrnArray();
+    moduleUrns.add(moduleUrn);
+    row.setModules(moduleUrns);
+
+    DataHubPageTemplateRowArray rows = new DataHubPageTemplateRowArray();
+    rows.add(row);
+    gmsProperties.setRows(rows);
+
+    // Create surface
+    DataHubPageTemplateSurface surface = new DataHubPageTemplateSurface();
+    surface.setSurfaceType(PageTemplateSurfaceType.HOME_PAGE);
+    gmsProperties.setSurface(surface);
+
+    // Create visibility
+    DataHubPageTemplateVisibility visibility = new DataHubPageTemplateVisibility();
+    visibility.setScope(PageTemplateScope.GLOBAL);
+    gmsProperties.setVisibility(visibility);
+
+    // Create audit stamps
+    AuditStamp created = new AuditStamp();
+    created.setTime(System.currentTimeMillis());
+    created.setActor(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+    gmsProperties.setCreated(created);
+
+    AuditStamp lastModified = new AuditStamp();
+    lastModified.setTime(System.currentTimeMillis());
+    lastModified.setActor(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+    gmsProperties.setLastModified(lastModified);
+
+    // Create entity response
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(UrnUtils.getUrn(urn));
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new com.linkedin.entity.Aspect(gmsProperties.data()));
+    aspectMap.put("dataHubPageTemplateProperties", aspect);
+    entityResponse.setAspects(aspectMap);
+
+    return entityResponse;
+  }
+
+  private EntityResponse createComplexMockEntityResponse(String urn) {
+    // Create GMS properties with more complex data
+    DataHubPageTemplateProperties gmsProperties = new DataHubPageTemplateProperties();
+
+    // Create multiple rows with multiple modules
+    DataHubPageTemplateRowArray rows = new DataHubPageTemplateRowArray();
+
+    // First row with one module
+    DataHubPageTemplateRow row1 = new DataHubPageTemplateRow();
+    UrnArray moduleUrns1 = new UrnArray();
+    moduleUrns1.add(UrnUtils.getUrn("urn:li:dataHubPageModule:module-1"));
+    row1.setModules(moduleUrns1);
+    rows.add(row1);
+
+    // Second row with two modules
+    DataHubPageTemplateRow row2 = new DataHubPageTemplateRow();
+    UrnArray moduleUrns2 = new UrnArray();
+    moduleUrns2.add(UrnUtils.getUrn("urn:li:dataHubPageModule:module-2"));
+    moduleUrns2.add(UrnUtils.getUrn("urn:li:dataHubPageModule:module-3"));
+    row2.setModules(moduleUrns2);
+    rows.add(row2);
+
+    gmsProperties.setRows(rows);
+
+    // Create surface
+    DataHubPageTemplateSurface surface = new DataHubPageTemplateSurface();
+    surface.setSurfaceType(PageTemplateSurfaceType.HOME_PAGE);
+    gmsProperties.setSurface(surface);
+
+    // Create visibility
+    DataHubPageTemplateVisibility visibility = new DataHubPageTemplateVisibility();
+    visibility.setScope(PageTemplateScope.GLOBAL);
+    gmsProperties.setVisibility(visibility);
+
+    // Create audit stamps
+    AuditStamp created = new AuditStamp();
+    created.setTime(System.currentTimeMillis());
+    created.setActor(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+    gmsProperties.setCreated(created);
+
+    AuditStamp lastModified = new AuditStamp();
+    lastModified.setTime(System.currentTimeMillis());
+    lastModified.setActor(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+    gmsProperties.setLastModified(lastModified);
+
+    // Create entity response
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(UrnUtils.getUrn(urn));
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new com.linkedin.entity.Aspect(gmsProperties.data()));
+    aspectMap.put("dataHubPageTemplateProperties", aspect);
+    entityResponse.setAspects(aspectMap);
+
+    return entityResponse;
+  }
+}

--- a/li-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/li-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -458,6 +458,16 @@ public class Constants {
   public static final String CLIENT_ID_URN = "urn:li:telemetry:clientId";
   public static final String CLIENT_ID_ASPECT = "telemetryClientId";
 
+  // Template
+  public static final String DATAHUB_PAGE_TEMPLATE_ENTITY_NAME = "dataHubPageTemplate";
+  public static final String DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME =
+      "dataHubPageTemplateProperties";
+
+  // Module
+  public static final String DATAHUB_PAGE_MODULE_ENTITY_NAME = "dataHubPageModule";
+  public static final String DATAHUB_PAGE_MODULE_PROPERTIES_ASPECT_NAME =
+      "dataHubPageModuleProperties";
+
   // Step
   public static final String DATAHUB_STEP_STATE_PROPERTIES_ASPECT_NAME =
       "dataHubStepStateProperties";

--- a/metadata-models/src/main/pegasus/com/linkedin/template/DataHubPageTemplateProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/template/DataHubPageTemplateProperties.pdl
@@ -15,7 +15,7 @@ record DataHubPageTemplateProperties  {
   @Relationship = {
     "/*/modules/*": {
       "name": "ContainedIn",
-      "entityTypes": [ "module" ]
+      "entityTypes": [ "dataHubPageModule" ]
     }
   } 
   rows: array[DataHubPageTemplateRow]


### PR DESCRIPTION
This PR has a very large diff but it is almost entirely boilerplate code and tests. This builds off of #13911 and does the following:
1. Adds the corresponding GraphQL object definitions for the new PDL object definitions
2. Adds the new "Type" Java classes for Modules and Templates in order to hydrate these entity types in the graphql layer
3. Adds mappers to get data from the PDL definition to the GraphQL definition for both Templates and Modules
4. Adds tests for all of these things

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
