### PR TITLE
feat(templates/modules) Ingest default page templates and modules

### DIFF
--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -43,6 +43,18 @@ bootstrap:
       async: false
       mcps_location: "bootstrap_mcps/roles.yaml"
 
+    - name: page-modules
+      version: v1
+      blocking: true
+      async: false
+      mcps_location: "bootstrap_mcps/page-modules.yaml"
+
+    - name: page-templates
+      version: v1
+      blocking: true
+      async: false
+      mcps_location: "bootstrap_mcps/page-templates.yaml"
+
     # Ingestion Recipes
     - name: ingestion-datahub-gc
       version: v5

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-modules.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-modules.yaml
@@ -1,0 +1,15 @@
+# Instructions to add additional entry
+# 1. Add new entry to this list
+# 2. Increment version in bootstrap_mcps.yaml for the entry referring to this file
+- entityUrn: urn:li:dataHubPageModule:your_assets
+  entityType: dataHubPageModule
+  aspectName: dataHubPageModuleProperties
+  changeType: UPSERT
+  aspect:
+    name: "Your Assets"
+    type: OWNED_ASSETS
+    visibility:
+      scope: GLOBAL
+    params: {}
+    created: {{&auditStamp}}
+    lastModified: {{&auditStamp}}

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-templates.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-templates.yaml
@@ -1,0 +1,17 @@
+# Instructions to add additional entry
+# 1. Add new entry to this list
+# 2. Increment version in bootstrap_mcps.yaml for the entry referring to this file
+- entityUrn: urn:li:dataHubPageTemplate:home_default_1
+  entityType: dataHubPageTemplate
+  aspectName: dataHubPageTemplateProperties
+  changeType: UPSERT
+  aspect:
+    rows:
+      - modules:
+        - "urn:li:dataHubPageModule:your_assets"
+    surface:
+      surfaceType: HOME_PAGE
+    visibility:
+      scope: GLOBAL
+    created: {{&auditStamp}}
+    lastModified: {{&auditStamp}}

--- a/metadata-service/war/src/main/resources/boot/global_settings.json
+++ b/metadata-service/war/src/main/resources/boot/global_settings.json
@@ -4,5 +4,8 @@
   "docPropagation": {
     "enabled": true,
     "columnPropagationEnabled": true
+  },
+  "homePage": {
+    "defaultTemplate": "urn:li:dataHubPageTemplate:home_default_1"
   }
 }


### PR DESCRIPTION
This PR ingests a default home page template and adds it to the global settings aspect. It also ingests a default page module that is referenced on the default page template.

When we add more default modules we can just extend this bootstrap step and update the version.

When we add these default page modules to our default home page template we can update the bootstrap step and increase the version.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
