### PR TITLE
refactor(ingest): centralise subtype strings

### DIFF
--- a/metadata-ingestion/examples/ai/dh_ai_client.py
+++ b/metadata-ingestion/examples/ai/dh_ai_client.py
@@ -6,6 +6,7 @@ import datahub.metadata.schema_classes as models
 from datahub.api.entities.dataset.dataset import Dataset
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.ingestion.source.common.subtypes import MLAssetSubTypes
 from datahub.metadata.com.linkedin.pegasus2avro.dataprocess import (
     DataProcessInstanceInput,
     DataProcessInstanceOutput,
@@ -294,7 +295,9 @@ class DatahubAIClient:
                 models.ContainerPropertiesClass, kwargs
             )
 
-        container_subtype = models.SubTypesClass(typeNames=["ML Experiment"])
+        container_subtype = models.SubTypesClass(
+            typeNames=[MLAssetSubTypes.MLFLOW_EXPERIMENT]
+        )
         browse_path = models.BrowsePathsV2Class(path=[])
         platform_instance = models.DataPlatformInstanceClass(platform=str(platform_urn))
 
@@ -327,7 +330,9 @@ class DatahubAIClient:
             aspects.append(properties)
 
         # Always add the subtype
-        aspects.append(models.SubTypesClass(typeNames=["ML Training Run"]))
+        aspects.append(
+            models.SubTypesClass(typeNames=[MLAssetSubTypes.MLFLOW_TRAINING_RUN])
+        )
 
         # Add training run properties if provided
         if training_run_properties:

--- a/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
@@ -26,6 +26,8 @@ class DatasetSubTypes(StrEnum):
     NEO4J_RELATIONSHIP = "Neo4j Relationship"
     SNOWFLAKE_STREAM = "Snowflake Stream"
     API_ENDPOINT = "API Endpoint"
+    SLACK_CHANNEL = "Slack Channel"
+    PROJECTIONS = "Projections"
 
     # TODO: Create separate entity...
     NOTEBOOK = "Notebook"

--- a/metadata-ingestion/src/datahub/ingestion/source/mock_data/datahub_mock_data.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mock_data/datahub_mock_data.py
@@ -15,6 +15,7 @@ from datahub.ingestion.api.decorators import (
 )
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.ingestion.source.mock_data.datahub_mock_data_report import (
     DataHubMockDataReport,
 )
@@ -211,15 +212,19 @@ class DataHubMockDataSource(Source):
         pattern = self.config.gen_1.subtype_pattern
 
         if pattern == SubTypePattern.ALTERNATING:
-            return "Table" if table_index % 2 == 0 else "View"
+            return (
+                DatasetSubTypes.TABLE if table_index % 2 == 0 else DatasetSubTypes.VIEW
+            )
         elif pattern == SubTypePattern.LEVEL_BASED:
-            return self.config.gen_1.level_subtypes.get(table_level, "Table")
+            return self.config.gen_1.level_subtypes.get(
+                table_level, DatasetSubTypes.TABLE
+            )
         elif pattern == SubTypePattern.ALL_TABLE:
-            return "Table"
+            return DatasetSubTypes.TABLE
         elif pattern == SubTypePattern.ALL_VIEW:
-            return "View"
+            return DatasetSubTypes.VIEW
         else:
-            return "Table"  # default
+            return DatasetSubTypes.TABLE  # default
 
     def _get_subtypes_aspect(
         self, table_name: str, table_level: int, table_index: int

--- a/metadata-ingestion/src/datahub/ingestion/source/slack/slack.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/slack/slack.py
@@ -23,6 +23,7 @@ from datahub.ingestion.api.source import (
     SourceReport,
 )
 from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalHandler,
     StaleEntityRemovalSourceReport,
@@ -493,7 +494,7 @@ class SlackSource(StatefulIngestionSourceBase):
                     mcp=MetadataChangeProposalWrapper(
                         entityUrn=urn_channel,
                         aspect=SubTypesClass(
-                            typeNames=["Slack Channel"],
+                            typeNames=[DatasetSubTypes.SLACK_CHANNEL],
                         ),
                     ),
                 )

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
@@ -25,6 +25,7 @@ from datahub.ingestion.api.decorators import (
 )
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.common.data_reader import DataReader
+from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.ingestion.source.sql.sql_common import (
     SQLAlchemySource,
     SqlWorkUnit,
@@ -497,7 +498,7 @@ class VerticaSource(SQLAlchemySource):
             changeType=ChangeTypeClass.UPSERT,
             entityUrn=dataset_urn,
             aspectName="subTypes",
-            aspect=SubTypesClass(typeNames=["Projections"]),
+            aspect=SubTypesClass(typeNames=[DatasetSubTypes.PROJECTIONS]),
         ).as_workunit()
 
         if self.config.domain:


### PR DESCRIPTION
Remove magic strings and use the established subtype classes so we know what subtypes we have available.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
