### PR TITLE
fix(token-service): extend validation for actor

### DIFF
--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/StatefulTokenService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/StatefulTokenService.java
@@ -46,7 +46,7 @@ public class StatefulTokenService extends StatelessTokenService {
       @Nullable final String iss,
       @Nonnull final EntityService<?> entityService,
       @Nonnull final String salt) {
-    super(signingKey, signingAlgorithm, iss);
+    super(systemOperationContext, signingKey, signingAlgorithm, iss);
     this.systemOperationContext = systemOperationContext;
     this._entityService = entityService;
     this._revokedTokenCache =

--- a/smoke-test/tests/tokens/session_access_token_test.py
+++ b/smoke-test/tests/tokens/session_access_token_test.py
@@ -100,8 +100,7 @@ def custom_user_session():
     assert {"username": "sessionUser"} not in res_data["data"]["listUsers"]["users"]
 
 
-@pytest.mark.dependency()
-def test_soft_delete(graph_client, custom_user_session):
+def test_01_soft_delete(graph_client, custom_user_session):
     # assert initial access
     assert getUserId(custom_user_session) == {"urn": user_urn}
 
@@ -110,15 +109,14 @@ def test_soft_delete(graph_client, custom_user_session):
 
     with pytest.raises(HTTPError) as req_info:
         getUserId(custom_user_session)
-    assert "403 Client Error: Forbidden" in str(req_info.value)
+    assert "401 Client Error: Unauthorized" in str(req_info.value)
 
     # undo soft delete
     graph_client.set_soft_delete_status(urn=user_urn, delete=False)
     wait_for_writes_to_sync()
 
 
-@pytest.mark.dependency(depends=["test_soft_delete"])
-def test_suspend(graph_client, custom_user_session):
+def test_02_suspend(graph_client, custom_user_session):
     # assert initial access
     assert getUserId(custom_user_session) == {"urn": user_urn}
 
@@ -140,7 +138,7 @@ def test_suspend(graph_client, custom_user_session):
 
     with pytest.raises(HTTPError) as req_info:
         getUserId(custom_user_session)
-    assert "403 Client Error: Forbidden" in str(req_info.value)
+    assert "401 Client Error: Unauthorized" in str(req_info.value)
 
     # undo suspend
     graph_client.emit(
@@ -160,8 +158,7 @@ def test_suspend(graph_client, custom_user_session):
     wait_for_writes_to_sync()
 
 
-@pytest.mark.dependency(depends=["test_suspend"])
-def test_hard_delete(graph_client, custom_user_session):
+def test_03_hard_delete(graph_client, custom_user_session):
     # assert initial access
     assert getUserId(custom_user_session) == {"urn": user_urn}
 
@@ -170,4 +167,4 @@ def test_hard_delete(graph_client, custom_user_session):
 
     with pytest.raises(HTTPError) as req_info:
         getUserId(custom_user_session)
-    assert "403 Client Error: Forbidden" in str(req_info.value)
+    assert "401 Client Error: Unauthorized" in str(req_info.value)


### PR DESCRIPTION
This PR enhances token security by adding actor validation during token verification when the endpoints don't already call this method for authorization checks. This does incur redundant validation however it should be mitigated by aspect caching.

The changes include:
* Added actor validation: StatelessTokenService now validates that actors are active when validating access tokens
* Added OperationContext dependency: Required for accessing AspectRetriever to check actor status
* Updated constructor signatures: All constructors now require an OperationContext parameter
* Comprehensive test coverage: Added 6 new tests covering all actor validation scenarios:
   * System actors (always active)
   * Hard deleted users (missing CorpUserKey)
   * Removed users
   * Suspended users
   * Active users
   * Users with missing optional aspects

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
