### PR TITLE
feat(tableau): add config flags to emit datasources regardless of workbook connection

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
@@ -528,6 +528,14 @@ class TableauConfig(
         default=False,
         description="Ingest details for tables external to (not embedded in) tableau as entities.",
     )
+    emit_published_datasources_regardless_of_workbook: bool = Field(
+        default=False,
+        description="Ingest all published data sources, including those not connected to workbooks.",
+    )
+    emit_embedded_datasources_regardless_of_workbook: bool = Field(
+        default=False,
+        description="Ingest all embedded data sources, including those not connected to workbooks.",
+    )
 
     env: str = Field(
         default=builder.DEFAULT_ENV,
@@ -2855,7 +2863,11 @@ class TableauSiteSource:
         return datasource
 
     def emit_published_datasources(self) -> Iterable[MetadataWorkUnit]:
-        datasource_filter = {c.ID_WITH_IN: self.datasource_ids_being_used}
+        datasource_filter = (
+            {}
+            if self.config.emit_published_datasources_regardless_of_workbook
+            else {c.ID_WITH_IN: self.datasource_ids_being_used}
+        )
 
         for datasource in self.get_connection_objects(
             query=published_datasource_graphql_query,
@@ -3548,7 +3560,11 @@ class TableauSiteSource:
         return browse_paths
 
     def emit_embedded_datasources(self) -> Iterable[MetadataWorkUnit]:
-        datasource_filter = {c.ID_WITH_IN: self.embedded_datasource_ids_being_used}
+        datasource_filter = (
+            {}
+            if self.config.emit_embedded_datasources_regardless_of_workbook
+            else {c.ID_WITH_IN: self.embedded_datasource_ids_being_used}
+        )
 
         for datasource in self.get_connection_objects(
             query=embedded_datasource_graphql_query,


### PR DESCRIPTION
## Summary
- Add two new configuration flags to ingest Tableau data sources that are not connected to workbooks
- `emit_published_datasources_regardless_of_workbook`: Ingest all published data sources (default: false)
- `emit_embedded_datasources_regardless_of_workbook`: Ingest all embedded data sources (default: false)

## Changes
- Added config flags to `TableauConfig` class with backward compatibility (default: false)
- Modified `emit_published_datasources()` to use empty filter when flag is enabled
- Modified `emit_embedded_datasources()` to use empty filter when flag is enabled
- Empty filters result in fetching all data sources within project scope

## Business Value
- Enables discovery of all Tableau data sources, including standalone ones not connected to workbooks
- Improves metadata completeness for users building new dashboards based on available data
- Addresses customer requirement for CUS-3698

## Status
🚧 **WIP - Pending end-to-end testing**

This PR implements the core functionality but requires validation with a real Tableau instance to ensure:
- Standalone published data sources are properly ingested
- Embedded data sources not connected to workbooks are captured
- Performance impact is acceptable for large Tableau deployments

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>