### PR TITLE
feat(gcs): add support for google workload identity federation

### DIFF
--- a/metadata-ingestion/docs/sources/gcs/gcs.md
+++ b/metadata-ingestion/docs/sources/gcs/gcs.md
@@ -1,3 +1,71 @@
+### Authentication
+
+The GCS source supports two authentication methods:
+
+1. **HMAC Keys** (default): Uses Google Cloud Storage HMAC keys for authentication
+2. **Workload Identity Federation**: Uses Google Cloud Workload Identity Federation for secure, temporary token-based authentication
+
+#### HMAC Authentication
+
+Configure HMAC authentication using access ID and secret key:
+
+```yaml
+source:
+  type: gcs
+  config:
+    credential:
+      hmac_access_id: <your-access-id>
+      hmac_access_secret: <your-access-secret>
+```
+
+#### Workload Identity Federation
+
+Configure Workload Identity Federation using one of three options:
+
+**Option 1: Configuration file**
+```yaml
+source:
+  type: gcs
+  config:
+    auth_type: workload_identity_federation
+    gcp_wif_configuration: "/path/to/gcp_wif_configuration.json"
+```
+
+**Option 2: Inline configuration (dict)**
+```yaml
+source:
+  type: gcs
+  config:
+    auth_type: workload_identity_federation
+    gcp_wif_configuration_json:
+      type: external_account
+      audience: "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"
+      subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
+      token_url: "https://sts.googleapis.com/v1/token"
+      credential_source:
+        file: "/var/run/secrets/tokens/gcp-ksa/token"
+```
+
+**Option 3: JSON string (copy-paste from file)**
+```yaml
+source:
+  type: gcs
+  config:
+    auth_type: workload_identity_federation
+    gcp_wif_configuration_json_string: |
+      {
+        "type": "external_account",
+        "audience": "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": {
+          "file": "/var/run/secrets/tokens/gcp-ksa/token"
+        }
+      }
+```
+
+For Workload Identity Federation setup, see the [Google Cloud documentation](https://cloud.google.com/iam/docs/workload-identity-federation).
+
 ### Path Specs
 
 **Example - Dataset per file**

--- a/metadata-ingestion/docs/sources/gcs/gcs_recipe.yml
+++ b/metadata-ingestion/docs/sources/gcs/gcs_recipe.yml
@@ -1,3 +1,4 @@
+# HMAC Authentication (default)
 source:
   type: gcs
   config:
@@ -6,3 +7,53 @@ source:
     credential:
       hmac_access_id: <hmac access id>
       hmac_access_secret: <hmac access secret>
+
+---
+
+# Workload Identity Federation with configuration file
+source:
+  type: gcs
+  config:
+    auth_type: workload_identity_federation
+    gcp_wif_configuration: "/path/to/gcp_wif_configuration.json"
+    path_specs: 
+       - include: gs://gcs-ingestion-bucket/parquet_example/{table}/year={partition[0]}/*.parquet
+
+---
+
+# Workload Identity Federation with inline configuration (dict)
+source:
+  type: gcs
+  config:
+    auth_type: workload_identity_federation
+    gcp_wif_configuration_json:
+      type: external_account
+      audience: "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID"
+      subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
+      token_url: "https://sts.googleapis.com/v1/token"
+      credential_source:
+        file: "/var/run/secrets/tokens/gcp-ksa/token"
+      service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/SERVICE_ACCOUNT_EMAIL:generateAccessToken"
+    path_specs: 
+       - include: gs://gcs-ingestion-bucket/parquet_example/{table}/year={partition[0]}/*.parquet
+
+---
+
+# Workload Identity Federation with JSON string (copy-paste from file)
+source:
+  type: gcs
+  config:
+    auth_type: workload_identity_federation
+    gcp_wif_configuration_json_string: |
+      {
+        "type": "external_account",
+        "audience": "//iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID",
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "token_url": "https://sts.googleapis.com/v1/token",
+        "credential_source": {
+          "file": "/var/run/secrets/tokens/gcp-ksa/token"
+        },
+        "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/SERVICE_ACCOUNT_EMAIL:generateAccessToken"
+      }
+    path_specs: 
+       - include: gs://gcs-ingestion-bucket/parquet_example/{table}/year={partition[0]}/*.parquet


### PR DESCRIPTION
This PR adds support for Google Cloud Workload Identity Federation (WIF) authentication to the GCS metadata ingestion connector, providing a more secure alternative to HMAC key authentication while maintaining full backward compatibility.