### PR TITLE
build(docker): use root as build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,11 @@ out
 **/*.class
 # Have to copy gradle/wrapper/gradle-wrapper.jar, can't exclude ALL jars
 **/build/**/*.jar
+# Jars/Wars that are final outputs of java projects.
+!**/build/libs/*.war
+!**/build/libs/*.jar
+!datahub-frontend/build/stage/main/**
+
 # Content in .git is used to get the git version
 # Just ignore the heavy parts that are not used
 .git/logs

--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -31,7 +31,7 @@ FROM base AS prod-install
 
 COPY --chown=datahub:datahub --chmod=755 ./docker/monitoring/client-prometheus-config.yaml /datahub-frontend/
 COPY --chown=datahub:datahub --chmod=755 ./docker/datahub-frontend/start.sh /
-COPY --chown=datahub:datahub --chmod=755 ./main /datahub-frontend/
+COPY --chown=datahub:datahub --chmod=755 ./datahub-frontend/build/stage/main /datahub-frontend/
 
 FROM base AS dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -55,7 +55,7 @@ COPY metadata-models/src/main/resources/entity-registry.yml /datahub/datahub-gms
 COPY docker/datahub-gms/start.sh /datahub/datahub-gms/scripts/start.sh
 COPY docker/monitoring/client-prometheus-config.yaml /datahub/datahub-gms/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-gms/scripts/start.sh
-COPY war.war /datahub/datahub-gms/bin/war.war
+COPY metadata-service/war/build/libs/war.war /datahub/datahub-gms/bin/war.war
 
 FROM base AS dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=binary /go/bin/dockerize /usr/local/bin
 ENV LD_LIBRARY_PATH="/lib:/lib64"
 
 FROM base AS prod-install
-COPY mae-consumer-job.jar /datahub/datahub-mae-consumer/bin/
+COPY metadata-jobs/mae-consumer-job/build/libs/mae-consumer-job.jar /datahub/datahub-mae-consumer/bin/
 COPY metadata-models/src/main/resources/entity-registry.yml /datahub/datahub-mae-consumer/resources/entity-registry.yml
 COPY docker/datahub-mae-consumer/start.sh /datahub/datahub-mae-consumer/scripts/
 COPY docker/monitoring/client-prometheus-config.yaml /datahub/datahub-mae-consumer/scripts/prometheus-config.yaml

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -48,7 +48,7 @@ RUN apk --no-cache --update-cache --available upgrade \
 COPY --from=binary /go/bin/dockerize /usr/local/bin
 
 FROM base AS prod-install
-COPY mce-consumer-job.jar /datahub/datahub-mce-consumer/bin/
+COPY metadata-jobs/mce-consumer-job/build/libs/mce-consumer-job.jar /datahub/datahub-mce-consumer/bin/
 COPY metadata-models/src/main/resources/entity-registry.yml /datahub/datahub-mce-consumer/resources/entity-registry.yml
 COPY docker/datahub-mce-consumer/start.sh /datahub/datahub-mce-consumer/scripts/
 COPY docker/monitoring/client-prometheus-config.yaml /datahub/datahub-mce-consumer/scripts/prometheus-config.yaml

--- a/docker/datahub-upgrade/Dockerfile
+++ b/docker/datahub-upgrade/Dockerfile
@@ -52,7 +52,7 @@ COPY --from=binary /go/bin/dockerize /usr/local/bin
 ENV LD_LIBRARY_PATH="/lib:/lib64"
 
 FROM base AS prod-install
-COPY datahub-upgrade.jar /datahub/datahub-upgrade/bin/
+COPY datahub-upgrade/build/libs/datahub-upgrade.jar /datahub/datahub-upgrade/bin/
 COPY docker/datahub-upgrade/start.sh /datahub/datahub-upgrade/scripts/start.sh
 COPY docker/monitoring/client-prometheus-config.yaml /datahub/datahub-upgrade/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-upgrade/scripts/start.sh

--- a/gradle/docker/docker.gradle
+++ b/gradle/docker/docker.gradle
@@ -125,28 +125,23 @@ class DockerPluginExtension {
 def extension = project.extensions.create("docker", DockerPluginExtension)
 
 project.afterEvaluate {
-  def buildContext = "${rootProject.buildDir}/dockerBuildContext/${rootProject.relativePath(project.projectDir)}/docker"
-  // ensure this directory exists
-  new File(buildContext).mkdirs()
-  println("buildContext: ${buildContext}")
+  def buildContext = "${rootProject.projectDir}"
 
-  tasks.register("dockerPrepare", Sync) {
+  tasks.register("dockerPrepare") {
     group "docker"
-    with extension.copySpec
-    from extension.dockerfile
-    into buildContext
     dependsOn extension.dependencies.get()
   }
 
   project.tasks.register("docker", Exec) {
+    // This task is no longer used once we have moved to bake based builds. This task is useful just to ensure individual
+    // docker builds still work. But a quickstart* tasks no longer uses this task.
     group "docker"
     description "Builds the docker image and applies all tags defined"
     dependsOn dockerPrepare
 
-    def marker = "${buildContext}/../imageCreated-${name}.json"
+    def marker = "${project.buildDir}/imageCreated-${name}.json"
 
     inputs.file(extension.dockerfile)
-    inputs.dir(buildContext)
     inputs.property("tags", extension.tags)
     inputs.property("buildArgs", extension.buildArgs)
     outputs.file(marker)


### PR DESCRIPTION
This eliminates the copy step that copies selected files from source root to a build context that is in the project build dir. A few files like jars were copied from build dir in Dockerfiles, they need to use a path relative to repo root for the source path. This was a pattern carried over from the older docker plugin that was being used.

This also addresses an occasional build error reported due to implicit dependencies between some components and test outputs. This happened because the earlier copy step would copy all files from a referenced source file (does not consider .dockerignore) which can contain outputs of a test task that is not a dependency, however gradle reports this as implicit dependency. An alternate way of addressing this is to make the copy step follow .dockerignore and skip files mentioned in them thus avoiding such implicit dependencies. 

This PR does not remove the copy file specs in each project yet (they are no longer used). Will do that in a follow on PR. They are no longer required, the Dockerfile COPY relative to source root (already the case for all folders) is sufficient. 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
