### PR TITLE
feat(ui) Finalize Your Assets module on the frontend

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Button/Button.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Button/Button.tsx
@@ -27,7 +27,6 @@ export const Button = ({
     isDisabled = buttonDefaults.isDisabled,
     isActive = buttonDefaults.isActive,
     children,
-    dataTestId,
     ...props
 }: ButtonProps) => {
     const styleProps = {
@@ -51,7 +50,7 @@ export const Button = ({
 
     // Prefer `icon.size` over `size` for icon size
     return (
-        <ButtonBase {...styleProps} {...props} data-testid={dataTestId}>
+        <ButtonBase {...styleProps} {...props}>
             {icon && iconPosition === 'left' && <Icon size={size} {...icon} />}
             {!isCircle && children}
             {icon && iconPosition === 'right' && <Icon size={size} {...icon} />}

--- a/datahub-web-react/src/alchemy-components/components/Button/Button.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Button/Button.tsx
@@ -27,6 +27,7 @@ export const Button = ({
     isDisabled = buttonDefaults.isDisabled,
     isActive = buttonDefaults.isActive,
     children,
+    dataTestId,
     ...props
 }: ButtonProps) => {
     const styleProps = {
@@ -50,7 +51,7 @@ export const Button = ({
 
     // Prefer `icon.size` over `size` for icon size
     return (
-        <ButtonBase {...styleProps} {...props}>
+        <ButtonBase {...styleProps} {...props} data-testid={dataTestId}>
             {icon && iconPosition === 'left' && <Icon size={size} {...icon} />}
             {!isCircle && children}
             {icon && iconPosition === 'right' && <Icon size={size} {...icon} />}

--- a/datahub-web-react/src/alchemy-components/components/Button/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/types.ts
@@ -10,6 +10,7 @@ export enum ButtonVariantValues {
     outline = 'outline',
     text = 'text',
     secondary = 'secondary',
+    link = 'link',
 }
 export type ButtonVariant = keyof typeof ButtonVariantValues;
 
@@ -22,6 +23,7 @@ export interface ButtonPropsDefaults {
     isLoading: boolean;
     isDisabled: boolean;
     isActive: boolean;
+    dataTestId?: string;
 }
 
 export interface ButtonProps

--- a/datahub-web-react/src/alchemy-components/components/Button/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/types.ts
@@ -23,7 +23,6 @@ export interface ButtonPropsDefaults {
     isLoading: boolean;
     isDisabled: boolean;
     isActive: boolean;
-    dataTestId?: string;
 }
 
 export interface ButtonProps

--- a/datahub-web-react/src/alchemy-components/components/Button/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/utils.ts
@@ -104,6 +104,19 @@ const getButtonColorStyles = (variant: ButtonVariant, color: ColorOptions, theme
         };
     }
 
+    // Override styles for secondary variant
+    if (variant === 'link') {
+        return {
+            ...base,
+            textColor: color500,
+            bgColor: colors.transparent,
+            borderColor: colors.transparent,
+            activeBgColor: colors.transparent,
+            disabledBgColor: colors.transparent,
+            disabledBorderColor: colors.transparent,
+        };
+    }
+
     // Filled variable is the base style
     return base;
 };
@@ -171,6 +184,18 @@ const getButtonVariantStyles = (variant: ButtonVariant, colorStyles: ColorStyles
                 color: colorStyles.disabledTextColor,
             },
         },
+        link: {
+            backgroundColor: 'transparent',
+            border: 'none',
+            color: colorStyles.textColor,
+            padding: 0,
+            '&:hover': {
+                textDecoration: 'underline',
+            },
+            '&:disabled': {
+                color: colorStyles.disabledTextColor,
+            },
+        },
     };
 
     return variantStyles[variant];
@@ -194,9 +219,10 @@ const getButtonRadiiStyles = (isCircle: boolean) => {
 };
 
 // Generate padding styles for button
-const getButtonPadding = (size: SizeOptions, hasChildren: boolean, isCircle: boolean) => {
+const getButtonPadding = (size: SizeOptions, hasChildren: boolean, isCircle: boolean, variant: ButtonVariant) => {
     if (isCircle) return { padding: spacing.xsm };
     if (!hasChildren) return { padding: spacing.xsm };
+    if (variant === 'link') return { padding: 0 };
 
     const paddingStyles = {
         xs: {
@@ -253,7 +279,7 @@ export const getButtonStyle = (props: ButtonStyleProps): CSSObject => {
     const variantStyles = getButtonVariantStyles(variant, colorStyles, color);
     const fontStyles = getButtonFontStyles(size);
     const radiiStyles = getButtonRadiiStyles(isCircle);
-    const paddingStyles = getButtonPadding(size, hasChildren, isCircle);
+    const paddingStyles = getButtonPadding(size, hasChildren, isCircle, variant);
 
     // Base of all generated styles
     let styles: CSSObject = {

--- a/datahub-web-react/src/app/homeV3/module/components/LargeModule.tsx
+++ b/datahub-web-react/src/app/homeV3/module/components/LargeModule.tsx
@@ -1,4 +1,4 @@
-import { Loader, borders, colors, radius, spacing } from '@components';
+import { Button, Loader, borders, colors, radius, spacing } from '@components';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -34,10 +34,10 @@ const FloatingRightHeaderSection = styled.div`
     height: 100%;
 `;
 
-const Content = styled.div`
+const Content = styled.div<{ $hasViewAll: boolean }>`
     margin: 16px;
     overflow-y: auto;
-    height: 222px;
+    height: ${({ $hasViewAll }) => ($hasViewAll ? '210px' : '222px')};
 `;
 
 const LoaderContainer = styled.div`
@@ -45,11 +45,18 @@ const LoaderContainer = styled.div`
     height: 100%;
 `;
 
+const ViewAllButton = styled(Button)`
+    margin-left: auto;
+    margin-right: 16px;
+    margin: 0 16px 0 auto;
+`;
+
 interface Props extends ModuleProps {
     loading?: boolean;
+    onClickViewAll?: () => void;
 }
 
-export default function LargeModule({ children, module, loading }: React.PropsWithChildren<Props>) {
+export default function LargeModule({ children, module, loading, onClickViewAll }: React.PropsWithChildren<Props>) {
     const { name } = module.properties;
     return (
         <ModuleContainer $height="316px">
@@ -61,7 +68,7 @@ export default function LargeModule({ children, module, loading }: React.PropsWi
                     <ModuleMenu />
                 </FloatingRightHeaderSection>
             </ModuleHeader>
-            <Content>
+            <Content $hasViewAll={!!onClickViewAll}>
                 {loading ? (
                     <LoaderContainer>
                         <Loader />
@@ -70,6 +77,11 @@ export default function LargeModule({ children, module, loading }: React.PropsWi
                     children
                 )}
             </Content>
+            {onClickViewAll && (
+                <ViewAllButton variant="link" color="gray" size="sm" onClick={onClickViewAll} dataTestId="view-all">
+                    View all
+                </ViewAllButton>
+            )}
         </ModuleContainer>
     );
 }

--- a/datahub-web-react/src/app/homeV3/module/components/LargeModule.tsx
+++ b/datahub-web-react/src/app/homeV3/module/components/LargeModule.tsx
@@ -78,7 +78,7 @@ export default function LargeModule({ children, module, loading, onClickViewAll 
                 )}
             </Content>
             {onClickViewAll && (
-                <ViewAllButton variant="link" color="gray" size="sm" onClick={onClickViewAll} dataTestId="view-all">
+                <ViewAllButton variant="link" color="gray" size="sm" onClick={onClickViewAll} data-testid="view-all">
                     View all
                 </ViewAllButton>
             )}

--- a/datahub-web-react/src/app/homeV3/module/components/__tests__/LargeModule.test.tsx
+++ b/datahub-web-react/src/app/homeV3/module/components/__tests__/LargeModule.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import LargeModule from '@app/homeV3/module/components/LargeModule';
+import { ModuleProps } from '@app/homeV3/module/types';
+
+import { DataHubPageModuleType, EntityType, PageModuleScope } from '@types';
+
+// Mock styled-components
+vi.mock('styled-components', () => {
+    const styledFactory = (Component: any) => () => {
+        return ({ children, ...props }: any) => <Component {...props}>{children}</Component>;
+    };
+    styledFactory.div = styledFactory('div');
+    styledFactory.button = styledFactory('button');
+    return {
+        __esModule: true,
+        default: styledFactory,
+    };
+});
+
+// Mock child components
+vi.mock('@app/homeV3/module/components/ModuleContainer', () => ({
+    default: ({ children, ...props }: any) => (
+        <div data-testid="module-container" {...props}>
+            {children}
+        </div>
+    ),
+}));
+
+vi.mock('@app/homeV3/module/components/ModuleMenu', () => ({
+    default: () => <div data-testid="module-menu">Module Menu</div>,
+}));
+
+vi.mock('@app/homeV3/module/components/ModuleName', () => ({
+    default: ({ text }: { text: string }) => <div data-testid="module-name">{text}</div>,
+}));
+
+vi.mock('@components', () => ({
+    Button: ({ children, onClick, ...props }: any) => (
+        <button type="button" data-testid="view-all-button" onClick={onClick} {...props}>
+            {children}
+        </button>
+    ),
+    Loader: () => <div data-testid="loader">Loading...</div>,
+    Text: ({ children }: any) => <span>{children}</span>,
+    borders: {
+        '1px': '1px solid',
+    },
+    colors: {
+        white: '#ffffff',
+        gray: {
+            100: '#f3f4f6',
+        },
+    },
+    radius: {
+        lg: '8px',
+    },
+    spacing: {
+        md: '16px',
+        xsm: '4px',
+    },
+}));
+
+describe('LargeModule', () => {
+    const mockModule: ModuleProps['module'] = {
+        urn: 'urn:li:dataHubPageModule:test',
+        type: EntityType.DatahubPageModule,
+        properties: {
+            name: 'Test Module',
+            type: DataHubPageModuleType.OwnedAssets,
+            visibility: {
+                scope: PageModuleScope.Global,
+            },
+        },
+    };
+
+    const defaultProps = {
+        module: mockModule,
+        children: <div data-testid="module-content">Module Content</div>,
+    };
+
+    it('should render the module with correct name', () => {
+        render(<LargeModule {...defaultProps} />);
+
+        expect(screen.getByTestId('module-name')).toHaveTextContent('Test Module');
+        expect(screen.getByTestId('module-content')).toBeInTheDocument();
+    });
+
+    it('should render view all button when onClickViewAll is provided', () => {
+        const mockOnClickViewAll = vi.fn();
+        render(<LargeModule {...defaultProps} onClickViewAll={mockOnClickViewAll} />);
+
+        const viewAllButton = screen.getByTestId('view-all-button');
+        expect(viewAllButton).toBeInTheDocument();
+        expect(viewAllButton).toHaveTextContent('View all');
+    });
+
+    it('should not render view all button when onClickViewAll is not provided', () => {
+        render(<LargeModule {...defaultProps} />);
+
+        expect(screen.queryByTestId('view-all-button')).not.toBeInTheDocument();
+    });
+
+    it('should call onClickViewAll when view all button is clicked', () => {
+        const mockOnClickViewAll = vi.fn();
+        render(<LargeModule {...defaultProps} onClickViewAll={mockOnClickViewAll} />);
+
+        const viewAllButton = screen.getByTestId('view-all-button');
+        viewAllButton.click();
+
+        expect(mockOnClickViewAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render loader when loading is true', () => {
+        render(<LargeModule {...defaultProps} loading />);
+
+        expect(screen.getByTestId('loader')).toBeInTheDocument();
+        expect(screen.queryByTestId('module-content')).not.toBeInTheDocument();
+    });
+
+    it('should render children when loading is false', () => {
+        render(<LargeModule {...defaultProps} loading={false} />);
+
+        expect(screen.getByTestId('module-content')).toBeInTheDocument();
+        expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
+    });
+
+    it('should render children when loading is not provided', () => {
+        render(<LargeModule {...defaultProps} />);
+
+        expect(screen.getByTestId('module-content')).toBeInTheDocument();
+        expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
+    });
+
+    it('should render module menu in header', () => {
+        render(<LargeModule {...defaultProps} />);
+
+        expect(screen.getByTestId('module-menu')).toBeInTheDocument();
+    });
+
+    it('should handle onClickViewAll as undefined', () => {
+        render(<LargeModule {...defaultProps} onClickViewAll={undefined} />);
+
+        expect(screen.queryByTestId('view-all-button')).not.toBeInTheDocument();
+    });
+
+    it('should handle onClickViewAll as null', () => {
+        render(<LargeModule {...defaultProps} onClickViewAll={null as any} />);
+
+        expect(screen.queryByTestId('view-all-button')).not.toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/app/homeV3/module/components/__tests__/LargeModule.test.tsx
+++ b/datahub-web-react/src/app/homeV3/module/components/__tests__/LargeModule.test.tsx
@@ -39,7 +39,7 @@ vi.mock('@app/homeV3/module/components/ModuleName', () => ({
 
 vi.mock('@components', () => ({
     Button: ({ children, onClick, ...props }: any) => (
-        <button type="button" data-testid="view-all-button" onClick={onClick} {...props}>
+        <button type="button" onClick={onClick} {...props}>
             {children}
         </button>
     ),
@@ -92,7 +92,7 @@ describe('LargeModule', () => {
         const mockOnClickViewAll = vi.fn();
         render(<LargeModule {...defaultProps} onClickViewAll={mockOnClickViewAll} />);
 
-        const viewAllButton = screen.getByTestId('view-all-button');
+        const viewAllButton = screen.getByTestId('view-all');
         expect(viewAllButton).toBeInTheDocument();
         expect(viewAllButton).toHaveTextContent('View all');
     });
@@ -100,14 +100,14 @@ describe('LargeModule', () => {
     it('should not render view all button when onClickViewAll is not provided', () => {
         render(<LargeModule {...defaultProps} />);
 
-        expect(screen.queryByTestId('view-all-button')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('view-all')).not.toBeInTheDocument();
     });
 
     it('should call onClickViewAll when view all button is clicked', () => {
         const mockOnClickViewAll = vi.fn();
         render(<LargeModule {...defaultProps} onClickViewAll={mockOnClickViewAll} />);
 
-        const viewAllButton = screen.getByTestId('view-all-button');
+        const viewAllButton = screen.getByTestId('view-all');
         viewAllButton.click();
 
         expect(mockOnClickViewAll).toHaveBeenCalledTimes(1);

--- a/datahub-web-react/src/app/homeV3/modules/YourAssetsModule.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/YourAssetsModule.tsx
@@ -6,13 +6,15 @@ import EmptyContent from '@app/homeV3/module/components/EmptyContent';
 import EntityItem from '@app/homeV3/module/components/EntityItem';
 import LargeModule from '@app/homeV3/module/components/LargeModule';
 import { ModuleProps } from '@app/homeV3/module/types';
+import useSearchYourAssets from '@app/homeV3/modules/useSearchYourAssets';
 
 export default function YourAssetsModule(props: ModuleProps) {
     const { user } = useUserContext();
     const { originEntities, loading } = useGetAssetsYouOwn(user);
+    const searchForYourAssets = useSearchYourAssets();
 
     return (
-        <LargeModule {...props} loading={loading}>
+        <LargeModule {...props} loading={loading} onClickViewAll={searchForYourAssets}>
             {originEntities.length === 0 ? (
                 <EmptyContent
                     icon="User"

--- a/datahub-web-react/src/app/homeV3/modules/__tests__/useSearchYourAssets.test.ts
+++ b/datahub-web-react/src/app/homeV3/modules/__tests__/useSearchYourAssets.test.ts
@@ -1,0 +1,107 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useHistory } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserContext } from '@app/context/useUserContext';
+import useSearchYourAssets from '@app/homeV3/modules/useSearchYourAssets';
+import { navigateToSearchUrl } from '@app/searchV2/utils/navigateToSearchUrl';
+
+// Mock dependencies
+vi.mock('react-router', () => ({
+    useHistory: vi.fn(),
+}));
+
+vi.mock('@app/context/useUserContext', () => ({
+    useUserContext: vi.fn(),
+}));
+
+vi.mock('@app/searchV2/utils/navigateToSearchUrl', () => ({
+    navigateToSearchUrl: vi.fn(),
+}));
+
+describe('useSearchYourAssets', () => {
+    const mockHistory = {
+        push: vi.fn(),
+        replace: vi.fn(),
+        goBack: vi.fn(),
+        goForward: vi.fn(),
+        go: vi.fn(),
+        listen: vi.fn(),
+        location: { pathname: '/', search: '', hash: '', state: undefined },
+        createHref: vi.fn(),
+    };
+
+    const mockNavigateToSearchUrl = navigateToSearchUrl as ReturnType<typeof vi.fn>;
+    const mockUseHistory = useHistory as ReturnType<typeof vi.fn>;
+    const mockUseUserContext = useUserContext as ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseHistory.mockReturnValue(mockHistory);
+    });
+
+    it('should call navigateToSearchUrl with correct parameters when URN is provided', () => {
+        const mockUrn = 'urn:li:corpuser:test-user';
+        mockUseUserContext.mockReturnValue({ urn: mockUrn } as any);
+
+        const { result } = renderHook(() => useSearchYourAssets());
+        result.current();
+
+        expect(mockNavigateToSearchUrl).toHaveBeenCalledWith({
+            query: '*',
+            history: mockHistory,
+            filters: [{ field: 'owners', values: [mockUrn] }],
+        });
+        expect(mockNavigateToSearchUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call navigateToSearchUrl when URN is not provided', () => {
+        mockUseUserContext.mockReturnValue({ urn: undefined } as any);
+
+        const { result } = renderHook(() => useSearchYourAssets());
+        result.current();
+
+        expect(mockNavigateToSearchUrl).not.toHaveBeenCalled();
+    });
+
+    it('should not call navigateToSearchUrl when URN is null', () => {
+        mockUseUserContext.mockReturnValue({ urn: null } as any);
+
+        const { result } = renderHook(() => useSearchYourAssets());
+        result.current();
+
+        expect(mockNavigateToSearchUrl).not.toHaveBeenCalled();
+    });
+
+    it('should not call navigateToSearchUrl when URN is empty string', () => {
+        mockUseUserContext.mockReturnValue({ urn: '' } as any);
+
+        const { result } = renderHook(() => useSearchYourAssets());
+        result.current();
+
+        expect(mockNavigateToSearchUrl).not.toHaveBeenCalled();
+    });
+
+    it('should return a stable callback function', () => {
+        const mockUrn = 'urn:li:corpuser:test-user';
+        mockUseUserContext.mockReturnValue({ urn: mockUrn } as any);
+
+        const { result, rerender } = renderHook(() => useSearchYourAssets());
+        const firstCallback = result.current;
+
+        rerender();
+        const secondCallback = result.current;
+
+        expect(firstCallback).toBe(secondCallback);
+    });
+
+    it('should call useHistory and useUserContext hooks', () => {
+        const mockUrn = 'urn:li:corpuser:test-user';
+        mockUseUserContext.mockReturnValue({ urn: mockUrn } as any);
+
+        renderHook(() => useSearchYourAssets());
+
+        expect(mockUseHistory).toHaveBeenCalledTimes(1);
+        expect(mockUseUserContext).toHaveBeenCalledTimes(1);
+    });
+});

--- a/datahub-web-react/src/app/homeV3/modules/useSearchYourAssets.ts
+++ b/datahub-web-react/src/app/homeV3/modules/useSearchYourAssets.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { useHistory } from 'react-router';
+
+import { useUserContext } from '@app/context/useUserContext';
+import { navigateToSearchUrl } from '@app/searchV2/utils/navigateToSearchUrl';
+
+export default function useSearchYourAssets() {
+    const history = useHistory();
+    const { urn } = useUserContext();
+
+    return useCallback(() => {
+        if (urn) {
+            navigateToSearchUrl({ query: '*', history, filters: [{ field: 'owners', values: [urn] }] });
+        }
+    }, [history, urn]);
+}


### PR DESCRIPTION
 This PR finishes up the Your Assets module by building off of #13978 and adding a "View all" button which takes you to search with a filter for your own assets. Most of the diff here is tests.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
