### PR TITLE
chore(python): drop support for Python 3.8

### DIFF
--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -34,9 +34,9 @@ jobs:
       matrix:
         include:
           # Note: this should be kept in sync with tox.ini.
-          - python-version: "3.8"
+          - python-version: "3.9"
             extra_pip_requirements: "apache-airflow~=2.7.3"
-            extra_pip_constraints: "-c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.8.txt"
+            extra_pip_constraints: "-c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.9.txt"
           - python-version: "3.10"
             extra_pip_requirements: "apache-airflow~=2.7.3"
             extra_pip_constraints: "-c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.10.txt"

--- a/.github/workflows/gx-plugin.yml
+++ b/.github/workflows/gx-plugin.yml
@@ -32,9 +32,9 @@ jobs:
       DATAHUB_TELEMETRY_ENABLED: false
     strategy:
       matrix:
-        python-version: ["3.8", "3.10"]
+        python-version: ["3.9", "3.10"]
         include:
-          - python-version: "3.8"
+          - python-version: "3.9"
             extraPythonRequirement: "great-expectations~=0.15.12"
           - python-version: "3.10"
             extraPythonRequirement: "great-expectations~=0.16.0 numpy~=1.26.0"

--- a/.github/workflows/metadata-ingestion.yml
+++ b/.github/workflows/metadata-ingestion.yml
@@ -35,7 +35,7 @@ jobs:
       # DATAHUB_LOOKML_GIT_TEST_SSH_KEY: ${{ secrets.DATAHUB_LOOKML_GIT_TEST_SSH_KEY }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.11"]
         command:
           [
             "testQuick",

--- a/.github/workflows/prefect-plugin.yml
+++ b/.github/workflows/prefect-plugin.yml
@@ -32,7 +32,7 @@ jobs:
       DATAHUB_TELEMETRY_ENABLED: false
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
       fail-fast: false
     steps:
       - name: Set up JDK 17

--- a/datahub-actions/build.gradle
+++ b/datahub-actions/build.gradle
@@ -40,7 +40,7 @@ def pip_install_command = "VIRTUAL_ENV=${venv_name} ${venv_name}/bin/uv pip inst
 
 task checkPythonVersion(type: Exec) {
   commandLine python_executable, '-c',
-          'import sys; sys.version_info >= (3, 8), f"Python version {sys.version_info[:2]} not allowed"'
+          'import sys; sys.version_info >= (3, 9), f"Python version {sys.version_info[:2]} not allowed"'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/datahub-actions/setup.py
+++ b/datahub-actions/setup.py
@@ -46,9 +46,6 @@ lint_requirements = {
 
 base_requirements = {
     f"acryl-datahub[datahub-kafka]{_self_pin}",
-    # Compatibility.
-    "typing_extensions>=3.7.4; python_version < '3.8'",
-    "mypy_extensions>=0.4.3",
     # Actual dependencies.
     "typing-inspect",
     "pydantic>=2.0.0,<3.0.0",
@@ -205,10 +202,6 @@ setuptools.setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",
         "Intended Audience :: System Administrators",
@@ -222,7 +215,7 @@ setuptools.setup(
     ],
     # Package info.
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="./src"),
     package_data={

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,7 +24,7 @@ source venv/bin/activate         # activate the environment
 Once inside the virtual environment, install `datahub` using the following commands
 
 ```shell
-# Requires Python 3.8+
+# Requires Python 3.9+
 python3 -m pip install --upgrade pip wheel setuptools
 python3 -m pip install --upgrade acryl-datahub
 # validate that the install was successful

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -29,6 +29,13 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ### Breaking Changes
 
+- All DataHub Python packages now require Python 3.9+. This affects the following packages:
+  - `acryl-datahub` (DataHub CLI and SDK)
+  - `acryl-datahub-actions`
+  - `acryl-datahub-airflow-plugin`
+  - `acryl-datahub-prefect-plugin`
+  - `acryl-datahub-gx-plugin`
+  - `acryl-datahub-dagster-plugin` (already required Python 3.9+)
 - #13619: The `acryl-datahub-airflow-plugin` has dropped support for Airflow versions less than 2.7.
 
 ### Known Issues

--- a/docs/lineage/airflow.md
+++ b/docs/lineage/airflow.md
@@ -17,7 +17,7 @@ There's two implementations of the plugin, with different Airflow version suppor
 
 | Approach  | Airflow Versions | Notes                                                                                   |
 | --------- | ---------------- | --------------------------------------------------------------------------------------- |
-| Plugin v2 | 2.7+             | Recommended. Requires Python 3.8+                                                       |
+| Plugin v2 | 2.7+             | Recommended. Requires Python 3.9+                                                       |
 | Plugin v1 | 2.5 - 2.8        | Deprecated. No automatic lineage extraction; may not extract lineage if the task fails. |
 
 If you're using Airflow older than 2.5, it's possible to use the plugin with older versions of `acryl-datahub-airflow-plugin`. See the [compatibility section](#compatibility) for more details.
@@ -29,7 +29,7 @@ If you're using Airflow older than 2.5, it's possible to use the plugin with old
 
 ### Installation
 
-The v2 plugin requires Airflow 2.7+ and Python 3.8+. If you don't meet these requirements, see the [compatibility section](#compatibility) for other options.
+The v2 plugin requires Airflow 2.7+ and Python 3.9+. If you don't meet these requirements, see the [compatibility section](#compatibility) for other options.
 
 ```shell
 pip install 'acryl-datahub-airflow-plugin[plugin-v2]'
@@ -85,7 +85,7 @@ enabled = True  # default
 
 ### Installation
 
-The v1 plugin requires Airflow 2.3 - 2.8 and Python 3.8+. If you're on older versions, it's still possible to use an older version of the plugin. See the [compatibility section](#compatibility) for more details.
+The v1 plugin requires Airflow 2.3 - 2.8 and Python 3.9+. If you're on older versions, it's still possible to use an older version of the plugin. See the [compatibility section](#compatibility) for more details.
 
 Note that the v1 plugin is less featureful than the v2 plugin, and is overall not actively maintained.
 Since datahub v0.15.0, the v2 plugin has been the default. If you need to use the v1 plugin with `acryl-datahub-airflow-plugin` v0.15.0+, you must also set the environment variable `DATAHUB_AIRFLOW_PLUGIN_USE_V1_PLUGIN=true`.
@@ -386,7 +386,7 @@ This will immediately disable the plugin without requiring a restart.
 We try to support Airflow releases for ~2 years after their release. This is a best-effort guarantee - it's not always possible due to dependency / security issues cropping up in older versions.
 
 We no longer officially support Airflow <2.7. However, you can use older versions of `acryl-datahub-airflow-plugin` with older versions of Airflow.
-The first two options support Python 3.7+, and the others require Python 3.8+.
+The first two options support Python 3.7+, and latter three require Python 3.8+.
 
 - Airflow 1.10.x, use DataHub plugin v1 with acryl-datahub-airflow-plugin <= 0.9.1.0.
 - Airflow 2.0.x, use DataHub plugin v1 with acryl-datahub-airflow-plugin <= 0.11.0.1.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,7 +22,7 @@ If you're interested in a managed version, [DataHub](https://www.datahub.com) pr
   | Linux    | [Docker for Linux](https://docs.docker.com/desktop/install/linux-install/) and [Docker Compose](https://docs.docker.com/compose/install/linux/) |
 
 - **Launch the Docker engine** from command line or the desktop app.
-- Ensure you have **Python 3.8+** installed & configured. (Check using `python3 --version`).
+- Ensure you have **Python 3.9+** installed & configured. (Check using `python3 --version`).
 
 :::note Docker Resource Allocation
 

--- a/metadata-ingestion-modules/airflow-plugin/setup.py
+++ b/metadata-ingestion-modules/airflow-plugin/setup.py
@@ -146,7 +146,7 @@ setuptools.setup(
     ],
     # Package info.
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     package_data={
         "datahub_airflow_plugin": ["py.typed"],
     },

--- a/metadata-ingestion-modules/airflow-plugin/tox.ini
+++ b/metadata-ingestion-modules/airflow-plugin/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py38-airflow27, py310-airflow27, py310-airflow28, py311-airflow29, py311-airflow210
+envlist = py39-airflow27, py310-airflow27, py310-airflow28, py311-airflow29, py311-airflow210
 
 [testenv]
 use_develop = true
@@ -24,7 +24,7 @@ deps =
     airflow210: apache-airflow~=2.10.0
 
     # Respect the Airflow constraints files.
-    py38-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.8.txt
+    py39-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.9.txt
     py310-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.10.txt
     py310-airflow28: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.8.1/constraints-3.10.txt
     py311-airflow29: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt

--- a/metadata-ingestion-modules/dagster-plugin/build.gradle
+++ b/metadata-ingestion-modules/dagster-plugin/build.gradle
@@ -16,7 +16,7 @@ if (!project.hasProperty("extra_pip_requirements")) {
 def pip_install_command = "VIRTUAL_ENV=${venv_name} ${venv_name}/bin/uv pip install -e ../../metadata-ingestion"
 
 task checkPythonVersion(type: Exec) {
-  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 8)'
+  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 9)'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/metadata-ingestion-modules/gx-plugin/build.gradle
+++ b/metadata-ingestion-modules/gx-plugin/build.gradle
@@ -16,7 +16,7 @@ if (!project.hasProperty("extra_pip_requirements")) {
 def pip_install_command = "VIRTUAL_ENV=${venv_name} ${venv_name}/bin/uv pip install -e ../../metadata-ingestion"
 
 task checkPythonVersion(type: Exec) {
-  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 8)'
+  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 9)'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/metadata-ingestion-modules/gx-plugin/setup.py
+++ b/metadata-ingestion-modules/gx-plugin/setup.py
@@ -127,7 +127,7 @@ setuptools.setup(
     ],
     # Package info.
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="./src"),
     entry_points=entry_points,

--- a/metadata-ingestion-modules/prefect-plugin/README.md
+++ b/metadata-ingestion-modules/prefect-plugin/README.md
@@ -28,7 +28,7 @@ The `prefect-datahub` collection allows you to easily integrate DataHub's metada
 
 ## Prerequisites
 
-- Python 3.8+
+- Python 3.9+
 - Prefect 2.0.0+ and < 3.0.0+
 - A running instance of DataHub
 

--- a/metadata-ingestion-modules/prefect-plugin/build.gradle
+++ b/metadata-ingestion-modules/prefect-plugin/build.gradle
@@ -16,7 +16,7 @@ if (!project.hasProperty("extra_pip_requirements")) {
 def pip_install_command = "VIRTUAL_ENV=${venv_name} ${venv_name}/bin/uv pip install -e ../../metadata-ingestion"
 
 task checkPythonVersion(type: Exec) {
-  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 7)'
+  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 9)'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/metadata-ingestion-modules/prefect-plugin/setup.py
+++ b/metadata-ingestion-modules/prefect-plugin/setup.py
@@ -24,8 +24,6 @@ _self_pin = (
 rest_common = {"requests", "requests_file"}
 
 base_requirements = {
-    # For python 3.7 and importlib-metadata>=5.0.0, build failed with attribute error
-    "importlib-metadata>=4.4.0,<5.0.0; python_version < '3.8'",
     # Actual dependencies.
     # Temporary pinning to 2.0.0 until we can upgrade to 3.0.0
     "prefect >= 2.0.0,<3.0.0",
@@ -111,7 +109,7 @@ setuptools.setup(
     ],
     # Package info.
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="./src"),
     entry_points=entry_points,

--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -17,7 +17,7 @@ if (!project.hasProperty("extra_pip_requirements")) {
 
 task checkPythonVersion(type: Exec) {
   commandLine python_executable, '-c',
-    'import sys; sys.version_info >= (3, 8), f"Python version {sys.version_info[:2]} not allowed"'
+    'import sys; sys.version_info >= (3, 9), f"Python version {sys.version_info[:2]} not allowed"'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/metadata-ingestion/developing.md
+++ b/metadata-ingestion/developing.md
@@ -9,7 +9,7 @@ Also take a look at the guide to [adding a source](./adding-source.md).
 
 ### Requirements
 
-1. Python 3.8+ must be installed in your host environment.
+1. Python 3.9+ must be installed in your host environment.
 2. Java 17 (gradle won't work with newer or older versions)
 3. On Debian/Ubuntu: `sudo apt install python3-dev python3-venv`
 4. On Fedora (if using LDAP source integration): `sudo yum install openldap-devel`

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -507,10 +507,7 @@ plugins: Dict[str, Set[str]] = {
         # It's technically wrong for packages to depend on setuptools. However, it seems mlflow does it anyways.
         "setuptools",
     },
-    "datahub-debug": {
-        "dnspython==2.7.0",
-        "requests"
-    },
+    "datahub-debug": {"dnspython==2.7.0", "requests"},
     "mode": {"requests", "python-liquid", "tenacity>=8.0.1"} | sqlglot_lib,
     "mongodb": {"pymongo[srv]>=3.11", "packaging"},
     "mssql": sql_common | mssql_common,
@@ -636,7 +633,7 @@ test_api_requirements = {
     "pytest-timeout",
     # Missing numpy requirement in 8.0.0
     "deepdiff!=8.0.0",
-    "orderly-set!=5.4.0",  # 5.4.0 uses invalid types on Python 3.8
+    "orderly-set!=5.4.0",  # 5.4.0 uses invalid types on older Python versions
     "PyYAML",
     "pytest-docker>=1.1.0",
 }
@@ -949,7 +946,7 @@ See the [DataHub docs](https://docs.datahub.com/docs/metadata-ingestion).
     ],
     # Package info.
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="./src"),
     package_data={

--- a/python-build/build.gradle
+++ b/python-build/build.gradle
@@ -8,7 +8,7 @@ ext {
 
 task checkPythonVersion(type: Exec) {
   commandLine python_executable, '-c',
-    'import sys; sys.version_info >= (3, 8), f"Python version {sys.version_info} is too old"'
+    'import sys; sys.version_info >= (3, 9), f"Python version {sys.version_info} is too old"'
 }
 
 task buildWheels(type: Exec, dependsOn: [


### PR DESCRIPTION
Python 3.8 hit end of life 9 months ago, so this is long overdue. We'll probably be dropping 3.9 in a couple months once that hits end of life as well.

Changes largely based on #9731.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
