### PR TITLE
fix(bigquery): allow profiling to proceed for pseudo-partitions 

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/profiler.py
@@ -228,7 +228,14 @@ WHERE
         )
 
         # For partitioned tables, if it has a row count but not a valid partition, that means something went wrong with the partition detection.
-        if partition is None and bq_table.partition_info and bq_table.rows_count:
+        # However, if it's a pseudo-partition (column=None), we should allow profiling to proceed
+        if (
+            partition is None
+            and bq_table.partition_info
+            and bq_table.rows_count
+            and bq_table.partition_info.column
+            is not None  # Only skip if it's a real partitioned column, not a pseudo-partition
+        ):
             self.report.report_warning(
                 title="Profile skipped for partitioned table",
                 message="profile skipped as partition id or type was invalid",


### PR DESCRIPTION
## Problem
The DataHub BigQuery connector throws an error when attempting to profile external tables that have partitions defined on pseudo-columns (columns that don't exist in the actual table schema). This is a common pattern in BigQuery where partition information is derived from file paths or metadata rather than explicit columns.
## Current Behavior
Profiling fails when encountering external tables with partition configuration like: PartitionInfo(field='partition_date', column=None, type='DAY')
The profiler expects the partition column to exist in the table schema
Error occurs because the profiler tries to reference a column that doesn't exist in the data files
## fix
This fix detects pseudo-partitioned tables and allows them to be profiled
