### PR TITLE
chore(capability): remove capability summary task from pre-commit

### DIFF
--- a/.github/scripts/pre-commit-override.yaml
+++ b/.github/scripts/pre-commit-override.yaml
@@ -7,12 +7,6 @@ repos:
         language: system
         files: ^smoke-test/tests/cypress/.*\.tsx$
         pass_filenames: false
-      - id: update-capability-summary
-        name: update-capability-summary
-        entry: ./gradlew :metadata-ingestion:capabilitySummary
-        language: system
-        files: ^metadata-ingestion/src/datahub/ingestion/source/.*\.py$
-        pass_filenames: false
       - id: update-lineage-file
         name: update-lineage-file
         entry: ./gradlew :metadata-ingestion:lineageGen

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -487,13 +487,6 @@ repos:
         files: ^smoke-test/tests/cypress/.*\.tsx$
         pass_filenames: false
 
-      - id: update-capability-summary
-        name: update-capability-summary
-        entry: ./gradlew :metadata-ingestion:capabilitySummary
-        language: system
-        files: ^metadata-ingestion/src/datahub/ingestion/source/.*\.py$
-        pass_filenames: false
-
       - id: update-lineage-file
         name: update-lineage-file
         entry: ./gradlew :metadata-ingestion:lineageGen


### PR DESCRIPTION
This was too slow for pre-commit hooks. This is still checked in the CI so should be ok.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
