### PR TITLE
fix(homepage): remove default subscription module and its type references

### DIFF
--- a/datahub-graphql-core/src/main/resources/module.graphql
+++ b/datahub-graphql-core/src/main/resources/module.graphql
@@ -155,10 +155,6 @@ enum DataHubPageModuleType {
   """
   OWNED_ASSETS
   """
-  Module displaying assets subscribed to by a given user
-  """
-  SUBSCRIBED_ASSETS
-  """
   Module displaying the top domains
   """
   DOMAINS

--- a/metadata-models/src/main/pegasus/com/linkedin/module/DataHubPageModuleType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/module/DataHubPageModuleType.pdl
@@ -25,10 +25,6 @@ enum DataHubPageModuleType {
    */
   OWNED_ASSETS
   /**
-   * Module displaying assets subscribed to by a given user
-   */
-  SUBSCRIBED_ASSETS
-  /**
    * Module displaying the top domains
    */
   DOMAINS

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -44,13 +44,13 @@ bootstrap:
       mcps_location: "bootstrap_mcps/roles.yaml"
 
     - name: page-modules
-      version: v2
+      version: v3
       blocking: true
       async: false
       mcps_location: "bootstrap_mcps/page-modules.yaml"
 
     - name: page-templates
-      version: v2
+      version: v3
       blocking: true
       async: false
       mcps_location: "bootstrap_mcps/page-templates.yaml"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-modules.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-modules.yaml
@@ -13,18 +13,6 @@
     params: {}
     created: {{&auditStamp}}
     lastModified: {{&auditStamp}}
-- entityUrn: urn:li:dataHubPageModule:your_subscriptions
-  entityType: dataHubPageModule
-  aspectName: dataHubPageModuleProperties
-  changeType: UPSERT
-  aspect:
-    name: "Your Subscriptions"
-    type: SUBSCRIBED_ASSETS
-    visibility:
-      scope: GLOBAL
-    params: {}
-    created: {{&auditStamp}}
-    lastModified: {{&auditStamp}}
 - entityUrn: urn:li:dataHubPageModule:top_domains
   entityType: dataHubPageModule
   aspectName: dataHubPageModuleProperties

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-templates.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-templates.yaml
@@ -9,7 +9,6 @@
     rows:
       - modules:
         - "urn:li:dataHubPageModule:your_assets"
-        - "urn:li:dataHubPageModule:your_subscriptions"
       - modules:
         - "urn:li:dataHubPageModule:top_domains"
     surface:


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-559/remove-subscription-type-module-from-oss

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
