### PR TITLE
feat(airflow): support Airflow 3 + update deps

### DIFF
--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -49,6 +49,9 @@ jobs:
           - python-version: "3.11"
             extra_pip_requirements: "apache-airflow~=2.10.3"
             extra_pip_constraints: "-c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.3/constraints-3.11.txt"
+          - python-version: "3.11"
+            extra_pip_requirements: "apache-airflow~=3.0.2"
+            extra_pip_constraints: "-c https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.11.txt"
       fail-fast: false
     steps:
       - name: Set up JDK 17

--- a/metadata-ingestion-modules/airflow-plugin/setup.py
+++ b/metadata-ingestion-modules/airflow-plugin/setup.py
@@ -25,7 +25,7 @@ _self_pin = (
 base_requirements = {
     f"acryl-datahub[datahub-rest]{_self_pin}",
     # We require Airflow 2.7.x at minimum, to be comatible with the native Airflow Openlineage provider.
-    "apache-airflow>=2.7.0,<3",
+    "apache-airflow>=2.7.0,<3.1",
 }
 
 plugins: Dict[str, Set[str]] = {
@@ -44,7 +44,7 @@ plugins: Dict[str, Set[str]] = {
         # We remain restrictive on the versions allowed here to prevent
         # us from being broken by backwards-incompatible changes in the
         # underlying package.
-        "openlineage-airflow>=1.2.0,<=1.30.1",
+        "openlineage-airflow>=1.2.0,<=1.34.0",
     },
 }
 

--- a/metadata-ingestion-modules/airflow-plugin/tox.ini
+++ b/metadata-ingestion-modules/airflow-plugin/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39-airflow27, py310-airflow27, py310-airflow28, py311-airflow29, py311-airflow210
+envlist = py39-airflow27, py310-airflow27, py310-airflow28, py311-airflow29, py311-airflow210, py311-airflow30
 
 [testenv]
 use_develop = true
@@ -22,6 +22,7 @@ deps =
     airflow28: apache-airflow~=2.8.0
     airflow29: apache-airflow~=2.9.0
     airflow210: apache-airflow~=2.10.0
+    airflow30: apache-airflow~=3.0.2
 
     # Respect the Airflow constraints files.
     py39-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.9.txt
@@ -29,6 +30,7 @@ deps =
     py310-airflow28: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.8.1/constraints-3.10.txt
     py311-airflow29: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt
     py311-airflow210: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.3/constraints-3.11.txt
+    py311-airflow30: -c https://raw.githubusercontent.com/apache/airflow/constraints-3.0.2/constraints-3.11.txt
 
     # Before pinning to the constraint files, we previously left the dependencies
     # more open. There were a number of packages for which this caused issues.


### PR DESCRIPTION
[WIP - this is an attempt to get AI to do this upgrade for us; unclear if it'll work out]

This PR updates the `airflow-plugin` to support **Apache Airflow v3.0.x** and the latest `openlineage-airflow` version.

**Why these changes**
- **Expand Airflow compatibility**: The `apache-airflow` upper bound in `setup.py` is increased to `<3.1` to explicitly allow Airflow 3.0.x.
- **Update OpenLineage integration**: The `openlineage-airflow` upper bound in `setup.py` is updated to `1.34.0` to ensure compatibility with the current latest version.
- **Validate Airflow 3.0 support**: New test environments for Airflow 3.0.2 (Python 3.11) are added to both `tox.ini` and the Airflow CI workflow, ensuring comprehensive and consistent validation of the plugin with the new Airflow version.

These updates ensure the DataHub Airflow plugin remains compatible with the latest Airflow releases and OpenLineage integrations, providing broader support for users.

Related to https://github.com/datahub-project/datahub/issues/13357