### PR TITLE
chore(ingest/teradata): fix lint errors

### DIFF
--- a/metadata-ingestion/tests/unit/test_teradata_integration.py
+++ b/metadata-ingestion/tests/unit/test_teradata_integration.py
@@ -315,11 +315,12 @@ class TestConfigurationIntegration:
                 source = TeradataSource(config, PipelineContext(run_id="test"))
 
             # Test database filtering logic
-            with patch(
-                "datahub.ingestion.source.sql.teradata.create_engine"
-            ) as mock_create_engine, patch(
-                "datahub.ingestion.source.sql.teradata.inspect"
-            ) as mock_inspect:
+            with (
+                patch(
+                    "datahub.ingestion.source.sql.teradata.create_engine"
+                ) as mock_create_engine,
+                patch("datahub.ingestion.source.sql.teradata.inspect") as mock_inspect,
+            ):
                 mock_engine = MagicMock()
                 mock_create_engine.return_value = mock_engine
 
@@ -464,10 +465,15 @@ class TestComplexQueryScenarios:
                     mock_connection
                 )
 
-                with patch.object(
-                    source, "get_metadata_engine", return_value=mock_engine
-                ), patch.object(
-                    source, "_execute_with_cursor_fallback", return_value=mock_result
+                with (
+                    patch.object(
+                        source, "get_metadata_engine", return_value=mock_engine
+                    ),
+                    patch.object(
+                        source,
+                        "_execute_with_cursor_fallback",
+                        return_value=mock_result,
+                    ),
                 ):
                     entries = list(source._fetch_lineage_entries_chunked())
 
@@ -640,11 +646,14 @@ class TestResourceManagement:
                     mock_connection
                 )
 
-                with patch.object(
-                    source, "get_metadata_engine", return_value=mock_engine
-                ), patch.object(
-                    source, "_execute_with_cursor_fallback"
-                ) as mock_execute:
+                with (
+                    patch.object(
+                        source, "get_metadata_engine", return_value=mock_engine
+                    ),
+                    patch.object(
+                        source, "_execute_with_cursor_fallback"
+                    ) as mock_execute,
+                ):
                     # Raise exception during query execution
                     mock_execute.side_effect = Exception("Database error")
 

--- a/metadata-ingestion/tests/unit/test_teradata_performance.py
+++ b/metadata-ingestion/tests/unit/test_teradata_performance.py
@@ -251,10 +251,15 @@ class TestMemoryOptimizations:
                     mock_connection
                 )
 
-                with patch.object(
-                    source, "get_metadata_engine", return_value=mock_engine
-                ), patch.object(
-                    source, "_execute_with_cursor_fallback", return_value=mock_result
+                with (
+                    patch.object(
+                        source, "get_metadata_engine", return_value=mock_engine
+                    ),
+                    patch.object(
+                        source,
+                        "_execute_with_cursor_fallback",
+                        return_value=mock_result,
+                    ),
                 ):
                     # Process entries
                     entries = list(source._fetch_lineage_entries_chunked())

--- a/metadata-ingestion/tests/unit/test_teradata_source.py
+++ b/metadata-ingestion/tests/unit/test_teradata_source.py
@@ -489,11 +489,12 @@ class TestStageTracking:
         config = TeradataConfig.parse_obj(_base_config())
 
         # Create source without mocking to test the actual stage tracking during init
-        with patch(
-            "datahub.sql_parsing.sql_parsing_aggregator.SqlParsingAggregator"
-        ), patch(
-            "datahub.ingestion.source.sql.teradata.TeradataSource.cache_tables_and_views"
-        ) as mock_cache:
+        with (
+            patch("datahub.sql_parsing.sql_parsing_aggregator.SqlParsingAggregator"),
+            patch(
+                "datahub.ingestion.source.sql.teradata.TeradataSource.cache_tables_and_views"
+            ) as mock_cache,
+        ):
             TeradataSource(config, PipelineContext(run_id="test"))
 
             # Verify cache_tables_and_views was called during init (stage tracking happens there)
@@ -775,11 +776,14 @@ class TestLineageQuerySeparation:
                     mock_connection
                 )
 
-                with patch.object(
-                    source, "get_metadata_engine", return_value=mock_engine
-                ), patch.object(
-                    source, "_execute_with_cursor_fallback"
-                ) as mock_execute:
+                with (
+                    patch.object(
+                        source, "get_metadata_engine", return_value=mock_engine
+                    ),
+                    patch.object(
+                        source, "_execute_with_cursor_fallback"
+                    ) as mock_execute,
+                ):
                     mock_execute.side_effect = [mock_result1, mock_result2]
 
                     entries = list(source._fetch_lineage_entries_chunked())
@@ -826,11 +830,16 @@ class TestLineageQuerySeparation:
                     mock_connection
                 )
 
-                with patch.object(
-                    source, "get_metadata_engine", return_value=mock_engine
-                ), patch.object(
-                    source, "_execute_with_cursor_fallback", return_value=mock_result
-                ) as mock_execute:
+                with (
+                    patch.object(
+                        source, "get_metadata_engine", return_value=mock_engine
+                    ),
+                    patch.object(
+                        source,
+                        "_execute_with_cursor_fallback",
+                        return_value=mock_result,
+                    ) as mock_execute,
+                ):
                     entries = list(source._fetch_lineage_entries_chunked())
 
                     # Should have executed only one query
@@ -878,10 +887,15 @@ class TestLineageQuerySeparation:
                     mock_connection
                 )
 
-                with patch.object(
-                    source, "get_metadata_engine", return_value=mock_engine
-                ), patch.object(
-                    source, "_execute_with_cursor_fallback", return_value=mock_result
+                with (
+                    patch.object(
+                        source, "get_metadata_engine", return_value=mock_engine
+                    ),
+                    patch.object(
+                        source,
+                        "_execute_with_cursor_fallback",
+                        return_value=mock_result,
+                    ),
                 ):
                     entries = list(source._fetch_lineage_entries_chunked())
 
@@ -1005,11 +1019,19 @@ class TestLineageQuerySeparation:
                     mock_connection
                 )
 
-                with patch.object(
-                    source, "get_metadata_engine", return_value=mock_engine
-                ), patch.object(
-                    source, "_execute_with_cursor_fallback", return_value=mock_result
-                ), patch("datahub.ingestion.source.sql.teradata.logger") as mock_logger:
+                with (
+                    patch.object(
+                        source, "get_metadata_engine", return_value=mock_engine
+                    ),
+                    patch.object(
+                        source,
+                        "_execute_with_cursor_fallback",
+                        return_value=mock_result,
+                    ),
+                    patch(
+                        "datahub.ingestion.source.sql.teradata.logger"
+                    ) as mock_logger,
+                ):
                     list(source._fetch_lineage_entries_chunked())
 
                     # Verify progress logging for multiple queries


### PR DESCRIPTION
Looks like these were caused by the upgrade to Python 3.9, so CI didn't catch it.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
