### PR TITLE
feat(search): custom search configuration for highlighting

### DIFF
--- a/docs/how/search.md
+++ b/docs/how/search.md
@@ -541,6 +541,78 @@ autocompleteConfigurations:
       boost_mode: multiply
 ```
 
+### Field Configurations
+
+Field configurations allow you to customize which fields are included in search queries and result highlighting. Each configuration is identified by a label and can modify the default behavior using three operations:
+
+- `add` - Adds fields to the system defaults
+- `remove` - Removes fields from the system defaults
+- `replace` - Completely replaces the system default field list
+
+As of today the UI will only exercise the `default` label, however calls to graphql can refer to other labels. See graphql documentation for further details.
+
+**Note:** The `replace` operation cannot be combined with `add` or `remove`. However, `add` and `remove` can be used together.
+
+#### Field Configuration Example
+
+```yaml
+fieldConfigurations:
+  # Default configuration - if searchFlags doesn't specify
+  default:
+    searchFields:
+      remove:
+        - fieldPaths
+
+    highlightFields:
+      enabled: true
+      remove:
+        - fieldPaths
+
+  # PDL legacy configuration
+  legacy:
+    searchFields:
+    # No modifications - use PDL defaults
+
+    highlightFields:
+      enabled: true
+      # No modifications - use PDL defaults
+
+  # Configuration for technical users - adds technical fields
+  technical:
+    searchFields:
+      add:
+        - fieldPaths
+        - platform
+      remove:
+        - customProperties
+    highlightFields:
+      enabled: true
+      add:
+        - fieldPaths
+        - platform
+
+  # Configuration for business users - simplified field set
+  business:
+    searchFields:
+      replace:
+        - name
+        - description
+        - tags
+        - glossaryTerms
+    highlightFields:
+      enabled: true
+      replace:
+        - name
+        - description
+
+  # Configuration with no highlighting
+  no-highlight:
+    searchFields:
+      # Uses system defaults
+    highlightFields:
+      enabled: false
+```
+
 ## FAQ and Troubleshooting
 
 **How are the results ordered?**

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/AutocompleteRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/AutocompleteRequestHandler.java
@@ -3,11 +3,11 @@ package com.linkedin.metadata.search.elasticsearch.query.request;
 import static com.linkedin.metadata.search.utils.ESAccessControlUtil.restrictUrn;
 import static com.linkedin.metadata.search.utils.ESUtils.applyDefaultSearchFilters;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.config.ConfigUtils;
+import com.linkedin.metadata.config.search.CustomConfiguration;
 import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
 import com.linkedin.metadata.config.search.SearchServiceConfiguration;
 import com.linkedin.metadata.config.search.custom.AutocompleteConfiguration;
@@ -73,7 +73,10 @@ public class AutocompleteRequestHandler extends BaseRequestHandler {
       @Nonnull SearchServiceConfiguration searchServiceConfiguration) {
     this.entitySpec = entitySpec;
     List<SearchableFieldSpec> fieldSpecs = entitySpec.getSearchableFieldSpecs();
-    this.customizedQueryHandler = CustomizedQueryHandler.builder(customSearchConfiguration).build();
+    this.customizedQueryHandler =
+        CustomizedQueryHandler.builder(
+                searchConfiguration.getSearch().getCustom(), customSearchConfiguration)
+            .build();
     _defaultAutocompleteFields =
         Stream.concat(
                 fieldSpecs.stream()
@@ -148,8 +151,17 @@ public class AutocompleteRequestHandler extends BaseRequestHandler {
             filter, false, searchableFieldTypes, opContext, queryFilterRewriteChain);
     baseQuery.filter(filterQuery);
 
+    // Apply field configuration to autocomplete fields
+    List<Pair<String, String>> baseAutocompleteFields = getAutocompleteFields(field);
+    List<Pair<String, String>> configuredFields =
+        customizedQueryHandler.applyAutocompleteFieldConfiguration(
+            baseAutocompleteFields,
+            customizedQueryHandler.resolveFieldConfiguration(
+                opContext.getSearchContext().getSearchFlags(),
+                CustomConfiguration::getAutoCompleteFieldConfigDefault));
+
     // Add autocomplete query
-    baseQuery.should(getQuery(opContext.getObjectMapper(), customAutocompleteConfig, input, field));
+    baseQuery.should(getQuery(opContext, customAutocompleteConfig, configuredFields, input));
 
     // Apply default filters
     BoolQueryBuilder queryWithDefaultFilters =
@@ -177,33 +189,92 @@ public class AutocompleteRequestHandler extends BaseRequestHandler {
 
     ESUtils.buildSortOrder(searchSourceBuilder, null, List.of(entitySpec));
 
-    // wire inner non-scored query
-    searchSourceBuilder.highlighter(
-        field == null || field.isEmpty() ? highlights : getHighlights(opContext, List.of(field)));
+    // Apply highlight field configuration
+    HighlightBuilder highlightBuilder =
+        buildConfiguredHighlights(
+            opContext,
+            field,
+            customizedQueryHandler.resolveFieldConfiguration(
+                opContext.getSearchContext().getSearchFlags(),
+                CustomConfiguration::getAutoCompleteFieldConfigDefault));
+    if (highlightBuilder != null) {
+      searchSourceBuilder.highlighter(highlightBuilder);
+    }
+
     searchRequest.source(searchSourceBuilder);
     return searchRequest;
   }
 
+  // Helper method to build highlights with field configuration
+  private HighlightBuilder buildConfiguredHighlights(
+      @Nonnull OperationContext opContext,
+      @Nullable String field,
+      @Nullable String fieldConfigLabel) {
+
+    // Check if highlighting is enabled for this configuration
+    if (!customizedQueryHandler.isHighlightingEnabled(fieldConfigLabel)) {
+      return null;
+    }
+
+    // Determine base highlight fields
+    Set<String> baseHighlightFields;
+    if (field != null && !field.isEmpty()) {
+      baseHighlightFields = Set.of(field);
+    } else {
+      // Get default highlight fields from autocomplete fields
+      baseHighlightFields =
+          _defaultAutocompleteFields.stream().map(Pair::getLeft).collect(Collectors.toSet());
+    }
+
+    // Apply field configuration
+    HighlightConfigurationResult configResult =
+        customizedQueryHandler.getHighlightFieldConfiguration(
+            baseHighlightFields, fieldConfigLabel);
+
+    if (configResult.getFieldsToHighlight().isEmpty()) {
+      // If no fields after configuration, use the base implementation with defaults
+      return getDefaultHighlights(opContext);
+    }
+
+    // Build highlights with configured fields
+    return buildHighlightsWithSelectiveExpansion(
+        opContext,
+        configResult.getFieldsToHighlight(),
+        configResult.getExplicitlyConfiguredFields());
+  }
+
   private BoolQueryBuilder getQuery(
-      @Nonnull ObjectMapper objectMapper,
+      @Nonnull OperationContext operationContext,
       @Nullable AutocompleteConfiguration customAutocompleteConfig,
       @Nonnull String query,
       @Nullable String field) {
-    return getQuery(objectMapper, customAutocompleteConfig, getAutocompleteFields(field), query);
+    return getQuery(
+        operationContext, customAutocompleteConfig, getAutocompleteFields(field), query);
   }
 
   public BoolQueryBuilder getQuery(
-      @Nonnull ObjectMapper objectMapper,
+      @Nonnull OperationContext operationContext,
       @Nullable AutocompleteConfiguration customAutocompleteConfig,
-      List<Pair<String, String>> autocompleteFields,
+      List<Pair<String, String>> baseFields,
       @Nonnull String query) {
+
+    // Apply field configuration
+    List<Pair<String, String>> configuredFields =
+        customizedQueryHandler.applyAutocompleteFieldConfiguration(
+            baseFields,
+            customizedQueryHandler.resolveFieldConfiguration(
+                operationContext.getSearchContext().getSearchFlags(),
+                CustomConfiguration::getAutoCompleteFieldConfigDefault));
 
     BoolQueryBuilder finalQuery =
         Optional.ofNullable(customAutocompleteConfig)
-            .flatMap(cac -> CustomizedQueryHandler.boolQueryBuilder(objectMapper, cac, query))
+            .flatMap(
+                cac ->
+                    CustomizedQueryHandler.boolQueryBuilder(
+                        operationContext.getObjectMapper(), cac, query))
             .orElse(QueryBuilders.boolQuery());
 
-    getAutocompleteQuery(customAutocompleteConfig, autocompleteFields, query)
+    getAutocompleteQuery(customAutocompleteConfig, configuredFields, query)
         .ifPresent(finalQuery::should);
 
     if (!finalQuery.should().isEmpty()) {
@@ -276,6 +347,10 @@ public class AutocompleteRequestHandler extends BaseRequestHandler {
   @Override
   protected Stream<String> highlightFieldExpansion(
       @Nonnull OperationContext opContext, @Nonnull String fieldName) {
+    if (fieldName.endsWith(".*")) {
+      return Stream.of(fieldName);
+    }
+
     return Stream.concat(
         Stream.of(fieldName, fieldName + ".*", fieldName + ".ngram", fieldName + ".delimited"),
         Stream.of(ESUtils.toKeywordField(fieldName, false, opContext.getAspectRetriever())));

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/CustomizedQueryHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/CustomizedQueryHandler.java
@@ -1,16 +1,26 @@
 package com.linkedin.metadata.search.elasticsearch.query.request;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.metadata.config.search.CustomConfiguration;
 import com.linkedin.metadata.config.search.custom.AutocompleteConfiguration;
 import com.linkedin.metadata.config.search.custom.BoolQueryConfiguration;
 import com.linkedin.metadata.config.search.custom.CustomSearchConfiguration;
+import com.linkedin.metadata.config.search.custom.FieldConfiguration;
+import com.linkedin.metadata.config.search.custom.HighlightFields;
 import com.linkedin.metadata.config.search.custom.QueryConfiguration;
+import com.linkedin.metadata.config.search.custom.SearchFields;
+import com.linkedin.metadata.query.SearchFlags;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -19,6 +29,7 @@ import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentType;
@@ -40,6 +51,7 @@ public class CustomizedQueryHandler {
     X_CONTENT_REGISTRY = new NamedXContentRegistry(searchModule.getNamedXContents());
   }
 
+  @Nullable private CustomConfiguration config;
   private CustomSearchConfiguration customSearchConfiguration;
 
   @Builder.Default
@@ -191,9 +203,12 @@ public class CustomizedQueryHandler {
   }
 
   public static CustomizedQueryHandlerBuilder builder(
+      @Nonnull CustomConfiguration config,
       @Nullable CustomSearchConfiguration customSearchConfiguration) {
     CustomizedQueryHandlerBuilder builder =
         hiddenBuilder().customSearchConfiguration(customSearchConfiguration);
+
+    builder.config(config);
 
     if (customSearchConfiguration != null) {
       builder.queryConfigurations(
@@ -207,5 +222,471 @@ public class CustomizedQueryHandler {
     }
 
     return builder;
+  }
+
+  /**
+   * Apply field configuration to a set of search fields Only processes fields that actually exist
+   * as searchable
+   */
+  public Set<SearchFieldConfig> applySearchFieldConfiguration(
+      @Nonnull Set<SearchFieldConfig> baseFields, @Nullable String fieldConfigLabel) {
+
+    if (customSearchConfiguration == null
+        || customSearchConfiguration.getFieldConfigurations() == null
+        || fieldConfigLabel == null) {
+      return baseFields;
+    }
+
+    FieldConfiguration fieldConfig =
+        customSearchConfiguration.getFieldConfigurations().get(fieldConfigLabel);
+
+    if (fieldConfig == null || fieldConfig.getSearchFields() == null) {
+      return baseFields;
+    }
+
+    SearchFields searchFields = fieldConfig.getSearchFields();
+
+    // Validate configuration
+    if (!searchFields.isValid()) {
+      log.error(
+          "Invalid field configuration for label: {}. Replace cannot be used with add/remove.",
+          fieldConfigLabel);
+      return baseFields;
+    }
+
+    // Handle replace mode - only include fields that exist
+    if (!searchFields.getReplace().isEmpty()) {
+      Set<SearchFieldConfig> replacementFields =
+          createSearchFieldConfigsFromNames(searchFields.getReplace(), baseFields, true);
+
+      if (replacementFields.isEmpty()) {
+        log.warn(
+            "Field configuration replace resulted in no valid fields for label: {}. "
+                + "Using base fields instead.",
+            fieldConfigLabel);
+        return baseFields;
+      }
+
+      return replacementFields;
+    }
+
+    // Handle add/remove mode
+    // Use LinkedHashMap to preserve order and automatically handle duplicates
+    Map<String, SearchFieldConfig> resultFieldsMap =
+        baseFields.stream()
+            .collect(
+                Collectors.toMap(
+                    SearchFieldConfig::fieldName, f -> f, (v1, v2) -> v1, LinkedHashMap::new));
+
+    // Remove fields - treating field names as literals
+    if (!searchFields.getRemove().isEmpty()) {
+      for (String fieldToRemove : searchFields.getRemove()) {
+        resultFieldsMap.remove(fieldToRemove);
+      }
+    }
+
+    // Add fields - only those that exist
+    if (!searchFields.getAdd().isEmpty()) {
+      Set<SearchFieldConfig> fieldsToAdd =
+          createSearchFieldConfigsFromNames(searchFields.getAdd(), baseFields, true);
+
+      // Add fields to the map (will replace if already exists, preventing duplicates)
+      fieldsToAdd.forEach(field -> resultFieldsMap.put(field.fieldName(), field));
+    }
+
+    if (resultFieldsMap.isEmpty()) {
+      log.warn(
+          "Field configuration resulted in no searchable fields for label: {}. "
+              + "Using base fields instead.",
+          fieldConfigLabel);
+      return baseFields;
+    }
+
+    return new HashSet<>(resultFieldsMap.values());
+  }
+
+  /**
+   * Apply field configuration to autocomplete fields Only processes fields that actually exist as
+   * searchable with autocomplete enabled
+   */
+  public List<Pair<String, String>> applyAutocompleteFieldConfiguration(
+      @Nonnull List<Pair<String, String>> baseFields, @Nullable String fieldConfigLabel) {
+
+    if (customSearchConfiguration == null
+        || customSearchConfiguration.getFieldConfigurations() == null
+        || fieldConfigLabel == null) {
+      return baseFields;
+    }
+
+    FieldConfiguration fieldConfig =
+        customSearchConfiguration.getFieldConfigurations().get(fieldConfigLabel);
+
+    if (fieldConfig == null || fieldConfig.getSearchFields() == null) {
+      log.warn("No field configuration found for label: {}", fieldConfigLabel);
+      return baseFields;
+    }
+
+    SearchFields searchFields = fieldConfig.getSearchFields();
+
+    // Validate configuration
+    if (!searchFields.isValid()) {
+      log.error(
+          "Invalid field configuration for label: {}. Replace cannot be used with add/remove.",
+          fieldConfigLabel);
+      return baseFields;
+    }
+
+    // Convert to map for easier manipulation - LinkedHashMap to avoid duplicates
+    Map<String, String> baseFieldMap =
+        baseFields.stream()
+            .collect(
+                Collectors.toMap(
+                    Pair::getLeft, Pair::getRight, (v1, v2) -> v1, LinkedHashMap::new));
+
+    // Handle replace mode
+    if (!searchFields.getReplace().isEmpty()) {
+      Map<String, String> replacementFields = new LinkedHashMap<>();
+      Set<String> notFoundFields = new HashSet<>();
+
+      for (String field : searchFields.getReplace()) {
+        String boost = findBoostForField(field, baseFieldMap);
+        if (boost != null) {
+          replacementFields.put(field, boost);
+        } else {
+          notFoundFields.add(field);
+        }
+      }
+
+      if (!notFoundFields.isEmpty()) {
+        log.warn(
+            "Field configuration references non-autocomplete fields: {}. These fields will be ignored.",
+            notFoundFields);
+      }
+
+      if (replacementFields.isEmpty()) {
+        log.warn(
+            "Field configuration replace resulted in no valid autocomplete fields for label: {}. "
+                + "Using base fields instead.",
+            fieldConfigLabel);
+        return baseFields;
+      }
+
+      return replacementFields.entrySet().stream()
+          .sorted(
+              (p1, p2) -> {
+                // Sort by boost score (descending) then by field name
+                int boostCompare =
+                    Double.compare(
+                        Double.parseDouble(p2.getValue()), Double.parseDouble(p1.getValue()));
+                return boostCompare != 0 ? boostCompare : p1.getKey().compareTo(p2.getKey());
+              })
+          .map(e -> Pair.of(e.getKey(), e.getValue()))
+          .collect(Collectors.toList());
+    }
+
+    // Handle add/remove mode
+    Map<String, String> resultFieldMap = new LinkedHashMap<>(baseFieldMap);
+
+    // Remove fields - treating as literals
+    if (!searchFields.getRemove().isEmpty()) {
+      searchFields.getRemove().forEach(resultFieldMap::remove);
+    }
+
+    // Add fields
+    if (!searchFields.getAdd().isEmpty()) {
+      Set<String> notFoundFields = new HashSet<>();
+
+      for (String fieldToAdd : searchFields.getAdd()) {
+        if (!resultFieldMap.containsKey(fieldToAdd)) {
+          // Try to find boost from base fields or use default
+          String boost = findBoostForField(fieldToAdd, baseFieldMap);
+          if (boost != null) {
+            resultFieldMap.put(fieldToAdd, boost);
+          } else {
+            notFoundFields.add(fieldToAdd);
+          }
+        }
+      }
+
+      if (!notFoundFields.isEmpty()) {
+        log.warn(
+            "Cannot add non-autocomplete fields: {}. These fields will be ignored.",
+            notFoundFields);
+      }
+    }
+
+    if (resultFieldMap.isEmpty()) {
+      log.warn(
+          "Field configuration resulted in no autocomplete fields for label: {}. "
+              + "Using base fields instead.",
+          fieldConfigLabel);
+      return baseFields;
+    }
+
+    // Convert back to list of pairs
+    return resultFieldMap.entrySet().stream()
+        .map(e -> Pair.of(e.getKey(), e.getValue()))
+        .sorted(
+            (p1, p2) -> {
+              // Sort by boost score (descending) then by field name
+              int boostCompare =
+                  Double.compare(
+                      Double.parseDouble(p2.getRight()), Double.parseDouble(p1.getRight()));
+              return boostCompare != 0 ? boostCompare : p1.getLeft().compareTo(p2.getLeft());
+            })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Find boost score for a field from reference fields Checks exact match and base field patterns
+   */
+  private String findBoostForField(String fieldName, Map<String, String> referenceFields) {
+    // Check for exact match
+    if (referenceFields.containsKey(fieldName)) {
+      return referenceFields.get(fieldName);
+    }
+
+    // Check for base field (e.g., "name" for "name.delimited")
+    if (fieldName.contains(".")) {
+      String baseField = fieldName.substring(0, fieldName.indexOf("."));
+      if (referenceFields.containsKey(baseField)) {
+        return referenceFields.get(baseField);
+      }
+    }
+
+    // Check if this field is a known subfield pattern
+    for (Map.Entry<String, String> entry : referenceFields.entrySet()) {
+      String refField = entry.getKey();
+      // Check if fieldName is a subfield of refField
+      if (fieldName.startsWith(refField + ".")) {
+        return entry.getValue();
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Get highlight field configuration with tracking of explicitly configured fields. This method
+   * returns both the fields to highlight and which fields were explicitly configured.
+   */
+  public HighlightConfigurationResult getHighlightFieldConfiguration(
+      @Nonnull Set<String> baseFields, @Nullable String fieldConfigLabel) {
+
+    if (customSearchConfiguration == null || fieldConfigLabel == null) {
+      return HighlightConfigurationResult.builder()
+          .fieldsToHighlight(baseFields)
+          .explicitlyConfiguredFields(Collections.emptySet())
+          .build();
+    }
+
+    FieldConfiguration fieldConfig =
+        customSearchConfiguration.getFieldConfigurations().get(fieldConfigLabel);
+
+    if (fieldConfig == null || fieldConfig.getHighlightFields() == null) {
+      return HighlightConfigurationResult.builder()
+          .fieldsToHighlight(baseFields)
+          .explicitlyConfiguredFields(Collections.emptySet())
+          .build();
+    }
+
+    HighlightFields highlightFields = fieldConfig.getHighlightFields();
+    Set<String> explicitlyConfiguredFields = new HashSet<>();
+
+    // Handle replace mode
+    if (!highlightFields.getReplace().isEmpty()) {
+      explicitlyConfiguredFields.addAll(highlightFields.getReplace());
+      return HighlightConfigurationResult.builder()
+          .fieldsToHighlight(new HashSet<>(highlightFields.getReplace()))
+          .explicitlyConfiguredFields(explicitlyConfiguredFields)
+          .build();
+    }
+
+    // Handle add/remove mode
+    Set<String> resultFields = new HashSet<>(baseFields);
+
+    if (!highlightFields.getRemove().isEmpty()) {
+      Set<String> expandedFieldsToRemove =
+          expandFieldPatterns(highlightFields.getRemove(), baseFields);
+      resultFields.removeAll(expandedFieldsToRemove);
+    }
+
+    if (!highlightFields.getAdd().isEmpty()) {
+      explicitlyConfiguredFields.addAll(highlightFields.getAdd());
+      resultFields.addAll(highlightFields.getAdd());
+    }
+
+    return HighlightConfigurationResult.builder()
+        .fieldsToHighlight(resultFields)
+        .explicitlyConfiguredFields(explicitlyConfiguredFields)
+        .build();
+  }
+
+  /**
+   * Apply highlight field configuration. Uses LinkedHashSet to maintain order while preventing
+   * duplicates.
+   */
+  public Set<String> applyHighlightFieldConfiguration(
+      @Nonnull Set<String> baseFields, @Nullable String fieldConfigLabel) {
+
+    if (customSearchConfiguration == null || fieldConfigLabel == null) {
+      return baseFields;
+    }
+
+    FieldConfiguration fieldConfig =
+        customSearchConfiguration.getFieldConfigurations().get(fieldConfigLabel);
+
+    if (fieldConfig == null || fieldConfig.getHighlightFields() == null) {
+      return baseFields;
+    }
+
+    HighlightFields highlightFields = fieldConfig.getHighlightFields();
+
+    // Handle replace mode
+    if (!highlightFields.getReplace().isEmpty()) {
+      // LinkedHashSet maintains insertion order and prevents duplicates
+      return new LinkedHashSet<>(highlightFields.getReplace());
+    }
+
+    // Handle add/remove mode
+    Set<String> resultFields = new LinkedHashSet<>(baseFields);
+
+    if (!highlightFields.getRemove().isEmpty()) {
+      resultFields.removeAll(highlightFields.getRemove());
+    }
+
+    if (!highlightFields.getAdd().isEmpty()) {
+      resultFields.addAll(highlightFields.getAdd());
+    }
+
+    return resultFields;
+  }
+
+  /** Check if highlighting is enabled for a configuration */
+  public boolean isHighlightingEnabled(@Nullable String fieldConfigLabel) {
+    if (customSearchConfiguration == null || fieldConfigLabel == null) {
+      return true; // Default enabled
+    }
+
+    FieldConfiguration fieldConfig =
+        customSearchConfiguration.getFieldConfigurations().get(fieldConfigLabel);
+
+    if (fieldConfig == null || fieldConfig.getHighlightFields() == null) {
+      return true; // Default enabled
+    }
+
+    return fieldConfig.getHighlightFields().isEnabled();
+  }
+
+  public String resolveFieldConfiguration(
+      @Nullable SearchFlags searchFlags, Function<CustomConfiguration, String> labelFunction) {
+    if (searchFlags == null || searchFlags.getFieldConfiguration() == null) {
+      return config != null ? labelFunction.apply(config) : null;
+    }
+    return searchFlags.getFieldConfiguration();
+  }
+
+  /**
+   * Create SearchFieldConfig objects from field names Only returns configs for fields that exist in
+   * the reference set
+   *
+   * @param forceQueryByDefault if true, sets queryByDefault=true for explicitly configured fields
+   */
+  /**
+   * Create SearchFieldConfig objects from field names Only returns configs for fields that exist in
+   * the reference set
+   *
+   * @param forceQueryByDefault if true, sets queryByDefault=true for explicitly configured fields
+   */
+  private Set<SearchFieldConfig> createSearchFieldConfigsFromNames(
+      List<String> fieldNames,
+      Set<SearchFieldConfig> referenceFields,
+      boolean forceQueryByDefault) {
+
+    Map<String, SearchFieldConfig> referenceMap =
+        referenceFields.stream()
+            .collect(Collectors.toMap(SearchFieldConfig::fieldName, f -> f, (v1, v2) -> v1));
+
+    // Use LinkedHashMap to preserve order and avoid duplicates
+    Map<String, SearchFieldConfig> resultMap = new LinkedHashMap<>();
+    Set<String> notFoundFields = new HashSet<>();
+
+    for (String fieldName : fieldNames) {
+      SearchFieldConfig fieldConfig = findReferenceField(fieldName, referenceMap);
+      if (fieldConfig != null) {
+        // Only force queryByDefault for explicitly configured fields
+        if (forceQueryByDefault && !fieldConfig.isQueryByDefault()) {
+          fieldConfig = fieldConfig.toBuilder().isQueryByDefault(true).build();
+          log.debug("Setting queryByDefault=true for explicitly configured field: {}", fieldName);
+        }
+        // Using map ensures no duplicates by field name
+        resultMap.put(fieldConfig.fieldName(), fieldConfig);
+      } else {
+        notFoundFields.add(fieldName);
+      }
+    }
+
+    if (!notFoundFields.isEmpty()) {
+      log.warn(
+          "Field configuration references non-searchable fields: {}. These fields will be ignored.",
+          notFoundFields);
+    }
+
+    return new HashSet<>(resultMap.values());
+  }
+
+  /**
+   * Expand field patterns (e.g., "schema.*") to actual field names and validate they exist in
+   * available fields.
+   *
+   * @param patterns List of field patterns, can include wildcards like "schema.*"
+   * @param availableFields Set of valid field names to match against
+   * @return Expanded set of field names, excluding any patterns that don't match
+   */
+  private Set<String> expandFieldPatterns(List<String> patterns, Set<String> availableFields) {
+    Set<String> expanded = new HashSet<>();
+    Set<String> notFoundPatterns = new HashSet<>();
+
+    for (String pattern : patterns) {
+      if (pattern.endsWith(".*")) {
+        String prefix = pattern.substring(0, pattern.length() - 2);
+        Set<String> matchedFields =
+            availableFields.stream()
+                .filter(field -> field.startsWith(prefix + "."))
+                .collect(Collectors.toSet());
+
+        if (matchedFields.isEmpty()) {
+          notFoundPatterns.add(pattern);
+        } else {
+          expanded.addAll(matchedFields);
+        }
+      } else {
+        if (availableFields.contains(pattern)) {
+          expanded.add(pattern);
+        } else {
+          notFoundPatterns.add(pattern);
+        }
+      }
+    }
+
+    if (!notFoundPatterns.isEmpty()) {
+      log.warn(
+          "Field configuration contains patterns that don't match any searchable fields: {}. "
+              + "These patterns will be ignored.",
+          notFoundPatterns);
+    }
+
+    return expanded;
+  }
+
+  private SearchFieldConfig findReferenceField(
+      String fieldName, Map<String, SearchFieldConfig> referenceMap) {
+    // Direct match
+    if (referenceMap.containsKey(fieldName)) {
+      return referenceMap.get(fieldName);
+    }
+    // Check if it's a subfield
+    String baseField = fieldName.split("\\.")[0];
+    return referenceMap.get(baseField);
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/HighlightConfigurationResult.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/HighlightConfigurationResult.java
@@ -1,0 +1,24 @@
+package com.linkedin.metadata.search.elasticsearch.query.request;
+
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Result of applying highlight field configuration. Contains both the fields to highlight and which
+ * fields were explicitly configured.
+ */
+@Getter
+@Builder
+public class HighlightConfigurationResult {
+
+  /** The final set of fields that should be highlighted */
+  @NonNull private final Set<String> fieldsToHighlight;
+
+  /**
+   * Fields that were explicitly configured via 'add' or 'replace' operations. These fields should
+   * not have field expansion applied.
+   */
+  @NonNull private final Set<String> explicitlyConfiguredFields;
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchFieldConfig.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchFieldConfig.java
@@ -19,7 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @Accessors(fluent = true)
 @EqualsAndHashCode

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -17,6 +17,7 @@ import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.schema.MapDataSchema;
 import com.linkedin.data.template.DoubleMap;
 import com.linkedin.metadata.config.ConfigUtils;
+import com.linkedin.metadata.config.search.CustomConfiguration;
 import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
 import com.linkedin.metadata.config.search.SearchServiceConfiguration;
 import com.linkedin.metadata.config.search.custom.CustomSearchConfiguration;
@@ -53,6 +54,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,7 +94,7 @@ public class SearchRequestHandler extends BaseRequestHandler {
   private final SearchQueryBuilder searchQueryBuilder;
   private final AggregationQueryBuilder aggregationQueryBuilder;
   private final Map<String, Set<SearchableAnnotation.FieldType>> searchableFieldTypes;
-
+  private final CustomizedQueryHandler customizedQueryHandler;
   private final QueryFilterRewriteChain queryFilterRewriteChain;
 
   private SearchRequestHandler(
@@ -134,6 +136,9 @@ public class SearchRequestHandler extends BaseRequestHandler {
     this.searchableFieldTypes =
         buildSearchableFieldTypes(opContext.getEntityRegistry(), entitySpecs);
     this.queryFilterRewriteChain = queryFilterRewriteChain;
+    this.customizedQueryHandler =
+        CustomizedQueryHandler.builder(configs.getSearch().getCustom(), customSearchConfiguration)
+            .build();
   }
 
   public static SearchRequestHandler getBuilder(
@@ -260,12 +265,9 @@ public class SearchRequestHandler extends BaseRequestHandler {
           .forEach(searchSourceBuilder::aggregation);
     }
     if (Boolean.FALSE.equals(searchFlags.isSkipHighlighting())) {
-      if (CollectionUtils.isNotEmpty(searchFlags.getCustomHighlightingFields())) {
-        searchSourceBuilder.highlighter(
-            getHighlights(opContext, searchFlags.getCustomHighlightingFields()));
-      } else {
-        searchSourceBuilder.highlighter(highlights);
-      }
+      // Apply custom highlight configuration
+      HighlightBuilder highlightBuilder = getHighlightBuilder(opContext, searchFlags);
+      searchSourceBuilder.highlighter(highlightBuilder);
     }
 
     ESUtils.buildSortOrder(searchSourceBuilder, sortCriteria, entitySpecs);
@@ -325,7 +327,9 @@ public class SearchRequestHandler extends BaseRequestHandler {
           .forEach(searchSourceBuilder::aggregation);
     }
     if (Boolean.FALSE.equals(searchFlags.isSkipHighlighting())) {
-      searchSourceBuilder.highlighter(highlights);
+      // Apply custom highlight configuration
+      HighlightBuilder highlightBuilder = getHighlightBuilder(opContext, searchFlags);
+      searchSourceBuilder.highlighter(highlightBuilder);
     }
     ESUtils.buildSortOrder(searchSourceBuilder, sortCriteria, entitySpecs);
     searchRequest.source(searchSourceBuilder);
@@ -402,6 +406,12 @@ public class SearchRequestHandler extends BaseRequestHandler {
   @Override
   protected Stream<String> highlightFieldExpansion(
       @Nonnull OperationContext opContext, @Nonnull String fieldName) {
+    // If the field already ends with .*, don't expand it further
+    if (fieldName.endsWith(".*")) {
+      return Stream.of(fieldName);
+    }
+
+    // For normal fields, expand as before
     return Stream.of(fieldName, fieldName + ".*");
   }
 
@@ -507,6 +517,50 @@ public class SearchRequestHandler extends BaseRequestHandler {
         .collect(Collectors.toList());
   }
 
+  private HighlightBuilder getHighlightBuilder(
+      @Nonnull OperationContext opContext, @Nonnull SearchFlags searchFlags) {
+
+    // Get field configuration label
+    String fieldConfigLabel =
+        customizedQueryHandler.resolveFieldConfiguration(
+            searchFlags, CustomConfiguration::getSearchFieldConfigDefault);
+
+    // Check if highlighting is enabled for this configuration
+    if (!customizedQueryHandler.isHighlightingEnabled(fieldConfigLabel)) {
+      return new HighlightBuilder().numOfFragments(0); // Effectively disable highlighting
+    }
+
+    // Determine base fields to highlight
+    Set<String> baseHighlightFields;
+    Set<String> explicitlyConfigured = Set.of();
+
+    if (CollectionUtils.isNotEmpty(searchFlags.getCustomHighlightingFields())) {
+      // If custom highlighting fields are specified in search flags, use them as base
+      // Use LinkedHashSet to prevent duplicates while maintaining order
+      baseHighlightFields = new LinkedHashSet<>(searchFlags.getCustomHighlightingFields());
+    } else {
+      // Otherwise use default query fields with expansion
+      // LinkedHashSet prevents duplicates from expansion
+      baseHighlightFields =
+          defaultQueryFieldNames.stream()
+              .flatMap(field -> highlightFieldExpansion(opContext, field))
+              .collect(Collectors.toCollection(LinkedHashSet::new));
+
+      // Apply custom highlight field configuration only when not using custom fields from search
+      // flags
+      HighlightConfigurationResult highlightConfig =
+          customizedQueryHandler.getHighlightFieldConfiguration(
+              baseHighlightFields, fieldConfigLabel);
+
+      baseHighlightFields = highlightConfig.getFieldsToHighlight();
+      explicitlyConfigured = highlightConfig.getExplicitlyConfiguredFields();
+    }
+
+    // Build highlights with the configured fields using the existing method from BaseRequestHandler
+    return buildHighlightsWithSelectiveExpansion(
+        opContext, baseHighlightFields, explicitlyConfigured);
+  }
+
   @Nonnull
   private Optional<String> getFieldName(String matchedField) {
     return defaultQueryFieldNames.stream().filter(matchedField::startsWith).findFirst();
@@ -601,7 +655,7 @@ public class SearchRequestHandler extends BaseRequestHandler {
   /**
    * Calculate the field types based on annotations if available, with fallback to ES mappings
    *
-   * @param entitySpecs entitySepcts
+   * @param entitySpecs entitySpecs
    * @return Field name to annotation field types
    */
   private static Map<String, Set<SearchableAnnotation.FieldType>> buildSearchableFieldTypes(

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/SearchDAOTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/SearchDAOTestBase.java
@@ -6,23 +6,29 @@ import static com.linkedin.metadata.search.fixtures.SampleDataFixtureTestBase.MA
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static com.linkedin.metadata.utils.SearchUtil.AGGREGATION_SEPARATOR_CHAR;
 import static com.linkedin.metadata.utils.SearchUtil.ES_INDEX_FIELD;
+import static com.linkedin.metadata.utils.SearchUtil.INDEX_VIRTUAL_FIELD;
 import static io.datahubproject.test.search.SearchTestUtils.TEST_ES_SEARCH_CONFIG;
 import static io.datahubproject.test.search.SearchTestUtils.TEST_SEARCH_SERVICE_CONFIG;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import com.linkedin.data.template.LongMap;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.config.search.SearchConfiguration;
 import com.linkedin.metadata.config.search.custom.CustomSearchConfiguration;
+import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
 import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.SortCriterion;
+import com.linkedin.metadata.query.filter.SortOrder;
 import com.linkedin.metadata.search.AggregationMetadata;
 import com.linkedin.metadata.search.AggregationMetadataArray;
 import com.linkedin.metadata.search.FilterValueArray;
@@ -37,11 +43,15 @@ import io.datahubproject.metadata.context.OperationContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Triple;
 import org.opensearch.action.explain.ExplainResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.index.query.BoolQueryBuilder;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
@@ -451,6 +461,58 @@ public abstract class SearchDAOTestBase extends AbstractTestNGSpringContextTests
     assertEquals(explainResponse.getExplanation().getValue(), 1.25f);
   }
 
+  @Test
+  public void testFilterTransform() {
+    ESSearchDAO esSearchDAO = getESSearchDao();
+    Filter testFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    new ConjunctiveCriterion()
+                        .setAnd(
+                            new CriterionArray(
+                                new Criterion()
+                                    .setField(INDEX_VIRTUAL_FIELD)
+                                    .setCondition(Condition.EQUAL)
+                                    .setValues(new StringArray(List.of("DATASET")))))));
+
+    Triple<SearchRequest, Filter, List<EntitySpec>> searchReq =
+        esSearchDAO.buildSearchRequest(
+            getOperationContext(),
+            List.of("dataset"),
+            "*",
+            testFilter,
+            List.of(new SortCriterion().setField("urn").setOrder(SortOrder.ASCENDING)),
+            0,
+            10,
+            List.of());
+    assertNotEquals(searchReq.getMiddle(), testFilter);
+    assertFalse(
+        ((BoolQueryBuilder) searchReq.getLeft().source().query())
+            .filter()
+            .toString()
+            .contains(INDEX_VIRTUAL_FIELD));
+
+    Triple<SearchRequest, Filter, List<EntitySpec>> scrollReq =
+        esSearchDAO.buildScrollRequest(
+            getOperationContext(),
+            getOperationContext().getSearchContext().getIndexConvention(),
+            null,
+            null,
+            List.of("dataset"),
+            10,
+            testFilter,
+            "*",
+            List.of(new SortCriterion().setField("urn").setOrder(SortOrder.ASCENDING)),
+            List.of());
+    assertNotEquals(scrollReq.getMiddle(), testFilter);
+    assertFalse(
+        ((BoolQueryBuilder) scrollReq.getLeft().source().query())
+            .filter()
+            .toString()
+            .contains(INDEX_VIRTUAL_FIELD));
+  }
+
   /**
    * Ensure default search configuration matches the test fixture configuration (allowing for some
    * differences)
@@ -477,5 +539,262 @@ public abstract class SearchDAOTestBase extends AbstractTestNGSpringContextTests
         .remove(1);
 
     assertEquals(fixtureConfig, defaultConfig);
+  }
+
+  @Test
+  public void testBuildSearchRequestRemovesEntityTypeFilter() {
+    // Create a filter with _entityType criterion
+    Criterion entityTypeCriterion = buildCriterion("_entityType", Condition.EQUAL, "dataset");
+    Criterion tagCriterion = buildCriterion("tags.keyword", Condition.EQUAL, "urn:li:tag:test");
+
+    Filter originalFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    new ConjunctiveCriterion()
+                        .setAnd(new CriterionArray(entityTypeCriterion, tagCriterion))));
+
+    // Build search request
+    Triple<SearchRequest, Filter, List<EntitySpec>> result =
+        getESSearchDao()
+            .buildSearchRequest(
+                getOperationContext(),
+                Arrays.asList("dataset"),
+                "test query",
+                originalFilter,
+                Collections.emptyList(),
+                0,
+                10,
+                Arrays.asList("tags"));
+
+    // Verify the transformed filter (middle) has _entityType replaced with _index
+    Filter transformedFilter = result.getMiddle();
+    assertNotNull(transformedFilter);
+    assertNotEquals(originalFilter, transformedFilter);
+
+    // Check that _entityType is not present in transformed filter
+    boolean hasEntityTypeField =
+        transformedFilter.getOr().stream()
+            .flatMap(cc -> cc.getAnd().stream())
+            .anyMatch(criterion -> "_entityType".equals(criterion.getField()));
+    assertFalse(hasEntityTypeField, "Transformed filter should not contain _entityType field");
+
+    // Check that _index field is present instead
+    boolean hasIndexField =
+        transformedFilter.getOr().stream()
+            .flatMap(cc -> cc.getAnd().stream())
+            .anyMatch(criterion -> ES_INDEX_FIELD.equals(criterion.getField()));
+    assertTrue(hasIndexField, "Transformed filter should contain _index field");
+
+    // Verify the SearchRequest and EntitySpecs are not null
+    assertNotNull(result.getLeft());
+    assertNotNull(result.getRight());
+    assertEquals(result.getRight().size(), 1);
+  }
+
+  @Test
+  public void testBuildSearchRequestMultipleEntityTypes() {
+    // Create a filter with multiple entity types
+    Criterion entityTypeCriterion1 = buildCriterion("_entityType", Condition.EQUAL, "dataset");
+    Criterion entityTypeCriterion2 = buildCriterion("_entityType", Condition.EQUAL, "chart");
+
+    Filter originalFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    new ConjunctiveCriterion().setAnd(new CriterionArray(entityTypeCriterion1)),
+                    new ConjunctiveCriterion().setAnd(new CriterionArray(entityTypeCriterion2))));
+
+    Triple<SearchRequest, Filter, List<EntitySpec>> result =
+        getESSearchDao()
+            .buildSearchRequest(
+                getOperationContext(),
+                Arrays.asList("dataset", "chart"),
+                "*",
+                originalFilter,
+                Collections.emptyList(),
+                0,
+                20,
+                Collections.emptyList());
+
+    // Verify all _entityType criteria are transformed
+    Filter transformedFilter = result.getMiddle();
+    boolean hasEntityTypeField =
+        transformedFilter.getOr().stream()
+            .flatMap(cc -> cc.getAnd().stream())
+            .anyMatch(criterion -> "_entityType".equals(criterion.getField()));
+    assertFalse(hasEntityTypeField, "No _entityType fields should remain after transformation");
+
+    // Verify entity specs match requested entities
+    assertEquals(result.getRight().size(), 2);
+  }
+
+  @Test
+  public void testBuildSearchRequestWithSortCriteria() {
+    SortCriterion sortByName =
+        new SortCriterion().setField("name.keyword").setOrder(SortOrder.ASCENDING);
+
+    SortCriterion sortByLastModified =
+        new SortCriterion().setField("lastModified").setOrder(SortOrder.DESCENDING);
+
+    List<SortCriterion> sortCriteria = Arrays.asList(sortByName, sortByLastModified);
+
+    Triple<SearchRequest, Filter, List<EntitySpec>> result =
+        getESSearchDao()
+            .buildSearchRequest(
+                getOperationContext(),
+                Arrays.asList("dataset"),
+                "search term",
+                null,
+                sortCriteria,
+                10,
+                50,
+                Arrays.asList("owners", "tags"));
+
+    assertNotNull(result.getLeft());
+    assertNotNull(result.getLeft().source());
+    // Verify sort criteria are applied to the search request
+    assertNotNull(result.getLeft().source().sorts());
+    assertEquals(
+        result.getLeft().source().sorts().size(),
+        sortCriteria.size() + 1); // +1 for default _score sort
+  }
+
+  @Test
+  public void testBuildScrollRequestRemovesEntityTypeFilter() {
+    Criterion entityTypeCriterion = buildCriterion("_entityType", Condition.EQUAL, "dataset");
+    Criterion ownerCriterion = buildCriterion("owners", Condition.EQUAL, "urn:li:corpuser:test");
+
+    Filter originalFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    new ConjunctiveCriterion()
+                        .setAnd(new CriterionArray(entityTypeCriterion, ownerCriterion))));
+
+    Triple<SearchRequest, Filter, List<EntitySpec>> result =
+        getESSearchDao()
+            .buildScrollRequest(
+                getOperationContext(),
+                getOperationContext().getSearchContext().getIndexConvention(),
+                null, // no scrollId
+                "5m",
+                Arrays.asList("dataset"),
+                25,
+                originalFilter,
+                "test",
+                Collections.emptyList(),
+                Arrays.asList("owners"));
+
+    // Verify filter transformation
+    Filter transformedFilter = result.getMiddle();
+    assertNotNull(transformedFilter);
+
+    boolean hasEntityTypeField =
+        transformedFilter.getOr().stream()
+            .flatMap(cc -> cc.getAnd().stream())
+            .anyMatch(criterion -> "_entityType".equals(criterion.getField()));
+    assertFalse(hasEntityTypeField, "Transformed filter should not contain _entityType");
+
+    boolean hasOwnerField =
+        transformedFilter.getOr().stream()
+            .flatMap(cc -> cc.getAnd().stream())
+            .anyMatch(criterion -> "owners".equals(criterion.getField()));
+    assertTrue(hasOwnerField, "Other criteria should be preserved");
+  }
+
+  @Test
+  public void testBuildScrollRequestComplexFilter() {
+    // Complex filter with nested conditions and entity type
+    Criterion entityTypeCriterion =
+        buildCriterion("_entityType", Condition.EQUAL, "dataset", "chart");
+    Criterion platformCriterion =
+        buildCriterion("platform", Condition.EQUAL, "urn:li:dataPlatform:hive");
+    Criterion tagCriterion = buildCriterion("tags", Condition.CONTAIN, "urn:li:tag:pii");
+
+    ConjunctiveCriterion cc1 =
+        new ConjunctiveCriterion()
+            .setAnd(new CriterionArray(entityTypeCriterion, platformCriterion));
+
+    ConjunctiveCriterion cc2 = new ConjunctiveCriterion().setAnd(new CriterionArray(tagCriterion));
+
+    Filter complexFilter = new Filter().setOr(new ConjunctiveCriterionArray(cc1, cc2));
+
+    Triple<SearchRequest, Filter, List<EntitySpec>> result =
+        getESSearchDao()
+            .buildScrollRequest(
+                getOperationContext(),
+                getOperationContext().getSearchContext().getIndexConvention(),
+                null,
+                "10m",
+                Arrays.asList("dataset", "chart"),
+                50,
+                complexFilter,
+                "*",
+                Arrays.asList(new SortCriterion().setField("urn").setOrder(SortOrder.ASCENDING)),
+                Arrays.asList("platform", "tags"));
+
+    // Verify complex filter transformation
+    Filter transformedFilter = result.getMiddle();
+    assertNotNull(transformedFilter);
+    assertEquals(transformedFilter.getOr().size(), 2);
+
+    // First conjunctive criterion should have _entityType transformed to _index
+    ConjunctiveCriterion transformedCc1 = transformedFilter.getOr().get(0);
+    boolean hasIndexInFirstCC =
+        transformedCc1.getAnd().stream()
+            .anyMatch(criterion -> ES_INDEX_FIELD.equals(criterion.getField()));
+    assertTrue(hasIndexInFirstCC, "First CC should have _index field");
+
+    boolean hasPlatformInFirstCC =
+        transformedCc1.getAnd().stream()
+            .anyMatch(criterion -> "platform".equals(criterion.getField()));
+    assertTrue(hasPlatformInFirstCC, "Platform criterion should be preserved");
+
+    // Second conjunctive criterion should remain unchanged
+    ConjunctiveCriterion transformedCc2 = transformedFilter.getOr().get(1);
+    assertEquals(transformedCc2.getAnd().size(), 1);
+    assertEquals(transformedCc2.getAnd().get(0).getField(), "tags");
+  }
+
+  @Test
+  public void testBuildSearchRequestNullFilter() {
+    Triple<SearchRequest, Filter, List<EntitySpec>> result =
+        getESSearchDao()
+            .buildSearchRequest(
+                getOperationContext(),
+                Arrays.asList("dataset"),
+                "test",
+                null,
+                Collections.emptyList(),
+                0,
+                10,
+                Collections.emptyList());
+
+    // When filter is null, transformed filter should also be null
+    assertEquals(result.getMiddle(), null);
+    assertNotNull(result.getLeft());
+    assertNotNull(result.getRight());
+  }
+
+  @Test
+  public void testBuildSearchRequestEmptyInput() {
+    // Test with empty input string - should be converted to "*"
+    Triple<SearchRequest, Filter, List<EntitySpec>> result =
+        getESSearchDao()
+            .buildSearchRequest(
+                getOperationContext(),
+                Arrays.asList("glossaryterm"),
+                "", // empty input
+                null,
+                Collections.emptyList(),
+                0,
+                10,
+                Arrays.asList("glossaryTerms"));
+
+    assertNotNull(result.getLeft());
+    // Verify that the query was built (empty string should be converted to "*")
+    assertNotNull(result.getLeft().source());
+    assertNotNull(result.getLeft().source().query());
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/AutocompleteRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/AutocompleteRequestHandlerTest.java
@@ -5,11 +5,16 @@ import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static io.datahubproject.test.search.SearchTestUtils.TEST_ES_SEARCH_CONFIG;
 import static io.datahubproject.test.search.SearchTestUtils.TEST_SEARCH_SERVICE_CONFIG;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.linkedin.metadata.TestEntitySpecBuilder;
+import com.linkedin.metadata.config.search.CustomConfiguration;
 import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
 import com.linkedin.metadata.config.search.ExactMatchConfiguration;
 import com.linkedin.metadata.config.search.PartialConfiguration;
@@ -18,11 +23,17 @@ import com.linkedin.metadata.config.search.WordGramConfiguration;
 import com.linkedin.metadata.config.search.custom.AutocompleteConfiguration;
 import com.linkedin.metadata.config.search.custom.BoolQueryConfiguration;
 import com.linkedin.metadata.config.search.custom.CustomSearchConfiguration;
+import com.linkedin.metadata.config.search.custom.FieldConfiguration;
+import com.linkedin.metadata.config.search.custom.HighlightFields;
 import com.linkedin.metadata.config.search.custom.QueryConfiguration;
+import com.linkedin.metadata.config.search.custom.SearchFields;
 import com.linkedin.metadata.config.shared.LimitConfig;
 import com.linkedin.metadata.config.shared.ResultsLimitConfig;
 import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.SearchableFieldSpec;
+import com.linkedin.metadata.models.annotation.SearchableAnnotation;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
@@ -31,7 +42,9 @@ import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
 import com.linkedin.metadata.search.elasticsearch.query.request.AutocompleteRequestHandler;
+import com.linkedin.metadata.search.elasticsearch.query.request.CustomizedQueryHandler;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.SearchContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.HashSet;
 import java.util.List;
@@ -39,6 +52,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -180,15 +194,23 @@ public class AutocompleteRequestHandlerTest {
     HighlightBuilder highlightBuilder = sourceBuilder.highlighter();
     List<HighlightBuilder.Field> highlightedFields = highlightBuilder.fields();
     assertEquals(highlightedFields.size(), 9);
-    assertEquals(highlightedFields.get(0).name(), "keyPart1");
-    assertEquals(highlightedFields.get(1).name(), "keyPart1.*");
-    assertEquals(highlightedFields.get(2).name(), "keyPart1.ngram");
-    assertEquals(highlightedFields.get(3).name(), "keyPart1.delimited");
-    assertEquals(highlightedFields.get(4).name(), "keyPart1.keyword");
-    assertEquals(highlightedFields.get(5).name(), "urn");
-    assertEquals(highlightedFields.get(6).name(), "urn.*");
-    assertEquals(highlightedFields.get(7).name(), "urn.ngram");
-    assertEquals(highlightedFields.get(8).name(), "urn.delimited");
+
+    Set<String> expectedFields =
+        Set.of(
+            "keyPart1",
+            "keyPart1.*",
+            "keyPart1.ngram",
+            "keyPart1.delimited",
+            "keyPart1.keyword",
+            "urn",
+            "urn.*",
+            "urn.ngram",
+            "urn.delimited");
+
+    Set<String> highlightFieldNames =
+        highlightedFields.stream().map(HighlightBuilder.Field::name).collect(Collectors.toSet());
+
+    assertEquals(expectedFields, highlightFieldNames);
   }
 
   @Test
@@ -739,5 +761,395 @@ public class AutocompleteRequestHandlerTest {
       // Expected exception
       assertTrue(e.getMessage().contains("Result count exceeds limit of 50"));
     }
+  }
+
+  @Test
+  public void testAutocompleteWithFieldConfiguration() {
+    // Create custom configuration with field configurations
+    CustomSearchConfiguration customConfig =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "minimal",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder().replace(List.of("keyPart1", "urn")).build())
+                        .build()))
+            .build();
+
+    AutocompleteRequestHandler configHandler =
+        AutocompleteRequestHandler.getBuilder(
+            mockOpContext,
+            TestEntitySpecBuilder.getSpec(),
+            customConfig,
+            QueryFilterRewriteChain.EMPTY,
+            testQueryConfig,
+            TEST_SEARCH_SERVICE_CONFIG);
+
+    // Create operation context with field configuration
+    OperationContext opContextWithConfig = mock(OperationContext.class);
+    SearchContext searchContext = mock(SearchContext.class);
+    SearchFlags searchFlags = new SearchFlags().setFieldConfiguration("minimal");
+
+    when(opContextWithConfig.getEntityRegistry()).thenReturn(mockOpContext.getEntityRegistry());
+    when(opContextWithConfig.getObjectMapper()).thenReturn(mockOpContext.getObjectMapper());
+    when(opContextWithConfig.getSearchContext()).thenReturn(searchContext);
+    when(opContextWithConfig.getAspectRetriever()).thenReturn(mockOpContext.getAspectRetriever());
+    when(searchContext.getSearchFlags()).thenReturn(searchFlags);
+
+    SearchRequest autocompleteRequest =
+        configHandler.getSearchRequest(opContextWithConfig, "input", null, null, 10);
+    SearchSourceBuilder sourceBuilder = autocompleteRequest.source();
+
+    BoolQueryBuilder wrapper =
+        (BoolQueryBuilder) ((FunctionScoreQueryBuilder) sourceBuilder.query()).query();
+    BoolQueryBuilder query = (BoolQueryBuilder) extractNestedQuery(wrapper);
+
+    // Should only have keyPart1 fields (urn doesn't have autocomplete fields in the test spec)
+    boolean hasKeyPart1 = false;
+    boolean hasOtherFields = false;
+
+    for (QueryBuilder shouldQuery : query.should()) {
+      if (shouldQuery instanceof MatchQueryBuilder) {
+        MatchQueryBuilder match = (MatchQueryBuilder) shouldQuery;
+        if (match.fieldName().startsWith("keyPart1")) {
+          hasKeyPart1 = true;
+        } else if (!match.fieldName().startsWith("urn")) {
+          hasOtherFields = true;
+        }
+      } else if (shouldQuery instanceof MultiMatchQueryBuilder) {
+        MultiMatchQueryBuilder multiMatch = (MultiMatchQueryBuilder) shouldQuery;
+        for (String field : multiMatch.fields().keySet()) {
+          if (field.startsWith("keyPart1")) {
+            hasKeyPart1 = true;
+          } else if (!field.startsWith("urn")) {
+            hasOtherFields = true;
+          }
+        }
+      }
+    }
+
+    assertTrue(hasKeyPart1, "Should have keyPart1 fields");
+    assertFalse(hasOtherFields, "Should not have other fields");
+  }
+
+  @Test
+  public void testAutocompleteFieldConfigurationWithAddRemove() {
+    CustomSearchConfiguration customConfig =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "custom",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .add(List.of("textFieldOverride"))
+                                .remove(List.of("keyPart1"))
+                                .build())
+                        .build()))
+            .build();
+
+    AutocompleteRequestHandler configHandler =
+        AutocompleteRequestHandler.getBuilder(
+            mockOpContext,
+            TestEntitySpecBuilder.getSpec(),
+            customConfig,
+            QueryFilterRewriteChain.EMPTY,
+            testQueryConfig,
+            TEST_SEARCH_SERVICE_CONFIG);
+
+    OperationContext opContextWithConfig = mock(OperationContext.class);
+    SearchContext searchContext = mock(SearchContext.class);
+    SearchFlags searchFlags = new SearchFlags().setFieldConfiguration("custom");
+
+    when(opContextWithConfig.getEntityRegistry()).thenReturn(mockOpContext.getEntityRegistry());
+    when(opContextWithConfig.getObjectMapper()).thenReturn(mockOpContext.getObjectMapper());
+    when(opContextWithConfig.getSearchContext()).thenReturn(searchContext);
+    when(opContextWithConfig.getAspectRetriever()).thenReturn(mockOpContext.getAspectRetriever());
+    when(searchContext.getSearchFlags()).thenReturn(searchFlags);
+
+    // Note: textFieldOverride is not in the default autocomplete fields, so it won't be added
+    // This test verifies that remove works correctly
+    SearchRequest autocompleteRequest =
+        configHandler.getSearchRequest(opContextWithConfig, "input", null, null, 10);
+    SearchSourceBuilder sourceBuilder = autocompleteRequest.source();
+
+    BoolQueryBuilder wrapper =
+        (BoolQueryBuilder) ((FunctionScoreQueryBuilder) sourceBuilder.query()).query();
+    BoolQueryBuilder query = (BoolQueryBuilder) extractNestedQuery(wrapper);
+
+    // Verify keyPart1 was removed
+    for (QueryBuilder shouldQuery : query.should()) {
+      if (shouldQuery instanceof MatchQueryBuilder) {
+        MatchQueryBuilder match = (MatchQueryBuilder) shouldQuery;
+        assertFalse(
+            match.fieldName().startsWith("keyPart1"),
+            "keyPart1 should be removed from autocomplete fields");
+      } else if (shouldQuery instanceof MultiMatchQueryBuilder) {
+        MultiMatchQueryBuilder multiMatch = (MultiMatchQueryBuilder) shouldQuery;
+        for (String field : multiMatch.fields().keySet()) {
+          assertFalse(
+              field.startsWith("keyPart1"), "keyPart1 should be removed from autocomplete fields");
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testAutocompleteHighlightFieldConfiguration() {
+    CustomSearchConfiguration customConfig =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "no-highlight",
+                        FieldConfiguration.builder()
+                            .highlightFields(HighlightFields.builder().enabled(false).build())
+                            .build(),
+                    "custom-highlight",
+                        FieldConfiguration.builder()
+                            .highlightFields(
+                                HighlightFields.builder()
+                                    .enabled(true)
+                                    .replace(List.of("keyPart1", "keyPart1.ngram"))
+                                    .build())
+                            .build()))
+            .build();
+
+    AutocompleteRequestHandler configHandler =
+        AutocompleteRequestHandler.getBuilder(
+            mockOpContext,
+            TestEntitySpecBuilder.getSpec(),
+            customConfig,
+            QueryFilterRewriteChain.EMPTY,
+            testQueryConfig,
+            TEST_SEARCH_SERVICE_CONFIG);
+
+    // Test disabled highlighting
+    OperationContext opContextNoHighlight = mock(OperationContext.class);
+    SearchContext searchContextNoHighlight = mock(SearchContext.class);
+    SearchFlags searchFlagsNoHighlight = new SearchFlags().setFieldConfiguration("no-highlight");
+
+    when(opContextNoHighlight.getEntityRegistry()).thenReturn(mockOpContext.getEntityRegistry());
+    when(opContextNoHighlight.getObjectMapper()).thenReturn(mockOpContext.getObjectMapper());
+    when(opContextNoHighlight.getSearchContext()).thenReturn(searchContextNoHighlight);
+    when(opContextNoHighlight.getAspectRetriever()).thenReturn(mockOpContext.getAspectRetriever());
+    when(searchContextNoHighlight.getSearchFlags()).thenReturn(searchFlagsNoHighlight);
+
+    SearchRequest noHighlightRequest =
+        configHandler.getSearchRequest(opContextNoHighlight, "input", null, null, 10);
+    assertNull(noHighlightRequest.source().highlighter(), "Highlighting should be disabled");
+
+    // Test custom highlighting
+    OperationContext opContextCustomHighlight = mock(OperationContext.class);
+    SearchContext searchContextCustom = mock(SearchContext.class);
+    SearchFlags searchFlagsCustom = new SearchFlags().setFieldConfiguration("custom-highlight");
+
+    when(opContextCustomHighlight.getEntityRegistry())
+        .thenReturn(mockOpContext.getEntityRegistry());
+    when(opContextCustomHighlight.getObjectMapper()).thenReturn(mockOpContext.getObjectMapper());
+    when(opContextCustomHighlight.getSearchContext()).thenReturn(searchContextCustom);
+    when(opContextCustomHighlight.getAspectRetriever())
+        .thenReturn(mockOpContext.getAspectRetriever());
+    when(searchContextCustom.getSearchFlags()).thenReturn(searchFlagsCustom);
+
+    SearchRequest customHighlightRequest =
+        configHandler.getSearchRequest(opContextCustomHighlight, "input", null, null, 10);
+    HighlightBuilder highlightBuilder = customHighlightRequest.source().highlighter();
+    assertNotNull(highlightBuilder);
+
+    List<String> highlightFieldNames =
+        highlightBuilder.fields().stream()
+            .map(HighlightBuilder.Field::name)
+            .collect(Collectors.toList());
+
+    assertEquals(highlightFieldNames.size(), 2);
+    assertTrue(highlightFieldNames.contains("keyPart1"));
+    assertTrue(highlightFieldNames.contains("keyPart1.ngram"));
+  }
+
+  @Test
+  public void testAutocompleteFieldConfigurationWithSpecificField() {
+    CustomSearchConfiguration customConfig =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "minimal",
+                    FieldConfiguration.builder()
+                        .searchFields(SearchFields.builder().replace(List.of("keyPart1")).build())
+                        .build()))
+            .build();
+
+    AutocompleteRequestHandler configHandler =
+        AutocompleteRequestHandler.getBuilder(
+            mockOpContext,
+            TestEntitySpecBuilder.getSpec(),
+            customConfig,
+            QueryFilterRewriteChain.EMPTY,
+            testQueryConfig,
+            TEST_SEARCH_SERVICE_CONFIG);
+
+    OperationContext opContextWithConfig = mock(OperationContext.class);
+    SearchContext searchContext = mock(SearchContext.class);
+    SearchFlags searchFlags = new SearchFlags().setFieldConfiguration("minimal");
+
+    when(opContextWithConfig.getEntityRegistry()).thenReturn(mockOpContext.getEntityRegistry());
+    when(opContextWithConfig.getObjectMapper()).thenReturn(mockOpContext.getObjectMapper());
+    when(opContextWithConfig.getSearchContext()).thenReturn(searchContext);
+    when(opContextWithConfig.getAspectRetriever()).thenReturn(mockOpContext.getAspectRetriever());
+    when(searchContext.getSearchFlags()).thenReturn(searchFlags);
+
+    // When a specific field is provided, field configuration should still be applied
+    // but only to that specific field if it's in the configuration
+    SearchRequest autocompleteRequest =
+        configHandler.getSearchRequest(opContextWithConfig, "input", "keyPart1", null, 10);
+
+    SearchSourceBuilder sourceBuilder = autocompleteRequest.source();
+    BoolQueryBuilder wrapper =
+        (BoolQueryBuilder) ((FunctionScoreQueryBuilder) sourceBuilder.query()).query();
+    BoolQueryBuilder query = (BoolQueryBuilder) extractNestedQuery(wrapper);
+
+    // Should have keyPart1 queries since it's in the replace list
+    assertTrue(query.should().size() > 0, "Should have queries for keyPart1");
+  }
+
+  @Test
+  public void testAutocompleteFieldConfigurationNullSafety() {
+    // Test with null configuration
+    AutocompleteRequestHandler nullConfigHandler =
+        AutocompleteRequestHandler.getBuilder(
+            mockOpContext,
+            TestEntitySpecBuilder.getSpec(),
+            null,
+            QueryFilterRewriteChain.EMPTY,
+            testQueryConfig,
+            TEST_SEARCH_SERVICE_CONFIG);
+
+    OperationContext opContextNullConfig = mock(OperationContext.class);
+    SearchContext searchContext = mock(SearchContext.class);
+    SearchFlags searchFlags = new SearchFlags().setFieldConfiguration("any-label");
+
+    when(opContextNullConfig.getEntityRegistry()).thenReturn(mockOpContext.getEntityRegistry());
+    when(opContextNullConfig.getObjectMapper()).thenReturn(mockOpContext.getObjectMapper());
+    when(opContextNullConfig.getSearchContext()).thenReturn(searchContext);
+    when(opContextNullConfig.getAspectRetriever()).thenReturn(mockOpContext.getAspectRetriever());
+    when(searchContext.getSearchFlags()).thenReturn(searchFlags);
+
+    // Should not throw and should use default behavior
+    SearchRequest request =
+        nullConfigHandler.getSearchRequest(opContextNullConfig, "input", null, null, 10);
+    assertNotNull(request);
+
+    // Test with null config
+    when(searchFlags.getFieldConfiguration()).thenReturn(null);
+    SearchRequest requestNullFlags =
+        nullConfigHandler.getSearchRequest(opContextNullConfig, "input", null, null, 10);
+    assertNotNull(requestNullFlags);
+  }
+
+  @Test
+  public void testAutocompleteBoostPreservation() {
+    // Create mock entity spec with specific boost values
+    EntitySpec mockSpec = mock(EntitySpec.class);
+    SearchableFieldSpec fieldSpec1 = mock(SearchableFieldSpec.class);
+    SearchableFieldSpec fieldSpec2 = mock(SearchableFieldSpec.class);
+
+    SearchableAnnotation annotation1 = mock(SearchableAnnotation.class);
+    when(annotation1.getFieldName()).thenReturn("field1");
+    when(annotation1.getBoostScore()).thenReturn(3.0);
+    when(annotation1.isEnableAutocomplete()).thenReturn(true);
+    when(fieldSpec1.getSearchableAnnotation()).thenReturn(annotation1);
+
+    SearchableAnnotation annotation2 = mock(SearchableAnnotation.class);
+    when(annotation2.getFieldName()).thenReturn("field2");
+    when(annotation2.getBoostScore()).thenReturn(1.5);
+    when(annotation2.isEnableAutocomplete()).thenReturn(true);
+    when(fieldSpec2.getSearchableAnnotation()).thenReturn(annotation2);
+
+    when(mockSpec.getSearchableFieldSpecs()).thenReturn(List.of(fieldSpec1, fieldSpec2));
+
+    CustomSearchConfiguration customConfig =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "reorder",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .replace(List.of("field2", "field1")) // Different order
+                                .build())
+                        .build()))
+            .build();
+
+    // Verify boost scores are preserved through CustomizedQueryHandler
+    CustomizedQueryHandler handler =
+        CustomizedQueryHandler.builder(new CustomConfiguration(), customConfig).build();
+    List<Pair<String, String>> baseFields =
+        List.of(Pair.of("field1", "3.0"), Pair.of("field2", "1.5"), Pair.of("urn", "1.0"));
+
+    List<Pair<String, String>> configuredFields =
+        handler.applyAutocompleteFieldConfiguration(baseFields, "reorder");
+
+    // Should be sorted by boost (descending)
+    assertEquals(configuredFields.size(), 2);
+    assertEquals(configuredFields.get(0), Pair.of("field1", "3.0"));
+    assertEquals(configuredFields.get(1), Pair.of("field2", "1.5"));
+  }
+
+  @Test
+  public void testAutocompleteWithInvalidFieldConfiguration() {
+    CustomSearchConfiguration customConfig =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "valid",
+                    FieldConfiguration.builder()
+                        .searchFields(SearchFields.builder().replace(List.of("keyPart1")).build())
+                        .build()))
+            .build();
+
+    AutocompleteRequestHandler configHandler =
+        AutocompleteRequestHandler.getBuilder(
+            mockOpContext,
+            TestEntitySpecBuilder.getSpec(),
+            customConfig,
+            QueryFilterRewriteChain.EMPTY,
+            testQueryConfig,
+            TEST_SEARCH_SERVICE_CONFIG);
+
+    OperationContext opContextInvalidConfig = mock(OperationContext.class);
+    SearchContext searchContext = mock(SearchContext.class);
+    SearchFlags searchFlags = new SearchFlags().setFieldConfiguration("nonexistent");
+
+    when(opContextInvalidConfig.getEntityRegistry()).thenReturn(mockOpContext.getEntityRegistry());
+    when(opContextInvalidConfig.getObjectMapper()).thenReturn(mockOpContext.getObjectMapper());
+    when(opContextInvalidConfig.getSearchContext()).thenReturn(searchContext);
+    when(opContextInvalidConfig.getAspectRetriever())
+        .thenReturn(mockOpContext.getAspectRetriever());
+    when(searchContext.getSearchFlags()).thenReturn(searchFlags);
+
+    // Should use default fields when configuration label doesn't exist
+    SearchRequest request =
+        configHandler.getSearchRequest(opContextInvalidConfig, "input", null, null, 10);
+
+    SearchSourceBuilder sourceBuilder = request.source();
+    BoolQueryBuilder wrapper =
+        (BoolQueryBuilder) ((FunctionScoreQueryBuilder) sourceBuilder.query()).query();
+    BoolQueryBuilder query = (BoolQueryBuilder) extractNestedQuery(wrapper);
+
+    // Should have default fields
+    boolean hasKeyPart1 =
+        query.should().stream()
+            .anyMatch(
+                q -> {
+                  if (q instanceof MatchQueryBuilder) {
+                    return ((MatchQueryBuilder) q).fieldName().startsWith("keyPart1");
+                  } else if (q instanceof MultiMatchQueryBuilder) {
+                    return ((MultiMatchQueryBuilder) q)
+                        .fields().keySet().stream().anyMatch(f -> f.startsWith("keyPart1"));
+                  }
+                  return false;
+                });
+
+    assertTrue(hasKeyPart1, "Should have default keyPart1 field when config doesn't exist");
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/CustomizedQueryHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/CustomizedQueryHandlerTest.java
@@ -2,7 +2,9 @@ package com.linkedin.metadata.search.query.request;
 
 import static com.linkedin.metadata.Constants.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,13 +13,23 @@ import com.linkedin.metadata.config.search.CustomConfiguration;
 import com.linkedin.metadata.config.search.SearchConfiguration;
 import com.linkedin.metadata.config.search.custom.BoolQueryConfiguration;
 import com.linkedin.metadata.config.search.custom.CustomSearchConfiguration;
+import com.linkedin.metadata.config.search.custom.FieldConfiguration;
+import com.linkedin.metadata.config.search.custom.HighlightFields;
 import com.linkedin.metadata.config.search.custom.QueryConfiguration;
+import com.linkedin.metadata.config.search.custom.SearchFields;
 import com.linkedin.metadata.search.elasticsearch.query.request.CustomizedQueryHandler;
+import com.linkedin.metadata.search.elasticsearch.query.request.HighlightConfigurationResult;
+import com.linkedin.metadata.search.elasticsearch.query.request.SearchFieldConfig;
 import com.linkedin.metadata.search.elasticsearch.query.request.SearchQueryBuilder;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.common.lucene.search.function.CombineFunction;
 import org.opensearch.common.lucene.search.function.FunctionScoreQuery;
 import org.opensearch.index.query.MatchAllQueryBuilder;
@@ -28,7 +40,8 @@ import org.testng.annotations.Test;
 
 public class CustomizedQueryHandlerTest {
   public static final ObjectMapper TEST_MAPPER = new YAMLMapper();
-  private static final CustomSearchConfiguration TEST_CONFIG;
+  private static final CustomConfiguration TEST_CONFIG = new CustomConfiguration();
+  private static final CustomSearchConfiguration TEST_SEARCH_CONFIG;
 
   static {
     try {
@@ -43,7 +56,7 @@ public class CustomizedQueryHandlerTest {
       CustomConfiguration customConfiguration = new CustomConfiguration();
       customConfiguration.setEnabled(true);
       customConfiguration.setFile("search_config_test.yml");
-      TEST_CONFIG = customConfiguration.resolve(TEST_MAPPER);
+      TEST_SEARCH_CONFIG = customConfiguration.resolve(TEST_MAPPER);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -52,7 +65,7 @@ public class CustomizedQueryHandlerTest {
   public static final SearchQueryBuilder SEARCH_QUERY_BUILDER;
 
   static {
-    SEARCH_QUERY_BUILDER = new SearchQueryBuilder(new SearchConfiguration(), TEST_CONFIG);
+    SEARCH_QUERY_BUILDER = new SearchQueryBuilder(new SearchConfiguration(), TEST_SEARCH_CONFIG);
   }
 
   private static final List<QueryConfiguration> EXPECTED_CONFIGURATION =
@@ -128,13 +141,14 @@ public class CustomizedQueryHandlerTest {
 
   @Test
   public void configParsingTest() {
-    assertNotNull(TEST_CONFIG);
-    assertEquals(TEST_CONFIG.getQueryConfigurations(), EXPECTED_CONFIGURATION);
+    assertNotNull(TEST_SEARCH_CONFIG);
+    assertEquals(TEST_SEARCH_CONFIG.getQueryConfigurations(), EXPECTED_CONFIGURATION);
   }
 
   @Test
   public void customizedQueryHandlerInitTest() {
-    CustomizedQueryHandler test = CustomizedQueryHandler.builder(TEST_CONFIG).build();
+    CustomizedQueryHandler test =
+        CustomizedQueryHandler.builder(TEST_CONFIG, TEST_SEARCH_CONFIG).build();
 
     assertEquals(
         test.getQueryConfigurations().stream()
@@ -153,7 +167,8 @@ public class CustomizedQueryHandlerTest {
 
   @Test
   public void patternMatchTest() {
-    CustomizedQueryHandler test = CustomizedQueryHandler.builder(TEST_CONFIG).build();
+    CustomizedQueryHandler test =
+        CustomizedQueryHandler.builder(TEST_CONFIG, TEST_SEARCH_CONFIG).build();
 
     for (String selectAllQuery : List.of("*", "")) {
       QueryConfiguration actual = test.lookupQueryConfig(selectAllQuery).get();
@@ -171,7 +186,8 @@ public class CustomizedQueryHandlerTest {
 
   @Test
   public void functionScoreQueryBuilderTest() {
-    CustomizedQueryHandler test = CustomizedQueryHandler.builder(TEST_CONFIG).build();
+    CustomizedQueryHandler test =
+        CustomizedQueryHandler.builder(TEST_CONFIG, TEST_SEARCH_CONFIG).build();
     MatchAllQueryBuilder inputQuery = QueryBuilders.matchAllQuery();
 
     /*
@@ -221,5 +237,1004 @@ public class CustomizedQueryHandlerTest {
             .boostMode(CombineFunction.MULTIPLY);
 
     assertEquals(defaultTest, expectedDefault);
+  }
+
+  @Test
+  public void testSearchFieldConfigurationWithReplace() {
+    // Create a custom configuration with field configurations
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "minimal",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder().replace(List.of("name", "description")).build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    // Create base fields
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("description")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("tags")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("owners")
+                .boost(1.0f)
+                .isQueryByDefault(false)
+                .build());
+
+    Set<SearchFieldConfig> result = handler.applySearchFieldConfiguration(baseFields, "minimal");
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.stream().anyMatch(f -> f.fieldName().equals("name")));
+    assertTrue(result.stream().anyMatch(f -> f.fieldName().equals("description")));
+    assertFalse(result.stream().anyMatch(f -> f.fieldName().equals("tags")));
+  }
+
+  @Test
+  public void testSearchFieldConfigurationWithAddRemove() {
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "custom",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .add(List.of("platform"))
+                                .remove(List.of("owners"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("owners")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("platform")
+                .boost(1.0f)
+                .isQueryByDefault(false)
+                .build());
+
+    Set<SearchFieldConfig> result = handler.applySearchFieldConfiguration(baseFields, "custom");
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.stream().anyMatch(f -> f.fieldName().equals("name")));
+    assertTrue(result.stream().anyMatch(f -> f.fieldName().equals("platform")));
+    assertFalse(result.stream().anyMatch(f -> f.fieldName().equals("owners")));
+
+    // Verify that platform was set to queryByDefault=true
+    SearchFieldConfig platformField =
+        result.stream().filter(f -> f.fieldName().equals("platform")).findFirst().orElse(null);
+    assertNotNull(platformField);
+    assertTrue(platformField.isQueryByDefault());
+  }
+
+  @Test
+  public void testSearchFieldConfigurationInvalidReplace() {
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "invalid",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder().replace(List.of("nonexistent")).build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build());
+
+    // Should fall back to base fields when replace results in empty set
+    Set<SearchFieldConfig> result = handler.applySearchFieldConfiguration(baseFields, "invalid");
+    assertEquals(result, baseFields);
+  }
+
+  @Test
+  public void testAutocompleteFieldConfiguration() {
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "name-only",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder().replace(List.of("name", "urn")).build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    List<Pair<String, String>> baseFields =
+        List.of(
+            Pair.of("name", "2.0"),
+            Pair.of("description", "1.5"),
+            Pair.of("tags", "1.0"),
+            Pair.of("urn", "1.0"));
+
+    List<Pair<String, String>> result =
+        handler.applyAutocompleteFieldConfiguration(baseFields, "name-only");
+
+    assertEquals(result.size(), 2);
+    assertTrue(
+        result.stream().anyMatch(p -> p.getLeft().equals("name") && p.getRight().equals("2.0")));
+    assertTrue(
+        result.stream().anyMatch(p -> p.getLeft().equals("urn") && p.getRight().equals("1.0")));
+  }
+
+  @Test
+  public void testHighlightFieldConfiguration() {
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "no-highlight",
+                        FieldConfiguration.builder()
+                            .highlightFields(HighlightFields.builder().enabled(false).build())
+                            .build(),
+                    "custom-highlight",
+                        FieldConfiguration.builder()
+                            .highlightFields(
+                                HighlightFields.builder()
+                                    .enabled(true)
+                                    .replace(List.of("name", "description"))
+                                    .build())
+                            .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    // Test disabled highlighting
+    assertFalse(handler.isHighlightingEnabled("no-highlight"));
+    assertTrue(handler.isHighlightingEnabled("unknown-label")); // Default is enabled
+
+    // Test highlight field replacement
+    Set<String> baseFields = Set.of("name", "description", "tags", "owners");
+    Set<String> result = handler.applyHighlightFieldConfiguration(baseFields, "custom-highlight");
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.contains("name"));
+    assertTrue(result.contains("description"));
+    assertFalse(result.contains("tags"));
+  }
+
+  @Test
+  public void testFieldConfigurationValidation() {
+    // Test invalid configuration with both replace and add
+    SearchFields invalidFields =
+        SearchFields.builder().replace(List.of("name")).add(List.of("description")).build();
+
+    assertFalse(invalidFields.isValid());
+
+    // Test valid configurations
+    SearchFields validReplace = SearchFields.builder().replace(List.of("name")).build();
+    assertTrue(validReplace.isValid());
+
+    SearchFields validAddRemove =
+        SearchFields.builder().add(List.of("name")).remove(List.of("description")).build();
+    assertTrue(validAddRemove.isValid());
+  }
+
+  @Test
+  public void testNullAndMissingFieldConfiguration() {
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, null).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build());
+
+    // Should return base fields when no configuration
+    assertEquals(handler.applySearchFieldConfiguration(baseFields, null), baseFields);
+    assertEquals(handler.applySearchFieldConfiguration(baseFields, "nonexistent"), baseFields);
+
+    // Highlighting should be enabled by default
+    assertTrue(handler.isHighlightingEnabled(null));
+    assertTrue(handler.isHighlightingEnabled("nonexistent"));
+  }
+
+  @Test
+  public void testAutocompleteBoostPreservation() {
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "reorder",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .replace(List.of("tags", "description", "name"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    List<Pair<String, String>> baseFields =
+        List.of(Pair.of("name", "3.0"), Pair.of("description", "2.0"), Pair.of("tags", "1.0"));
+
+    List<Pair<String, String>> result =
+        handler.applyAutocompleteFieldConfiguration(baseFields, "reorder");
+
+    // Should be sorted by boost (descending) then by name
+    assertEquals(result.size(), 3);
+    assertEquals(result.get(0), Pair.of("name", "3.0"));
+    assertEquals(result.get(1), Pair.of("description", "2.0"));
+    assertEquals(result.get(2), Pair.of("tags", "1.0"));
+  }
+
+  @Test
+  public void testSearchFieldConfigurationWithNonExistentWildcard() {
+    // Test wildcard pattern that doesn't match any fields
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "no-match",
+                    FieldConfiguration.builder()
+                        .searchFields(SearchFields.builder().add(List.of("nonexistent.*")).build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("description")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build());
+
+    Set<SearchFieldConfig> result = handler.applySearchFieldConfiguration(baseFields, "no-match");
+
+    // Should keep base fields since no matches were found
+    assertEquals(result.size(), 2);
+    assertEquals(result, baseFields);
+  }
+
+  @Test
+  public void testSearchFieldConfigurationPreservesBoostScores() {
+    // Test that boost scores are preserved when fields are not explicitly configured
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "preserve-boost",
+                    FieldConfiguration.builder()
+                        .searchFields(SearchFields.builder().add(List.of("platform")).build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(10.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("platform")
+                .boost(5.0f)
+                .isQueryByDefault(false)
+                .build());
+
+    Set<SearchFieldConfig> result =
+        handler.applySearchFieldConfiguration(baseFields, "preserve-boost");
+
+    // Check that name field preserves its boost
+    SearchFieldConfig nameField =
+        result.stream().filter(f -> f.fieldName().equals("name")).findFirst().orElse(null);
+    assertNotNull(nameField);
+    assertEquals(nameField.boost(), 10.0f);
+
+    // Check that platform field preserves its boost but gets queryByDefault=true
+    SearchFieldConfig platformField =
+        result.stream().filter(f -> f.fieldName().equals("platform")).findFirst().orElse(null);
+    assertNotNull(platformField);
+    assertEquals(platformField.boost(), 5.0f);
+    assertTrue(platformField.isQueryByDefault());
+  }
+
+  @Test
+  public void testHighlightFieldConfigurationWithReplace() {
+    // Test highlight fields with replace mode
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "highlight-replace",
+                    FieldConfiguration.builder()
+                        .highlightFields(
+                            HighlightFields.builder()
+                                .replace(List.of("name", "description"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<String> baseFields = Set.of("name", "description", "platform", "owners");
+
+    Set<String> result = handler.applyHighlightFieldConfiguration(baseFields, "highlight-replace");
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.contains("name"));
+    assertTrue(result.contains("description"));
+    assertFalse(result.contains("platform"));
+    assertFalse(result.contains("owners"));
+  }
+
+  @Test
+  public void testHighlightFieldConfigurationDisabled() {
+    // Test when highlighting is disabled
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "highlight-disabled",
+                    FieldConfiguration.builder()
+                        .highlightFields(HighlightFields.builder().enabled(false).build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    assertFalse(handler.isHighlightingEnabled("highlight-disabled"));
+    assertTrue(handler.isHighlightingEnabled("non-existent")); // Default is enabled
+  }
+
+  @Test
+  public void testAutocompleteFieldConfigurationWithReplace() {
+    // Test autocomplete fields with replace mode
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "autocomplete-replace",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder().replace(List.of("name", "description")).build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    List<Pair<String, String>> baseFields =
+        List.of(
+            Pair.of("name", "10.0"),
+            Pair.of("description", "5.0"),
+            Pair.of("platform", "1.0"),
+            Pair.of("owners", "1.0"));
+
+    List<Pair<String, String>> result =
+        handler.applyAutocompleteFieldConfiguration(baseFields, "autocomplete-replace");
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.stream().anyMatch(p -> p.getLeft().equals("name")));
+    assertTrue(result.stream().anyMatch(p -> p.getLeft().equals("description")));
+
+    // Check boost scores are preserved
+    result.stream()
+        .filter(p -> p.getLeft().equals("name"))
+        .findFirst()
+        .ifPresent(p -> assertEquals(p.getRight(), "10.0"));
+  }
+
+  @Test
+  public void testAutocompleteFieldConfigurationWithWildcard() {
+    // Test autocomplete with wildcard patterns
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "autocomplete-wildcard",
+                    FieldConfiguration.builder()
+                        .searchFields(SearchFields.builder().add(List.of("schema.*")).build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    List<Pair<String, String>> baseFields =
+        List.of(
+            Pair.of("name", "10.0"),
+            Pair.of("schema.fieldName", "5.0"),
+            Pair.of("schema.fieldType", "5.0"),
+            Pair.of("platform", "1.0"));
+
+    List<Pair<String, String>> result =
+        handler.applyAutocompleteFieldConfiguration(baseFields, "autocomplete-wildcard");
+
+    assertEquals(result.size(), 4);
+    assertTrue(result.stream().anyMatch(p -> p.getLeft().equals("schema.fieldName")));
+    assertTrue(result.stream().anyMatch(p -> p.getLeft().equals("schema.fieldType")));
+  }
+
+  @Test
+  public void testIsQuotedAndUnquote() {
+    // Test quote detection and unquoting
+    assertTrue(CustomizedQueryHandler.isQuoted("\"test query\""));
+    assertTrue(CustomizedQueryHandler.isQuoted("'test query'"));
+    assertTrue(CustomizedQueryHandler.isQuoted("test \"quoted\" query"));
+    assertFalse(CustomizedQueryHandler.isQuoted("test query"));
+
+    assertEquals(CustomizedQueryHandler.unquote("\"test query\""), "test query");
+    assertEquals(CustomizedQueryHandler.unquote("'test query'"), "test query");
+    assertEquals(CustomizedQueryHandler.unquote("test \"quoted\" query"), "test quoted query");
+  }
+
+  @Test
+  public void testLookupQueryConfig() {
+    // Test query configuration lookup with regex patterns
+    QueryConfiguration config1 = QueryConfiguration.builder().queryRegex("^exact match$").build();
+    QueryConfiguration config2 = QueryConfiguration.builder().queryRegex(".*wildcard.*").build();
+
+    CustomSearchConfiguration searchConfig =
+        CustomSearchConfiguration.builder().queryConfigurations(List.of(config1, config2)).build();
+
+    CustomizedQueryHandler handler =
+        CustomizedQueryHandler.builder(TEST_CONFIG, searchConfig).build();
+
+    Optional<QueryConfiguration> result = handler.lookupQueryConfig("exact match");
+    assertTrue(result.isPresent());
+    assertEquals(result.get().getQueryRegex(), "^exact match$");
+
+    result = handler.lookupQueryConfig("contains wildcard pattern");
+    assertTrue(result.isPresent());
+    assertEquals(result.get().getQueryRegex(), ".*wildcard.*");
+
+    result = handler.lookupQueryConfig("no match");
+    assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testEmptyFieldConfigurationReturnsBaseFields() {
+    // Test that empty field configuration returns base fields unchanged
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "empty",
+                    FieldConfiguration.builder()
+                        .searchFields(SearchFields.builder().build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("description")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build());
+
+    Set<SearchFieldConfig> result = handler.applySearchFieldConfiguration(baseFields, "empty");
+
+    assertEquals(result, baseFields);
+  }
+
+  @Test
+  public void testInvalidFieldConfigurationLogsError() {
+    // Test invalid configuration (replace with add/remove)
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "invalid",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .replace(List.of("name"))
+                                .add(List.of("description"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build());
+
+    // Should return base fields due to invalid configuration
+    Set<SearchFieldConfig> result = handler.applySearchFieldConfiguration(baseFields, "invalid");
+
+    assertEquals(result, baseFields);
+  }
+
+  @Test
+  public void testApplySearchFieldConfiguration_NullCustomSearchConfiguration() {
+    // Test when customSearchConfiguration is null
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, null).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build());
+
+    Set<SearchFieldConfig> result = handler.applySearchFieldConfiguration(baseFields, "any-label");
+    assertEquals(result, baseFields);
+  }
+
+  @Test
+  public void testApplySearchFieldConfiguration_NullFieldConfigurations() {
+    // Test when fieldConfigurations is null
+    CustomSearchConfiguration config = CustomSearchConfiguration.builder().build();
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build());
+
+    Set<SearchFieldConfig> result = handler.applySearchFieldConfiguration(baseFields, "label");
+    assertEquals(result, baseFields);
+  }
+
+  @Test
+  public void testApplySearchFieldConfiguration_EmptyResultFieldsMap() {
+    // Test when resultFieldsMap becomes empty after remove operations
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "remove-all",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder().remove(List.of("name", "description")).build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("description")
+                .boost(1.0f)
+                .isQueryByDefault(true)
+                .build());
+
+    Set<SearchFieldConfig> result = handler.applySearchFieldConfiguration(baseFields, "remove-all");
+
+    // Should return base fields when result would be empty
+    assertEquals(result, baseFields);
+  }
+
+  @Test
+  public void testApplyAutocompleteFieldConfiguration_FindBoostForField() {
+    // Test findBoostForField scenarios
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "test-boost",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .add(List.of("name.delimited", "description.ngram", "newField"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    List<Pair<String, String>> baseFields =
+        List.of(Pair.of("name", "10.0"), Pair.of("description", "5.0"), Pair.of("tags", "1.0"));
+
+    List<Pair<String, String>> result =
+        handler.applyAutocompleteFieldConfiguration(baseFields, "test-boost");
+
+    // Should include base fields plus subfields that inherit boost from base
+    assertTrue(
+        result.stream()
+            .anyMatch(p -> p.getLeft().equals("name.delimited") && p.getRight().equals("10.0")));
+    assertTrue(
+        result.stream()
+            .anyMatch(p -> p.getLeft().equals("description.ngram") && p.getRight().equals("5.0")));
+    // newField should not be added as it doesn't exist in base fields
+    assertFalse(result.stream().anyMatch(p -> p.getLeft().equals("newField")));
+  }
+
+  @Test
+  public void testApplyAutocompleteFieldConfiguration_NotFoundFields() {
+    // Test when adding fields that don't exist
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "add-nonexistent",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .add(List.of("nonexistent1", "nonexistent2"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    List<Pair<String, String>> baseFields =
+        List.of(Pair.of("name", "10.0"), Pair.of("description", "5.0"));
+
+    List<Pair<String, String>> result =
+        handler.applyAutocompleteFieldConfiguration(baseFields, "add-nonexistent");
+
+    // Should return base fields when no valid fields can be added
+    assertEquals(result.size(), 2);
+    assertTrue(result.stream().anyMatch(p -> p.getLeft().equals("name")));
+    assertTrue(result.stream().anyMatch(p -> p.getLeft().equals("description")));
+  }
+
+  @Test
+  public void testApplyAutocompleteFieldConfiguration_EmptyReplacementFields() {
+    // Test when replacement results in empty fields
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "replace-nonexistent",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .replace(List.of("nonexistent1", "nonexistent2"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    List<Pair<String, String>> baseFields =
+        List.of(Pair.of("name", "10.0"), Pair.of("description", "5.0"));
+
+    List<Pair<String, String>> result =
+        handler.applyAutocompleteFieldConfiguration(baseFields, "replace-nonexistent");
+
+    // Should fall back to base fields
+    assertEquals(result, baseFields);
+  }
+
+  @Test
+  public void testGetHighlightFieldConfiguration_WithWildcardPatterns() {
+    // Test highlight field configuration with wildcard patterns
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "wildcard-highlight",
+                    FieldConfiguration.builder()
+                        .highlightFields(
+                            HighlightFields.builder()
+                                .remove(List.of("schema.*", "tags"))
+                                .add(List.of("customField"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<String> baseFields =
+        Set.of(
+            "name",
+            "description",
+            "schema.fieldName",
+            "schema.fieldType",
+            "schema.dataType",
+            "tags",
+            "owners");
+
+    HighlightConfigurationResult result =
+        handler.getHighlightFieldConfiguration(baseFields, "wildcard-highlight");
+
+    // Verify wildcard pattern expansion
+    assertFalse(result.getFieldsToHighlight().contains("schema.fieldName"));
+    assertFalse(result.getFieldsToHighlight().contains("schema.fieldType"));
+    assertFalse(result.getFieldsToHighlight().contains("schema.dataType"));
+    assertFalse(result.getFieldsToHighlight().contains("tags"));
+    assertTrue(result.getFieldsToHighlight().contains("name"));
+    assertTrue(result.getFieldsToHighlight().contains("customField"));
+
+    // Check explicitly configured fields
+    assertTrue(result.getExplicitlyConfiguredFields().contains("customField"));
+  }
+
+  @Test
+  public void testApplyHighlightFieldConfiguration_AddRemoveMode() {
+    // Test highlight configuration with add/remove mode
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "add-remove-highlight",
+                    FieldConfiguration.builder()
+                        .highlightFields(
+                            HighlightFields.builder()
+                                .remove(List.of("description", "tags"))
+                                .add(List.of("newHighlight", "anotherHighlight"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<String> baseFields = new LinkedHashSet<>(List.of("name", "description", "tags", "owners"));
+
+    Set<String> result =
+        handler.applyHighlightFieldConfiguration(baseFields, "add-remove-highlight");
+
+    // Verify remove operation
+    assertFalse(result.contains("description"));
+    assertFalse(result.contains("tags"));
+
+    // Verify add operation
+    assertTrue(result.contains("newHighlight"));
+    assertTrue(result.contains("anotherHighlight"));
+
+    // Verify remaining fields
+    assertTrue(result.contains("name"));
+    assertTrue(result.contains("owners"));
+  }
+
+  @Test
+  public void testExpandFieldPatterns_MixedPatterns() {
+    // Test expandFieldPatterns with various pattern types
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "pattern-test",
+                    FieldConfiguration.builder()
+                        .highlightFields(
+                            HighlightFields.builder()
+                                .remove(List.of("schema.*", "literal", "nonexistent.*", "missing"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<String> baseFields =
+        Set.of("name", "literal", "schema.field1", "schema.field2", "other.field");
+
+    HighlightConfigurationResult result =
+        handler.getHighlightFieldConfiguration(baseFields, "pattern-test");
+
+    // Verify pattern expansion
+    assertFalse(result.getFieldsToHighlight().contains("schema.field1"));
+    assertFalse(result.getFieldsToHighlight().contains("schema.field2"));
+    assertFalse(result.getFieldsToHighlight().contains("literal"));
+    assertTrue(result.getFieldsToHighlight().contains("name"));
+    assertTrue(result.getFieldsToHighlight().contains("other.field"));
+  }
+
+  @Test
+  public void testFindReferenceField_SubfieldMatching() {
+    // Test subfield matching in createSearchFieldConfigsFromNames
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "subfield-test",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .add(List.of("name.keyword", "description.analyzed"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(10.0f)
+                .isQueryByDefault(true)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("description")
+                .boost(5.0f)
+                .isQueryByDefault(false)
+                .build());
+
+    Set<SearchFieldConfig> result =
+        handler.applySearchFieldConfiguration(baseFields, "subfield-test");
+
+    // Should find base fields for subfields
+    assertEquals(result.size(), 2);
+
+    // Verify that subfields inherit from base fields and get queryByDefault=true
+    SearchFieldConfig nameField =
+        result.stream().filter(f -> f.fieldName().equals("name")).findFirst().orElse(null);
+    assertNotNull(nameField);
+    assertEquals(nameField.boost(), 10.0f);
+    assertTrue(nameField.isQueryByDefault());
+
+    SearchFieldConfig descField =
+        result.stream().filter(f -> f.fieldName().equals("description")).findFirst().orElse(null);
+    assertNotNull(descField);
+    assertEquals(descField.boost(), 5.0f);
+    assertTrue(descField.isQueryByDefault()); // Should be set to true for explicitly added fields
+  }
+
+  @Test
+  public void testAutocompleteConfiguration_ComplexBoostInheritance() {
+    // Test complex boost inheritance scenarios
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "complex-boost",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .add(List.of("name.delimited", "tags.keyword", "newField.subfield"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    List<Pair<String, String>> baseFields =
+        List.of(
+            Pair.of("name", "10.0"),
+            Pair.of("tags.raw", "5.0"), // Different subfield
+            Pair.of("description", "3.0"));
+
+    List<Pair<String, String>> result =
+        handler.applyAutocompleteFieldConfiguration(baseFields, "complex-boost");
+
+    // Should include existing fields plus successfully matched new fields
+    assertTrue(result.size() >= 3);
+
+    // name.delimited should inherit boost from name
+    Optional<Pair<String, String>> nameDelimited =
+        result.stream().filter(p -> p.getLeft().equals("name.delimited")).findFirst();
+    assertTrue(nameDelimited.isPresent());
+    assertEquals(nameDelimited.get().getRight(), "10.0");
+  }
+
+  @Test
+  public void testHighlightConfiguration_PreservesInsertionOrder() {
+    // Test that LinkedHashSet preserves insertion order
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "ordered-highlight",
+                    FieldConfiguration.builder()
+                        .highlightFields(
+                            HighlightFields.builder()
+                                .replace(List.of("field3", "field1", "field2"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<String> baseFields = Set.of("field1", "field2", "field3", "field4");
+
+    Set<String> result = handler.applyHighlightFieldConfiguration(baseFields, "ordered-highlight");
+
+    // Convert to list to check order
+    List<String> resultList = new ArrayList<>(result);
+    assertEquals(resultList.size(), 3);
+    assertEquals(resultList.get(0), "field3");
+    assertEquals(resultList.get(1), "field1");
+    assertEquals(resultList.get(2), "field2");
+  }
+
+  @Test
+  public void testDuplicateFieldHandling() {
+    // Test that duplicates are properly handled in various configurations
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "duplicate-test",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder()
+                                .add(List.of("name", "name", "description"))
+                                .build())
+                        .build()))
+            .build();
+
+    CustomizedQueryHandler handler = CustomizedQueryHandler.builder(TEST_CONFIG, config).build();
+
+    Set<SearchFieldConfig> baseFields =
+        Set.of(
+            SearchFieldConfig.builder()
+                .fieldName("name")
+                .boost(10.0f)
+                .isQueryByDefault(false)
+                .build(),
+            SearchFieldConfig.builder()
+                .fieldName("description")
+                .boost(5.0f)
+                .isQueryByDefault(true)
+                .build());
+
+    Set<SearchFieldConfig> result =
+        handler.applySearchFieldConfiguration(baseFields, "duplicate-test");
+
+    // Should only have 2 fields despite duplicate in add list
+    assertEquals(result.size(), 2);
+
+    // Verify no duplicates by checking field names
+    Set<String> fieldNames =
+        result.stream().map(SearchFieldConfig::fieldName).collect(Collectors.toSet());
+    assertEquals(fieldNames.size(), 2);
+    assertTrue(fieldNames.contains("name"));
+    assertTrue(fieldNames.contains("description"));
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
@@ -158,7 +158,6 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
 
   @Test
   public void testCustomHighlights() {
-    EntitySpec entitySpec = operationContext.getEntityRegistry().getEntitySpec("dataset");
     SearchRequestHandler requestHandler =
         SearchRequestHandler.getBuilder(
             operationContext,
@@ -180,7 +179,7 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
             List.of());
     SearchSourceBuilder sourceBuilder = searchRequest.source();
     assertNotNull(sourceBuilder.highlighter());
-    assertEquals(4, sourceBuilder.highlighter().fields().size());
+    assertEquals(sourceBuilder.highlighter().fields().size(), 8);
     assertTrue(
         sourceBuilder.highlighter().fields().stream()
             .map(HighlightBuilder.Field::name)

--- a/metadata-io/src/test/resources/search_config_fixture_test.yml
+++ b/metadata-io/src/test/resources/search_config_fixture_test.yml
@@ -1,3 +1,37 @@
+fieldConfigurations:
+  # Excludes column match and highlight
+  excludeColumns:
+    searchFields:
+      remove:
+        - fieldPaths
+        - fieldPaths.*
+
+    highlightFields:
+      enabled: true
+      remove:
+        - fieldPaths
+        - fieldPaths.*
+
+  excludeColumnHighlight:
+    searchFields:
+    # No modifications - use PDL defaults
+
+    highlightFields:
+      enabled: true
+      remove:
+        - fieldPaths
+        - fieldPaths.*
+
+
+  # PDL legacy configuration
+  legacy:
+    searchFields:
+    # No modifications - use PDL defaults
+
+    highlightFields:
+      enabled: true
+      # No modifications - use PDL defaults
+
 # Use for testing with search fixtures
 queryConfigurations:
   # Select */explore all

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/restli/RestliServletConfig.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/restli/RestliServletConfig.java
@@ -9,6 +9,7 @@ import com.linkedin.restli.server.RestliHandlerServlet;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -62,6 +63,7 @@ public class RestliServletConfig {
   }
 
   @Bean
+  @ConditionalOnBean
   public ElasticSearchConfiguration elasticSearchConfiguration(
       final ConfigurationProvider configurationProvider) {
     return configurationProvider.getElasticSearch();

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
@@ -69,4 +69,10 @@ record SearchFlags {
    * Include only latest versions in version sets, default true
    */
    filterNonLatestVersions: optional boolean = true
+
+   /**
+    * Which fieldConfiguration should be applied. The possible values
+    * are defined in the configuration file `search_config.yaml`
+    */
+    fieldConfiguration:optional string
 }

--- a/metadata-service/configuration/build.gradle
+++ b/metadata-service/configuration/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     testImplementation externalDependency.testng
     testImplementation externalDependency.springBootTest
+    testImplementation externalDependency.jacksonDataFormatYaml
 }
 
 processResources.configure {

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/CustomConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/CustomConfiguration.java
@@ -5,16 +5,24 @@ import com.linkedin.metadata.config.search.custom.CustomSearchConfiguration;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 
-@Data
 @Slf4j
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class CustomConfiguration {
   private boolean enabled;
   private String file;
+  private String searchFieldConfigDefault;
+  private String autoCompleteFieldConfigDefault;
 
   /**
    * Materialize the search configuration from a location external to main application.yaml

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/custom/CustomSearchConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/custom/CustomSearchConfiguration.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -15,6 +16,9 @@ import lombok.ToString;
 @ToString
 @JsonDeserialize(builder = CustomSearchConfiguration.CustomSearchConfigurationBuilder.class)
 public class CustomSearchConfiguration {
+
+  @Builder.Default
+  private Map<String, FieldConfiguration> fieldConfigurations = Collections.emptyMap();
 
   @Builder.Default private List<QueryConfiguration> queryConfigurations = Collections.emptyList();
 

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/custom/FieldConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/custom/FieldConfiguration.java
@@ -1,0 +1,23 @@
+package com.linkedin.metadata.config.search.custom;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder(toBuilder = true)
+@Getter
+@ToString
+@EqualsAndHashCode
+@JsonDeserialize(builder = FieldConfiguration.FieldConfigurationBuilder.class)
+public class FieldConfiguration {
+
+  private SearchFields searchFields;
+
+  private HighlightFields highlightFields;
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class FieldConfigurationBuilder {}
+}

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/custom/HighlightFields.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/custom/HighlightFields.java
@@ -1,0 +1,46 @@
+package com.linkedin.metadata.config.search.custom;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.util.Collections;
+import java.util.List;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder(toBuilder = true)
+@Getter
+@ToString
+@EqualsAndHashCode
+@JsonDeserialize(builder = HighlightFields.HighlightFieldsBuilder.class)
+public class HighlightFields {
+
+  // Whether highlighting is enabled
+  @Builder.Default private boolean enabled = true;
+
+  // Fields to add to the system defaults
+  @Builder.Default private List<String> add = Collections.emptyList();
+
+  // Fields to remove from the system defaults
+  @Builder.Default private List<String> remove = Collections.emptyList();
+
+  // Fields to completely replace the system defaults with
+  @Builder.Default private List<String> replace = Collections.emptyList();
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class HighlightFieldsBuilder {}
+
+  /**
+   * Validates that operations are mutually exclusive with replace (add + remove is allowed, but
+   * replace must be used alone)
+   */
+  @JsonIgnore
+  public boolean isValid() {
+    if (!replace.isEmpty()) {
+      return add.isEmpty() && remove.isEmpty();
+    }
+    return true;
+  }
+}

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/custom/SearchFields.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/custom/SearchFields.java
@@ -1,0 +1,43 @@
+package com.linkedin.metadata.config.search.custom;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.util.Collections;
+import java.util.List;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder(toBuilder = true)
+@Getter
+@ToString
+@EqualsAndHashCode
+@JsonDeserialize(builder = SearchFields.SearchFieldsBuilder.class)
+public class SearchFields {
+
+  // Fields to add to the system defaults
+  @Builder.Default private List<String> add = Collections.emptyList();
+
+  // Fields to remove from the system defaults
+  @Builder.Default private List<String> remove = Collections.emptyList();
+
+  // Fields to completely replace the system defaults with
+  @Builder.Default private List<String> replace = Collections.emptyList();
+
+  @JsonPOJOBuilder(withPrefix = "")
+  public static class SearchFieldsBuilder {}
+
+  /**
+   * Validates that operations are mutually exclusive with replace (add + remove is allowed, but
+   * replace must be used alone)
+   */
+  @JsonIgnore
+  public boolean isValid() {
+    if (!replace.isEmpty()) {
+      return add.isEmpty() && remove.isEmpty();
+    }
+    return true;
+  }
+}

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -304,6 +304,8 @@ elasticsearch:
     custom:
       enabled: ${ELASTICSEARCH_QUERY_CUSTOM_CONFIG_ENABLED:true}
       file: ${ELASTICSEARCH_QUERY_CUSTOM_CONFIG_FILE:search_config.yaml}
+      searchFieldConfigDefault: ${ELASTICSEARCH_QUERY_SEARCH_FIELD_CONFIG_DEFAULT:legacy} # which field configuration to use by default for search
+      autoCompleteFieldConfigDefault: ${ELASTICSEARCH_QUERY_AUTOCOMPLETE_FIELD_CONFIG_DEFAULT:legacy} # which field configuration to use by default for autocomplete
     graph:
       timeoutSeconds: ${ELASTICSEARCH_SEARCH_GRAPH_TIMEOUT_SECONDS:50} # graph dao timeout seconds
       batchSize: ${ELASTICSEARCH_SEARCH_GRAPH_BATCH_SIZE:1000} # graph dao batch size

--- a/metadata-service/configuration/src/main/resources/search_config.yaml
+++ b/metadata-service/configuration/src/main/resources/search_config.yaml
@@ -1,4 +1,46 @@
-# Notes:
+##################################################
+# `fieldConfigurations` Notes:
+#
+# Here we define field and highlighting options that can be referred to
+# in the `searchFlags` in the graphql API
+#
+
+fieldConfigurations:
+  # Excludes column match and highlight
+  excludeColumns:
+    searchFields:
+      remove:
+        - fieldPaths
+        - fieldPaths.*
+
+    highlightFields:
+      enabled: true
+      remove:
+        - fieldPaths
+        - fieldPaths.*
+
+  excludeColumnHighlight:
+    searchFields:
+      # No modifications - use PDL defaults
+
+    highlightFields:
+      enabled: true
+      remove:
+        - fieldPaths
+        - fieldPaths.*
+
+
+  # PDL legacy configuration
+  legacy:
+    searchFields:
+      # No modifications - use PDL defaults
+
+    highlightFields:
+      enabled: true
+      # No modifications - use PDL defaults
+
+##################################################
+# `queryConfigurations` Notes:
 #
 # First match wins
 #

--- a/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/search/custom/CustomSearchConfigurationTest.java
+++ b/metadata-service/configuration/src/test/java/com/linkedin/metadata/config/search/custom/CustomSearchConfigurationTest.java
@@ -1,0 +1,531 @@
+package com.linkedin.metadata.config.search.custom;
+
+import static org.testng.Assert.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CustomSearchConfigurationTest {
+
+  private ObjectMapper yamlMapper;
+
+  @BeforeMethod
+  public void setup() {
+    yamlMapper = new ObjectMapper(new YAMLFactory());
+  }
+
+  @Test
+  public void testDeserializeMinimalConfiguration() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  default:\n"
+            + "    searchFields: {}\n"
+            + "    highlightFields:\n"
+            + "      enabled: true\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    assertNotNull(config);
+    assertNotNull(config.getFieldConfigurations());
+    assertEquals(config.getFieldConfigurations().size(), 1);
+    assertTrue(config.getFieldConfigurations().containsKey("default"));
+
+    FieldConfiguration defaultConfig = config.getFieldConfigurations().get("default");
+    assertNotNull(defaultConfig.getSearchFields());
+    assertNotNull(defaultConfig.getHighlightFields());
+    assertTrue(defaultConfig.getHighlightFields().isEnabled());
+  }
+
+  @Test
+  public void testDeserializeWithAddOperation() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  technical:\n"
+            + "    searchFields:\n"
+            + "      add:\n"
+            + "        - fieldPaths\n"
+            + "        - platform\n"
+            + "        - origin\n"
+            + "    highlightFields:\n"
+            + "      enabled: true\n"
+            + "      add:\n"
+            + "        - fieldPaths\n"
+            + "        - platform\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    FieldConfiguration techConfig = config.getFieldConfigurations().get("technical");
+    assertNotNull(techConfig);
+
+    SearchFields searchFields = techConfig.getSearchFields();
+    assertEquals(searchFields.getAdd().size(), 3);
+    assertTrue(searchFields.getAdd().contains("fieldPaths"));
+    assertTrue(searchFields.getAdd().contains("platform"));
+    assertTrue(searchFields.getAdd().contains("origin"));
+    assertTrue(searchFields.getRemove().isEmpty());
+    assertTrue(searchFields.getReplace().isEmpty());
+
+    HighlightFields highlightFields = techConfig.getHighlightFields();
+    assertTrue(highlightFields.isEnabled());
+    assertEquals(highlightFields.getAdd().size(), 2);
+    assertTrue(highlightFields.getAdd().contains("fieldPaths"));
+    assertTrue(highlightFields.getAdd().contains("platform"));
+  }
+
+  @Test
+  public void testDeserializeWithRemoveOperation() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  public:\n"
+            + "    searchFields:\n"
+            + "      remove:\n"
+            + "        - owners\n"
+            + "        - customProperties\n"
+            + "    highlightFields:\n"
+            + "      enabled: true\n"
+            + "      remove:\n"
+            + "        - owners\n"
+            + "        - customProperties\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    FieldConfiguration publicConfig = config.getFieldConfigurations().get("public");
+    assertNotNull(publicConfig);
+
+    SearchFields searchFields = publicConfig.getSearchFields();
+    assertEquals(searchFields.getRemove().size(), 2);
+    assertTrue(searchFields.getRemove().contains("owners"));
+    assertTrue(searchFields.getRemove().contains("customProperties"));
+    assertTrue(searchFields.getAdd().isEmpty());
+    assertTrue(searchFields.getReplace().isEmpty());
+  }
+
+  @Test
+  public void testDeserializeWithReplaceOperation() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  business:\n"
+            + "    searchFields:\n"
+            + "      replace:\n"
+            + "        - name\n"
+            + "        - description\n"
+            + "        - tags\n"
+            + "    highlightFields:\n"
+            + "      enabled: true\n"
+            + "      replace:\n"
+            + "        - name\n"
+            + "        - description\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    FieldConfiguration businessConfig = config.getFieldConfigurations().get("business");
+    assertNotNull(businessConfig);
+
+    SearchFields searchFields = businessConfig.getSearchFields();
+    assertEquals(searchFields.getReplace().size(), 3);
+    assertTrue(searchFields.getReplace().contains("name"));
+    assertTrue(searchFields.getReplace().contains("description"));
+    assertTrue(searchFields.getReplace().contains("tags"));
+    assertTrue(searchFields.getAdd().isEmpty());
+    assertTrue(searchFields.getRemove().isEmpty());
+  }
+
+  @Test
+  public void testDeserializeWithDisabledHighlighting() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  no-highlight:\n"
+            + "    searchFields: {}\n"
+            + "    highlightFields:\n"
+            + "      enabled: false\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    FieldConfiguration noHighlightConfig = config.getFieldConfigurations().get("no-highlight");
+    assertNotNull(noHighlightConfig);
+    assertFalse(noHighlightConfig.getHighlightFields().isEnabled());
+  }
+
+  @Test
+  public void testDeserializeWithQueryConfiguration() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  default:\n"
+            + "    searchFields: {}\n"
+            + "    highlightFields:\n"
+            + "      enabled: true\n"
+            + "queryConfigurations:\n"
+            + "  - queryRegex: \".*\"\n"
+            + "    simpleQuery: true\n"
+            + "    prefixMatchQuery: true\n"
+            + "    exactMatchQuery: true\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    assertNotNull(config.getQueryConfigurations());
+    assertEquals(config.getQueryConfigurations().size(), 1);
+
+    QueryConfiguration queryConfig = config.getQueryConfigurations().get(0);
+    assertEquals(queryConfig.getQueryRegex(), ".*");
+    assertTrue(queryConfig.isSimpleQuery());
+    assertTrue(queryConfig.isPrefixMatchQuery());
+    assertTrue(queryConfig.isExactMatchQuery());
+  }
+
+  @Test
+  public void testDeserializeWithAutocompleteConfiguration() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  autocomplete:\n"
+            + "    searchFields:\n"
+            + "      replace:\n"
+            + "        - name\n"
+            + "        - name.keyword\n"
+            + "    highlightFields:\n"
+            + "      enabled: false\n"
+            + "autocompleteConfigurations:\n"
+            + "  - queryRegex: \".*\"\n"
+            + "    defaultQuery: true\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    assertNotNull(config.getAutocompleteConfigurations());
+    assertEquals(config.getAutocompleteConfigurations().size(), 1);
+
+    AutocompleteConfiguration autocompleteConfig = config.getAutocompleteConfigurations().get(0);
+    assertEquals(autocompleteConfig.getQueryRegex(), ".*");
+    assertTrue(autocompleteConfig.isDefaultQuery());
+  }
+
+  @Test
+  public void testSerializeConfiguration() throws IOException {
+    // Build a configuration programmatically
+    CustomSearchConfiguration config =
+        CustomSearchConfiguration.builder()
+            .fieldConfigurations(
+                Map.of(
+                    "test",
+                    FieldConfiguration.builder()
+                        .searchFields(
+                            SearchFields.builder().add(Arrays.asList("field1", "field2")).build())
+                        .highlightFields(
+                            HighlightFields.builder()
+                                .enabled(true)
+                                .replace(Arrays.asList("field1"))
+                                .build())
+                        .build()))
+            .queryConfigurations(
+                Collections.singletonList(
+                    QueryConfiguration.builder().queryRegex(".*").simpleQuery(true).build()))
+            .build();
+
+    // Serialize to YAML
+    String yaml = yamlMapper.writeValueAsString(config);
+
+    // Deserialize back
+    CustomSearchConfiguration deserialized =
+        yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    // Verify round-trip
+    assertEquals(deserialized.getFieldConfigurations().size(), 1);
+    assertTrue(deserialized.getFieldConfigurations().containsKey("test"));
+
+    FieldConfiguration testConfig = deserialized.getFieldConfigurations().get("test");
+    assertEquals(testConfig.getSearchFields().getAdd().size(), 2);
+    assertTrue(testConfig.getSearchFields().getAdd().contains("field1"));
+    assertTrue(testConfig.getSearchFields().getAdd().contains("field2"));
+
+    assertEquals(testConfig.getHighlightFields().getReplace().size(), 1);
+    assertTrue(testConfig.getHighlightFields().getReplace().contains("field1"));
+  }
+
+  @Test
+  public void testComplexConfiguration() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  default:\n"
+            + "    searchFields: {}\n"
+            + "    highlightFields:\n"
+            + "      enabled: true\n"
+            + "  technical:\n"
+            + "    searchFields:\n"
+            + "      add:\n"
+            + "        - fieldPaths\n"
+            + "        - platform\n"
+            + "      remove:\n"
+            + "        - owners\n"
+            + "    highlightFields:\n"
+            + "      enabled: true\n"
+            + "      add:\n"
+            + "        - fieldPaths\n"
+            + "  business:\n"
+            + "    searchFields:\n"
+            + "      replace:\n"
+            + "        - name\n"
+            + "        - description\n"
+            + "    highlightFields:\n"
+            + "      enabled: false\n"
+            + "queryConfigurations:\n"
+            + "  - queryRegex: \".*\"\n"
+            + "    simpleQuery: true\n"
+            + "  - queryRegex: \"technical:.*\"\n"
+            + "    simpleQuery: false\n"
+            + "autocompleteConfigurations:\n"
+            + "  - queryRegex: \".*\"\n"
+            + "    defaultQuery: true\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    // Verify field configurations
+    assertEquals(config.getFieldConfigurations().size(), 3);
+    assertTrue(config.getFieldConfigurations().containsKey("default"));
+    assertTrue(config.getFieldConfigurations().containsKey("technical"));
+    assertTrue(config.getFieldConfigurations().containsKey("business"));
+
+    // Verify query configurations
+    assertEquals(config.getQueryConfigurations().size(), 2);
+
+    // Verify autocomplete configurations
+    assertEquals(config.getAutocompleteConfigurations().size(), 1);
+  }
+
+  @Test
+  public void testSearchFieldsValidation() {
+    // Valid: only add operation
+    SearchFields validAdd = SearchFields.builder().add(Arrays.asList("field1", "field2")).build();
+    assertTrue(validAdd.isValid());
+
+    // Valid: only remove operation
+    SearchFields validRemove =
+        SearchFields.builder().remove(Arrays.asList("field1", "field2")).build();
+    assertTrue(validRemove.isValid());
+
+    // Valid: only replace operation
+    SearchFields validReplace =
+        SearchFields.builder().replace(Arrays.asList("field1", "field2")).build();
+    assertTrue(validReplace.isValid());
+
+    // Valid: no operations
+    SearchFields validEmpty = SearchFields.builder().build();
+    assertTrue(validEmpty.isValid());
+
+    // Valid: add and remove together
+    SearchFields validAddRemove =
+        SearchFields.builder()
+            .add(Arrays.asList("field1", "field2"))
+            .remove(Arrays.asList("field3", "field4"))
+            .build();
+    assertTrue(validAddRemove.isValid());
+
+    // Invalid: replace with add
+    SearchFields invalidReplaceAdd =
+        SearchFields.builder()
+            .replace(Arrays.asList("field1"))
+            .add(Arrays.asList("field2"))
+            .build();
+    assertFalse(invalidReplaceAdd.isValid());
+
+    // Invalid: replace with remove
+    SearchFields invalidReplaceRemove =
+        SearchFields.builder()
+            .replace(Arrays.asList("field1"))
+            .remove(Arrays.asList("field2"))
+            .build();
+    assertFalse(invalidReplaceRemove.isValid());
+
+    // Invalid: replace with both add and remove
+    SearchFields invalidReplaceAll =
+        SearchFields.builder()
+            .replace(Arrays.asList("field1"))
+            .add(Arrays.asList("field2"))
+            .remove(Arrays.asList("field3"))
+            .build();
+    assertFalse(invalidReplaceAll.isValid());
+  }
+
+  @Test
+  public void testHighlightFieldsValidation() {
+    // Valid: only add operation with enabled
+    HighlightFields validAdd =
+        HighlightFields.builder().enabled(true).add(Arrays.asList("field1", "field2")).build();
+    assertTrue(validAdd.isValid());
+
+    // Valid: disabled with no operations
+    HighlightFields validDisabled = HighlightFields.builder().enabled(false).build();
+    assertTrue(validDisabled.isValid());
+
+    // Valid: add and remove together
+    HighlightFields validAddRemove =
+        HighlightFields.builder()
+            .enabled(true)
+            .add(Arrays.asList("field1"))
+            .remove(Arrays.asList("field2"))
+            .build();
+    assertTrue(validAddRemove.isValid());
+
+    // Invalid: replace with add
+    HighlightFields invalidReplaceAdd =
+        HighlightFields.builder()
+            .enabled(true)
+            .replace(Arrays.asList("field1"))
+            .add(Arrays.asList("field2"))
+            .build();
+    assertFalse(invalidReplaceAdd.isValid());
+  }
+
+  @Test
+  public void testDeserializeWithAddAndRemoveOperations() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  custom:\n"
+            + "    searchFields:\n"
+            + "      add:\n"
+            + "        - platform\n"
+            + "        - origin\n"
+            + "      remove:\n"
+            + "        - owners\n"
+            + "        - customProperties\n"
+            + "    highlightFields:\n"
+            + "      enabled: true\n"
+            + "      add:\n"
+            + "        - platform\n"
+            + "      remove:\n"
+            + "        - owners\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    FieldConfiguration customConfig = config.getFieldConfigurations().get("custom");
+    assertNotNull(customConfig);
+
+    SearchFields searchFields = customConfig.getSearchFields();
+    assertEquals(searchFields.getAdd().size(), 2);
+    assertTrue(searchFields.getAdd().contains("platform"));
+    assertTrue(searchFields.getAdd().contains("origin"));
+    assertEquals(searchFields.getRemove().size(), 2);
+    assertTrue(searchFields.getRemove().contains("owners"));
+    assertTrue(searchFields.getRemove().contains("customProperties"));
+    assertTrue(searchFields.getReplace().isEmpty());
+    assertTrue(searchFields.isValid());
+
+    HighlightFields highlightFields = customConfig.getHighlightFields();
+    assertTrue(highlightFields.isEnabled());
+    assertEquals(highlightFields.getAdd().size(), 1);
+    assertTrue(highlightFields.getAdd().contains("platform"));
+    assertEquals(highlightFields.getRemove().size(), 1);
+    assertTrue(highlightFields.getRemove().contains("owners"));
+    assertTrue(highlightFields.isValid());
+  }
+
+  @Test
+  public void testDeserializeWithMissingFieldConfigurations() throws IOException {
+    String yaml =
+        "queryConfigurations:\n"
+            + "  - queryRegex: \".*\"\n"
+            + "    simpleQuery: true\n"
+            + "autocompleteConfigurations:\n"
+            + "  - queryRegex: \".*\"\n"
+            + "    defaultQuery: true\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    assertNotNull(config);
+    assertNotNull(config.getFieldConfigurations());
+    assertTrue(config.getFieldConfigurations().isEmpty());
+    assertEquals(config.getQueryConfigurations().size(), 1);
+    assertEquals(config.getAutocompleteConfigurations().size(), 1);
+  }
+
+  @Test
+  public void testDeserializeWithEmptyFieldConfigurations() throws IOException {
+    String yaml =
+        "fieldConfigurations: {}\n"
+            + "queryConfigurations:\n"
+            + "  - queryRegex: \".*\"\n"
+            + "    simpleQuery: true\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    assertNotNull(config);
+    assertNotNull(config.getFieldConfigurations());
+    assertTrue(config.getFieldConfigurations().isEmpty());
+    assertEquals(config.getQueryConfigurations().size(), 1);
+  }
+
+  @Test
+  public void testDeserializeCompletelyEmpty() throws IOException {
+    String yaml = "{}";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    assertNotNull(config);
+    assertNotNull(config.getFieldConfigurations());
+    assertTrue(config.getFieldConfigurations().isEmpty());
+    assertNotNull(config.getQueryConfigurations());
+    assertTrue(config.getQueryConfigurations().isEmpty());
+    assertNotNull(config.getAutocompleteConfigurations());
+    assertTrue(config.getAutocompleteConfigurations().isEmpty());
+  }
+
+  @Test
+  public void testDeserializeWithNullFieldConfigurationLabel() throws IOException {
+    String yaml = "queryConfigurations:\n" + "  - queryRegex: \".*\"\n" + "    simpleQuery: true\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    assertNotNull(config.getQueryConfigurations().get(0));
+  }
+
+  @Test
+  public void testDeserializeWithMissingSearchAndHighlightFields() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  minimal:\n"
+            + "    searchFields: {}\n"
+            + "    highlightFields: {}\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    FieldConfiguration minimalConfig = config.getFieldConfigurations().get("minimal");
+    assertNotNull(minimalConfig);
+    assertNotNull(minimalConfig.getSearchFields());
+    assertNotNull(minimalConfig.getHighlightFields());
+    assertTrue(minimalConfig.getSearchFields().getAdd().isEmpty());
+    assertTrue(minimalConfig.getSearchFields().getRemove().isEmpty());
+    assertTrue(minimalConfig.getSearchFields().getReplace().isEmpty());
+    assertTrue(minimalConfig.getHighlightFields().isEnabled()); // Should default to true
+  }
+
+  @Test
+  public void testDeserializeWithPartialFieldConfiguration() throws IOException {
+    String yaml =
+        "fieldConfigurations:\n"
+            + "  searchOnly:\n"
+            + "    searchFields:\n"
+            + "      add:\n"
+            + "        - field1\n"
+            + "  highlightOnly:\n"
+            + "    highlightFields:\n"
+            + "      enabled: false\n";
+
+    CustomSearchConfiguration config = yamlMapper.readValue(yaml, CustomSearchConfiguration.class);
+
+    // Check searchOnly config
+    FieldConfiguration searchOnlyConfig = config.getFieldConfigurations().get("searchOnly");
+    assertNotNull(searchOnlyConfig);
+    assertNotNull(searchOnlyConfig.getSearchFields());
+    assertNull(searchOnlyConfig.getHighlightFields()); // Should be null if not specified
+
+    // Check highlightOnly config
+    FieldConfiguration highlightOnlyConfig = config.getFieldConfigurations().get("highlightOnly");
+    assertNotNull(highlightOnlyConfig);
+    assertNull(highlightOnlyConfig.getSearchFields()); // Should be null if not specified
+    assertNotNull(highlightOnlyConfig.getHighlightFields());
+    assertFalse(highlightOnlyConfig.getHighlightFields().isEnabled());
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchServiceFactory.java
@@ -41,31 +41,49 @@ public class ElasticSearchServiceFactory {
   @Qualifier("entityRegistry")
   private EntityRegistry entityRegistry;
 
+  @Bean
+  protected ElasticSearchConfiguration elasticSearchConfiguration(
+      final ConfigurationProvider configurationProvider) {
+    log.info("Search configuration: {}", configurationProvider.getElasticSearch().getSearch());
+    return configurationProvider.getElasticSearch();
+  }
+
+  @Bean
+  protected CustomSearchConfiguration customSearchConfiguration(
+      final ElasticSearchConfiguration elasticSearchConfiguration) throws IOException {
+    SearchConfiguration searchConfiguration = elasticSearchConfiguration.getSearch();
+    return searchConfiguration.getCustom() == null
+        ? null
+        : searchConfiguration.getCustom().resolve(ObjectMapperContext.DEFAULT.getYamlMapper());
+  }
+
+  @Bean
+  protected ESSearchDAO esSearchDAO(
+      final ConfigurationProvider configurationProvider,
+      final QueryFilterRewriteChain queryFilterRewriteChain,
+      final ElasticSearchConfiguration elasticSearchConfiguration,
+      final CustomSearchConfiguration customSearchConfiguration) {
+
+    return new ESSearchDAO(
+        components.getSearchClient(),
+        configurationProvider.getFeatureFlags().isPointInTimeCreationEnabled(),
+        elasticSearchConfiguration.getImplementation(),
+        elasticSearchConfiguration,
+        customSearchConfiguration,
+        queryFilterRewriteChain,
+        configurationProvider.getSearchService());
+  }
+
   @Bean(name = "elasticSearchService")
   @Nonnull
   protected ElasticSearchService getInstance(
       final ConfigurationProvider configurationProvider,
-      final QueryFilterRewriteChain queryFilterRewriteChain)
+      final QueryFilterRewriteChain queryFilterRewriteChain,
+      final ElasticSearchConfiguration elasticSearchConfiguration,
+      final CustomSearchConfiguration customSearchConfiguration,
+      final ESSearchDAO esSearchDAO)
       throws IOException {
-    log.info("Search configuration: {}", configurationProvider.getElasticSearch().getSearch());
 
-    ElasticSearchConfiguration elasticSearchConfiguration =
-        configurationProvider.getElasticSearch();
-    SearchConfiguration searchConfiguration = elasticSearchConfiguration.getSearch();
-    CustomSearchConfiguration customSearchConfiguration =
-        searchConfiguration.getCustom() == null
-            ? null
-            : searchConfiguration.getCustom().resolve(ObjectMapperContext.DEFAULT.getYamlMapper());
-
-    ESSearchDAO esSearchDAO =
-        new ESSearchDAO(
-            components.getSearchClient(),
-            configurationProvider.getFeatureFlags().isPointInTimeCreationEnabled(),
-            elasticSearchConfiguration.getImplementation(),
-            elasticSearchConfiguration,
-            customSearchConfiguration,
-            queryFilterRewriteChain,
-            configurationProvider.getSearchService());
     return new ElasticSearchService(
         components.getIndexBuilder(),
         entityRegistry,

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/elastic/ElasticsearchController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/elastic/ElasticsearchController.java
@@ -12,16 +12,20 @@ import com.deblock.jsondiff.matcher.LenientNumberPrimitivePartialMatcher;
 import com.deblock.jsondiff.matcher.StrictPrimitivePartialMatcher;
 import com.deblock.jsondiff.viewer.PatchDiffViewer;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
 import com.linkedin.metadata.entity.restoreindices.RestoreIndicesResult;
+import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.elasticsearch.query.ESSearchDAO;
+import com.linkedin.metadata.search.elasticsearch.query.request.AutocompleteRequestHandler;
 import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.r2.RemoteInvocationException;
@@ -33,19 +37,31 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.json.JSONObject;
 import org.opensearch.action.explain.ExplainResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.tasks.GetTaskResponse;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -53,6 +69,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -62,10 +79,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/openapi/operations/elasticSearch")
 @Slf4j
-@Tag(
-    name = "ElasticSearch Operations",
-    description = "An API for managing your elasticsearch instance")
 public class ElasticsearchController {
+  private static final String ES_DEBUG_DESCRIPTION =
+      "An API for debugging your elasticsearch requests";
+  private static final String DEFAULT_SORT_CRITERIA =
+      "[{\"field\":\"_score\",\"order\": \"DESCENDING\"}]";
   private final AuthorizerChain authorizerChain;
   private final OperationContext systemOperationContext;
   private final SystemMetadataService systemMetadataService;
@@ -73,6 +91,7 @@ public class ElasticsearchController {
   private final EntitySearchService searchService;
   private final EntityService<?> entityService;
   private final ObjectMapper objectMapper;
+  private final ESSearchDAO esSearchDAO;
 
   public ElasticsearchController(
       OperationContext systemOperationContext,
@@ -81,14 +100,15 @@ public class ElasticsearchController {
       EntitySearchService searchService,
       EntityService<?> entityService,
       AuthorizerChain authorizerChain,
-      ObjectMapper objectMapper) {
+      ESSearchDAO esSearchDAO) {
     this.systemOperationContext = systemOperationContext;
     this.authorizerChain = authorizerChain;
     this.systemMetadataService = systemMetadataService;
     this.timeseriesAspectService = timeseriesAspectService;
     this.searchService = searchService;
     this.entityService = entityService;
-    this.objectMapper = objectMapper;
+    this.objectMapper = systemOperationContext.getObjectMapper();
+    this.esSearchDAO = esSearchDAO;
   }
 
   @InitBinder
@@ -96,6 +116,9 @@ public class ElasticsearchController {
     binder.registerCustomEditor(String[].class, new StringArrayPropertyEditor(null));
   }
 
+  @Tag(
+      name = "ElasticSearch Operations",
+      description = "An API for managing your elasticsearch instance")
   @GetMapping(path = "/getTaskStatus", produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "Get Task Status")
   public ResponseEntity<String> getTaskStatus(
@@ -139,6 +162,9 @@ public class ElasticsearchController {
     return ResponseEntity.ok(j.toString());
   }
 
+  @Tag(
+      name = "ElasticSearch Operations",
+      description = "An API for managing your elasticsearch instance")
   @GetMapping(path = "/getIndexSizes", produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "Get Index Sizes")
   public ResponseEntity<String> getIndexSizes(HttpServletRequest request) {
@@ -176,6 +202,9 @@ public class ElasticsearchController {
     return ResponseEntity.ok(j.toString());
   }
 
+  @Tag(
+      name = "ElasticSearch Debugging",
+      description = "An API for debugging your elasticsearch instance")
   @GetMapping(path = "/explainSearchQuery", produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(summary = "Explain Search Query")
   public ResponseEntity<ExplainResponse> explainSearchQuery(
@@ -222,13 +251,13 @@ public class ElasticsearchController {
           @RequestParam(value = "filters", required = false)
           @Nullable
           String filters,
-      @Parameter(
-              name = "sortCriteria",
+      @Parameter(name = "sortCriteria", description = "Criteria to sort results on.")
+          @RequestParam(
+              value = "sortCriteria",
               required = false,
-              description = "Criteria to sort results on.")
-          @RequestParam("sortCriteria")
+              defaultValue = DEFAULT_SORT_CRITERIA)
           @Nullable
-          List<SortCriterion> sortCriteria,
+          String sortCriteria,
       @Parameter(name = "searchFlags", description = "Optional configuration flags.")
           @RequestParam(
               value = "searchFlags",
@@ -270,7 +299,7 @@ public class ElasticsearchController {
             encodeValue(documentId),
             entityName,
             filters == null ? null : objectMapper.readValue(filters, Filter.class),
-            sortCriteria,
+            toSortCriteria(sortCriteria),
             scrollId,
             keepAlive,
             size,
@@ -279,6 +308,7 @@ public class ElasticsearchController {
     return ResponseEntity.ok(response);
   }
 
+  @Tag(name = "ElasticSearch Debugging", description = ES_DEBUG_DESCRIPTION)
   @GetMapping(path = "/explainSearchQueryDiff", produces = MediaType.TEXT_PLAIN_VALUE)
   @Operation(summary = "Explain the differences in scoring for 2 documents")
   public ResponseEntity<String> explainSearchQueryDiff(
@@ -332,13 +362,13 @@ public class ElasticsearchController {
           @RequestParam(value = "filters", required = false)
           @Nullable
           String filters,
-      @Parameter(
-              name = "sortCriteria",
+      @Parameter(name = "sortCriteria", description = "Criteria to sort results on.")
+          @RequestParam(
+              value = "sortCriteria",
               required = false,
-              description = "Criteria to sort results on.")
-          @RequestParam("sortCriteria")
+              defaultValue = DEFAULT_SORT_CRITERIA)
           @Nullable
-          List<SortCriterion> sortCriteria,
+          String sortCriteria,
       @Parameter(name = "searchFlags", description = "Optional configuration flags.")
           @RequestParam(
               value = "searchFlags",
@@ -381,7 +411,7 @@ public class ElasticsearchController {
             encodeValue(documentIdA),
             entityName,
             filters == null ? null : objectMapper.readValue(filters, Filter.class),
-            sortCriteria,
+            toSortCriteria(sortCriteria),
             scrollId,
             keepAlive,
             size);
@@ -393,7 +423,7 @@ public class ElasticsearchController {
             encodeValue(documentIdB),
             entityName,
             filters == null ? null : objectMapper.readValue(filters, Filter.class),
-            sortCriteria,
+            toSortCriteria(sortCriteria),
             scrollId,
             keepAlive,
             size);
@@ -417,6 +447,427 @@ public class ElasticsearchController {
     PatchDiffViewer patch = PatchDiffViewer.from(jsondiff);
 
     return ResponseEntity.ok(patch.toString());
+  }
+
+  @Tag(name = "ElasticSearch Debugging", description = ES_DEBUG_DESCRIPTION)
+  @GetMapping(path = "/query/scroll/request", produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(summary = "Return the raw elasticsearch query given common options")
+  public ResponseEntity<Map<String, Object>> getQueryScrollRequest(
+      HttpServletRequest request,
+      @Parameter(
+              name = "query",
+              required = true,
+              description =
+                  "Search term to evaluate for specified document, will be applied as an input string to standard search query builder.")
+          @RequestParam(value = "query", defaultValue = "*")
+          @Nonnull
+          String query,
+      @Parameter(
+              name = "entityName",
+              required = true,
+              description = "Name of the entity the document belongs to.")
+          @RequestParam(value = "entityName", defaultValue = "dataset")
+          @Nonnull
+          String entityName,
+      @Parameter(name = "size", required = true, description = "Page size for pagination.")
+          @RequestParam(value = "size", required = false, defaultValue = "10")
+          @Nullable
+          Integer size,
+      @Parameter(name = "filters", description = "Additional filters to apply to query.")
+          @RequestParam(value = "filters", required = false)
+          @Nullable
+          String filters,
+      @Parameter(name = "sortCriteria", description = "Criteria to sort results on.")
+          @RequestParam(
+              value = "sortCriteria",
+              required = false,
+              defaultValue = DEFAULT_SORT_CRITERIA)
+          @Nullable
+          String sortCriteria,
+      @Parameter(name = "scrollId", description = "Scroll ID for pagination.")
+          @RequestParam("scrollId")
+          @Nullable
+          String scrollId,
+      @Parameter(
+              name = "keepAlive",
+              description =
+                  "Keep alive time for point in time scroll context"
+                      + ", only relevant where point in time is supported.")
+          @RequestParam("keepAlive")
+          @Nullable
+          String keepAlive,
+      @Parameter(name = "searchFlags", description = "Optional configuration flags.")
+          @RequestParam(
+              value = "searchFlags",
+              required = false,
+              defaultValue = "{\"fulltext\":true}")
+          @Nullable
+          String searchFlags)
+      throws JsonProcessingException {
+
+    Authentication authentication = AuthenticationContext.getAuthentication();
+    String actorUrnStr = authentication.getActor().toUrnStr();
+
+    OperationContext opContext =
+        systemOperationContext
+            .asSession(
+                RequestContext.builder()
+                    .buildOpenapi(actorUrnStr, request, "getQueryScrollRequest", entityName),
+                authorizerChain,
+                authentication)
+            .withSearchFlags(
+                flags -> {
+                  try {
+                    return searchFlags == null
+                        ? flags
+                        : objectMapper.readValue(searchFlags, SearchFlags.class);
+                  } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+
+    if (!AuthUtil.isAPIOperationsAuthorized(
+        opContext, PoliciesConfig.MANAGE_SYSTEM_OPERATIONS_PRIVILEGE)) {
+      log.error(
+          "{} is not authorized for privilege " + PoliciesConfig.MANAGE_SYSTEM_OPERATIONS_PRIVILEGE,
+          actorUrnStr);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+    }
+
+    Triple<SearchRequest, Filter, List<EntitySpec>> searchRequestComponents =
+        esSearchDAO.buildScrollRequest(
+            opContext,
+            opContext.getSearchContext().getIndexConvention(),
+            scrollId,
+            keepAlive,
+            List.of(entityName),
+            size,
+            filters == null ? null : objectMapper.readValue(filters, Filter.class),
+            query,
+            toSortCriteria(sortCriteria),
+            List.of());
+
+    Map<String, Object> responseMap = new HashMap<>();
+    try {
+      SearchSourceBuilder source = searchRequestComponents.getLeft().source();
+      if (source != null) {
+        // Use toXContent to get proper JSON representation
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        source.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        // Use toXContent to serialize the source
+        source.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        // Convert to string first, then to Map
+        responseMap =
+            XContentHelper.convertToMap(JsonXContent.jsonXContent, builder.toString(), true);
+      }
+    } catch (IOException e) {
+      // Handle the exception appropriately
+      throw new RuntimeException("Failed to convert SearchSourceBuilder to Map", e);
+    }
+
+    return ResponseEntity.ok(responseMap);
+  }
+
+  @Tag(name = "ElasticSearch Debugging", description = ES_DEBUG_DESCRIPTION)
+  @GetMapping(path = "/query/search/request", produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(summary = "Return the raw elasticsearch query given common options")
+  public ResponseEntity<Map<String, Object>> getQuerySearchRequest(
+      HttpServletRequest request,
+      @Parameter(
+              name = "query",
+              required = true,
+              description =
+                  "Search term to evaluate for specified document, will be applied as an input string to standard search query builder.")
+          @RequestParam(value = "query", defaultValue = "*")
+          @Nonnull
+          String query,
+      @Parameter(
+              name = "entityName",
+              required = true,
+              description = "Name of the entity the document belongs to.")
+          @RequestParam(value = "entityName", defaultValue = "dataset")
+          @Nonnull
+          String entityName,
+      @Parameter(name = "size", required = true, description = "Page size for pagination.")
+          @RequestParam(value = "size", required = false, defaultValue = "10")
+          @Nullable
+          Integer size,
+      @Parameter(name = "filters", description = "Additional filters to apply to query.")
+          @RequestParam(value = "filters", required = false)
+          @Nullable
+          String filters,
+      @Parameter(name = "sortCriteria", description = "Criteria to sort results on.")
+          @RequestParam(
+              value = "sortCriteria",
+              required = false,
+              defaultValue = DEFAULT_SORT_CRITERIA)
+          @Nullable
+          String sortCriteria,
+      @Parameter(name = "searchFlags", description = "Optional configuration flags.")
+          @RequestParam(
+              value = "searchFlags",
+              required = false,
+              defaultValue = "{\"fulltext\":true}")
+          @Nullable
+          String searchFlags)
+      throws JsonProcessingException {
+
+    Authentication authentication = AuthenticationContext.getAuthentication();
+    String actorUrnStr = authentication.getActor().toUrnStr();
+
+    OperationContext opContext =
+        systemOperationContext
+            .asSession(
+                RequestContext.builder()
+                    .buildOpenapi(actorUrnStr, request, "getQuerySearchRequest", entityName),
+                authorizerChain,
+                authentication)
+            .withSearchFlags(
+                flags -> {
+                  try {
+                    return searchFlags == null
+                        ? flags
+                        : objectMapper.readValue(searchFlags, SearchFlags.class);
+                  } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+
+    if (!AuthUtil.isAPIOperationsAuthorized(
+        opContext, PoliciesConfig.MANAGE_SYSTEM_OPERATIONS_PRIVILEGE)) {
+      log.error(
+          "{} is not authorized for privilege " + PoliciesConfig.MANAGE_SYSTEM_OPERATIONS_PRIVILEGE,
+          actorUrnStr);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+    }
+
+    Triple<SearchRequest, Filter, List<EntitySpec>> searchRequestComponents =
+        esSearchDAO.buildSearchRequest(
+            opContext,
+            List.of(entityName),
+            query,
+            filters == null ? null : objectMapper.readValue(filters, Filter.class),
+            toSortCriteria(sortCriteria),
+            0,
+            size,
+            List.of());
+
+    Map<String, Object> responseMap = new HashMap<>();
+    try {
+      SearchSourceBuilder source = searchRequestComponents.getLeft().source();
+      if (source != null) {
+        // Use toXContent to get proper JSON representation
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        source.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        // Use toXContent to serialize the source
+        source.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        // Convert to string first, then to Map
+        responseMap =
+            XContentHelper.convertToMap(JsonXContent.jsonXContent, builder.toString(), true);
+      }
+    } catch (IOException e) {
+      // Handle the exception appropriately
+      throw new RuntimeException("Failed to convert SearchSourceBuilder to Map", e);
+    }
+
+    return ResponseEntity.ok(responseMap);
+  }
+
+  @Tag(name = "ElasticSearch Debugging", description = ES_DEBUG_DESCRIPTION)
+  @GetMapping(
+      path = "/query/autocomplete/request/{fieldName}",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(summary = "Return the raw elasticsearch query given common options")
+  public ResponseEntity<Map<String, Object>> getQueryAutocompleteRequest(
+      HttpServletRequest request,
+      @PathVariable("fieldName") String fieldName,
+      @Parameter(
+              name = "query",
+              required = true,
+              description =
+                  "Search term to evaluate for specified document, will be applied as an input string to standard search query builder.")
+          @RequestParam(value = "query", defaultValue = "*")
+          @Nonnull
+          String query,
+      @Parameter(
+              name = "entityName",
+              required = true,
+              description = "Name of the entity the document belongs to.")
+          @RequestParam(value = "entityName", defaultValue = "dataset")
+          @Nonnull
+          String entityName,
+      @Parameter(name = "size", required = true, description = "Page size for pagination.")
+          @RequestParam(value = "size", required = false, defaultValue = "10")
+          @Nullable
+          Integer size,
+      @Parameter(name = "filters", description = "Additional filters to apply to query.")
+          @RequestParam(value = "filters", required = false)
+          @Nullable
+          String filters,
+      @Parameter(name = "searchFlags", description = "Optional configuration flags.")
+          @RequestParam(
+              value = "searchFlags",
+              required = false,
+              defaultValue = "{\"fulltext\":true}")
+          @Nullable
+          String searchFlags)
+      throws JsonProcessingException {
+
+    Authentication authentication = AuthenticationContext.getAuthentication();
+    String actorUrnStr = authentication.getActor().toUrnStr();
+
+    OperationContext opContext =
+        systemOperationContext
+            .asSession(
+                RequestContext.builder()
+                    .buildOpenapi(actorUrnStr, request, "getQueryAutocompleteRequest", entityName),
+                authorizerChain,
+                authentication)
+            .withSearchFlags(
+                flags -> {
+                  try {
+                    return searchFlags == null
+                        ? flags
+                        : objectMapper.readValue(searchFlags, SearchFlags.class);
+                  } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+
+    if (!AuthUtil.isAPIOperationsAuthorized(
+        opContext, PoliciesConfig.MANAGE_SYSTEM_OPERATIONS_PRIVILEGE)) {
+      log.error(
+          "{} is not authorized for privilege " + PoliciesConfig.MANAGE_SYSTEM_OPERATIONS_PRIVILEGE,
+          actorUrnStr);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+    }
+
+    Pair<SearchRequest, AutocompleteRequestHandler> searchRequestComponents =
+        esSearchDAO.buildAutocompleteRequest(
+            opContext,
+            entityName,
+            query,
+            fieldName,
+            filters == null ? null : objectMapper.readValue(filters, Filter.class),
+            size);
+
+    Map<String, Object> responseMap = new HashMap<>();
+    try {
+      SearchSourceBuilder source = searchRequestComponents.getLeft().source();
+      if (source != null) {
+        // Use toXContent to get proper JSON representation
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        source.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        // Use toXContent to serialize the source
+        source.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        // Convert to string first, then to Map
+        responseMap =
+            XContentHelper.convertToMap(JsonXContent.jsonXContent, builder.toString(), true);
+      }
+    } catch (IOException e) {
+      // Handle the exception appropriately
+      throw new RuntimeException("Failed to convert SearchSourceBuilder to Map", e);
+    }
+
+    return ResponseEntity.ok(responseMap);
+  }
+
+  @Tag(name = "ElasticSearch Debugging", description = ES_DEBUG_DESCRIPTION)
+  @GetMapping(
+      path = "/query/aggregate/request/{fieldName}",
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  @Operation(summary = "Return the raw elasticsearch query given common options")
+  public ResponseEntity<Map<String, Object>> getQueryAggregateRequest(
+      HttpServletRequest request,
+      @PathVariable("fieldName") String fieldName,
+      @Parameter(
+              name = "entityName",
+              required = true,
+              description = "Name of the entity the document belongs to.")
+          @RequestParam(value = "entityName", defaultValue = "dataset")
+          @Nonnull
+          String entityName,
+      @Parameter(name = "size", required = true, description = "Page size for pagination.")
+          @RequestParam(value = "size", required = false, defaultValue = "10")
+          @Nullable
+          Integer size,
+      @Parameter(name = "filters", description = "Additional filters to apply to query.")
+          @RequestParam(value = "filters", required = false)
+          @Nullable
+          String filters,
+      @Parameter(name = "searchFlags", description = "Optional configuration flags.")
+          @RequestParam(
+              value = "searchFlags",
+              required = false,
+              defaultValue = "{\"fulltext\":true}")
+          @Nullable
+          String searchFlags)
+      throws JsonProcessingException {
+
+    Authentication authentication = AuthenticationContext.getAuthentication();
+    String actorUrnStr = authentication.getActor().toUrnStr();
+
+    OperationContext opContext =
+        systemOperationContext
+            .asSession(
+                RequestContext.builder()
+                    .buildOpenapi(actorUrnStr, request, "getQueryAggregateRequest", entityName),
+                authorizerChain,
+                authentication)
+            .withSearchFlags(
+                flags -> {
+                  try {
+                    return searchFlags == null
+                        ? flags
+                        : objectMapper.readValue(searchFlags, SearchFlags.class);
+                  } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+
+    if (!AuthUtil.isAPIOperationsAuthorized(
+        opContext, PoliciesConfig.MANAGE_SYSTEM_OPERATIONS_PRIVILEGE)) {
+      log.error(
+          "{} is not authorized for privilege " + PoliciesConfig.MANAGE_SYSTEM_OPERATIONS_PRIVILEGE,
+          actorUrnStr);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+    }
+
+    SearchRequest searchRequest =
+        esSearchDAO.buildAggregateByValue(
+            opContext,
+            List.of(entityName),
+            fieldName,
+            filters == null ? null : objectMapper.readValue(filters, Filter.class),
+            size);
+
+    Map<String, Object> responseMap = new HashMap<>();
+    try {
+      SearchSourceBuilder source = searchRequest.source();
+      if (source != null) {
+        // Use toXContent to get proper JSON representation
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        source.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        // Use toXContent to serialize the source
+        source.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        // Convert to string first, then to Map
+        responseMap =
+            XContentHelper.convertToMap(JsonXContent.jsonXContent, builder.toString(), true);
+      }
+    } catch (IOException e) {
+      // Handle the exception appropriately
+      throw new RuntimeException("Failed to convert SearchSourceBuilder to Map", e);
+    }
+
+    return ResponseEntity.ok(responseMap);
   }
 
   private static String encodeValue(String value) {
@@ -513,5 +964,17 @@ public class ElasticsearchController {
                 aspectNames,
                 batchSize,
                 createDefaultAspects)));
+  }
+
+  @Nullable
+  private List<SortCriterion> toSortCriteria(@Nullable String sortCriteriaJson)
+      throws JsonProcessingException {
+    if (sortCriteriaJson == null) {
+      return null;
+    }
+
+    return systemOperationContext
+        .getObjectMapper()
+        .readValue(sortCriteriaJson, new TypeReference<List<SortCriterion>>() {});
   }
 }

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/elastic/ElasticsearchControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/elastic/ElasticsearchControllerTest.java
@@ -24,8 +24,12 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.restoreindices.RestoreIndicesResult;
 import com.linkedin.metadata.graph.GraphService;
+import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.elasticsearch.query.ESSearchDAO;
+import com.linkedin.metadata.search.elasticsearch.query.request.AutocompleteRequestHandler;
 import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.timeseries.TimeseriesIndexSizeResult;
@@ -38,6 +42,8 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,9 +51,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.opensearch.action.explain.ExplainResponse;
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.client.tasks.GetTaskResponse;
 import org.opensearch.core.tasks.TaskId;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.tasks.TaskInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -83,8 +95,6 @@ public class ElasticsearchControllerTest extends AbstractTestNGSpringContextTest
   private static final Urn TEST_URN_2 =
       UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:snowflake,test.table,PROD)");
 
-  private OperationContext opContext = TestOperationContexts.systemContextNoValidate();
-
   @Autowired private ElasticsearchController elasticsearchController;
 
   @Autowired private MockMvc mockMvc;
@@ -98,6 +108,8 @@ public class ElasticsearchControllerTest extends AbstractTestNGSpringContextTest
   @Autowired private EntityService<?> mockEntityService;
 
   @Autowired private AuthorizerChain authorizerChain;
+
+  @Autowired private ESSearchDAO mockESSearchDAO;
 
   @BeforeMethod
   public void setupMocks() {
@@ -385,6 +397,372 @@ public class ElasticsearchControllerTest extends AbstractTestNGSpringContextTest
         .andExpect(MockMvcResultMatchers.jsonPath("$[0].lastAspect").exists());
   }
 
+  @Test
+  public void testGetEntityRawWithEmptySet() throws Exception {
+    // Prepare empty request body
+    Set<String> urnStrs = new HashSet<>();
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    String requestBody = objectMapper.writeValueAsString(urnStrs);
+
+    // Mock empty response
+    Map<Urn, Map<String, Object>> emptyMap = new HashMap<>();
+    when(mockSearchService.raw(any(OperationContext.class), anySet())).thenReturn(emptyMap);
+
+    // Test the endpoint
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/openapi/operations/elasticSearch/entity/raw")
+                .content(requestBody)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$").isEmpty());
+  }
+
+  @Test
+  public void testExplainSearchQueryWithAllParameters() throws Exception {
+    // Mock explain response
+    ExplainResponse explainResponse = mock(ExplainResponse.class);
+    when(mockSearchService.explain(
+            any(OperationContext.class),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any(),
+            anyString(),
+            anyString(),
+            anyInt(),
+            anyList()))
+        .thenReturn(explainResponse);
+
+    // Test the endpoint with all parameters
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/operations/elasticSearch/explainSearchQuery")
+                .param("query", "complex test query")
+                .param("documentId", TEST_URN_1.toString())
+                .param("entityName", "dataset")
+                .param("scrollId", "scroll123")
+                .param("keepAlive", "5m")
+                .param("size", "10")
+                .param("filters", "{}")
+                .param("searchFlags", "{\"fulltext\":true,\"skipHighlighting\":false}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  public void testExplainSearchQueryDiff() throws Exception {
+    // Mock explain responses for both documents
+    ExplainResponse explainResponseA = mock(ExplainResponse.class);
+    ExplainResponse explainResponseB = mock(ExplainResponse.class);
+
+    when(mockSearchService.explain(
+            any(OperationContext.class),
+            eq("test query"),
+            eq(URLEncoder.encode(TEST_URN_1.toString(), StandardCharsets.UTF_8)),
+            eq("dataset"),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyInt()))
+        .thenReturn(explainResponseA);
+
+    when(mockSearchService.explain(
+            any(OperationContext.class),
+            eq("test query"),
+            eq(URLEncoder.encode(TEST_URN_2.toString(), StandardCharsets.UTF_8)),
+            eq("dataset"),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyInt()))
+        .thenReturn(explainResponseB);
+
+    // Test the endpoint
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/operations/elasticSearch/explainSearchQueryDiff")
+                .param("query", "test query")
+                .param("documentIdA", TEST_URN_1.toString())
+                .param("documentIdB", TEST_URN_2.toString())
+                .param("entityName", "dataset")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.TEXT_PLAIN))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  public void testGetQueryScrollRequest() throws Exception {
+    // Mock the search request components
+    SearchRequest searchRequest = mock(SearchRequest.class);
+    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+    searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+    searchSourceBuilder.size(10);
+    when(searchRequest.source()).thenReturn(searchSourceBuilder);
+
+    List<EntitySpec> entitySpecs = new ArrayList<>();
+    Triple<SearchRequest, Filter, List<EntitySpec>> searchRequestComponents =
+        Triple.of(searchRequest, null, entitySpecs);
+
+    when(mockESSearchDAO.buildScrollRequest(
+            any(OperationContext.class),
+            any(),
+            anyString(),
+            anyString(),
+            anyList(),
+            anyInt(),
+            any(),
+            anyString(),
+            any(),
+            anyList()))
+        .thenReturn(searchRequestComponents);
+
+    // Test the endpoint
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/operations/elasticSearch/query/scroll/request")
+                .param("query", "test query")
+                .param("entityName", "dataset")
+                .param("size", "10")
+                .param("scrollId", "scroll123")
+                .param("keepAlive", "5m")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.query").exists())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.size").value(10));
+  }
+
+  @Test
+  public void testGetQuerySearchRequest() throws Exception {
+    // Mock the search request components
+    SearchRequest searchRequest = mock(SearchRequest.class);
+    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+    searchSourceBuilder.query(QueryBuilders.matchQuery("name", "test"));
+    searchSourceBuilder.size(20);
+    when(searchRequest.source()).thenReturn(searchSourceBuilder);
+
+    Filter filter = mock(Filter.class);
+    List<EntitySpec> entitySpecs = new ArrayList<>();
+    Triple<SearchRequest, Filter, List<EntitySpec>> searchRequestComponents =
+        Triple.of(searchRequest, filter, entitySpecs);
+
+    when(mockESSearchDAO.buildSearchRequest(
+            any(OperationContext.class),
+            anyList(),
+            anyString(),
+            any(),
+            any(),
+            anyInt(),
+            anyInt(),
+            anyList()))
+        .thenReturn(searchRequestComponents);
+
+    // Test the endpoint
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/operations/elasticSearch/query/search/request")
+                .param("query", "test")
+                .param("entityName", "dataset")
+                .param("size", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.query").exists())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.size").value(20));
+  }
+
+  @Test
+  public void testGetQueryAutocompleteRequest() throws Exception {
+    // Mock the autocomplete request components
+    SearchRequest searchRequest = mock(SearchRequest.class);
+    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+    searchSourceBuilder.size(10);
+    when(searchRequest.source()).thenReturn(searchSourceBuilder);
+
+    AutocompleteRequestHandler handler = mock(AutocompleteRequestHandler.class);
+    Pair<SearchRequest, AutocompleteRequestHandler> searchRequestComponents =
+        Pair.of(searchRequest, handler);
+
+    when(mockESSearchDAO.buildAutocompleteRequest(
+            any(OperationContext.class), anyString(), anyString(), anyString(), any(), anyInt()))
+        .thenReturn(searchRequestComponents);
+
+    // Test the endpoint
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(
+                    "/openapi/operations/elasticSearch/query/autocomplete/request/name")
+                .param("query", "test")
+                .param("entityName", "dataset")
+                .param("size", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.size").value(10));
+  }
+
+  @Test
+  public void testGetQueryAggregateRequest() throws Exception {
+    // Mock the aggregate request
+    SearchRequest searchRequest = mock(SearchRequest.class);
+    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+    searchSourceBuilder.size(0); // Aggregations typically have size 0
+    searchSourceBuilder.aggregation(
+        AggregationBuilders.terms("fieldName").field("fieldName").size(10));
+    when(searchRequest.source()).thenReturn(searchSourceBuilder);
+
+    when(mockESSearchDAO.buildAggregateByValue(
+            any(OperationContext.class), anyList(), anyString(), any(), anyInt()))
+        .thenReturn(searchRequest);
+
+    // Test the endpoint
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get(
+                    "/openapi/operations/elasticSearch/query/aggregate/request/platform")
+                .param("entityName", "dataset")
+                .param("size", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.size").value(0))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.aggregations").exists());
+  }
+
+  @Test
+  public void testRestoreIndicesGetWithAllParameters() throws Exception {
+    // Mock restore indices response
+    List<RestoreIndicesResult> restoreResults = new ArrayList<>();
+    RestoreIndicesResult restoreResult = mock(RestoreIndicesResult.class);
+    when(restoreResult.getIgnored()).thenReturn(5);
+    when(restoreResult.getRowsMigrated()).thenReturn(100);
+    when(restoreResult.getTimeSqlQueryMs()).thenReturn(1500L);
+    when(restoreResult.getTimeGetRowMs()).thenReturn(200L);
+    when(restoreResult.getTimeUrnMs()).thenReturn(300L);
+    when(restoreResult.getTimeEntityRegistryCheckMs()).thenReturn(50L);
+    when(restoreResult.getAspectCheckMs()).thenReturn(100L);
+    when(restoreResult.getCreateRecordMs()).thenReturn(150L);
+    when(restoreResult.getSendMessageMs()).thenReturn(75L);
+    when(restoreResult.getDefaultAspectsCreated()).thenReturn(10L);
+    when(restoreResult.getLastUrn()).thenReturn(TEST_URN_2.toString());
+    when(restoreResult.getLastAspect()).thenReturn("datasetProperties");
+    restoreResults.add(restoreResult);
+
+    when(mockEntityService.restoreIndices(any(OperationContext.class), any(), any()))
+        .thenReturn(restoreResults);
+
+    // Test GET endpoint with all parameters
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/operations/elasticSearch/restoreIndices")
+                .param("aspectName", "datasetProperties")
+                .param("urn", TEST_URN_1.toString())
+                .param("urnLike", "%dataset%")
+                .param("batchSize", "1000")
+                .param("start", "100")
+                .param("limit", "500")
+                .param("gePitEpochMs", "1640995200000")
+                .param("lePitEpochMs", "1672531200000")
+                .param("createDefaultAspects", "true")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].ignored").value(5))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].rowsMigrated").value(100))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].timeSqlQueryMs").value(1500))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].defaultAspectsCreated").value(10))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].lastUrn").value(TEST_URN_2.toString()))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].lastAspect").value("datasetProperties"));
+  }
+
+  @Test
+  public void testRestoreIndicesPostWithMultipleAspects() throws Exception {
+    // Mock restore indices response
+    List<RestoreIndicesResult> restoreResults = new ArrayList<>();
+    RestoreIndicesResult restoreResult1 = mock(RestoreIndicesResult.class);
+    when(restoreResult1.getIgnored()).thenReturn(0);
+    when(restoreResult1.getRowsMigrated()).thenReturn(50);
+    when(restoreResult1.getTimeSqlQueryMs()).thenReturn(800L);
+    when(restoreResult1.getLastAspect()).thenReturn("datasetProperties");
+
+    RestoreIndicesResult restoreResult2 = mock(RestoreIndicesResult.class);
+    when(restoreResult2.getIgnored()).thenReturn(2);
+    when(restoreResult2.getRowsMigrated()).thenReturn(30);
+    when(restoreResult2.getTimeSqlQueryMs()).thenReturn(600L);
+    when(restoreResult2.getLastAspect()).thenReturn("schemaMetadata");
+
+    restoreResults.add(restoreResult1);
+    restoreResults.add(restoreResult2);
+
+    when(mockEntityService.restoreIndices(
+            any(OperationContext.class), any(), any(), anyInt(), anyBoolean()))
+        .thenReturn(restoreResults);
+
+    // Prepare request body
+    Set<String> urnStrs = new HashSet<>();
+    urnStrs.add(TEST_URN_1.toString());
+    urnStrs.add(TEST_URN_2.toString());
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    String requestBody = objectMapper.writeValueAsString(urnStrs);
+
+    // Test POST endpoint with multiple aspects
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/openapi/operations/elasticSearch/restoreIndices")
+                .content(requestBody)
+                .param("aspectNames", "datasetProperties", "schemaMetadata")
+                .param("batchSize", "200")
+                .param("createDefaultAspects", "true")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].rowsMigrated").value(50))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].lastAspect").value("datasetProperties"))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].rowsMigrated").value(30))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].lastAspect").value("schemaMetadata"));
+  }
+
+  @Test
+  public void testSearchFlagsDeserialization() throws Exception {
+    // Mock explain response
+    ExplainResponse explainResponse = mock(ExplainResponse.class);
+    when(mockSearchService.explain(
+            any(OperationContext.class),
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any(),
+            anyString(),
+            anyString(),
+            anyInt(),
+            anyList()))
+        .thenReturn(explainResponse);
+
+    // Test with complex search flags
+    String complexSearchFlags =
+        "{\"fulltext\":true,\"skipHighlighting\":true,\"skipCache\":false,\"skipAggregates\":true}";
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/operations/elasticSearch/explainSearchQuery")
+                .param("query", "test query")
+                .param("documentId", TEST_URN_1.toString())
+                .param("entityName", "dataset")
+                .param("searchFlags", complexSearchFlags)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
   @SpringBootConfiguration
   @Import({ElasticsearchControllerTestConfig.class, TracingInterceptor.class})
   @ComponentScan(basePackages = {"io.datahubproject.openapi.operations.elastic"})
@@ -397,6 +775,7 @@ public class ElasticsearchControllerTest extends AbstractTestNGSpringContextTest
     @MockBean public EntitySearchService searchService;
     @MockBean public EntityService<?> entityService;
     @MockBean public GraphService graphService;
+    @MockBean public ESSearchDAO mockESSearchDAO;
 
     @Bean
     public ObjectMapper objectMapper() {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -6191,6 +6191,12 @@
       "doc" : "Include only latest versions in version sets, default true",
       "default" : true,
       "optional" : true
+    }, {
+      "name" : "fieldConfiguration",
+      "type" : "string",
+      "doc" : "Which fieldConfiguration should be applied. The possible values\nare defined in the configuration file `search_config.yaml`",
+      "default" : "default",
+      "optional" : true
     } ]
   }, {
     "type" : "enum",

--- a/metadata-service/war/src/main/java/com/linkedin/gms/servlet/RestliServletConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/servlet/RestliServletConfig.java
@@ -2,6 +2,7 @@ package com.linkedin.gms.servlet;
 
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RestliServletConfig {
   @Bean
+  @ConditionalOnBean
   public ElasticSearchConfiguration elasticSearchConfiguration(
       final ConfigurationProvider configurationProvider) {
     return configurationProvider.getElasticSearch();


### PR DESCRIPTION
# Field Configuration for Search and Autocomplete

## Overview
This PR introduces a powerful field configuration system that allows customization of which fields are included in search queries, autocomplete operations, and result highlighting. This addresses the need for different search experiences for different use cases without requiring code changes.

## Key Features

### 1. Field Configuration System
- New `fieldConfigurations` in `search_config.yaml` allowing named configurations
- Three operations for field customization:
  - `add` - Add fields to the system defaults
  - `remove` - Remove fields from the system defaults  
  - `replace` - Completely replace the system default field list
- Configurations can be applied to:
  - Search fields (which fields are searched)
  - Highlight fields (which fields are highlighted in results)
  - Autocomplete fields

### 2. Built-in Configurations
The PR includes several pre-defined configurations:
- `legacy` - Uses PDL defaults (system default)
- `excludeColumns` - Excludes `fieldPaths` from search and highlighting
- `excludeColumnHighlight` - Only excludes `fieldPaths` from highlighting

### 3. Dynamic Configuration Selection
- New `fieldConfiguration` parameter in `SearchFlags`
- Can be specified per search request via GraphQL API
- Environment variables for defaults:
  - `ELASTICSEARCH_QUERY_SEARCH_FIELD_CONFIG_DEFAULT`
  - `ELASTICSEARCH_QUERY_AUTOCOMPLETE_FIELD_CONFIG_DEFAULT`

## Technical Implementation

### Core Changes
1. **Configuration Classes**:
   - `FieldConfiguration` - Container for search and highlight field configs
   - `SearchFields` - Manages add/remove/replace operations for search
   - `HighlightFields` - Manages highlighting configuration with enable/disable support

2. **Query Building Enhancement**:
   - `CustomizedQueryHandler` applies field configurations during query construction
   - Field configurations are validated (e.g., replace cannot be combined with add/remove)
   - Maintains boost scores and other field properties when reconfiguring

3. **Backward Compatibility**:
   - Default behavior unchanged when no configuration specified
   - Existing search behavior preserved with `legacy` configuration

## Benefits
1. **Flexibility** - Different search experiences without code changes
2. **Performance** - Exclude expensive fields like `fieldPaths` when not needed
3. **User Experience** - Tailor search to specific user groups
4. **Maintainability** - Configuration-driven approach reduces code complexity

## Testing
- Comprehensive unit tests for all configuration scenarios
- Tests for validation, null safety, and edge cases
- Integration with existing search test infrastructure

## API Changes
- Added `fieldConfiguration` parameter to `SearchFlags` 
- New debugging endpoints for inspecting generated Elasticsearch queries
- No breaking changes to existing APIs

This PR significantly enhances DataHub's search customization capabilities while maintaining full backward compatibility.


# Changing Environment Defaults

Available field configurations are [here](https://github.com/datahub-project/datahub/pull/14057/files#diff-95ab8ebf86aad5d90be11f9f34a9faa991a493d7230f6b57dac9da4fa44b945e)
- `excludeColumns`
- `excludeColumnHighlight`
- `legacy`

Populate environment variables:

`ELASTICSEARCH_QUERY_SEARCH_FIELD_CONFIG_DEFAULT `
`ELASTICSEARCH_QUERY_AUTOCOMPLETE_FIELD_CONFIG_DEFAULT `

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
