### PR TITLE
fix(openapi): nullable openapi 3.1.0 syntax for aspect ref fields

### DIFF
--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
@@ -1142,12 +1142,12 @@ public class OpenAPIV3Generator {
                           }
 
                           if ($ref != null && !isNameRequired) {
-                            // A non-required $ref property must be wrapped in a { anyOf: [ $ref ] }
+                            // A non-required $ref property must be wrapped in a { oneOf: [ $ref, null ] }
                             // object to allow the
                             // property to be marked as nullable
                             schema.setType(null);
                             schema.set$ref(null);
-                            schema.setAnyOf(
+                            schema.setOneOf(
                                 List.of(newSchema().$ref($ref), newSchema().type(TYPE_NULL)));
                           }
 
@@ -1578,7 +1578,7 @@ public class OpenAPIV3Generator {
       internalRef =
           String.format(FORMAT_PATH_DEFINITIONS, toUpperFirst(aspect), ASPECT_REQUEST_SUFFIX);
     }
-    result.setAnyOf(List.of(newSchema().$ref(internalRef)));
+    result.setOneOf(List.of(newSchema().$ref(internalRef), newSchema().type(TYPE_NULL)));
     return result;
   }
 


### PR DESCRIPTION
Upon debugging with openapi-generator, I found that we missed a nullable ref in aspect ref fields.
Also it should be using `oneOf`, not `anyOf` to be more precise since we don't allow for validation against multiple schemas in a given request.

Current syntax:
```
          "TCOwnership" : {
            "type" : "object",
            "nullable" : true,
            "anyOf" : [ {
              "$ref" : "#/components/schemas/TCOwnershipAspectRequest_v3"
            } ]
          },

```

Correct syntax:
```
"TCOwnership": {
  "oneOf": [
    { "$ref": "#/components/schemas/TCOwnershipAspectRequest_v3" },
    { "type": "null" }
  ]
}
```

We're actually doing the right thing