### PR TITLE
feat(ingest): improve readability by using tables

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Set, Union, cast, runtime_checkabl
 import humanfriendly
 import pydantic
 from pydantic import BaseModel
+from tabulate import tabulate
 from typing_extensions import Literal, Protocol
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
@@ -95,7 +96,60 @@ class Report(SupportsAsObj):
         }
 
     def as_string(self) -> str:
-        return pprint.pformat(self.as_obj(), width=150, sort_dicts=False)
+        self_obj = self.as_obj()
+        _aspects_by_subtypes = self_obj.pop("aspects_by_subtypes", None)
+
+        # Format the main report data
+        result = pprint.pformat(self_obj, width=150, sort_dicts=False)
+
+        # Add aspects_by_subtypes table if it exists
+        if _aspects_by_subtypes:
+            result += "\n\nAspects by Subtypes:\n"
+            result += self._format_aspects_by_subtypes_table(_aspects_by_subtypes)
+
+        return result
+
+    def _format_aspects_by_subtypes_table(
+        self, aspects_by_subtypes: Dict[str, Dict[str, Dict[str, int]]]
+    ) -> str:
+        """Format aspects_by_subtypes data as a table with aspects as rows and entity/subtype as columns."""
+        if not aspects_by_subtypes:
+            return "No aspects by subtypes data available."
+
+        # Collect all unique aspects across all entity types and subtypes
+        all_aspects = set()
+        for subtypes in aspects_by_subtypes.values():
+            for aspects in subtypes.values():
+                all_aspects.update(aspects.keys())
+
+        # Sort aspects for consistent row ordering
+        aspect_rows = sorted(all_aspects)
+
+        # Create entity/subtype column combinations
+        entity_subtype_columns = []
+        for entity_type, subtypes in aspects_by_subtypes.items():
+            for subtype in subtypes:
+                entity_subtype_columns.append(f"{entity_type} ({subtype})")
+
+        # Sort columns for consistent ordering
+        entity_subtype_columns.sort()
+
+        # Create headers: Aspect, then all entity/subtype combinations
+        headers = ["Aspect"] + entity_subtype_columns
+
+        # Build table data
+        table_data = []
+        for aspect in aspect_rows:
+            row = [aspect]
+            for subtypes in aspects_by_subtypes.values():
+                for aspects in subtypes.values():
+                    row.append(aspects.get(aspect, 0))
+            table_data.append(row)
+
+        if table_data:
+            return tabulate(table_data, headers=headers, tablefmt="grid")
+        else:
+            return "No aspects by subtypes data available."
 
     def as_json(self) -> str:
         return json.dumps(self.as_obj())


### PR DESCRIPTION
`aspects_by_subtype` now shows up as this
```
Source (datahub-mock-data) report:
{'aspects': {'dataset': {'status': 3, 'subTypes': 3, 'datasetProfile': 3, 'datasetUsageStatistics': 3, 'upstreamLineage': 2}},
 'samples': {'profiling': {'Table': ['urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h0_t0,PROD)',
                                     'urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t0,PROD)'],
                           'View': ['urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t1,PROD)']},
             'usage': {'Table': ['urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h0_t0,PROD)',
                                 'urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t0,PROD)',
                                 'urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t1,PROD)'],
                       'View': ['urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h0_t0,PROD)',
                                'urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t0,PROD)',
                                'urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t1,PROD)']},
             'lineage': {'Table': ['urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t0,PROD)'],
                         'View': ['urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t1,PROD)']},
             'all_3': {'Table': ['urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t0,PROD)'],
                       'View': ['urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h1_t1,PROD)']}},
 'event_not_produced_warn': True,
 'events_produced': 14,
 'events_produced_per_sec': 0,
 'first_urn_seen': 'urn:li:dataset:(urn:li:dataPlatform:fake,hops_1_f_2_h0_t0,PROD)',
 'start_time': '2025-07-14 16:46:43.937134 (31.07 seconds ago)',
 'running_time': '31.07 seconds',
 'failures': [],
 'warnings': [],
 'infos': []}

Aspects by Subtypes:
+------------------------+-------------------+------------------+
| Aspect                 |   dataset (Table) |   dataset (View) |
+========================+===================+==================+
| datasetProfile         |                 2 |                1 |
+------------------------+-------------------+------------------+
| datasetUsageStatistics |                 2 |                1 |
+------------------------+-------------------+------------------+
| status                 |                 2 |                1 |
+------------------------+-------------------+------------------+
| subTypes               |                 2 |                1 |
+------------------------+-------------------+------------------+
| upstreamLineage        |                 1 |                1 |
+------------------------+-------------------+------------------+
Sink (datahub-rest) report:

```

`datahub check get-kafka-consumer-offsets` shows up as this

```
-> % datahub check get-kafka-consumer-offsets
+----------------+---------------------------------+---------------------------------+-------------+----------+--------+-----------+-----------+-------------+
| Topic          | Consumer Group                  | Schema                          |   Partition |   Offset |    Lag |   Avg Lag |   Max Lag |   Total Lag |
+================+=================================+=================================+=============+==========+========+===========+===========+=============+
| mcp            | generic-mce-consumer-job-client | MetadataChangeProposal_v1       |           0 |    37431 | 211626 |    211626 |    211626 |      211626 |
+----------------+---------------------------------+---------------------------------+-------------+----------+--------+-----------+-----------+-------------+
| mcl            | generic-mae-consumer-job-client | MetadataChangeLog_Versioned_v1  |           0 |     1143 |  53273 |     53273 |     53273 |       53273 |
+----------------+---------------------------------+---------------------------------+-------------+----------+--------+-----------+-----------+-------------+
| mcl-timeseries | generic-mae-consumer-job-client | MetadataChangeLog_Timeseries_v1 |           0 |      226 |  14817 |     14817 |     14817 |       14817 |
+----------------+---------------------------------+---------------------------------+-------------+----------+--------+-----------+-----------+-------------+

```


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
