### PR TITLE
feat(permissions) Add platform privilege for editing global home page

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
@@ -366,6 +366,11 @@ public class AuthorizationUtils {
         context.getOperationContext(), PoliciesConfig.MANAGE_FEATURES_PRIVILEGE);
   }
 
+  public static boolean canManageHomePageTemplates(@Nonnull QueryContext context) {
+    return AuthUtil.isAuthorized(
+        context.getOperationContext(), PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE);
+  }
+
   public static boolean isAuthorized(
       @Nonnull QueryContext context,
       @Nonnull String resourceType,

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/module/UpsertPageModuleResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/module/UpsertPageModuleResolver.java
@@ -6,7 +6,9 @@ import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.DataHubPageModule;
 import com.linkedin.datahub.graphql.generated.DataHubPageModuleType;
 import com.linkedin.datahub.graphql.generated.PageModuleScope;
@@ -43,7 +45,10 @@ public class UpsertPageModuleResolver implements DataFetcher<CompletableFuture<D
     PageModuleScope scope = input.getScope();
     com.linkedin.datahub.graphql.generated.PageModuleParamsInput paramsInput = input.getParams();
 
-    // TODO: check permissions if the scope is GLOBAL
+    if (input.getScope().equals(PageModuleScope.GLOBAL)
+        && !AuthorizationUtils.canManageHomePageTemplates(context)) {
+      throw new AuthorizationException("User does not have permission to update global modules.");
+    }
 
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/template/UpsertPageTemplateResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/template/UpsertPageTemplateResolver.java
@@ -6,7 +6,9 @@ import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.DataHubPageTemplate;
 import com.linkedin.datahub.graphql.generated.PageTemplateRowInput;
 import com.linkedin.datahub.graphql.generated.PageTemplateScope;
@@ -44,7 +46,10 @@ public class UpsertPageTemplateResolver
     PageTemplateScope scope = input.getScope();
     PageTemplateSurfaceType surfaceType = input.getSurfaceType();
 
-    // TODO: check permissions if the scope is GLOBAL
+    if (input.getScope().equals(PageTemplateScope.GLOBAL)
+        && !AuthorizationUtils.canManageHomePageTemplates(context)) {
+      throw new AuthorizationException("User does not have permission to update global templates.");
+    }
 
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/module/UpsertPageModuleResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/module/UpsertPageModuleResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.module;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContext;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -15,6 +16,7 @@ import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.DataHubPageModule;
 import com.linkedin.datahub.graphql.generated.DataHubPageModuleType;
 import com.linkedin.datahub.graphql.generated.LinkModuleParamsInput;
@@ -157,6 +159,64 @@ public class UpsertPageModuleResolverTest {
     assertEquals(result.getUrn(), TEST_MODULE_URN);
     verify(mockService, times(1)).upsertPageModule(any(), any(), any(), any(), any(), any());
     verify(mockService, times(1)).getPageModuleEntityResponse(any(), eq(moduleUrn));
+  }
+
+  @Test
+  public void testUpsertGlobalPageModuleSuccessWithPermission() throws Exception {
+    // Arrange
+    UpsertPageModuleInput input = new UpsertPageModuleInput();
+    input.setName(TEST_MODULE_NAME);
+    input.setType(DataHubPageModuleType.RICH_TEXT);
+    input.setScope(PageModuleScope.GLOBAL);
+
+    RichTextModuleParamsInput richTextParams = new RichTextModuleParamsInput();
+    richTextParams.setContent(TEST_RICH_TEXT_CONTENT);
+    PageModuleParamsInput paramsInput = new PageModuleParamsInput();
+    paramsInput.setRichTextParams(richTextParams);
+    input.setParams(paramsInput);
+
+    Urn moduleUrn = UrnUtils.getUrn(TEST_MODULE_URN);
+    EntityResponse mockResponse = createMockEntityResponse(moduleUrn);
+
+    when(mockEnvironment.getArgument("input")).thenReturn(input);
+    when(mockEnvironment.getContext()).thenReturn(mockQueryContext);
+    when(mockService.upsertPageModule(any(), eq(null), any(), any(), any(), any()))
+        .thenReturn(moduleUrn);
+    when(mockService.getPageModuleEntityResponse(any(), eq(moduleUrn))).thenReturn(mockResponse);
+
+    // Act
+    CompletableFuture<DataHubPageModule> future = resolver.get(mockEnvironment);
+    DataHubPageModule result = future.get();
+
+    // Assert
+    assertNotNull(result);
+    assertEquals(result.getUrn(), TEST_MODULE_URN);
+    assertEquals(result.getType().toString(), "DATAHUB_PAGE_MODULE");
+    verify(mockService, times(1)).upsertPageModule(any(), eq(null), any(), any(), any(), any());
+    verify(mockService, times(1)).getPageModuleEntityResponse(any(), eq(moduleUrn));
+  }
+
+  @Test
+  public void testUpsertGlobalPageModuleFailureWithoutPermission() throws Exception {
+    // Arrange
+    UpsertPageModuleInput input = new UpsertPageModuleInput();
+    input.setName(TEST_MODULE_NAME);
+    input.setType(DataHubPageModuleType.RICH_TEXT);
+    input.setScope(PageModuleScope.GLOBAL);
+
+    RichTextModuleParamsInput richTextParams = new RichTextModuleParamsInput();
+    richTextParams.setContent(TEST_RICH_TEXT_CONTENT);
+    PageModuleParamsInput paramsInput = new PageModuleParamsInput();
+    paramsInput.setRichTextParams(richTextParams);
+    input.setParams(paramsInput);
+
+    QueryContext mockDenyContext = getMockDenyContext();
+
+    when(mockEnvironment.getArgument("input")).thenReturn(input);
+    when(mockEnvironment.getContext()).thenReturn(mockDenyContext);
+
+    // Act & Assert
+    assertThrows(AuthorizationException.class, () -> resolver.get(mockEnvironment).get());
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/template/UpsertPageTemplateResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/template/UpsertPageTemplateResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.template;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContext;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
@@ -9,6 +10,7 @@ import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.PageTemplateRowInput;
 import com.linkedin.datahub.graphql.generated.PageTemplateScope;
 import com.linkedin.datahub.graphql.generated.PageTemplateSurfaceType;
@@ -116,6 +118,131 @@ public class UpsertPageTemplateResolverTest {
 
     DataHubPageTemplateVisibility visibility = new DataHubPageTemplateVisibility();
     visibility.setScope(com.linkedin.template.PageTemplateScope.GLOBAL);
+    properties.setVisibility(visibility);
+
+    AuditStamp auditStamp = new AuditStamp();
+    auditStamp.setTime(System.currentTimeMillis());
+    auditStamp.setActor(UrnUtils.getUrn("urn:li:corpuser:test"));
+    properties.setCreated(auditStamp);
+    properties.setLastModified(auditStamp);
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new com.linkedin.entity.Aspect(properties.data()));
+    aspectMap.put(
+        com.linkedin.metadata.Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME, aspect);
+    when(mockResponse.getAspects()).thenReturn(aspectMap);
+    when(mockResponse.getUrn()).thenReturn(urn);
+    when(mockService.getPageTemplateEntityResponse(any(), eq(urn))).thenReturn(mockResponse);
+    when(mockEnv.getArgument(eq("input"))).thenReturn(input);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    resolver.get(mockEnv).join();
+    verify(mockService, times(1)).upsertPageTemplate(any(), eq(null), any(), any(), any());
+    verify(mockService, times(1)).getPageTemplateEntityResponse(any(), eq(urn));
+  }
+
+  @Test
+  public void testCreateGlobalTemplateSuccessWithPermission() throws Exception {
+    PageTemplateService mockService = mock(PageTemplateService.class);
+    UpsertPageTemplateResolver resolver = new UpsertPageTemplateResolver(mockService);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    UpsertPageTemplateInput input = new UpsertPageTemplateInput();
+    input.setUrn(null);
+    input.setRows(createTestRowInputs());
+    input.setScope(PageTemplateScope.GLOBAL);
+    input.setSurfaceType(PageTemplateSurfaceType.HOME_PAGE);
+
+    Urn urn = UrnUtils.getUrn(TEST_TEMPLATE_URN);
+    when(mockService.upsertPageTemplate(any(), eq(null), any(), any(), any())).thenReturn(urn);
+
+    // Mock EntityResponse with a valid aspect map
+    EntityResponse mockResponse = mock(EntityResponse.class);
+    DataHubPageTemplateProperties properties = new DataHubPageTemplateProperties();
+
+    // Set required fields
+    DataHubPageTemplateRowArray rows = new DataHubPageTemplateRowArray();
+    properties.setRows(rows);
+
+    DataHubPageTemplateSurface surface = new DataHubPageTemplateSurface();
+    surface.setSurfaceType(com.linkedin.template.PageTemplateSurfaceType.HOME_PAGE);
+    properties.setSurface(surface);
+
+    DataHubPageTemplateVisibility visibility = new DataHubPageTemplateVisibility();
+    visibility.setScope(com.linkedin.template.PageTemplateScope.GLOBAL);
+    properties.setVisibility(visibility);
+
+    AuditStamp auditStamp = new AuditStamp();
+    auditStamp.setTime(System.currentTimeMillis());
+    auditStamp.setActor(UrnUtils.getUrn("urn:li:corpuser:test"));
+    properties.setCreated(auditStamp);
+    properties.setLastModified(auditStamp);
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new com.linkedin.entity.Aspect(properties.data()));
+    aspectMap.put(
+        com.linkedin.metadata.Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME, aspect);
+    when(mockResponse.getAspects()).thenReturn(aspectMap);
+    when(mockResponse.getUrn()).thenReturn(urn);
+    when(mockService.getPageTemplateEntityResponse(any(), eq(urn))).thenReturn(mockResponse);
+    when(mockEnv.getArgument(eq("input"))).thenReturn(input);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+    resolver.get(mockEnv).join();
+    verify(mockService, times(1)).upsertPageTemplate(any(), eq(null), any(), any(), any());
+    verify(mockService, times(1)).getPageTemplateEntityResponse(any(), eq(urn));
+  }
+
+  @Test
+  public void testCreateGlobalTemplateFailureWithoutPermission() throws Exception {
+    PageTemplateService mockService = mock(PageTemplateService.class);
+    UpsertPageTemplateResolver resolver = new UpsertPageTemplateResolver(mockService);
+
+    QueryContext mockContext = getMockDenyContext();
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    UpsertPageTemplateInput input = new UpsertPageTemplateInput();
+    input.setUrn(null);
+    input.setRows(createTestRowInputs());
+    input.setScope(PageTemplateScope.GLOBAL);
+    input.setSurfaceType(PageTemplateSurfaceType.HOME_PAGE);
+
+    when(mockEnv.getArgument(eq("input"))).thenReturn(input);
+    when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(AuthorizationException.class, () -> resolver.get(mockEnv).join());
+  }
+
+  @Test
+  public void testCreatePersonalTemplateSuccessWithoutPermission() throws Exception {
+    PageTemplateService mockService = mock(PageTemplateService.class);
+    UpsertPageTemplateResolver resolver = new UpsertPageTemplateResolver(mockService);
+
+    QueryContext mockContext = getMockDenyContext();
+    DataFetchingEnvironment mockEnv = mock(DataFetchingEnvironment.class);
+    UpsertPageTemplateInput input = new UpsertPageTemplateInput();
+    input.setUrn(null);
+    input.setRows(createTestRowInputs());
+    input.setScope(PageTemplateScope.PERSONAL);
+    input.setSurfaceType(PageTemplateSurfaceType.HOME_PAGE);
+
+    Urn urn = UrnUtils.getUrn(TEST_TEMPLATE_URN);
+    when(mockService.upsertPageTemplate(any(), eq(null), any(), any(), any())).thenReturn(urn);
+
+    // Mock EntityResponse with a valid aspect map
+    EntityResponse mockResponse = mock(EntityResponse.class);
+    DataHubPageTemplateProperties properties = new DataHubPageTemplateProperties();
+
+    // Set required fields
+    DataHubPageTemplateRowArray rows = new DataHubPageTemplateRowArray();
+    properties.setRows(rows);
+
+    DataHubPageTemplateSurface surface = new DataHubPageTemplateSurface();
+    surface.setSurfaceType(com.linkedin.template.PageTemplateSurfaceType.HOME_PAGE);
+    properties.setSurface(surface);
+
+    DataHubPageTemplateVisibility visibility = new DataHubPageTemplateVisibility();
+    visibility.setScope(com.linkedin.template.PageTemplateScope.PERSONAL);
     properties.setVisibility(visibility);
 
     AuditStamp auditStamp = new AuditStamp();

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageModuleService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageModuleService.java
@@ -1,11 +1,13 @@
 package com.linkedin.metadata.service;
 
+import com.datahub.authorization.AuthUtil;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.AspectUtils;
 import com.linkedin.metadata.key.DataHubPageModuleKey;
 import com.linkedin.metadata.utils.EntityKeyUtils;
@@ -193,6 +195,11 @@ public class PageModuleService {
       throw new IllegalArgumentException(
           String.format(
               "Attempted to delete a page module that does not exist with urn %s", moduleUrn));
+    }
+
+    if (properties.getVisibility().getScope().equals(PageModuleScope.GLOBAL)
+        && AuthUtil.isAuthorized(opContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE)) {
+      throw new UnauthorizedException("User is unauthorized to delete global modules.");
     }
 
     if (properties.getVisibility().getScope().equals(PageModuleScope.PERSONAL)

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/PageModuleServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/PageModuleServiceTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -12,6 +13,7 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import com.datahub.authorization.AuthUtil;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -20,6 +22,7 @@ import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.module.DataHubPageModuleParams;
 import com.linkedin.module.DataHubPageModuleProperties;
 import com.linkedin.module.DataHubPageModuleType;
@@ -27,7 +30,9 @@ import com.linkedin.module.DataHubPageModuleVisibility;
 import com.linkedin.module.PageModuleScope;
 import com.linkedin.module.RichTextModuleParams;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.openapi.exception.UnauthorizedException;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -207,6 +212,7 @@ public class PageModuleServiceTest {
     org.mockito.Mockito.doReturn(createTestModuleProperties())
         .when(spyService)
         .getPageModuleProperties(mockOpContext, moduleUrn);
+
     // Mock actor context and actor URN
     io.datahubproject.metadata.context.ActorContext mockActorContext =
         org.mockito.Mockito.mock(io.datahubproject.metadata.context.ActorContext.class);
@@ -214,11 +220,22 @@ public class PageModuleServiceTest {
     org.mockito.Mockito.when(mockActorContext.getActorUrn())
         .thenReturn(UrnUtils.getUrn("urn:li:corpuser:test-user"));
 
-    // Act
-    spyService.deletePageModule(mockOpContext, moduleUrn);
+    // Mock AuthUtil to return false for MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE (should not have
+    // permission)
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(false);
 
-    // Assert
-    verify(mockEntityClient, times(1)).deleteEntity(mockOpContext, moduleUrn);
+      // Act
+      spyService.deletePageModule(mockOpContext, moduleUrn);
+
+      // Assert
+      verify(mockEntityClient, times(1)).deleteEntity(mockOpContext, moduleUrn);
+    }
   }
 
   @Test
@@ -286,6 +303,7 @@ public class PageModuleServiceTest {
     org.mockito.Mockito.doReturn(properties)
         .when(spyService)
         .getPageModuleProperties(mockOpContext, moduleUrn);
+
     // Mock actor context and actor URN (the actor is NOT the creator)
     io.datahubproject.metadata.context.ActorContext mockActorContext =
         org.mockito.Mockito.mock(io.datahubproject.metadata.context.ActorContext.class);
@@ -293,18 +311,105 @@ public class PageModuleServiceTest {
     org.mockito.Mockito.when(mockActorContext.getActorUrn())
         .thenReturn(UrnUtils.getUrn("urn:li:corpuser:test-user"));
 
-    // Act & Assert
-    try {
+    // Mock AuthUtil to return false for MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE (should not have
+    // permission)
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(false);
+
+      // Act & Assert
+      try {
+        spyService.deletePageModule(mockOpContext, moduleUrn);
+        fail("Should not be able to delete a PERSONAL page module not created by the actor");
+      } catch (RuntimeException ex) {
+        assertTrue(ex.getCause() instanceof UnauthorizedException);
+        assertTrue(
+            ex.getCause()
+                .getMessage()
+                .contains(
+                    "Attempted to delete personal a page module that was not created by the actor"));
+      }
+    }
+  }
+
+  @Test
+  public void testDeleteGlobalPageModuleWithManagePermissionThrowsUnauthorized() throws Exception {
+    // Arrange
+    Urn moduleUrn = UrnUtils.getUrn(TEST_MODULE_URN);
+    PageModuleService spyService = org.mockito.Mockito.spy(service);
+    // Create properties with GLOBAL scope
+    DataHubPageModuleProperties properties = createTestModuleProperties();
+    properties.getVisibility().setScope(com.linkedin.module.PageModuleScope.GLOBAL);
+    org.mockito.Mockito.doReturn(properties)
+        .when(spyService)
+        .getPageModuleProperties(mockOpContext, moduleUrn);
+
+    // Mock actor context and actor URN
+    io.datahubproject.metadata.context.ActorContext mockActorContext =
+        org.mockito.Mockito.mock(io.datahubproject.metadata.context.ActorContext.class);
+    org.mockito.Mockito.when(mockOpContext.getActorContext()).thenReturn(mockActorContext);
+    org.mockito.Mockito.when(mockActorContext.getActorUrn())
+        .thenReturn(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+
+    // Mock AuthUtil to return true for MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(true);
+
+      // Act & Assert
+      try {
+        spyService.deletePageModule(mockOpContext, moduleUrn);
+        fail(
+            "Should throw UnauthorizedException when user has manage privilege for personal module");
+      } catch (RuntimeException ex) {
+        assertTrue(ex.getCause() instanceof UnauthorizedException);
+        assertTrue(
+            ex.getCause().getMessage().contains("User is unauthorized to delete global modules"));
+      }
+    }
+  }
+
+  @Test
+  public void testDeleteGlobalPageModuleWithoutManagePermissionSuccess() throws Exception {
+    // Arrange
+    Urn moduleUrn = UrnUtils.getUrn(TEST_MODULE_URN);
+    PageModuleService spyService = org.mockito.Mockito.spy(service);
+    // Create properties with GLOBAL scope
+    DataHubPageModuleProperties properties = createTestModuleProperties();
+    properties.getVisibility().setScope(com.linkedin.module.PageModuleScope.GLOBAL);
+    org.mockito.Mockito.doReturn(properties)
+        .when(spyService)
+        .getPageModuleProperties(mockOpContext, moduleUrn);
+
+    // Mock actor context and actor URN
+    io.datahubproject.metadata.context.ActorContext mockActorContext =
+        org.mockito.Mockito.mock(io.datahubproject.metadata.context.ActorContext.class);
+    org.mockito.Mockito.when(mockOpContext.getActorContext()).thenReturn(mockActorContext);
+    org.mockito.Mockito.when(mockActorContext.getActorUrn())
+        .thenReturn(UrnUtils.getUrn("urn:li:corpuser:test-user"));
+
+    // Mock AuthUtil to return false for MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE
+    try (MockedStatic<AuthUtil> authUtilMock = mockStatic(AuthUtil.class)) {
+      authUtilMock
+          .when(
+              () ->
+                  AuthUtil.isAuthorized(
+                      mockOpContext, PoliciesConfig.MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE))
+          .thenReturn(false);
+
+      // Act
       spyService.deletePageModule(mockOpContext, moduleUrn);
-      fail("Should not be able to delete a PERSONAL page module not created by the actor");
-    } catch (RuntimeException ex) {
-      assertTrue(
-          ex.getCause() instanceof io.datahubproject.openapi.exception.UnauthorizedException);
-      assertTrue(
-          ex.getCause()
-              .getMessage()
-              .contains(
-                  "Attempted to delete personal a page module that was not created by the actor"));
+
+      // Assert
+      verify(mockEntityClient, times(1)).deleteEntity(mockOpContext, moduleUrn);
     }
   }
 

--- a/metadata-service/war/src/main/resources/boot/policies.json
+++ b/metadata-service/war/src/main/resources/boot/policies.json
@@ -40,7 +40,8 @@
         "MANAGE_DOCUMENTATION_FORMS",
         "MANAGE_FEATURES",
         "MANAGE_SYSTEM_OPERATIONS",
-        "GET_PLATFORM_EVENTS"
+        "GET_PLATFORM_EVENTS",
+        "MANAGE_HOME_PAGE_TEMPLATES"
       ],
       "displayName": "Root User - All Platform Privileges",
       "description": "Grants all platform privileges to root user.",
@@ -196,7 +197,8 @@
         "MANAGE_DOCUMENTATION_FORMS",
         "MANAGE_FEATURES",
         "MANAGE_SYSTEM_OPERATIONS",
-        "GET_PLATFORM_EVENTS"
+        "GET_PLATFORM_EVENTS",
+        "MANAGE_HOME_PAGE_TEMPLATES"
       ],
       "displayName": "Admins - Platform Policy",
       "description": "Admins have all platform privileges.",

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -212,6 +212,12 @@ public class PoliciesConfig {
           "Get Platform Events",
           "The ability to use the Events API to read Platform Events - Entity Change Events and Notification Request Events.");
 
+  public static final Privilege MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE =
+      Privilege.of(
+          "MANAGE_HOME_PAGE_TEMPLATES",
+          "Manage Home Page Templates",
+          "Privilege allowing users to manage the default home page template and the global modules in it.");
+
   public static final List<Privilege> PLATFORM_PRIVILEGES =
       ImmutableList.of(
           MANAGE_POLICIES_PRIVILEGE,
@@ -249,7 +255,8 @@ public class PoliciesConfig {
           MANAGE_DOCUMENTATION_FORMS_PRIVILEGE,
           MANAGE_FEATURES_PRIVILEGE,
           MANAGE_SYSTEM_OPERATIONS_PRIVILEGE,
-          GET_PLATFORM_EVENTS_PRIVILEGE);
+          GET_PLATFORM_EVENTS_PRIVILEGE,
+          MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE);
 
   // Resource Privileges //
 


### PR DESCRIPTION
This PR adds the platform privilege for whether or not you can manage the global home page. Specifically, this controls whether you can create/editdelete global templates or global modules. This will also be used in the UI later for controlling who can see the edit button for editing a global global templates for the rest of folk.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
