### PR TITLE
fix(ingest/deltalake): pin upperbound for delta lake

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -349,8 +349,9 @@ delta_lake = {
     *s3_base,
     *abs_base,
     # Version 0.18.0 broken on ARM Macs: https://github.com/delta-io/delta-rs/issues/2577
-    "deltalake>=0.6.3, != 0.6.4, != 0.18.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "deltalake>=0.6.3, != 0.6.4; platform_system != 'Darwin' or platform_machine != 'arm64'",
+    # Version 1.0.2 breaks due to Unsupported reader features required: [DeletionVectors]: https://github.com/delta-io/delta-rs/issues/1094
+    "deltalake>=0.6.3, != 0.6.4, != 0.18.0, <1.0.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "deltalake>=0.6.3, != 0.6.4, <1.0.0; platform_system != 'Darwin' or platform_machine != 'arm64'",
 }
 
 powerbi_report_server = {"requests", "requests_ntlm"}


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

Bug in Delta Lake source ingestion — fails when Delta Table contains Deletion Vectors (DV).
Resolves https://github.com/datahub-project/datahub/issues/14051

### Repro Steps
1. Create a Delta Table with DV enabled (Delta 2.4.0+, Spark 3.4.4)
```
from pyspark.sql import SparkSession
from pyspark.sql.types import StructType, StructField, LongType, StringType

table_path = "tmp/dv_test_table"

spark = SparkSession.builder \
    .appName("DeltaTableWithDV") \
    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
    .config("spark.databricks.delta.properties.defaults.enableDeletionVectors", "true") \
    .master("local[*]") \
    .getOrCreate()

schema = StructType([
    StructField("id", LongType(), True),
    StructField("name", StringType(), True),
])

data = [(1, "Alice"), (2, "Bob"), (3, "Charlie")]
df = spark.createDataFrame(data, schema)

df.write.format("delta").mode("overwrite").save(table_path)

df_loaded = spark.read.format("delta").load(table_path)
df_loaded.createOrReplaceTempView("dv_table")

spark.sql("DELETE FROM dv_table WHERE id = 2")
spark.stop()
```

run with ` spark-submit --packages io.delta:delta-core_2.12:2.4.0 dv_test.py`

2. install deltalake  with `pip install deltalake==1.0.2` (or other versions for test)

3. Ingest local DV tables with `datahub ingest -c delta-lake.yaml`  with the recipe below:

```
source:
  type: "delta-lake"
  config:
    base_path: "tmp/dv_test_table/"
sink:
  type: "datahub-rest"
  config:
    server: "http://localhost:8080"
```    


   - `deltalake==0.25.5` → works
   - `deltalake==1.0.0` to `1.1.0` → fails with `<class '_internal.CommitFailedError'>: Unsupported reader features required: [DeletionVectors]"]`
