### PR TITLE
fix(quickstart): update commit hash with resolved quickstart profile

### DIFF
--- a/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
+++ b/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
@@ -162,12 +162,10 @@ class QuickstartVersionMappingConfig(BaseModel):
         # docker compose based resolved compose file. In those cases, we pick up the composefile from
         # MINIMUM_SUPPORTED_VERSION which contains the compose file.
         if _is_it_a_version(result.composefile_git_ref):
-            if (
-                parse("v1.2.0") > parse(result.composefile_git_ref)
-            ):  # TODO: Once we decide what the new version that supports profile based compose.
-                # The merge commit where the labels were added
-                # https://github.com/datahub-project/datahub/pull/7473
-                result.composefile_git_ref = "1d3339276129a7cb8385c07a958fcc93acda3b4e"  # TODO update after compose file is merged
+            if parse("v1.2.0") > parse(result.composefile_git_ref):
+                # The merge commit where profiles based resolved compose file was added.
+                # https://github.com/datahub-project/datahub/pull/13566
+                result.composefile_git_ref = "21726bc3341490f4182b904626c793091ac95edd"
 
         return result
 

--- a/metadata-ingestion/tests/unit/cli/docker/test_quickstart_version_mapping.py
+++ b/metadata-ingestion/tests/unit/cli/docker/test_quickstart_version_mapping.py
@@ -103,3 +103,31 @@ def test_quickstart_forced_not_a_version_tag():
 def test_quickstart_get_older_version():
     with pytest.raises(ClickException, match="Minimum supported version not met"):
         example_version_mapper.get_quickstart_execution_plan("v0.9.6")
+
+
+def test_quickstart_version_older_than_v1_2_0_uses_commit_hash():
+    """
+    Test that versions older than v1.2.0 get their composefile_git_ref set to the specific commit hash
+    that contains the profiles based resolved compose file.
+    This exercises line 168 in quickstart_versioning.py.
+    """
+    # Create a version mapping with a version older than v1.2.0
+    version_mapper = QuickstartVersionMappingConfig.parse_obj(
+        {
+            "quickstart_version_map": {
+                "v1.1.0": {
+                    "composefile_git_ref": "v1.1.0",
+                    "docker_tag": "v1.1.0",
+                    "mysql_tag": "8.2",
+                },
+            },
+        }
+    )
+
+    execution_plan = version_mapper.get_quickstart_execution_plan("v1.1.0")
+    expected = QuickstartExecutionPlan(
+        docker_tag="v1.1.0",
+        composefile_git_ref="21726bc3341490f4182b904626c793091ac95edd",  # This should be the commit hash from line 168
+        mysql_tag="8.2",
+    )
+    assert execution_plan == expected


### PR DESCRIPTION
This commit hash is used to download the resolved quickstart profile if using the latest CLI to install an older version - - like 1.1 that does not contain the profile based resolved quick start compose file.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
