### PR TITLE
fix(snowflake): use schema-qualified pagination markers for SHOW VIEWS/STREAMS

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -247,6 +247,8 @@ class SnowflakeQuery:
         assert limit <= SHOW_VIEWS_MAX_PAGE_SIZE
 
         # To work around this, we paginate through the results using the FROM clause.
+        # The pagination marker should be schema-qualified (e.g., "schema.view_name") to avoid
+        # issues with partial matching when the same view name exists in multiple schemas.
         from_clause = (
             f"""FROM '{view_pagination_marker}'""" if view_pagination_marker else ""
         )
@@ -936,6 +938,8 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
         assert limit <= SHOW_STREAM_MAX_PAGE_SIZE
 
         # To work around this, we paginate through the results using the FROM clause.
+        # The pagination marker should be schema-qualified (e.g., "schema.stream_name") to avoid
+        # issues with partial matching when the same stream name exists in multiple schemas.
         from_clause = (
             f"""FROM '{stream_pagination_marker}'""" if stream_pagination_marker else ""
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -445,9 +445,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
             if result_set_size >= page_limit:
                 # If we hit the limit, we need to send another request to get the next page.
                 logger.info(
-                    f"Fetching next page of views for {db_name} - after {view_name}"
+                    f"Fetching next page of views for {db_name} - after {schema_name}.{view_name}"
                 )
-                view_pagination_marker = view_name
+                view_pagination_marker = f"{schema_name}.{view_name}"
 
         return views
 
@@ -710,9 +710,9 @@ class SnowflakeDataDictionary(SupportsAsObj):
             if result_set_size >= page_limit:
                 # If we hit the limit, we need to send another request to get the next page.
                 logger.info(
-                    f"Fetching next page of streams for {db_name} - after {stream_name}"
+                    f"Fetching next page of streams for {db_name} - after {schema_name}.{stream_name}"
                 )
-                stream_pagination_marker = stream_name
+                stream_pagination_marker = f"{schema_name}.{stream_name}"
 
         return streams
 


### PR DESCRIPTION
## Summary
- Fix pagination markers in `get_views_for_database` and `get_streams_for_database` to use schema-qualified names
- Add comments explaining the need for schema-qualified pagination markers

## Problem
Snowflake's `SHOW VIEWS FROM` and `SHOW STREAMS FROM` commands use partial name matching, which can cause issues when the same view or stream name exists in multiple schemas within the same database. This leads to:
- Inconsistent pagination results
- Missing views/streams during ingestion
- Ambiguous cursor positioning

## Solution
Changed pagination markers from using just the object name to using fully qualified `schema_name.object_name` format:
- `view_pagination_marker = view_name` → `view_pagination_marker = f"{schema_name}.{view_name}"`
- `stream_pagination_marker = stream_name` → `stream_pagination_marker = f"{schema_name}.{stream_name}"`

This aligns with Snowflake's lexicographic ordering (database, schema, object name) and eliminates ambiguity when objects with the same name exist across different schemas.

## Test plan
- Existing unit tests should continue to pass
- Integration tests with Snowflake environments containing views/streams with duplicate names across schemas should now work reliably

🤖 Generated with [Claude Code](https://claude.ai/code)