### PR TITLE
fix(ingest/athena): Make Athena simple column v1 conversion optional

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
@@ -305,7 +305,7 @@ class AthenaConfig(SQLCommonConfig):
 
     convert_simple_field_paths_to_v1 = pydantic.Field(
         default=False,
-        description="Convert simple field paths to datahub field path v1 format. Simple column paths are those that do not contain any nested fields.",
+        description="Convert simple field paths to DataHub field path v1 format. Simple column paths are those that do not contain any nested fields.",
     )
 
     profiling: AthenaProfilingConfig = AthenaProfilingConfig()

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
@@ -303,7 +303,7 @@ class AthenaConfig(SQLCommonConfig):
         print_warning=True,
     )
 
-    convert_simple_field_paths_to_v1 = pydantic.Field(
+    emit_schema_fieldpaths_as_v1 = pydantic.Field(
         default=False,
         description="Convert simple field paths to DataHub field path v1 format. Simple column paths are those that do not contain any nested fields.",
     )
@@ -648,7 +648,7 @@ class AthenaSource(SQLAlchemySource):
         )
 
         # Keeping it as individual check to make it more explicit and easier to understand
-        if not self.config.convert_simple_field_paths_to_v1:
+        if not self.config.emit_schema_fieldpaths_as_v1:
             return fields
 
         if isinstance(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
@@ -303,6 +303,11 @@ class AthenaConfig(SQLCommonConfig):
         print_warning=True,
     )
 
+    convert_simple_field_paths_to_v1 = pydantic.Field(
+        default=False,
+        description="Convert simple field paths to datahub field path v1 format. Simple column paths are those that do not contain any nested fields.",
+    )
+
     profiling: AthenaProfilingConfig = AthenaProfilingConfig()
 
     def get_sql_alchemy_url(self):
@@ -641,6 +646,11 @@ class AthenaSource(SQLAlchemySource):
                 partition_keys is not None and column["name"] in partition_keys
             ),
         )
+
+        # Keeping it as individual check to make it more explicit and easier to understand
+        if not self.config.convert_simple_field_paths_to_v1:
+            return fields
+
         if isinstance(
             fields[0].type.type, (RecordTypeClass, MapTypeClass, ArrayTypeClass)
         ):

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/athena.py
@@ -303,7 +303,7 @@ class AthenaConfig(SQLCommonConfig):
         print_warning=True,
     )
 
-    emit_schema_fieldpaths_as_v1 = pydantic.Field(
+    emit_schema_fieldpaths_as_v1: bool = pydantic.Field(
         default=False,
         description="Convert simple field paths to DataHub field path v1 format. Simple column paths are those that do not contain any nested fields.",
     )

--- a/metadata-ingestion/tests/integration/athena/athena_mce_golden.json
+++ b/metadata-ingestion/tests/integration/athena/athena_mce_golden.json
@@ -273,7 +273,7 @@
                         },
                         "fields": [
                             {
-                                "fieldPath": "employee_id",
+                                "fieldPath": "[version=2.0].[type=string].employee_id",
                                 "nullable": false,
                                 "description": "Unique identifier for the employee",
                                 "type": {
@@ -287,7 +287,7 @@
                                 "isPartitioningKey": false
                             },
                             {
-                                "fieldPath": "annual_salary",
+                                "fieldPath": "[version=2.0].[type=long].annual_salary",
                                 "nullable": true,
                                 "description": "Annual salary of the employee in USD",
                                 "type": {
@@ -301,7 +301,7 @@
                                 "isPartitioningKey": false
                             },
                             {
-                                "fieldPath": "employee_name",
+                                "fieldPath": "[version=2.0].[type=string].employee_name",
                                 "nullable": false,
                                 "description": "Full name of the employee",
                                 "type": {
@@ -515,7 +515,7 @@
                         },
                         "fields": [
                             {
-                                "fieldPath": "employee_id",
+                                "fieldPath": "[version=2.0].[type=string].employee_id",
                                 "nullable": false,
                                 "description": "Unique identifier for the employee",
                                 "type": {
@@ -529,7 +529,7 @@
                                 "isPartitioningKey": false
                             },
                             {
-                                "fieldPath": "annual_salary",
+                                "fieldPath": "[version=2.0].[type=long].annual_salary",
                                 "nullable": true,
                                 "description": "Annual salary of the employee in USD",
                                 "type": {
@@ -543,7 +543,7 @@
                                 "isPartitioningKey": false
                             },
                             {
-                                "fieldPath": "employee_name",
+                                "fieldPath": "[version=2.0].[type=string].employee_name",
                                 "nullable": false,
                                 "description": "Full name of the employee",
                                 "type": {
@@ -775,7 +775,7 @@
                         },
                         "fields": [
                             {
-                                "fieldPath": "employee_id",
+                                "fieldPath": "[version=2.0].[type=string].employee_id",
                                 "nullable": false,
                                 "description": "Unique identifier for the employee",
                                 "type": {
@@ -789,7 +789,7 @@
                                 "isPartitioningKey": false
                             },
                             {
-                                "fieldPath": "annual_salary",
+                                "fieldPath": "[version=2.0].[type=long].annual_salary",
                                 "nullable": true,
                                 "description": "Annual salary of the employee in USD",
                                 "type": {
@@ -803,7 +803,7 @@
                                 "isPartitioningKey": false
                             },
                             {
-                                "fieldPath": "employee_name",
+                                "fieldPath": "[version=2.0].[type=string].employee_name",
                                 "nullable": false,
                                 "description": "Full name of the employee",
                                 "type": {

--- a/metadata-ingestion/tests/unit/test_athena_source.py
+++ b/metadata-ingestion/tests/unit/test_athena_source.py
@@ -289,15 +289,15 @@ def test_casted_partition_key():
 
 
 def test_convert_simple_field_paths_to_v1_enabled():
-    """Test that convert_simple_field_paths_to_v1 correctly converts simple field paths when enabled"""
+    """Test that emit_schema_fieldpaths_as_v1 correctly converts simple field paths when enabled"""
 
-    # Test config with convert_simple_field_paths_to_v1 enabled
+    # Test config with emit_schema_fieldpaths_as_v1 enabled
     config = AthenaConfig.parse_obj(
         {
             "aws_region": "us-west-1",
             "query_result_location": "s3://query-result-location/",
             "work_group": "test-workgroup",
-            "convert_simple_field_paths_to_v1": True,
+            "emit_schema_fieldpaths_as_v1": True,
         }
     )
 
@@ -353,15 +353,15 @@ def test_convert_simple_field_paths_to_v1_enabled():
 
 
 def test_convert_simple_field_paths_to_v1_disabled():
-    """Test that convert_simple_field_paths_to_v1 keeps v2 field paths when disabled"""
+    """Test that emit_schema_fieldpaths_as_v1 keeps v2 field paths when disabled"""
 
-    # Test config with convert_simple_field_paths_to_v1 disabled (default)
+    # Test config with emit_schema_fieldpaths_as_v1 disabled (default)
     config = AthenaConfig.parse_obj(
         {
             "aws_region": "us-west-1",
             "query_result_location": "s3://query-result-location/",
             "work_group": "test-workgroup",
-            "convert_simple_field_paths_to_v1": False,
+            "emit_schema_fieldpaths_as_v1": False,
         }
     )
 
@@ -391,15 +391,15 @@ def test_convert_simple_field_paths_to_v1_disabled():
 
 
 def test_convert_simple_field_paths_to_v1_complex_types_ignored():
-    """Test that complex types (arrays, maps, structs) are not affected by convert_simple_field_paths_to_v1"""
+    """Test that complex types (arrays, maps, structs) are not affected by emit_schema_fieldpaths_as_v1"""
 
-    # Test config with convert_simple_field_paths_to_v1 enabled
+    # Test config with emit_schema_fieldpaths_as_v1 enabled
     config = AthenaConfig.parse_obj(
         {
             "aws_region": "us-west-1",
             "query_result_location": "s3://query-result-location/",
             "work_group": "test-workgroup",
-            "convert_simple_field_paths_to_v1": True,
+            "emit_schema_fieldpaths_as_v1": True,
         }
     )
 
@@ -451,15 +451,15 @@ def test_convert_simple_field_paths_to_v1_complex_types_ignored():
 
 
 def test_convert_simple_field_paths_to_v1_with_partition_keys():
-    """Test that convert_simple_field_paths_to_v1 works correctly with partition keys"""
+    """Test that emit_schema_fieldpaths_as_v1 works correctly with partition keys"""
 
-    # Test config with convert_simple_field_paths_to_v1 enabled
+    # Test config with emit_schema_fieldpaths_as_v1 enabled
     config = AthenaConfig.parse_obj(
         {
             "aws_region": "us-west-1",
             "query_result_location": "s3://query-result-location/",
             "work_group": "test-workgroup",
-            "convert_simple_field_paths_to_v1": True,
+            "emit_schema_fieldpaths_as_v1": True,
         }
     )
 
@@ -490,10 +490,10 @@ def test_convert_simple_field_paths_to_v1_with_partition_keys():
 
 
 def test_convert_simple_field_paths_to_v1_default_behavior():
-    """Test that convert_simple_field_paths_to_v1 defaults to False"""
+    """Test that emit_schema_fieldpaths_as_v1 defaults to False"""
     from datahub.ingestion.source.sql.athena import AthenaConfig
 
-    # Test config without specifying convert_simple_field_paths_to_v1
+    # Test config without specifying emit_schema_fieldpaths_as_v1
     config = AthenaConfig.parse_obj(
         {
             "aws_region": "us-west-1",
@@ -502,4 +502,4 @@ def test_convert_simple_field_paths_to_v1_default_behavior():
         }
     )
 
-    assert config.convert_simple_field_paths_to_v1 is False  # Should default to False
+    assert config.emit_schema_fieldpaths_as_v1 is False  # Should default to False


### PR DESCRIPTION
Make Athena simple column v1 conversion optional and disabled by default, to not introduce a breaking change

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
