### PR TITLE
fix(build): Add --copies flag to Python venv creation for better compatibility

### DIFF
--- a/metadata-ingestion-modules/airflow-plugin/build.gradle
+++ b/metadata-ingestion-modules/airflow-plugin/build.gradle
@@ -31,8 +31,9 @@ task environmentSetup(type: Exec) {
   def sentinel_file = "${venv_name}/.venv_environment_sentinel"
   inputs.file file('setup.py')
   outputs.file(sentinel_file)
-  commandLine 'bash', '-c', 
-    "${python_executable} -m venv ${venv_name} && set -x && " +
+  def venv_copies_flag = System.getenv('DATAHUB_VENV_USE_COPIES') == 'true' ? '--copies' : ''
+  commandLine 'bash', '-c',
+    "${python_executable} -m venv ${venv_copies_flag} ${venv_name} && set -x && " +
     "${venv_name}/bin/python -m pip install --upgrade uv && " +
     "touch ${sentinel_file}"
 }

--- a/metadata-ingestion-modules/dagster-plugin/build.gradle
+++ b/metadata-ingestion-modules/dagster-plugin/build.gradle
@@ -23,8 +23,9 @@ task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {
   def sentinel_file = "${venv_name}/.venv_environment_sentinel"
   inputs.file file('setup.py')
   outputs.file(sentinel_file)
+  def venv_copies_flag = System.getenv('DATAHUB_VENV_USE_COPIES') == 'true' ? '--copies' : ''
   commandLine 'bash', '-c',
-      "${python_executable} -m venv ${venv_name} && " +
+      "${python_executable} -m venv ${venv_copies_flag} ${venv_name} && " +
       "${venv_name}/bin/python -m pip install --upgrade uv && " +
       "touch ${sentinel_file}"
 }

--- a/metadata-ingestion-modules/gx-plugin/build.gradle
+++ b/metadata-ingestion-modules/gx-plugin/build.gradle
@@ -23,8 +23,9 @@ task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {
   def sentinel_file = "${venv_name}/.venv_environment_sentinel"
   inputs.file file('setup.py')
   outputs.file(sentinel_file)
+  def venv_copies_flag = System.getenv('DATAHUB_VENV_USE_COPIES') == 'true' ? '--copies' : ''
   commandLine 'bash', '-c',
-      "${python_executable} -m venv ${venv_name} && " +
+      "${python_executable} -m venv ${venv_copies_flag} ${venv_name} && " +
       "${venv_name}/bin/pip install --upgrade uv && " +
       "touch ${sentinel_file}"
 }

--- a/metadata-ingestion-modules/prefect-plugin/build.gradle
+++ b/metadata-ingestion-modules/prefect-plugin/build.gradle
@@ -23,8 +23,9 @@ task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {
   def sentinel_file = "${venv_name}/.venv_environment_sentinel"
   inputs.file file('setup.py')
   outputs.file(sentinel_file)
+  def venv_copies_flag = System.getenv('DATAHUB_VENV_USE_COPIES') == 'true' ? '--copies' : ''
   commandLine 'bash', '-c',
-      "${python_executable} -m venv ${venv_name} && " +
+      "${python_executable} -m venv ${venv_copies_flag} ${venv_name} && " +
       "${venv_name}/bin/python -m pip install --upgrade uv && " +
       "touch ${sentinel_file}"
 }

--- a/metadata-ingestion/CLAUDE.md
+++ b/metadata-ingestion/CLAUDE.md
@@ -36,6 +36,17 @@ pytest tests/path/to/file.py::TestClass    # Single test class
 pytest tests/path/to/file.py::TestClass::test_method  # Single test
 ```
 
+## Environment Variables
+
+**Build configuration:**
+
+- `DATAHUB_VENV_USE_COPIES`: Set to `true` to use `--copies` flag when creating Python virtual environments. This copies the Python binary instead of creating a symlink. Useful for Nix environments, immutable filesystems, Windows, or container environments where symlinks don't work correctly. Increases disk usage and setup time, so only enable if needed.
+
+  ```bash
+  export DATAHUB_VENV_USE_COPIES=true
+  ../gradlew :metadata-ingestion:installDev
+  ```
+
 ## Directory Structure
 
 - `src/datahub/`: Source code for the DataHub CLI and ingestion framework

--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -24,8 +24,9 @@ task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {
   def sentinel_file = "${venv_name}/.venv_environment_sentinel"
   inputs.file file('setup.py')
   outputs.file(sentinel_file)
+  def venv_copies_flag = System.getenv('DATAHUB_VENV_USE_COPIES') == 'true' ? '--copies' : ''
   commandLine 'bash', '-c',
-    "if [ ! -d ${venv_name} ] || [ ! -f ${venv_name}/bin/python ]; then ${python_executable} -m venv ${venv_name}; fi && " +
+    "if [ ! -d ${venv_name} ] || [ ! -f ${venv_name}/bin/python ]; then ${python_executable} -m venv ${venv_copies_flag} ${venv_name}; fi && " +
     "set -x && " +
     // If we already have uv available, use it to upgrade uv. Otherwise, install it with pip.
     "if [ ! -f ${venv_name}/bin/uv ]; then ${venv_name}/bin/python -m pip install --upgrade uv; else ${venv_name}/bin/python -m uv pip install --upgrade uv; fi && " +

--- a/metadata-ingestion/developing.md
+++ b/metadata-ingestion/developing.md
@@ -106,6 +106,22 @@ datahub version  # should print "DataHub CLI version: unavailable (installed in 
 Common issues (click to expand):
 
 <details>
+  <summary>Virtual environment creation fails with symlink errors (Nix, immutable filesystems, Windows)</summary>
+
+If you're using Nix, an immutable Python installation, Windows with certain filesystem configurations, or working in container environments where symlinks don't work correctly, you may encounter errors during virtual environment creation.
+
+You can enable the `--copies` flag for Python's venv by setting an environment variable before running the gradle commands:
+
+```shell
+export DATAHUB_VENV_USE_COPIES=true
+../gradlew :metadata-ingestion:installDev
+```
+
+This copies the Python binary instead of creating a symlink. Note that this increases disk usage and setup time, so only enable it if you're experiencing issues with the default symlink-based approach.
+
+</details>
+
+<details>
   <summary>datahub command not found with PyPI install</summary>
 
 If you've already run the pip install, but running `datahub` in your command line doesn't work, then there is likely an issue with your PATH setup and Python.


### PR DESCRIPTION
This change adds the `--copies` flag to the Python virtual environment creation command in the metadata-ingestion build.gradle file.

  What changed:
  - Modified the `environmentSetup` task to use `python -m venv --copies ${venv_name}` instead of `python -m venv ${venv_name}
`
  Why this matters:
  The `--copies` flag ensures that Python files are copied into the virtual environment rather than symlinked. This can resolve issues with:
  - File system compatibility (especially on Windows or network drives)
  - Container environments where symlinks might not work correctly
  - Build reproducibility across different environments
  - Scenarios where the python executable is immutable (Nix environments)

  This is a low-risk change that improves compatibility without affecting functionality.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
