### PR TITLE
feat(ui): show access management tab for containers

### DIFF
--- a/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
@@ -1,4 +1,4 @@
-import { AppstoreOutlined, FileOutlined, FolderOutlined } from '@ant-design/icons';
+import { AppstoreOutlined, FileOutlined, FolderOutlined, UnlockOutlined } from '@ant-design/icons';
 import { ListBullets } from '@phosphor-icons/react';
 import * as React from 'react';
 
@@ -27,6 +27,8 @@ import { DocumentationTab } from '@app/entityV2/shared/tabs/Documentation/Docume
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';
 import { getDataProduct, isOutputPort } from '@app/entityV2/shared/utils';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
+import { useAppConfig } from '@app/useAppConfig';
+import AccessManagement from "@app/entity/shared/tabs/Dataset/AccessManagement/AccessManagement";
 
 import { GetContainerQuery, useGetContainerQuery } from '@graphql/container.generated';
 import { Container, EntityType, SearchResult } from '@types';
@@ -83,6 +85,8 @@ export class ContainerEntity implements Entity<Container> {
 
     useEntityQuery = useGetContainerQuery;
 
+    appconfig = useAppConfig;
+
     renderProfile = (urn: string) => (
         <EntityProfile
             urn={urn}
@@ -116,6 +120,20 @@ export class ContainerEntity implements Entity<Container> {
                     name: 'Properties',
                     component: PropertiesTab,
                     icon: ListBullets,
+                },
+                {
+                    name: 'Access Management',
+                    component: AccessManagement,
+                    icon: UnlockOutlined,
+                    display: {
+                        visible: (_, container: GetContainerQuery) => {
+                            return (
+                                this.appconfig().config.featureFlags.showAccessManagement &&
+                                !!container?.container?.access
+                            );
+                        },
+                        enabled: (_, _2) => true,
+                    },
                 },
             ]}
             sidebarSections={this.getSidebarSections()}


### PR DESCRIPTION
We use the Access Management feature of Datahub in our organisation and saw that this aspect is not currently supported for Containers. This PR aims to change that.

<img width="1035" height="475" alt="image" src="https://github.com/user-attachments/assets/bf8e80bc-e2f5-427b-8ae8-e7ccc0ddfdf7" />


### Checkist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
