### PR TITLE
fix(ui): clamp Tooltip max-width to viewport width

### DIFF
--- a/datahub-web-react/src/app/recommendations/renderer/component/HoverEntityTooltip.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/HoverEntityTooltip.tsx
@@ -36,6 +36,12 @@ export const HoverEntityTooltip = ({
         return <>{children}</>;
     }
 
+    const clampToViewportWidth = (value: number | string) => {
+        // defensive programming in case HoverEntityTooltip ever starts allowing
+        // maxWidth as a string.
+        return `min(100vw, ${value}${typeof value === 'number' ? 'px' : ''})`;
+    };
+
     return (
         <HoverEntityTooltipContext.Provider value={{ entityCount }}>
             <Tooltip
@@ -43,7 +49,7 @@ export const HoverEntityTooltip = ({
                 open={canOpen ? undefined : false}
                 color="white"
                 placement={placement || 'bottom'}
-                overlayStyle={{ minWidth: width, maxWidth, zIndex: 1100 }}
+                overlayStyle={{ minWidth: width, maxWidth: clampToViewportWidth(maxWidth), zIndex: 1100 }}
                 overlayInnerStyle={{ padding: 20, borderRadius: 20, overflow: 'hidden', position: 'relative' }}
                 title={entityRegistry.renderPreview(entity.type, PreviewType.HOVER_CARD, entity)}
                 zIndex={1000}


### PR DESCRIPTION
Visible mainly in the embed sidebar, where it causes flicker issues when a tooltip is wider than the sidebar itself and creates scrollbars.

**Before:**

<img src="https://github.com/user-attachments/assets/7a47c581-4278-4145-ab48-7ebab597bee7" width=400 />

**After:**

<img src="https://github.com/user-attachments/assets/f0d843a8-47c1-4a96-bec7-1820c52f51e3" width=400 />
