### PR TITLE
feat(sdk): use discriminated unions for Filter types

### DIFF
--- a/metadata-ingestion/src/datahub/sdk/search_filters.py
+++ b/metadata-ingestion/src/datahub/sdk/search_filters.py
@@ -74,15 +74,19 @@ class _EntityTypeFilter(_BaseFilter):
 
 
 class _EntitySubtypeFilter(_BaseFilter):
-    entity_subtype: str = pydantic.Field(
+    entity_subtype: List[str] = pydantic.Field(
         description="The entity subtype to filter on. Can be 'Table', 'View', 'Source', etc. depending on the native platform's concepts.",
     )
+
+    @pydantic.validator("entity_subtype", pre=True)
+    def validate_entity_subtype(cls, v: str) -> List[str]:
+        return [v] if not isinstance(v, list) else v
 
     def _build_rule(self) -> SearchFilterRule:
         return SearchFilterRule(
             field="typeNames",
             condition="EQUAL",
-            values=[self.entity_subtype],
+            values=self.entity_subtype,
         )
 
     def compile(self) -> _OrFilters:

--- a/metadata-ingestion/src/datahub/sdk/search_filters.py
+++ b/metadata-ingestion/src/datahub/sdk/search_filters.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import abc
 from typing import (
+    TYPE_CHECKING,
+    Annotated,
     Any,
     ClassVar,
     Iterator,
@@ -42,11 +44,28 @@ class _BaseFilter(ConfigModel):
             populate_by_name = True
 
     @abc.abstractmethod
-    def compile(self) -> _OrFilters:
-        pass
+    def compile(self) -> _OrFilters: ...
 
     def dfs(self) -> Iterator[_BaseFilter]:
         yield self
+
+    @classmethod
+    def _field_discriminator(cls) -> str:
+        if cls is _BaseFilter:
+            raise ValueError("Cannot get discriminator for _BaseFilter")
+        if PYDANTIC_VERSION_2:
+            fields: dict = cls.model_fields  # type: ignore
+        else:
+            fields = cls.__fields__  # type: ignore
+
+        # Assumes that there's only one field name per filter.
+        # If that's not the case, this method should be overridden.
+        if len(fields.keys()) != 1:
+            raise ValueError(
+                f"Found multiple fields that could be the discriminator for this filter: {list(fields.keys())}"
+            )
+        name, field = next(iter(fields.items()))
+        return field.alias or name  # type: ignore
 
 
 class _EntityTypeFilter(_BaseFilter):
@@ -200,6 +219,10 @@ class _CustomCondition(_BaseFilter):
         )
         return [{"and": [rule]}]
 
+    @classmethod
+    def _field_discriminator(cls) -> str:
+        return "_custom"
+
 
 class _And(_BaseFilter):
     """Represents an AND conjunction of filters."""
@@ -306,31 +329,68 @@ class _Not(_BaseFilter):
         yield from self.not_.dfs()
 
 
-# TODO: With pydantic 2, we can use a RootModel with a
-# discriminated union to make the error messages more informative.
-Filter = Union[
-    _And,
-    _Or,
-    _Not,
-    _EntityTypeFilter,
-    _EntitySubtypeFilter,
-    _StatusFilter,
-    _PlatformFilter,
-    _DomainFilter,
-    _EnvFilter,
-    _CustomCondition,
-]
+if TYPE_CHECKING or not PYDANTIC_VERSION_2:
+    # The `not TYPE_CHECKING` bit is required to make the linter happy,
+    # since we currently only run mypy with pydantic v1.
+    Filter = Union[
+        _And,
+        _Or,
+        _Not,
+        _EntityTypeFilter,
+        _EntitySubtypeFilter,
+        _StatusFilter,
+        _PlatformFilter,
+        _DomainFilter,
+        _EnvFilter,
+        _CustomCondition,
+    ]
 
-
-# Required to resolve forward references to "Filter"
-if PYDANTIC_VERSION_2:
-    _And.model_rebuild()  # type: ignore
-    _Or.model_rebuild()  # type: ignore
-    _Not.model_rebuild()  # type: ignore
-else:
     _And.update_forward_refs()
     _Or.update_forward_refs()
     _Not.update_forward_refs()
+else:
+    from pydantic import Discriminator, Tag
+
+    def _filter_discriminator(v: Any) -> Optional[str]:
+        if isinstance(v, _BaseFilter):
+            return v._field_discriminator()
+
+        if not isinstance(v, dict):
+            return None
+
+        keys = list(v.keys())
+        if len(keys) == 1:
+            return keys[0]
+        elif set(keys).issuperset({"field", "condition"}):
+            return _CustomCondition._field_discriminator()
+
+        return None
+
+    # TODO: Once we're fully on pydantic 2, we can use a RootModel here.
+    # That way we'd be able to attach methods to the Filter type.
+    # e.g. replace load_filters(...) with Filter.load(...)
+    Filter = Annotated[
+        Union[
+            Annotated[_And, Tag(_And._field_discriminator())],
+            Annotated[_Or, Tag(_Or._field_discriminator())],
+            Annotated[_Not, Tag(_Not._field_discriminator())],
+            Annotated[_EntityTypeFilter, Tag(_EntityTypeFilter._field_discriminator())],
+            Annotated[
+                _EntitySubtypeFilter, Tag(_EntitySubtypeFilter._field_discriminator())
+            ],
+            Annotated[_StatusFilter, Tag(_StatusFilter._field_discriminator())],
+            Annotated[_PlatformFilter, Tag(_PlatformFilter._field_discriminator())],
+            Annotated[_DomainFilter, Tag(_DomainFilter._field_discriminator())],
+            Annotated[_EnvFilter, Tag(_EnvFilter._field_discriminator())],
+            Annotated[_CustomCondition, Tag(_CustomCondition._field_discriminator())],
+        ],
+        Discriminator(_filter_discriminator),
+    ]
+
+    # Required to resolve forward references to "Filter"
+    _And.model_rebuild()  # type: ignore
+    _Or.model_rebuild()  # type: ignore
+    _Not.model_rebuild()  # type: ignore
 
 
 def load_filters(obj: Any) -> Filter:

--- a/metadata-ingestion/tests/unit/sdk_v2/test_lineage_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_lineage_client.py
@@ -1,6 +1,6 @@
 import pathlib
 from typing import Dict, List, Optional, Sequence, Set, cast
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -141,7 +141,6 @@ def test_infer_lineage_from_sql(client: DataHubClient) -> None:
             "urn:li:dataset:(urn:li:dataPlatform:snowflake,sales_summary,PROD)"
         ],
         query_type=QueryType.SELECT,
-        debug_info=MagicMock(error=None, table_error=None),
     )
 
     query_text = (
@@ -197,7 +196,6 @@ def test_infer_lineage_from_sql_with_multiple_upstreams(
             ),
         ],
         query_type=QueryType.SELECT,
-        debug_info=MagicMock(error=None, table_error=None),
     )
 
     query_text = """

--- a/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
@@ -170,6 +170,52 @@ and:
     ]
 
 
+def test_entity_subtype_filter() -> None:
+    filter_obj_1: Filter = load_filters({"entity_subtype": ["Table"]})
+    assert filter_obj_1 == F.entity_subtype("Table")
+
+    # Ensure it works without the list wrapper to maintain backwards compatibility.
+    filter_obj_2: Filter = load_filters({"entity_subtype": "Table"})
+    assert filter_obj_1 == filter_obj_2
+
+
+def test_filters_all_types() -> None:
+    filter_obj: Filter = load_filters(
+        {
+            "and": [
+                {
+                    "or": [
+                        {"entity_type": ["dataset"]},
+                        {"entity_type": ["chart", "dashboard"]},
+                    ]
+                },
+                {"not": {"entity_subtype": ["Table"]}},
+                {"platform": ["snowflake"]},
+                {"domain": ["urn:li:domain:marketing"]},
+                {"env": ["PROD"]},
+                {"status": "NOT_SOFT_DELETED"},
+                {
+                    "field": "custom_field",
+                    "condition": "GREATER_THAN_OR_EQUAL_TO",
+                    "values": ["5"],
+                },
+            ]
+        }
+    )
+    assert filter_obj == F.and_(
+        F.or_(
+            F.entity_type("dataset"),
+            F.entity_type(["chart", "dashboard"]),
+        ),
+        F.not_(F.entity_subtype("Table")),
+        F.platform("snowflake"),
+        F.domain("urn:li:domain:marketing"),
+        F.env("PROD"),
+        F.soft_deleted(RemovedStatusFilter.NOT_SOFT_DELETED),
+        F.custom_filter("custom_field", "GREATER_THAN_OR_EQUAL_TO", ["5"]),
+    )
+
+
 def test_invalid_filter() -> None:
     with pytest.raises(InvalidUrnError):
         F.domain("marketing")


### PR DESCRIPTION
This should make the error messages and json schema for the Filter type much more understandable when using pydantic v2.

Unfortunately our CI only runs with pydantic v1, so I needed to test these things manually locally. Once we have https://github.com/datahub-project/datahub/pull/14014 merged, this should be possible to test in CI as well.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
