### PR TITLE
feat(homepage): support documentation modules in the new home page

### DIFF
--- a/datahub-web-react/src/app/homeV3/module/Module.tsx
+++ b/datahub-web-react/src/app/homeV3/module/Module.tsx
@@ -4,6 +4,7 @@ import { ModuleProps } from '@app/homeV3/module/types';
 import SampleLargeModule from '@app/homeV3/modules/SampleLargeModule';
 import YourAssetsModule from '@app/homeV3/modules/YourAssetsModule';
 import AssetCollectionModule from '@app/homeV3/modules/assetCollection/AssetCollectionModule';
+import DocumentationModule from '@app/homeV3/modules/documentation/DocumentationModule';
 import TopDomainsModule from '@app/homeV3/modules/domains/TopDomainsModule';
 
 import { DataHubPageModuleType } from '@types';
@@ -14,6 +15,7 @@ export default function Module(props: ModuleProps) {
         if (module.properties.type === DataHubPageModuleType.OwnedAssets) return YourAssetsModule;
         if (module.properties.type === DataHubPageModuleType.Domains) return TopDomainsModule;
         if (module.properties.type === DataHubPageModuleType.AssetCollection) return AssetCollectionModule;
+        if (module.properties.type === DataHubPageModuleType.RichText) return DocumentationModule;
 
         // TODO: remove the sample large module once we have other modules to fill this out
         console.error(`Issue finding module with type ${module.properties.type}`);

--- a/datahub-web-react/src/app/homeV3/moduleModals/ModuleModalMapper.tsx
+++ b/datahub-web-react/src/app/homeV3/moduleModals/ModuleModalMapper.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 
 import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
 import AssetCollectionModal from '@app/homeV3/modules/assetCollection/AssetCollectionModal';
+import DocumentationModal from '@app/homeV3/modules/documentation/DocumentationModal';
 
 import { DataHubPageModuleType } from '@types';
 
@@ -15,6 +16,8 @@ export default function ModuleModalMapper() {
             // TODO: add support of other module types
             case DataHubPageModuleType.AssetCollection:
                 return AssetCollectionModal;
+            case DataHubPageModuleType.RichText:
+                return DocumentationModal;
             default:
                 return null;
         }

--- a/datahub-web-react/src/app/homeV3/moduleModals/common/BaseModuleModal.tsx
+++ b/datahub-web-react/src/app/homeV3/moduleModals/common/BaseModuleModal.tsx
@@ -5,11 +5,11 @@ import { ModalButton } from '@components/components/Modal/Modal';
 
 import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
 
-const modalStyles = {
-    maxWidth: '1000px',
-    minWidth: '800px',
-    maxHeight: '90%',
+const modalBodyStyles = {
+    overflow: 'auto',
+    maxHeight: '70vh',
 };
+
 interface Props {
     title: string;
     subtitle?: string;
@@ -25,7 +25,7 @@ export default function BaseModuleModal({ title, subtitle, children, onUpsert }:
     const buttons: ModalButton[] = [
         {
             text: 'Cancel',
-            color: 'primary',
+            color: 'gray',
             variant: 'text',
             onClick: close,
         },
@@ -45,8 +45,8 @@ export default function BaseModuleModal({ title, subtitle, children, onUpsert }:
             buttons={buttons}
             onCancel={close}
             maskClosable={false} // to avoid accidental clicks that closes the modal
-            style={modalStyles}
-            width="90%"
+            bodyStyle={modalBodyStyles}
+            width="70%"
         >
             {children}
         </Modal>

--- a/datahub-web-react/src/app/homeV3/moduleModals/common/BaseModuleModal.tsx
+++ b/datahub-web-react/src/app/homeV3/moduleModals/common/BaseModuleModal.tsx
@@ -14,9 +14,16 @@ interface Props {
     title: string;
     subtitle?: string;
     onUpsert: () => void;
+    submitButtonProps?: Partial<ModalButton>;
 }
 
-export default function BaseModuleModal({ title, subtitle, children, onUpsert }: React.PropsWithChildren<Props>) {
+export default function BaseModuleModal({
+    title,
+    subtitle,
+    children,
+    onUpsert,
+    submitButtonProps,
+}: React.PropsWithChildren<Props>) {
     const {
         moduleModalState: { close, isOpen, isEditing },
     } = usePageTemplateContext();
@@ -34,6 +41,7 @@ export default function BaseModuleModal({ title, subtitle, children, onUpsert }:
             color: 'primary',
             variant: 'filled',
             onClick: onUpsert,
+            ...submitButtonProps,
         },
     ];
 

--- a/datahub-web-react/src/app/homeV3/moduleModals/common/BaseModuleModal.tsx
+++ b/datahub-web-react/src/app/homeV3/moduleModals/common/BaseModuleModal.tsx
@@ -55,6 +55,7 @@ export default function BaseModuleModal({
             maskClosable={false} // to avoid accidental clicks that closes the modal
             bodyStyle={modalBodyStyles}
             width="70%"
+            style={{ maxWidth: 1100 }}
         >
             {children}
         </Modal>

--- a/datahub-web-react/src/app/homeV3/modules/assetCollection/AssetCollectionModal.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/assetCollection/AssetCollectionModal.tsx
@@ -28,6 +28,10 @@ const AssetCollectionModal = () => {
     const urn = initialState?.urn;
     const [selectedAssetUrns, setSelectedAssetUrns] = useState<string[]>(currentAssets);
 
+    const nameValue = Form.useWatch('name', form);
+
+    const isDisabled = !nameValue?.trim() || !selectedAssetUrns.length;
+
     const handleUpsertAssetCollectionModule = () => {
         form.validateFields().then((values) => {
             const { name } = values;
@@ -51,6 +55,7 @@ const AssetCollectionModal = () => {
             title={`${isEditing ? 'Edit' : 'Add'} Asset Collection`}
             subtitle="Create a widget by selecting assets and information that will be shown to your users"
             onUpsert={handleUpsertAssetCollectionModule}
+            submitButtonProps={{ disabled: isDisabled }}
         >
             <ModalContent>
                 <ModuleDetailsForm form={form} formValues={{ name: currentName }} />

--- a/datahub-web-react/src/app/homeV3/modules/documentation/DocumentationModal.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/documentation/DocumentationModal.tsx
@@ -25,6 +25,11 @@ const DocumentationModal = () => {
     const currentContent = initialState?.properties?.params?.richTextParams?.content;
     const urn = initialState?.urn;
 
+    const nameValue = Form.useWatch('name', form);
+    const contentValue = Form.useWatch('content', form);
+
+    const isDisabled = !nameValue?.trim() || !contentValue?.trim();
+
     const handleUpsertDocumentationModule = () => {
         form.validateFields().then((values) => {
             const { name, content } = values;
@@ -48,6 +53,7 @@ const DocumentationModal = () => {
             title={`${isEditing ? 'Edit' : 'Add'} Documentation`}
             subtitle="Document important information for you users"
             onUpsert={handleUpsertDocumentationModule}
+            submitButtonProps={{ disabled: isDisabled }}
         >
             <ModalContent>
                 <ModuleDetailsForm form={form} formValues={{ name: currentName }} />

--- a/datahub-web-react/src/app/homeV3/modules/documentation/DocumentationModal.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/documentation/DocumentationModal.tsx
@@ -1,0 +1,60 @@
+import { Form } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+
+import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
+import BaseModuleModal from '@app/homeV3/moduleModals/common/BaseModuleModal';
+import ModuleDetailsForm from '@app/homeV3/moduleModals/common/ModuleDetailsForm';
+import RichTextContent from '@app/homeV3/modules/documentation/RichTextContent';
+
+import { DataHubPageModuleType } from '@types';
+
+const ModalContent = styled.div`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+`;
+
+const DocumentationModal = () => {
+    const {
+        upsertModule,
+        moduleModalState: { position, close, isEditing, initialState },
+    } = usePageTemplateContext();
+    const [form] = Form.useForm();
+    const currentName = initialState?.properties.name || '';
+    const currentContent = initialState?.properties?.params?.richTextParams?.content;
+    const urn = initialState?.urn;
+
+    const handleUpsertDocumentationModule = () => {
+        form.validateFields().then((values) => {
+            const { name, content } = values;
+            upsertModule({
+                urn,
+                name,
+                position: position ?? {},
+                type: DataHubPageModuleType.RichText,
+                params: {
+                    richTextParams: {
+                        content,
+                    },
+                },
+            });
+            close();
+        });
+    };
+
+    return (
+        <BaseModuleModal
+            title={`${isEditing ? 'Edit' : 'Add'} Documentation`}
+            subtitle="Document important information for you users"
+            onUpsert={handleUpsertDocumentationModule}
+        >
+            <ModalContent>
+                <ModuleDetailsForm form={form} formValues={{ name: currentName }} />
+                <RichTextContent content={currentContent} form={form} />
+            </ModalContent>
+        </BaseModuleModal>
+    );
+};
+
+export default DocumentationModal;

--- a/datahub-web-react/src/app/homeV3/modules/documentation/DocumentationModule.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/documentation/DocumentationModule.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import LargeModule from '@app/homeV3/module/components/LargeModule';
+import { ModuleProps } from '@app/homeV3/module/types';
+import { Editor } from '@src/alchemy-components/components/Editor/Editor';
+
+const StyledEditor = styled(Editor)`
+    border: none;
+    &&& {
+        .remirror-editor {
+            padding: 0;
+        }
+    }
+`;
+
+const DocumentationModule = (props: ModuleProps) => {
+    const content = props.module.properties.params.richTextParams?.content;
+    return (
+        <LargeModule {...props}>
+            <StyledEditor content={content} readOnly />
+        </LargeModule>
+    );
+};
+
+export default DocumentationModule;

--- a/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
@@ -18,7 +18,7 @@ const RichTextContent = ({ content, form }: Props) => {
     return (
         <Form form={form} initialValues={{ content }}>
             <Form.Item name="content">
-                <StyledEditor content={content} placeholder='Write some text here...' />
+                <StyledEditor content={content} placeholder="Write some text here..." />
             </Form.Item>
         </Form>
     );

--- a/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
@@ -1,17 +1,20 @@
 import { Form, FormInstance } from 'antd';
 import React from 'react';
+import styled from 'styled-components';
 
 import { Editor } from '@src/alchemy-components/components/Editor/Editor';
+
+const StyledEditor = styled(Editor)`
+    height: 300px;
+    overflow: auto;
+`;
 
 type Props = {
     content: string | undefined;
     form: FormInstance;
 };
 
-const RichTextContent = ({
-    content,
-    form,
-}: Props) => {
+const RichTextContent = ({ content, form }: Props) => {
     return (
         <Form form={form} initialValues={{ content }}>
             <Form.Item
@@ -23,7 +26,7 @@ const RichTextContent = ({
                     },
                 ]}
             >
-                <Editor content={content} />
+                <StyledEditor content={content} />
             </Form.Item>
         </Form>
     );

--- a/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
@@ -18,7 +18,7 @@ const RichTextContent = ({ content, form }: Props) => {
     return (
         <Form form={form} initialValues={{ content }}>
             <Form.Item name="content">
-                <StyledEditor content={content} />
+                <StyledEditor content={content} placeholder='Write some text here...' />
             </Form.Item>
         </Form>
     );

--- a/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
@@ -17,15 +17,7 @@ type Props = {
 const RichTextContent = ({ content, form }: Props) => {
     return (
         <Form form={form} initialValues={{ content }}>
-            <Form.Item
-                name="content"
-                rules={[
-                    {
-                        required: true,
-                        message: 'Please add content',
-                    },
-                ]}
-            >
+            <Form.Item name="content">
                 <StyledEditor content={content} />
             </Form.Item>
         </Form>

--- a/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
@@ -1,0 +1,32 @@
+import { Form, FormInstance } from 'antd';
+import React from 'react';
+
+import { Editor } from '@src/alchemy-components/components/Editor/Editor';
+
+type Props = {
+    content: string | undefined;
+    form: FormInstance;
+};
+
+const RichTextContent = ({
+    content,
+    form,
+}: Props) => {
+    return (
+        <Form form={form} initialValues={{ content }}>
+            <Form.Item
+                name="content"
+                rules={[
+                    {
+                        required: true,
+                        message: 'Please add content',
+                    },
+                ]}
+            >
+                <Editor content={content} />
+            </Form.Item>
+        </Form>
+    );
+};
+
+export default RichTextContent;

--- a/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
+++ b/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
@@ -82,7 +82,7 @@ export default function useAddModuleMenu(
             key: 'documentation',
             label: <MenuItem description="Pin docs for your DataHub users" title="Documentation" icon="TextT" />,
             onClick: () => {
-                // TODO: open up modal to add documentation
+                handleOpenCreateModuleModal(DataHubPageModuleType.RichText);
             },
         };
 


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-515/add-ability-to-create-documentation-module
https://linear.app/acryl-data/issue/CH-516/ability-to-view-documentation-module-on-homepage
https://linear.app/acryl-data/issue/CH-520/ability-to-edit-documentation-module

**Description:**

This PR adds support to create, edit and render Documentation (Rich-text) type modules.
It also disables the Create/Update button in the modal when the required values are not present.
And makes the content inside the modal scrollable, keeping the header and footer fixed.


**Screenshots:**

<img width="776" height="274" alt="image" src="https://github.com/user-attachments/assets/c2e5cc85-8814-4917-8c77-ce520d4564c3" />

<img width="1366" height="581" alt="image" src="https://github.com/user-attachments/assets/50efabe5-5de9-45d7-b677-2296e66841ed" />



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
