### PR TITLE
fix(docs): add missing privileges for 3.12

### DIFF
--- a/docs/authorization/policies.md
+++ b/docs/authorization/policies.md
@@ -214,6 +214,7 @@ These privileges are to view & modify any entity within DataHub.
 | Delete                             | Allow actor to delete this entity.                                                         |
 | Create Entity                      | Allow actor to create an entity if it doesn't exist.                                       |
 | Entity Exists                      | Allow actor to determine whether the entity exists.                                        |
+| Execute Entity                     | Allow actor to execute entity ingestion.                                                   |
 | Get Timeline API[^3]               | Allow actor to use the GET Timeline API.                                                   |
 | Get Entity + Relationships API[^3] | Allow actor to use the GET Entity and Relationships API.                                   |
 | Get Aspect/Entity Count APIs[^3]   | Allow actor to use the GET Aspect/Entity Count APIs.                                       |

--- a/docs/authorization/roles.md
+++ b/docs/authorization/roles.md
@@ -130,6 +130,7 @@ These privileges are common to both Self-Hosted DataHub and DataHub Cloud.
 | Edit Tag Color                     | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to change the color of a Tag.                                                        |
 | Edit Lineage                       | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to add and remove lineage edges for this entity.                                     |
 | Edit Dataset Queries               | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to edit the Queries for a Dataset.                                                   |
+| Execute Entity                     | :heavy_check_mark: | :x:                | :x:                | The ability to execute ingestion for an Entity.                                                  |
 | Manage Data Products               | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to create, edit, and delete Data Products within a Domain                            |
 | Edit Properties                    | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to edit the properties for an entity.                                                |
 | Edit Owners                        | :heavy_check_mark: | :x:                | :x:                | The ability to add and remove owners of an entity.                                               |


### PR DESCRIPTION
This privilege was missing from the docs for the ingestion privileges feature https://docs.datahub.com/docs/ui-ingestion#option-2-resource-specific-policies 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
