### PR TITLE
fix(api): missing time duration for token expiration

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/AccessTokenUtil.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/AccessTokenUtil.java
@@ -14,6 +14,8 @@ public class AccessTokenUtil {
         return Optional.of(Duration.of(1, ChronoUnit.HOURS).toMillis());
       case ONE_DAY:
         return Optional.of(Duration.of(1, ChronoUnit.DAYS).toMillis());
+      case ONE_WEEK:
+        return Optional.of(Duration.of(7, ChronoUnit.DAYS).toMillis());
       case ONE_MONTH:
         return Optional.of(Duration.of(30, ChronoUnit.DAYS).toMillis());
       case THREE_MONTHS:


### PR DESCRIPTION
When I tried to create a token in graphql with `duration: ONE_WEEK`, I saw an error in the gms logs. Looks like this was never implemented on the backend.
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
