### PR TITLE
feat(ui) Add user role to custom home page behind feature flag

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -284,6 +284,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
             .setShowProductUpdates(_featureFlags.isShowProductUpdates())
             .setLineageGraphV3(_featureFlags.isLineageGraphV3())
             .setLogicalModelsEnabled(_featureFlags.isLogicalModelsEnabled())
+            .setShowHomepageUserRole(_featureFlags.isShowHomepageUserRole())
             .build();
 
     appConfig.setFeatureFlags(featureFlagsConfig);

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -762,6 +762,11 @@ type FeatureFlagsConfig {
   Enables logical models feature
   """
   logicalModelsEnabled: Boolean!
+
+  """
+  Enables displaying the homepage user role underneath the name. Only available for custom home page.
+  """
+  showHomepageUserRole: Boolean!
 }
 
 """

--- a/datahub-web-react/src/alchemy-components/components/PageTitle/PageTitle.tsx
+++ b/datahub-web-react/src/alchemy-components/components/PageTitle/PageTitle.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
-import styled from 'styled-components';
 
 import { OverflowText } from '@components/components/OverflowText/OverflowText';
 import { Container, SubTitle, Title } from '@components/components/PageTitle/components';
 import { PageTitleProps } from '@components/components/PageTitle/types';
 import { Pill } from '@components/components/Pills';
-
-const StyledSubTitle = styled(SubTitle)`
-    margin-top: 4px;
-`;
 
 export const PageTitle = ({ title, subTitle, pillLabel, variant = 'pageHeader' }: PageTitleProps) => {
     return (
@@ -18,7 +13,7 @@ export const PageTitle = ({ title, subTitle, pillLabel, variant = 'pageHeader' }
                 {pillLabel ? <Pill label={pillLabel} size="sm" clickable={false} /> : null}
             </Title>
 
-            {subTitle ? <StyledSubTitle variant={variant}>{subTitle}</StyledSubTitle> : null}
+            {subTitle ? <SubTitle variant={variant}>{subTitle}</SubTitle> : null}
         </Container>
     );
 };

--- a/datahub-web-react/src/app/homeV3/header/components/GreetingText.tsx
+++ b/datahub-web-react/src/app/homeV3/header/components/GreetingText.tsx
@@ -3,7 +3,9 @@ import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
 import { useUserContext } from '@app/context/useUserContext';
+import { useUserPersonaTitle } from '@app/homeV2/persona/useUserPersona';
 import { getGreetingText } from '@app/homeV2/reference/header/getGreetingText';
+import { useAppConfig } from '@app/useAppConfig';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 
 import { EntityType } from '@types';
@@ -18,6 +20,12 @@ export default function GreetingText() {
     const greetingText = getGreetingText();
     const { user } = useUserContext();
     const entityRegistry = useEntityRegistryV2();
+    const maybeRole = useUserPersonaTitle();
+    const {
+        config: {
+            featureFlags: { showHomepageUserRole },
+        },
+    } = useAppConfig();
 
     const finalText = useMemo(() => {
         if (!user) return `${greetingText}!`;
@@ -26,7 +34,7 @@ export default function GreetingText() {
 
     return (
         <Container>
-            <PageTitle title={finalText} />
+            <PageTitle title={finalText} subTitle={showHomepageUserRole ? maybeRole : null} />
         </Container>
     );
 }

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -84,6 +84,7 @@ export const DEFAULT_APP_CONFIG = {
         showProductUpdates: false,
         lineageGraphV3: false,
         logicalModelsEnabled: false,
+        showHomepageUserRole: false,
     },
     chromeExtensionConfig: {
         enabled: false,

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -106,6 +106,7 @@ query appConfig {
             showProductUpdates
             lineageGraphV3
             logicalModelsEnabled
+            showHomepageUserRole
         }
         chromeExtensionConfig {
             enabled

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -46,4 +46,5 @@ public class FeatureFlags {
   private boolean lineageGraphV3 = true;
   private boolean showProductUpdates = false;
   private boolean logicalModelsEnabled = false;
+  private boolean showHomepageUserRole = false;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -642,6 +642,7 @@ featureFlags:
   lineageGraphV3: ${LINEAGE_GRAPH_V3:false}  # Enables the redesign of the lineage v2 graph
   showProductUpdates: ${SHOW_PRODUCT_UPDATES:true} # Whether to show in-product update popover on new updates.
   logicalModelsEnabled: ${LOGICAL_MODELS_ENABLED:false}  # Enables logical models feature
+  showHomepageUserRole: ${SHOW_HOMEPAGE_USER_ROLE:false}  # Enables displaying the homepage user role underneath the name. Only relevant for custom home page
 
 entityChangeEvents:
   enabled: ${ENABLE_ENTITY_CHANGE_EVENTS_HOOK:true}


### PR DESCRIPTION
Shows the user role on the new custom home page behind a feature flag. By default we don't want this on for folks, but some people very much want this so they can enable it with a flag.

**With flag on**
<img width="1475" height="909" alt="image" src="https://github.com/user-attachments/assets/134f5d9c-4647-44fb-960a-e332085e23f0" />


**With flag off**
<img width="1476" height="909" alt="image" src="https://github.com/user-attachments/assets/6c227569-dac2-4652-bc7b-c96a74a2949f" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
