### PR TITLE
fix(tests): disable auth for spark test via env var instead of env file

### DIFF
--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -99,7 +99,8 @@ ext {
                             ':datahub-actions',
                     ],
                     additionalEnv: [
-                            'DATAHUB_LOCAL_COMMON_ENV': "${rootProject.project(':metadata-integration:java:spark-lineage-legacy').projectDir}/spark-smoke-test/smoke-gms.env"
+                            'DATAHUB_LOCAL_COMMON_ENV': "${rootProject.project(':metadata-integration:java:spark-lineage-legacy').projectDir}/spark-smoke-test/smoke-gms.env",
+                            'METADATA_SERVICE_AUTH_ENABLED': 'false'
                     ]
             ],
             'quickstartStorage': [

--- a/metadata-integration/java/spark-lineage-legacy/spark-smoke-test/smoke-gms.env
+++ b/metadata-integration/java/spark-lineage-legacy/spark-smoke-test/smoke-gms.env
@@ -1,2 +1,4 @@
 REST_API_AUTHORIZATION_ENABLED=false
-METADATA_SERVICE_AUTH_ENABLED=false
+# This does not work from an env file since this is also defined in the environment list which takes precedence over env files.
+# This environment variable must be set to disable METADATA_SERVICE_AUTH_ENABLED
+# METADATA_SERVICE_AUTH_ENABLED=false


### PR DESCRIPTION
quickstart CLI which by default uses METADATA_SERVICE_AUTH_ENABLED=false
The docker compose file did not define this env and hence defaulted to the value in application.yaml (which is true). 
When generating a resolved compose file, all env sections are stripped off and the expanded in the resulting environment variables section in the compose file. So, the profile-based quickstart implementation added this env var to the `environment` section so that it can be overriden to false during generating the resolved compose file for quickstart CLI
The consequence of adding this to environment section is that it takes precedence over env files, it can no longer be overriden by env files to disable METADATA_SERVICE_AUTH_ENABLED (but the environment variable defined with this name still works). 
This choice was required to ensure the resolved compose file is generated from quickstart build script and was as close as possible to what is used using the development builds with gradle. 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
