### PR TITLE
feat(ui/homepage): handle drag and drop with small modules

### DIFF
--- a/datahub-web-react/src/app/homeV3/context/hooks/useDragAndDrop.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useDragAndDrop.ts
@@ -22,6 +22,7 @@ export interface DroppableData {
 export interface ActiveDragModule {
     module: PageModuleFragment;
     position: ModulePositionInput;
+    isSmall: boolean;
 }
 
 export function useDragAndDrop() {
@@ -35,6 +36,7 @@ export function useDragAndDrop() {
             | {
                   module?: PageModuleFragment;
                   position?: ModulePositionInput;
+                  isSmall: boolean;
               }
             | undefined;
 
@@ -42,6 +44,7 @@ export function useDragAndDrop() {
             setActiveModule({
                 module: draggedData.module,
                 position: draggedData.position,
+                isSmall: draggedData.isSmall,
             });
         }
     }, []);

--- a/datahub-web-react/src/app/homeV3/context/hooks/useDragAndDrop.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useDragAndDrop.ts
@@ -9,12 +9,14 @@ import { PageModuleFragment } from '@graphql/template.generated';
 interface DraggedModuleData {
     module: PageModuleFragment;
     position: ModulePositionInput;
+    isSmall: boolean;
 }
 
 export interface DroppableData {
     rowIndex: number;
     moduleIndex?: number; // If undefined, drop at the end of the row
     insertNewRow?: boolean; // If true, create a new row at this position
+    isSmall?: boolean; // If undefined, accept any module size
 }
 
 export interface ActiveDragModule {
@@ -54,6 +56,14 @@ export function useDragAndDrop() {
 
             const draggedData = active.data.current as DraggedModuleData;
             const droppableData = over.data.current as DroppableData;
+
+            const isDragSmall = draggedData.isSmall;
+            const isDropSmall = droppableData.isSmall;
+
+            // Check if we're dropping in mis-matched sized row
+            if (isDropSmall !== undefined && isDragSmall !== undefined && isDragSmall !== isDropSmall) {
+                return;
+            }
 
             // Check if we're dropping in the same position
             if (

--- a/datahub-web-react/src/app/homeV3/module/components/LargeModule.tsx
+++ b/datahub-web-react/src/app/homeV3/module/components/LargeModule.tsx
@@ -64,6 +64,7 @@ function LargeModule({ children, module, position, loading, onClickViewAll }: Re
         data: {
             module,
             position,
+            isSmall: false,
         },
     });
 

--- a/datahub-web-react/src/app/homeV3/module/components/SmallModule.tsx
+++ b/datahub-web-react/src/app/homeV3/module/components/SmallModule.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '@components';
+import { useDraggable } from '@dnd-kit/core';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -6,12 +8,29 @@ import ModuleMenu from '@app/homeV3/module/components/ModuleMenu';
 import { ModuleProps } from '@app/homeV3/module/types';
 import { FloatingRightHeaderSection } from '@app/homeV3/styledComponents';
 
-const Container = styled.div`
+const DragIcon = styled(Icon)<{ isDragging: boolean }>`
+    cursor: ${(props) => (props.isDragging ? 'grabbing' : 'grab')};
+    display: none;
+    position: absolute;
+    left: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+`;
+
+const ContainerWithHover = styled.div`
     display: flex;
     flex-direction: column;
     position: relative;
     height: 100%;
     justify-content: center;
+
+    :hover {
+        background: linear-gradient(180deg, #fff 0%, #fafafb 100%);
+    }
+
+    :hover ${DragIcon} {
+        display: block;
+    }
 `;
 
 const Content = styled.div`
@@ -20,20 +39,37 @@ const Content = styled.div`
 `;
 
 const StyledModuleContainer = styled(ModuleContainer)<{ clickable?: boolean }>`
-    max-height: 72px;
+    max-height: 64px;
 
     ${({ clickable }) => clickable && `cursor: pointer;`}
 `;
 
 export default function SmallModule({ children, module, position, onClick }: React.PropsWithChildren<ModuleProps>) {
+    const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+        id: `module-${module.urn}-${position.rowIndex}-${position.moduleIndex}`,
+        data: {
+            module,
+            position,
+            isSmall: true,
+        },
+    });
+
     return (
-        <StyledModuleContainer clickable={!!onClick} onClick={onClick}>
-            <Container>
+        <StyledModuleContainer clickable={!!onClick} onClick={onClick} ref={setNodeRef} {...attributes}>
+            <ContainerWithHover>
+                <DragIcon
+                    {...listeners}
+                    size="lg"
+                    color="gray"
+                    icon="DotsSixVertical"
+                    source="phosphor"
+                    isDragging={isDragging}
+                />
                 <Content>{children}</Content>
                 <FloatingRightHeaderSection>
                     <ModuleMenu module={module} position={position} />
                 </FloatingRightHeaderSection>
-            </Container>
+            </ContainerWithHover>
         </StyledModuleContainer>
     );
 }

--- a/datahub-web-react/src/app/homeV3/modules/constants.ts
+++ b/datahub-web-react/src/app/homeV3/modules/constants.ts
@@ -89,3 +89,5 @@ export const LARGE_MODULE_TYPES: DataHubPageModuleType[] = [
     DataHubPageModuleType.Hierarchy,
     DataHubPageModuleType.RichText,
 ];
+
+export const SMALL_MODULE_TYPES: DataHubPageModuleType[] = [DataHubPageModuleType.Link];

--- a/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
+++ b/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useMemo } from 'react';
 import { RESET_DROPDOWN_MENU_STYLES_CLASSNAME } from '@components/components/Dropdown/constants';
 
 import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
-import { LARGE_MODULE_TYPES } from '@app/homeV3/modules/constants';
+import { LARGE_MODULE_TYPES, SMALL_MODULE_TYPES } from '@app/homeV3/modules/constants';
 import { ModulesAvailableToAdd } from '@app/homeV3/modules/types';
 import { convertModuleToModuleInfo } from '@app/homeV3/modules/utils';
 import GroupItem from '@app/homeV3/template/components/addModuleMenu/components/GroupItem';
@@ -48,10 +48,15 @@ export default function useAddModuleMenu(
         template,
     } = usePageTemplateContext();
 
-    const isRowWithLargeModule =
+    const isLargeModuleRow =
         position.rowIndex !== undefined &&
         template?.properties.rows[position.rowIndex]?.modules?.some((module) =>
             LARGE_MODULE_TYPES.includes(module.properties.type),
+        );
+    const isSmallModuleRow =
+        position.rowIndex !== undefined &&
+        template?.properties.rows[position.rowIndex]?.modules?.some((module) =>
+            SMALL_MODULE_TYPES.includes(module.properties.type),
         );
 
     const handleAddExistingModule = useCallback(
@@ -83,7 +88,7 @@ export default function useAddModuleMenu(
             onClick: () => {
                 handleOpenCreateModuleModal(DataHubPageModuleType.Link);
             },
-            disabled: isRowWithLargeModule,
+            disabled: isLargeModuleRow,
         };
 
         const documentation = {
@@ -93,6 +98,7 @@ export default function useAddModuleMenu(
             onClick: () => {
                 handleOpenCreateModuleModal(DataHubPageModuleType.RichText);
             },
+            disabled: isSmallModuleRow,
         };
 
         items.push({
@@ -109,6 +115,7 @@ export default function useAddModuleMenu(
             onClick: () => {
                 handleAddExistingModule(YOUR_ASSETS_MODULE);
             },
+            disabled: isSmallModuleRow,
         };
 
         const domains = {
@@ -118,6 +125,7 @@ export default function useAddModuleMenu(
             onClick: () => {
                 handleAddExistingModule(DOMAINS_MODULE);
             },
+            disabled: isSmallModuleRow,
         };
 
         const assetCollection = {
@@ -133,6 +141,7 @@ export default function useAddModuleMenu(
             onClick: () => {
                 handleOpenCreateModuleModal(DataHubPageModuleType.AssetCollection);
             },
+            disabled: isSmallModuleRow,
         };
 
         items.push({
@@ -170,7 +179,8 @@ export default function useAddModuleMenu(
 
         return { items };
     }, [
-        isRowWithLargeModule,
+        isLargeModuleRow,
+        isSmallModuleRow,
         modulesAvailableToAdd.adminCreatedModules,
         handleOpenCreateModuleModal,
         handleAddExistingModule,

--- a/datahub-web-react/src/app/homeV3/templateRow/TemplateRow.tsx
+++ b/datahub-web-react/src/app/homeV3/templateRow/TemplateRow.tsx
@@ -1,3 +1,4 @@
+import { useDndContext } from '@dnd-kit/core';
 import React, { memo } from 'react';
 
 import { ModulesAvailableToAdd } from '@app/homeV3/modules/types';
@@ -13,12 +14,21 @@ interface Props {
 
 function TemplateRow({ row, modulesAvailableToAdd, rowIndex }: Props) {
     const { modulePositions, shouldDisableDropZones, isSmallRow } = useTemplateRowLogic(row, rowIndex);
+    const { active } = useDndContext();
+    const isActiveModuleSmall = active?.data?.current?.isSmall;
+
+    const isDropAllowed =
+        !active ||
+        isSmallRow == null || // empty row
+        isActiveModuleSmall === isSmallRow;
+
+    const isDropZoneDisabled = shouldDisableDropZones || !isDropAllowed;
 
     return (
         <RowLayout
             rowIndex={rowIndex}
             modulePositions={modulePositions}
-            shouldDisableDropZones={shouldDisableDropZones}
+            shouldDisableDropZones={isDropZoneDisabled}
             modulesAvailableToAdd={modulesAvailableToAdd}
             isSmallRow={isSmallRow}
         />

--- a/datahub-web-react/src/app/homeV3/templateRow/TemplateRow.tsx
+++ b/datahub-web-react/src/app/homeV3/templateRow/TemplateRow.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 function TemplateRow({ row, modulesAvailableToAdd, rowIndex }: Props) {
-    const { modulePositions, shouldDisableDropZones } = useTemplateRowLogic(row, rowIndex);
+    const { modulePositions, shouldDisableDropZones, isSmallRow } = useTemplateRowLogic(row, rowIndex);
 
     return (
         <RowLayout
@@ -20,6 +20,7 @@ function TemplateRow({ row, modulesAvailableToAdd, rowIndex }: Props) {
             modulePositions={modulePositions}
             shouldDisableDropZones={shouldDisableDropZones}
             modulesAvailableToAdd={modulesAvailableToAdd}
+            isSmallRow={isSmallRow}
         />
     );
 }

--- a/datahub-web-react/src/app/homeV3/templateRow/components/ModuleDropZone.tsx
+++ b/datahub-web-react/src/app/homeV3/templateRow/components/ModuleDropZone.tsx
@@ -2,8 +2,8 @@ import { useDroppable } from '@dnd-kit/core';
 import React, { memo } from 'react';
 import styled from 'styled-components';
 
-const DropZone = styled.div<{ $isOver?: boolean; $canDrop?: boolean }>`
-    height: 316px;
+const DropZone = styled.div<{ $isOver?: boolean; $canDrop?: boolean; $isSmall?: boolean }>`
+    height: ${(props) => (props.$isSmall ? '64px' : '316px')};
     transition: all 0.2s ease;
 
     ${({ $isOver, $canDrop }) => {
@@ -24,19 +24,21 @@ interface Props {
     rowIndex: number;
     moduleIndex?: number;
     disabled?: boolean;
+    isSmall?: boolean;
 }
 
-function ModuleDropZone({ rowIndex, moduleIndex, disabled }: Props) {
+function ModuleDropZone({ rowIndex, moduleIndex, disabled, isSmall }: Props) {
     const { isOver, setNodeRef } = useDroppable({
         id: `drop-zone-${rowIndex}-${moduleIndex ?? 'end'}`,
         disabled,
         data: {
             rowIndex,
             moduleIndex,
+            isSmall,
         },
     });
 
-    return <DropZone ref={setNodeRef} $isOver={isOver} $canDrop={!disabled} />;
+    return <DropZone ref={setNodeRef} $isOver={isOver} $canDrop={!disabled} $isSmall={isSmall} />;
 }
 
 export default memo(ModuleDropZone);

--- a/datahub-web-react/src/app/homeV3/templateRow/components/ModuleDropZone.tsx
+++ b/datahub-web-react/src/app/homeV3/templateRow/components/ModuleDropZone.tsx
@@ -2,7 +2,7 @@ import { useDroppable } from '@dnd-kit/core';
 import React, { memo } from 'react';
 import styled from 'styled-components';
 
-const DropZone = styled.div<{ $isOver?: boolean; $canDrop?: boolean; $isSmall?: boolean }>`
+const DropZone = styled.div<{ $isOver?: boolean; $canDrop?: boolean; $isSmall?: boolean | null }>`
     height: ${(props) => (props.$isSmall ? '64px' : '316px')};
     transition: all 0.2s ease;
 
@@ -24,7 +24,7 @@ interface Props {
     rowIndex: number;
     moduleIndex?: number;
     disabled?: boolean;
-    isSmall?: boolean;
+    isSmall: boolean | null;
 }
 
 function ModuleDropZone({ rowIndex, moduleIndex, disabled, isSmall }: Props) {

--- a/datahub-web-react/src/app/homeV3/templateRow/components/RowLayout.tsx
+++ b/datahub-web-react/src/app/homeV3/templateRow/components/RowLayout.tsx
@@ -26,7 +26,7 @@ interface Props {
     modulePositions: ModulePosition[];
     shouldDisableDropZones: boolean;
     modulesAvailableToAdd: ModulesAvailableToAdd;
-    isSmallRow?: boolean;
+    isSmallRow: boolean | null;
 }
 
 interface ModuleWrapperProps {

--- a/datahub-web-react/src/app/homeV3/templateRow/components/RowLayout.tsx
+++ b/datahub-web-react/src/app/homeV3/templateRow/components/RowLayout.tsx
@@ -26,6 +26,7 @@ interface Props {
     modulePositions: ModulePosition[];
     shouldDisableDropZones: boolean;
     modulesAvailableToAdd: ModulesAvailableToAdd;
+    isSmallRow?: boolean;
 }
 
 interface ModuleWrapperProps {
@@ -38,7 +39,7 @@ const ModuleWrapper = memo(({ module, position }: ModuleWrapperProps) => (
     <Module module={module} position={position} />
 ));
 
-function RowLayout({ rowIndex, modulePositions, shouldDisableDropZones, modulesAvailableToAdd }: Props) {
+function RowLayout({ rowIndex, modulePositions, shouldDisableDropZones, modulesAvailableToAdd, isSmallRow }: Props) {
     return (
         <RowWrapper>
             <AddModuleButton
@@ -49,7 +50,12 @@ function RowLayout({ rowIndex, modulePositions, shouldDisableDropZones, modulesA
             />
 
             {/* Drop zone at the beginning of the row */}
-            <ModuleDropZone rowIndex={rowIndex} moduleIndex={0} disabled={shouldDisableDropZones} />
+            <ModuleDropZone
+                rowIndex={rowIndex}
+                moduleIndex={0}
+                disabled={shouldDisableDropZones}
+                isSmall={isSmallRow}
+            />
 
             {modulePositions.map(({ module, position, key }, moduleIndex) => (
                 <React.Fragment key={key}>
@@ -59,6 +65,7 @@ function RowLayout({ rowIndex, modulePositions, shouldDisableDropZones, modulesA
                         rowIndex={rowIndex}
                         moduleIndex={moduleIndex + 1}
                         disabled={shouldDisableDropZones}
+                        isSmall={isSmallRow}
                     />
                 </React.Fragment>
             ))}

--- a/datahub-web-react/src/app/homeV3/templateRow/hooks/useTemplateRowLogic.ts
+++ b/datahub-web-react/src/app/homeV3/templateRow/hooks/useTemplateRowLogic.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { SMALL_MODULE_TYPES } from '@app/homeV3/modules/constants';
 import { ModulePositionInput } from '@app/homeV3/template/types';
 import { useDragRowContext } from '@app/homeV3/templateRow/hooks/useDragRowContext';
 import { WrappedRow } from '@app/homeV3/templateRow/types';
@@ -39,11 +40,17 @@ export function useTemplateRowLogic(row: WrappedRow, rowIndex: number) {
         [row.modules, rowIndex],
     );
 
+    const isSmallRow = useMemo(
+        () => (row.modules.length > 0 ? SMALL_MODULE_TYPES.includes(row.modules[0].properties.type) : undefined),
+        [row.modules],
+    );
+
     return {
         // Row state
         isRowFull,
         currentModuleCount,
         maxModulesPerRow,
+        isSmallRow,
 
         // Drag state
         isDraggingFromSameRow,

--- a/datahub-web-react/src/app/homeV3/templateRow/hooks/useTemplateRowLogic.ts
+++ b/datahub-web-react/src/app/homeV3/templateRow/hooks/useTemplateRowLogic.ts
@@ -41,7 +41,7 @@ export function useTemplateRowLogic(row: WrappedRow, rowIndex: number) {
     );
 
     const isSmallRow = useMemo(
-        () => (row.modules.length > 0 ? SMALL_MODULE_TYPES.includes(row.modules[0].properties.type) : undefined),
+        () => (row.modules.length > 0 ? SMALL_MODULE_TYPES.includes(row.modules[0].properties.type) : null),
         [row.modules],
     );
 


### PR DESCRIPTION
**Linear tickets:**
https://linear.app/acryl-data/issue/CH-584/handle-height-of-drop-zones-for-small-modules
https://linear.app/acryl-data/issue/CH-585/handle-drag-and-drop-with-small-and-large-modules

**Description:**

- Adds the ability to the small modules (currently Link type) to be dragged and dropped. 
- Handles the extra space after small modules (due to the large height of drop zones). 
- Restricts the drag and drop of small modules into the rows with large modules and vice-versa.

**Screenshots:**

<img width="927" height="121" alt="image" src="https://github.com/user-attachments/assets/393eb3d8-da88-4056-9d4b-27c4869a3540" />


<img width="934" height="174" alt="image" src="https://github.com/user-attachments/assets/8c1dbb5d-ae48-4b89-983d-ad1d05047e8d" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
