### PR TITLE
ci(cypress): resize observer fix (#6263)

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_graph.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_graph.js
@@ -19,12 +19,6 @@ const MONTHLY_TEMPERATURE_DATASET_URN =
 describe("lineage_graph", () => {
   beforeEach(() => {
     cy.setIsThemeV2Enabled(true);
-    const resizeObserverLoopErrRe = "ResizeObserver loop limit exceeded";
-    cy.on("uncaught:exception", (err) => {
-      if (err.message.includes(resizeObserverLoopErrRe)) {
-        return false;
-      }
-    });
   });
   it("can see full history", () => {
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/siblings/siblings.js
+++ b/smoke-test/tests/cypress/cypress/e2e/siblings/siblings.js
@@ -33,14 +33,6 @@ describe("siblings", () => {
   });
 
   it("can view individual nodes", () => {
-    const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
-    cy.on("uncaught:exception", (err) => {
-      /* returning false here prevents Cypress from failing the test */
-      if (resizeObserverLoopErrRe.test(err.message)) {
-        return false;
-      }
-    });
-
     cy.visitWithLogin(`/dataset/${DBT_URN}/?is_lineage_mode=false`);
     cy.get(".ant-table-row").should("be.visible");
     // navigate to the bq entity

--- a/smoke-test/tests/cypress/cypress/e2e/siblingsV2/v2_siblings.js
+++ b/smoke-test/tests/cypress/cypress/e2e/siblingsV2/v2_siblings.js
@@ -1,12 +1,6 @@
 describe("siblings", () => {
   beforeEach(() => {
     cy.setIsThemeV2Enabled(true);
-    const resizeObserverLoopErrRe = "ResizeObserver loop limit exceeded";
-    cy.on("uncaught:exception", (err) => {
-      if (err.message.includes(resizeObserverLoopErrRe)) {
-        return false;
-      }
-    });
   });
 
   it("will merge metadata to non-primary sibling", () => {
@@ -52,13 +46,6 @@ describe("siblings", () => {
     cy.login();
     cy.visit("/");
     cy.skipIntroducePage();
-    const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
-    cy.on("uncaught:exception", (err) => {
-      /* returning false here prevents Cypress from failing the test */
-      if (resizeObserverLoopErrRe.test(err.message)) {
-        return false;
-      }
-    });
 
     cy.visit(
       "/dataset/urn:li:dataset:(urn:li:dataPlatform:dbt,cypress_project.jaffle_shop.customers,PROD)/?is_lineage_mode=false",
@@ -123,12 +110,6 @@ describe("siblings", () => {
   });
 
   it.only("separates siblings in lineage", () => {
-    Cypress.on("uncaught:exception", (err, runnable) => {
-      if (err.message.includes("ResizeObserver loop limit exceeded")) {
-        return false;
-      }
-    });
-
     cy.login();
     cy.visit("/");
     cy.skipIntroducePage();

--- a/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_view_select.js
+++ b/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_view_select.js
@@ -15,13 +15,6 @@ describe("view select", () => {
     const newViewName = `New View Name ${randomNumber}`;
 
     // Resize Observer Loop warning can be safely ignored - ref. https://github.com/cypress-io/cypress/issues/22113
-    const resizeObserverLoopErrRe = "ResizeObserver loop limit exceeded";
-    cy.on("uncaught:exception", (err) => {
-      if (err.message.includes(resizeObserverLoopErrRe)) {
-        return false;
-      }
-    });
-
     cy.visit("/");
     cy.skipIntroducePage();
     cy.goToStarSearchList();

--- a/smoke-test/tests/cypress/cypress/e2e/views/view_select.js
+++ b/smoke-test/tests/cypress/cypress/e2e/views/view_select.js
@@ -13,12 +13,6 @@ describe("view select", () => {
     const newViewName = `New View Name ${randomNumber}`;
 
     // Resize Observer Loop warning can be safely ignored - ref. https://github.com/cypress-io/cypress/issues/22113
-    const resizeObserverLoopErrRe = "ResizeObserver loop limit exceeded";
-    cy.on(
-      "uncaught:exception",
-      (err) => !err.message.includes(resizeObserverLoopErrRe),
-    );
-
     cy.goToStarSearchList();
 
     cy.log("Create a View from the select");

--- a/smoke-test/tests/cypress/cypress/support/commands.js
+++ b/smoke-test/tests/cypress/cypress/support/commands.js
@@ -554,12 +554,21 @@ Cypress.Commands.add("setIsThemeV2Enabled", (isEnabled) => {
 });
 
 Cypress.on("uncaught:exception", (err) => {
-  const resizeObserverLoopErrMessage = "ResizeObserver loop limit exceeded";
+  const resizeObserverLoopLimitErrMessage =
+    "ResizeObserver loop limit exceeded";
+  const resizeObserverLoopErrMessage =
+    "ResizeObserver loop completed with undelivered notifications.";
 
   /* returning false here prevents Cypress from failing the test */
-  if (err.message.includes(resizeObserverLoopErrMessage)) {
+  if (
+    err.message.includes(resizeObserverLoopLimitErrMessage) ||
+    err.message.includes(resizeObserverLoopErrMessage)
+  ) {
     return false;
   }
+
+  // Allow other uncaught exceptions to fail the test
+  return true;
 });
 
 //


### PR DESCRIPTION
## Summary
Fix for Cypress 14.5.1 upgrade compatibility issues

## What changed
- Global handler in `commands.js` now handles all `ResizeObserver` errors
- Supports both Cypress 12.x and 14.x error message formats:
	- 	"ResizeObserver loop limit exceeded" in older Electron/Chromium VS "ResizeObserver loop completed with undelivered notifications."
- Remove individual `cy.on('uncaught:exception')` handlers from 9 test files (158 lines of redundant code)

## What is ResizeObserver and why do these errors occur?
- ResizeObserver is a browser API that monitors changes to element dimensions. 
-  In complex web applications you can get into situations where:
```Observer watches element → Element resizes → Observer triggers callback → Callback causes layout change → Element resizes again → Infinite loop!```
- Browser detects the loop and throws an error to prevent hanging/crashing

## See also
- https://trackjs.com/javascript-errors/resizeobserver-loop-completed-with-undelivered-notifications/

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
