### PR TITLE
docs(lineage): clarifying datajob->dataset lineage is supported

### DIFF
--- a/docs/api/tutorials/lineage.md
+++ b/docs/api/tutorials/lineage.md
@@ -229,6 +229,7 @@ The Lineage APIs support the following entity combinations:
 | Dataset         | Dataset           |
 | Dataset         | DataJob           |
 | DataJob         | DataJob           |
+| DataJob         | Dataset           |
 | Dataset         | Dashboard         |
 | Chart           | Dashboard         |
 | Dashboard       | Dashboard         |


### PR DESCRIPTION
This table is missing datajob->dataset lineage

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
