### PR TITLE
feat(ui) Create and replace when editing global modules on personal template

### DIFF
--- a/datahub-web-react/src/app/homeV3/context/PageTemplateContext.tsx
+++ b/datahub-web-react/src/app/homeV3/context/PageTemplateContext.tsx
@@ -48,6 +48,7 @@ export const PageTemplateProvider = ({
         removeModuleFromTemplate,
         upsertTemplate,
         moduleModalState.isEditing,
+        moduleModalState.initialState,
     );
 
     const value = useMemo(

--- a/datahub-web-react/src/app/homeV3/context/__tests__/PageTemplateContext.test.tsx
+++ b/datahub-web-react/src/app/homeV3/context/__tests__/PageTemplateContext.test.tsx
@@ -186,6 +186,7 @@ describe('PageTemplateContext', () => {
                 mockRemoveModuleFromTemplate,
                 mockUpsertTemplate,
                 false,
+                null,
             );
         });
 
@@ -285,6 +286,7 @@ describe('PageTemplateContext', () => {
                 mockRemoveModuleFromTemplate,
                 mockUpsertTemplate,
                 false,
+                null,
             );
         });
 

--- a/datahub-web-react/src/app/homeV3/context/hooks/__tests__/useModuleModalState.test.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/__tests__/useModuleModalState.test.ts
@@ -75,23 +75,23 @@ describe('useModuleModalState', () => {
 
     it('should set edit state module on openToEdit()', () => {
         const { result } = renderHook(() => useModuleModalState());
-        act(() => result.current.openToEdit(TYPE, mockModule));
+        act(() => result.current.openToEdit(TYPE, mockModule, POS1));
         expect(result.current.isOpen).toBe(true);
         expect(result.current.moduleType).toBe(TYPE);
         expect(result.current.isEditing).toBe(true);
         expect(result.current.initialState).toBe(mockModule);
-        expect(result.current.position).toBeNull();
+        expect(result.current.position).toEqual(POS1);
     });
 
     it('should update to latest args on consecutive openToEdit()', () => {
         const { result } = renderHook(() => useModuleModalState());
-        act(() => result.current.openToEdit(TYPE, mockModule));
-        act(() => result.current.openToEdit(TYPE2, anotherMockModule));
+        act(() => result.current.openToEdit(TYPE, mockModule, POS1));
+        act(() => result.current.openToEdit(TYPE2, anotherMockModule, POS2));
         expect(result.current.isOpen).toBe(true);
         expect(result.current.moduleType).toBe(TYPE2);
         expect(result.current.isEditing).toBe(true);
         expect(result.current.initialState).toBe(anotherMockModule);
-        expect(result.current.position).toBeNull();
+        expect(result.current.position).toEqual(POS2);
     });
 
     it('should reset state after open() then close()', () => {
@@ -107,7 +107,7 @@ describe('useModuleModalState', () => {
 
     it('should reset state after openToEdit() then close()', () => {
         const { result } = renderHook(() => useModuleModalState());
-        act(() => result.current.openToEdit(TYPE, mockModule));
+        act(() => result.current.openToEdit(TYPE, mockModule, POS1));
         act(() => result.current.close());
         expect(result.current.isOpen).toBe(false);
         expect(result.current.moduleType).toBeNull();
@@ -118,7 +118,7 @@ describe('useModuleModalState', () => {
 
     it('should reset edit state on open() after openToEdit()', () => {
         const { result } = renderHook(() => useModuleModalState());
-        act(() => result.current.openToEdit(TYPE, mockModule));
+        act(() => result.current.openToEdit(TYPE, mockModule, POS1));
         act(() => result.current.open(TYPE2, POS2));
         expect(result.current.isOpen).toBe(true);
         expect(result.current.moduleType).toBe(TYPE2);
@@ -131,18 +131,18 @@ describe('useModuleModalState', () => {
         const { result } = renderHook(() => useModuleModalState());
         act(() => result.current.open(TYPE, POS1));
         expect(result.current.position).toEqual(POS1);
-        act(() => result.current.openToEdit(TYPE, mockModule));
+        act(() => result.current.openToEdit(TYPE, mockModule, POS1));
         expect(result.current.position).toEqual(POS1);
         act(() => result.current.open(TYPE, POS2));
         expect(result.current.position).toEqual(POS2);
-        act(() => result.current.openToEdit(TYPE2, mockModule));
+        act(() => result.current.openToEdit(TYPE2, mockModule, POS2));
         expect(result.current.position).toEqual(POS2);
     });
 
     it('should fully reset all state after a complex sequence and close()', () => {
         const { result } = renderHook(() => useModuleModalState());
         act(() => result.current.open(TYPE, POS1));
-        act(() => result.current.openToEdit(TYPE2, mockModule));
+        act(() => result.current.openToEdit(TYPE2, mockModule, POS2));
         act(() => result.current.open(TYPE, POS2));
         act(() => result.current.close());
         expect(result.current.isOpen).toBe(false);
@@ -167,9 +167,9 @@ describe('useModuleModalState', () => {
     it('should retain latest initialState and position after successive edits', () => {
         const { result } = renderHook(() => useModuleModalState());
         act(() => result.current.open(TYPE, POS1));
-        act(() => result.current.openToEdit(TYPE, mockModule));
-        act(() => result.current.openToEdit(TYPE, anotherMockModule));
+        act(() => result.current.openToEdit(TYPE, mockModule, POS1));
+        act(() => result.current.openToEdit(TYPE, anotherMockModule, POS3));
         expect(result.current.initialState).toBe(anotherMockModule);
-        expect(result.current.position).toEqual(POS1);
+        expect(result.current.position).toEqual(POS3);
     });
 });

--- a/datahub-web-react/src/app/homeV3/context/hooks/__tests__/useModuleOperations.test.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/__tests__/useModuleOperations.test.ts
@@ -109,6 +109,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -161,6 +162,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -208,6 +210,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false,
+                    null, // originalModuleData
                 ),
             );
 
@@ -256,6 +259,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false,
+                    null, // originalModuleData
                 ),
             );
 
@@ -322,6 +326,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -372,6 +377,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -422,6 +428,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -475,6 +482,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -532,6 +540,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -577,6 +586,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -616,6 +626,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -661,6 +672,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -702,6 +714,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false,
+                    null, // originalModuleData
                 ),
             );
 
@@ -802,6 +815,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false,
+                    null, // originalModuleData
                 ),
             );
 
@@ -858,6 +872,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false,
+                    null, // originalModuleData
                 ),
             );
 
@@ -914,6 +929,7 @@ describe('useModuleOperations', () => {
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
                     false,
+                    null, // originalModuleData
                 ),
             );
 
@@ -1000,6 +1016,390 @@ describe('useModuleOperations', () => {
             expect(mockSetGlobalTemplate).toHaveBeenCalledWith(updatedTemplate);
             expect(mockUpsertTemplate).toHaveBeenCalledWith(updatedTemplate, false, mockPersonalTemplate);
         });
+
+        // Tests for global module replacement functionality
+        describe('global module replacement', () => {
+            const mockGlobalModuleToEdit: PageModuleFragment = {
+                urn: 'urn:li:pageModule:globalToEdit',
+                type: EntityType.DatahubPageModule,
+                properties: {
+                    name: 'Global Module To Edit',
+                    type: DataHubPageModuleType.Link,
+                    visibility: { scope: PageModuleScope.Global },
+                    params: {},
+                },
+            };
+
+            const mockPersonalModuleToEdit: PageModuleFragment = {
+                urn: 'urn:li:pageModule:personalToEdit',
+                type: EntityType.DatahubPageModule,
+                properties: {
+                    name: 'Personal Module To Edit',
+                    type: DataHubPageModuleType.Link,
+                    visibility: { scope: PageModuleScope.Personal },
+                    params: {},
+                },
+            };
+
+            it('should create new personal module when editing global module on personal template', async () => {
+                const { result } = renderHook(() =>
+                    useModuleOperations(
+                        false, // isEditingGlobalTemplate = false (editing personal template)
+                        mockPersonalTemplate,
+                        mockGlobalTemplate,
+                        mockSetPersonalTemplate,
+                        mockSetGlobalTemplate,
+                        mockUpdateTemplateWithModule,
+                        mockRemoveModuleFromTemplate,
+                        mockUpsertTemplate,
+                        true, // isEditingModule = true
+                        mockGlobalModuleToEdit, // originalModuleData = global module
+                    ),
+                );
+
+                const position: ModulePositionInput = {
+                    rowIndex: 0,
+                    moduleIndex: 0,
+                };
+
+                const upsertModuleInput = {
+                    urn: mockGlobalModuleToEdit.urn,
+                    name: 'Updated Global Module Name',
+                    type: DataHubPageModuleType.Link,
+                    position,
+                    params: { newParam: 'updatedValue' },
+                };
+
+                const newPersonalModuleUrn = 'urn:li:pageModule:newPersonal';
+                mockUpsertPageModuleMutation.mockResolvedValue({
+                    data: {
+                        upsertPageModule: {
+                            urn: newPersonalModuleUrn,
+                        },
+                    },
+                });
+
+                const templateAfterRemoval = {
+                    ...mockPersonalTemplate,
+                    properties: {
+                        ...mockPersonalTemplate.properties!,
+                        rows: [{ modules: [] }], // Global module removed
+                    },
+                };
+
+                const templateAfterReplacement = {
+                    ...templateAfterRemoval,
+                    properties: {
+                        ...templateAfterRemoval.properties!,
+                        rows: [
+                            {
+                                modules: [
+                                    {
+                                        urn: newPersonalModuleUrn,
+                                        type: EntityType.DatahubPageModule,
+                                        properties: {
+                                            name: 'Updated Global Module Name',
+                                            type: DataHubPageModuleType.Link,
+                                            visibility: { scope: PageModuleScope.Personal },
+                                            params: { newParam: 'updatedValue' },
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                };
+
+                mockRemoveModuleFromTemplate.mockReturnValue(templateAfterRemoval);
+                mockUpdateTemplateWithModule.mockReturnValue(templateAfterReplacement);
+                mockUpsertTemplate.mockResolvedValue({});
+
+                await act(async () => {
+                    result.current.upsertModule(upsertModuleInput);
+                });
+
+                // Should create new module WITHOUT the original urn (creates new instead of updating)
+                expect(mockUpsertPageModuleMutation).toHaveBeenCalledWith({
+                    variables: {
+                        input: {
+                            name: 'Updated Global Module Name',
+                            type: DataHubPageModuleType.Link,
+                            scope: PageModuleScope.Personal, // Should use personal scope
+                            params: { newParam: 'updatedValue' },
+                            urn: undefined, // Should NOT pass original urn (creates new module)
+                        },
+                    },
+                });
+
+                // Should remove the original global module
+                expect(mockRemoveModuleFromTemplate).toHaveBeenCalledWith(
+                    mockPersonalTemplate,
+                    mockGlobalModuleToEdit.urn,
+                    position,
+                );
+
+                // Should add the new personal module in the same position
+                expect(mockUpdateTemplateWithModule).toHaveBeenCalledWith(
+                    templateAfterRemoval,
+                    {
+                        urn: newPersonalModuleUrn,
+                        type: EntityType.DatahubPageModule,
+                        properties: {
+                            name: 'Updated Global Module Name',
+                            type: DataHubPageModuleType.Link,
+                            visibility: { scope: PageModuleScope.Personal },
+                            params: { newParam: 'updatedValue' },
+                        },
+                    },
+                    position,
+                    false, // isEditing = false (adding new module)
+                );
+
+                // Should update the personal template
+                expect(mockSetPersonalTemplate).toHaveBeenCalledWith(templateAfterReplacement);
+                expect(mockUpsertTemplate).toHaveBeenCalledWith(templateAfterReplacement, true, mockPersonalTemplate);
+            });
+
+            it('should edit global module in place when editing global template', async () => {
+                const { result } = renderHook(() =>
+                    useModuleOperations(
+                        true, // isEditingGlobalTemplate = true (editing global template)
+                        mockPersonalTemplate,
+                        mockGlobalTemplate,
+                        mockSetPersonalTemplate,
+                        mockSetGlobalTemplate,
+                        mockUpdateTemplateWithModule,
+                        mockRemoveModuleFromTemplate,
+                        mockUpsertTemplate,
+                        true, // isEditingModule = true
+                        mockGlobalModuleToEdit, // originalModuleData = global module
+                    ),
+                );
+
+                const position: ModulePositionInput = {
+                    rowIndex: 0,
+                    moduleIndex: 0,
+                };
+
+                const upsertModuleInput = {
+                    urn: mockGlobalModuleToEdit.urn,
+                    name: 'Updated Global Module Name',
+                    type: DataHubPageModuleType.Link,
+                    position,
+                    params: { newParam: 'updatedValue' },
+                };
+
+                const updatedModuleUrn = mockGlobalModuleToEdit.urn; // Same urn (editing in place)
+                mockUpsertPageModuleMutation.mockResolvedValue({
+                    data: {
+                        upsertPageModule: {
+                            urn: updatedModuleUrn,
+                        },
+                    },
+                });
+
+                const templateAfterUpdate = {
+                    ...mockGlobalTemplate,
+                    // Template updated with modified module
+                };
+
+                mockUpdateTemplateWithModule.mockReturnValue(templateAfterUpdate);
+                mockUpsertTemplate.mockResolvedValue({});
+
+                await act(async () => {
+                    result.current.upsertModule(upsertModuleInput);
+                });
+
+                // Should edit the existing module (pass the original urn)
+                expect(mockUpsertPageModuleMutation).toHaveBeenCalledWith({
+                    variables: {
+                        input: {
+                            name: 'Updated Global Module Name',
+                            type: DataHubPageModuleType.Link,
+                            scope: PageModuleScope.Global, // Should keep global scope
+                            params: { newParam: 'updatedValue' },
+                            urn: mockGlobalModuleToEdit.urn, // Should pass original urn (edit in place)
+                        },
+                    },
+                });
+
+                // Should NOT remove and replace - just add the updated module normally
+                expect(mockRemoveModuleFromTemplate).not.toHaveBeenCalled();
+
+                // Should use normal addModule flow (not replacement flow)
+                expect(mockUpdateTemplateWithModule).toHaveBeenCalledWith(
+                    mockGlobalTemplate,
+                    {
+                        urn: updatedModuleUrn,
+                        type: EntityType.DatahubPageModule,
+                        properties: {
+                            name: 'Updated Global Module Name',
+                            type: DataHubPageModuleType.Link,
+                            visibility: { scope: PageModuleScope.Global },
+                            params: { newParam: 'updatedValue' },
+                        },
+                    },
+                    position,
+                    true, // isEditingModule = true (normal editing flow)
+                );
+
+                // Should update the global template
+                expect(mockSetGlobalTemplate).toHaveBeenCalledWith(templateAfterUpdate);
+                expect(mockUpsertTemplate).toHaveBeenCalledWith(templateAfterUpdate, false, mockPersonalTemplate);
+            });
+
+            it('should edit personal module in place when editing personal template', async () => {
+                const { result } = renderHook(() =>
+                    useModuleOperations(
+                        false, // isEditingGlobalTemplate = false (editing personal template)
+                        mockPersonalTemplate,
+                        mockGlobalTemplate,
+                        mockSetPersonalTemplate,
+                        mockSetGlobalTemplate,
+                        mockUpdateTemplateWithModule,
+                        mockRemoveModuleFromTemplate,
+                        mockUpsertTemplate,
+                        true, // isEditingModule = true
+                        mockPersonalModuleToEdit, // originalModuleData = personal module
+                    ),
+                );
+
+                const position: ModulePositionInput = {
+                    rowIndex: 0,
+                    moduleIndex: 0,
+                };
+
+                const upsertModuleInput = {
+                    urn: mockPersonalModuleToEdit.urn,
+                    name: 'Updated Personal Module Name',
+                    type: DataHubPageModuleType.Link,
+                    position,
+                    params: { newParam: 'updatedValue' },
+                };
+
+                const updatedModuleUrn = mockPersonalModuleToEdit.urn; // Same urn (editing in place)
+                mockUpsertPageModuleMutation.mockResolvedValue({
+                    data: {
+                        upsertPageModule: {
+                            urn: updatedModuleUrn,
+                        },
+                    },
+                });
+
+                const templateAfterUpdate = {
+                    ...mockPersonalTemplate,
+                    // Template updated with modified module
+                };
+
+                mockUpdateTemplateWithModule.mockReturnValue(templateAfterUpdate);
+                mockUpsertTemplate.mockResolvedValue({});
+
+                await act(async () => {
+                    result.current.upsertModule(upsertModuleInput);
+                });
+
+                // Should edit the existing personal module (pass the original urn)
+                expect(mockUpsertPageModuleMutation).toHaveBeenCalledWith({
+                    variables: {
+                        input: {
+                            name: 'Updated Personal Module Name',
+                            type: DataHubPageModuleType.Link,
+                            scope: PageModuleScope.Personal, // Should keep personal scope
+                            params: { newParam: 'updatedValue' },
+                            urn: mockPersonalModuleToEdit.urn, // Should pass original urn (edit in place)
+                        },
+                    },
+                });
+
+                // Should NOT use replacement flow for personal modules
+                expect(mockRemoveModuleFromTemplate).not.toHaveBeenCalled();
+
+                // Should use normal addModule flow (not replacement flow)
+                expect(mockUpdateTemplateWithModule).toHaveBeenCalledWith(
+                    mockPersonalTemplate,
+                    {
+                        urn: updatedModuleUrn,
+                        type: EntityType.DatahubPageModule,
+                        properties: {
+                            name: 'Updated Personal Module Name',
+                            type: DataHubPageModuleType.Link,
+                            visibility: { scope: PageModuleScope.Personal },
+                            params: { newParam: 'updatedValue' },
+                        },
+                    },
+                    position,
+                    true, // isEditingModule = true (normal editing flow)
+                );
+
+                // Should update the personal template
+                expect(mockSetPersonalTemplate).toHaveBeenCalledWith(templateAfterUpdate);
+                expect(mockUpsertTemplate).toHaveBeenCalledWith(templateAfterUpdate, true, mockPersonalTemplate);
+            });
+
+            it('should handle error when replacement flow fails during global module edit', async () => {
+                const { result } = renderHook(() =>
+                    useModuleOperations(
+                        false, // isEditingGlobalTemplate = false
+                        mockPersonalTemplate,
+                        mockGlobalTemplate,
+                        mockSetPersonalTemplate,
+                        mockSetGlobalTemplate,
+                        mockUpdateTemplateWithModule,
+                        mockRemoveModuleFromTemplate,
+                        mockUpsertTemplate,
+                        true, // isEditingModule = true
+                        mockGlobalModuleToEdit, // originalModuleData = global module
+                    ),
+                );
+
+                const position: ModulePositionInput = {
+                    rowIndex: 0,
+                    moduleIndex: 0,
+                };
+
+                const upsertModuleInput = {
+                    urn: mockGlobalModuleToEdit.urn,
+                    name: 'Updated Global Module Name',
+                    type: DataHubPageModuleType.Link,
+                    position,
+                };
+
+                const newPersonalModuleUrn = 'urn:li:pageModule:newPersonal';
+                mockUpsertPageModuleMutation.mockResolvedValue({
+                    data: {
+                        upsertPageModule: {
+                            urn: newPersonalModuleUrn,
+                        },
+                    },
+                });
+
+                // Mock template update failure
+                mockRemoveModuleFromTemplate.mockReturnValue(null);
+
+                const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+                await act(async () => {
+                    result.current.upsertModule(upsertModuleInput);
+                });
+
+                // Should still create the new module
+                expect(mockUpsertPageModuleMutation).toHaveBeenCalled();
+
+                // Should attempt to remove the original module
+                expect(mockRemoveModuleFromTemplate).toHaveBeenCalledWith(
+                    mockPersonalTemplate,
+                    mockGlobalModuleToEdit.urn,
+                    position,
+                );
+
+                // Should not proceed with template update if removal fails
+                expect(mockUpdateTemplateWithModule).not.toHaveBeenCalled();
+                expect(mockSetPersonalTemplate).not.toHaveBeenCalled();
+                expect(mockUpsertTemplate).not.toHaveBeenCalled();
+
+                consoleSpy.mockRestore();
+            });
+        });
     });
 
     describe('moveModule with 3-module row constraints', () => {
@@ -1069,15 +1469,16 @@ describe('useModuleOperations', () => {
         it('should allow rearranging modules within a row that has 3 modules', () => {
             const { result } = renderHook(() =>
                 useModuleOperations(
-                    false,
-                    templateWith3ModulesInFirstRow,
-                    null,
+                    false, // isEditingGlobalTemplate
+                    null, // personalTemplate
+                    templateWith3ModulesInFirstRow, // globalTemplate
                     mockSetPersonalTemplate,
                     mockSetGlobalTemplate,
                     mockUpdateTemplateWithModule,
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
-                    false,
+                    false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -1097,15 +1498,16 @@ describe('useModuleOperations', () => {
         it('should allow moving a module from another row to a full row, creating new row', () => {
             const { result } = renderHook(() =>
                 useModuleOperations(
-                    false,
-                    templateWith3ModulesInFirstRow,
-                    null,
+                    false, // isEditingGlobalTemplate
+                    null, // personalTemplate
+                    templateWith3ModulesInFirstRow, // globalTemplate
                     mockSetPersonalTemplate,
                     mockSetGlobalTemplate,
                     mockUpdateTemplateWithModule,
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
-                    false,
+                    false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -1124,15 +1526,16 @@ describe('useModuleOperations', () => {
         it('should allow moving a module from a row with 3 modules to another row', () => {
             const { result } = renderHook(() =>
                 useModuleOperations(
-                    false,
-                    templateWith3ModulesInFirstRow,
-                    null,
+                    false, // isEditingGlobalTemplate
+                    null, // personalTemplate
+                    templateWith3ModulesInFirstRow, // globalTemplate
                     mockSetPersonalTemplate,
                     mockSetGlobalTemplate,
                     mockUpdateTemplateWithModule,
                     mockRemoveModuleFromTemplate,
                     mockUpsertTemplate,
-                    false,
+                    false, // isEditingModule
+                    null, // originalModuleData
                 ),
             );
 
@@ -1164,6 +1567,7 @@ describe('useModuleOperations', () => {
                         mockRemoveModuleFromTemplate,
                         mockUpsertTemplate,
                         false,
+                        null, // originalModuleData
                     ),
                 {
                     initialProps: {
@@ -1198,6 +1602,7 @@ describe('useModuleOperations', () => {
                         mockRemoveModuleFromTemplate,
                         mockUpsertTemplate,
                         false,
+                        null, // originalModuleData
                     ),
                 {
                     initialProps: {

--- a/datahub-web-react/src/app/homeV3/context/hooks/useModuleModalState.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useModuleModalState.ts
@@ -21,12 +21,20 @@ export function useModuleModalState(): ModuleModalState {
         setInitialState(null);
     }, []);
 
-    const openToEdit = useCallback((moduleTypeToEdit: DataHubPageModuleType, currentData: PageModuleFragment) => {
-        setModuleType(moduleTypeToEdit);
-        setIsEditing(true);
-        setInitialState(currentData);
-        setIsOpen(true);
-    }, []);
+    const openToEdit = useCallback(
+        (
+            moduleTypeToEdit: DataHubPageModuleType,
+            currentData: PageModuleFragment,
+            currentPosition: ModulePositionInput,
+        ) => {
+            setModuleType(moduleTypeToEdit);
+            setIsEditing(true);
+            setInitialState(currentData);
+            setPosition(currentPosition);
+            setIsOpen(true);
+        },
+        [],
+    );
 
     const close = useCallback(() => {
         setModuleType(null);

--- a/datahub-web-react/src/app/homeV3/context/types.ts
+++ b/datahub-web-react/src/app/homeV3/context/types.ts
@@ -30,7 +30,11 @@ export interface ModuleModalState {
     close: () => void;
     isEditing: boolean;
     initialState: PageModuleFragment | null;
-    openToEdit: (moduleType: DataHubPageModuleType, currentData: PageModuleFragment) => void;
+    openToEdit: (
+        moduleType: DataHubPageModuleType,
+        currentData: PageModuleFragment,
+        currentPosition: ModulePositionInput,
+    ) => void;
 }
 
 export interface MoveModuleInput {

--- a/datahub-web-react/src/app/homeV3/module/components/ModuleMenu.tsx
+++ b/datahub-web-react/src/app/homeV3/module/components/ModuleMenu.tsx
@@ -32,8 +32,8 @@ export default function ModuleMenu({ module, position }: Props) {
     } = usePageTemplateContext();
 
     const handleEditModule = useCallback(() => {
-        openToEdit(type, module);
-    }, [module, openToEdit, type]);
+        openToEdit(type, module, position);
+    }, [module, openToEdit, type, position]);
 
     const handleDelete = useCallback(() => {
         removeModule({


### PR DESCRIPTION
This PR updates the edit logic when a user tries to edit a global module while not explicitly editing the global template, we let them feel like they'r editing, but in reality they're creating a new module with the edits and replacing the global module under the hood. That way users don't change global modules that exist on the default home page for all users.

Majority of diff here are tests.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
