### PR TITLE
feat(ui/homepage): handle adding module to a row with 3 modules already

### DIFF
--- a/datahub-web-react/src/app/homeV3/context/hooks/__tests__/moduleOperationsUtils.test.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/__tests__/moduleOperationsUtils.test.ts
@@ -218,6 +218,7 @@ describe('Module Operations Utility Functions', () => {
         const module1 = createMockModule('Module 1', 'urn:li:module:1');
         const module2 = createMockModule('Module 2', 'urn:li:module:2');
         const module3 = createMockModule('Module 3', 'urn:li:module:3');
+        const module4 = createMockModule('Module 4', 'urn:li:module:4');
 
         it('should allow move when target row has space', () => {
             const template = createMockTemplate([
@@ -231,16 +232,17 @@ describe('Module Operations Utility Functions', () => {
             expect(result).toBeNull();
         });
 
-        it('should prevent move when target row is full and dragging from different row', () => {
+        it('should allow move when moving module into a full row', () => {
             const template = createMockTemplate([
                 { modules: [module1, module2, module3] }, // Full row (3 modules)
+                { modules: [module4] },
             ]);
             const fromPosition: ModulePositionInput = { rowIndex: 1, moduleIndex: 0 };
             const toPosition: ModulePositionInput = { rowIndex: 0, moduleIndex: 3 };
 
             const result = validateModuleMoveConstraints(template, fromPosition, toPosition);
 
-            expect(result).toBe('Cannot move module: Target row already has maximum number of modules');
+            expect(result).toBeNull();
         });
 
         it('should allow move within same row even when full', () => {

--- a/datahub-web-react/src/app/homeV3/context/hooks/__tests__/useModuleOperations.test.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/__tests__/useModuleOperations.test.ts
@@ -1094,7 +1094,7 @@ describe('useModuleOperations', () => {
             expect(mockSetPersonalTemplate).toHaveBeenCalled();
         });
 
-        it('should prevent moving a module from another row to a row with 3 modules', () => {
+        it('should allow moving a module from another row to a full row, creating new row', () => {
             const { result } = renderHook(() =>
                 useModuleOperations(
                     false,
@@ -1110,7 +1110,7 @@ describe('useModuleOperations', () => {
             );
 
             act(() => {
-                // Try to move module from row 1 to row 0 (which has 3 modules)
+                // Move module from row 1 to row 0 (which has 3 modules)
                 result.current.moveModule({
                     module: templateWith3ModulesInFirstRow.properties.rows[1].modules[0],
                     fromPosition: { rowIndex: 1, moduleIndex: 0 },
@@ -1118,11 +1118,9 @@ describe('useModuleOperations', () => {
                 });
             });
 
-            // Should not call upsert template because move was prevented
-            expect(mockUpsertTemplate).not.toHaveBeenCalled();
-            expect(mockSetPersonalTemplate).not.toHaveBeenCalled();
+            expect(mockUpsertTemplate).toHaveBeenCalled();
+            expect(mockSetPersonalTemplate).toHaveBeenCalled();
         });
-
         it('should allow moving a module from a row with 3 modules to another row', () => {
             const { result } = renderHook(() =>
                 useModuleOperations(

--- a/datahub-web-react/src/app/homeV3/context/hooks/useDragAndDrop.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useDragAndDrop.ts
@@ -71,7 +71,8 @@ export function useDragAndDrop() {
             // Check if we're dropping in the same position
             if (
                 draggedData.position.rowIndex === droppableData.rowIndex &&
-                draggedData.position.moduleIndex === droppableData.moduleIndex
+                draggedData.position.moduleIndex === droppableData.moduleIndex &&
+                !droppableData.insertNewRow
             ) {
                 return;
             }

--- a/datahub-web-react/src/app/homeV3/context/hooks/useTemplateOperations.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useTemplateOperations.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import { insertModuleIntoRows } from '@app/homeV3/context/hooks/utils/moduleOperationsUtils';
 import { ModulePositionInput } from '@app/homeV3/template/types';
 
 import { PageModuleFragment, PageTemplateFragment, useUpsertPageTemplateMutation } from '@graphql/template.generated';
@@ -86,17 +87,20 @@ export function useTemplateOperations() {
                         modules: [module],
                     });
                 } else {
-                    const row = { ...newRows[rowIndex] };
-                    const newModules = [...(row.modules || [])];
+                    const rowModules = newRows[rowIndex]?.modules || [];
+                    // Find index to insert
+                    let moduleIndex: number;
 
-                    if (position.rowSide === 'left') {
-                        newModules.unshift(module);
+                    if (position.moduleIndex !== undefined) {
+                        moduleIndex = position.moduleIndex;
+                    } else if (position.rowSide === 'left') {
+                        moduleIndex = 0;
                     } else {
-                        newModules.push(module);
+                        moduleIndex = rowModules.length;
                     }
 
-                    row.modules = newModules;
-                    newRows[rowIndex] = row;
+                    // Insert module into the rows at given position
+                    newRows = insertModuleIntoRows(newRows, module, { ...position, moduleIndex }, rowIndex);
                 }
             }
 

--- a/datahub-web-react/src/app/homeV3/templateRow/TemplateRow.tsx
+++ b/datahub-web-react/src/app/homeV3/templateRow/TemplateRow.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 function TemplateRow({ row, modulesAvailableToAdd, rowIndex }: Props) {
-    const { modulePositions, shouldDisableDropZones, isSmallRow } = useTemplateRowLogic(row, rowIndex);
+    const { modulePositions, isSmallRow } = useTemplateRowLogic(row, rowIndex);
     const { active } = useDndContext();
     const isActiveModuleSmall = active?.data?.current?.isSmall;
 
@@ -22,7 +22,7 @@ function TemplateRow({ row, modulesAvailableToAdd, rowIndex }: Props) {
         isSmallRow == null || // empty row
         isActiveModuleSmall === isSmallRow;
 
-    const isDropZoneDisabled = shouldDisableDropZones || !isDropAllowed;
+    const isDropZoneDisabled = !isDropAllowed;
 
     return (
         <RowLayout


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-566/handle-situation-where-you-add-module-to-a-row-with-3-modules-in-it


**Video:**

https://github.com/user-attachments/assets/312adc52-17c1-4677-9abc-91eac69f164b


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
