### PR TITLE
feat(homePage) Migrate existing home page links to modules on default template

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/BootstrapManagerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/BootstrapManagerFactory.java
@@ -15,6 +15,7 @@ import com.linkedin.metadata.boot.steps.IngestDefaultGlobalSettingsStep;
 import com.linkedin.metadata.boot.steps.IngestEntityTypesStep;
 import com.linkedin.metadata.boot.steps.IngestPoliciesStep;
 import com.linkedin.metadata.boot.steps.IngestRetentionPoliciesStep;
+import com.linkedin.metadata.boot.steps.MigrateHomePageLinksStep;
 import com.linkedin.metadata.boot.steps.RemoveClientIdAspectStep;
 import com.linkedin.metadata.boot.steps.RestoreColumnLineageIndices;
 import com.linkedin.metadata.boot.steps.RestoreDbtSiblingsIndices;
@@ -113,6 +114,8 @@ public class BootstrapManagerFactory {
     final IngestEntityTypesStep ingestEntityTypesStep = new IngestEntityTypesStep(_entityService);
     final RestoreFormInfoIndicesStep restoreFormInfoIndicesStep =
         new RestoreFormInfoIndicesStep(_entityService);
+    final MigrateHomePageLinksStep migrateHomePageLinksStep =
+        new MigrateHomePageLinksStep(_entityService, _entitySearchService);
 
     final List<BootstrapStep> finalSteps =
         new ArrayList<>(
@@ -129,6 +132,10 @@ public class BootstrapManagerFactory {
                 restoreColumnLineageIndices,
                 ingestEntityTypesStep,
                 restoreFormInfoIndicesStep));
+
+    if (_configurationProvider.getFeatureFlags().isShowHomePageRedesign()) {
+      finalSteps.add(migrateHomePageLinksStep);
+    }
 
     return new BootstrapManager(finalSteps);
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/MigrateHomePageLinksStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/MigrateHomePageLinksStep.java
@@ -1,0 +1,299 @@
+package com.linkedin.metadata.boot.steps;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.boot.UpgradeStep;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.ebean.batch.AspectsBatchImpl;
+import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.module.DataHubPageModuleParams;
+import com.linkedin.module.DataHubPageModuleProperties;
+import com.linkedin.module.DataHubPageModuleType;
+import com.linkedin.module.DataHubPageModuleVisibility;
+import com.linkedin.module.LinkModuleParams;
+import com.linkedin.module.PageModuleScope;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.post.PostContentType;
+import com.linkedin.post.PostInfo;
+import com.linkedin.post.PostType;
+import com.linkedin.template.DataHubPageTemplateProperties;
+import com.linkedin.template.DataHubPageTemplateRow;
+import com.linkedin.template.DataHubPageTemplateRowArray;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MigrateHomePageLinksStep extends UpgradeStep {
+  private static final String VERSION = "1";
+  private static final String UPGRADE_ID = "migrate-homepage-links";
+  private static final String DEFAULT_HOME_PAGE_TEMPLATE_URN =
+      "urn:li:dataHubPageTemplate:home_default_1";
+  private static final Integer BATCH_SIZE = 1000;
+
+  private final EntitySearchService _entitySearchService;
+
+  public MigrateHomePageLinksStep(
+      @Nonnull final EntityService<?> entityService,
+      @Nonnull final EntitySearchService entitySearchService) {
+    super(entityService, VERSION, UPGRADE_ID);
+    this._entitySearchService = entitySearchService;
+  }
+
+  @Override
+  public void upgrade(@Nonnull OperationContext systemOperationContext) throws Exception {
+    final AuditStamp auditStamp =
+        new AuditStamp()
+            .setActor(Urn.createFromString(Constants.SYSTEM_ACTOR))
+            .setTime(System.currentTimeMillis());
+
+    log.info("Starting migration of home page links to page modules...");
+
+    // Step 1: Fetch existing homepage links
+    List<Urn> postUrns = fetchPostUrns(systemOperationContext);
+    log.info("Found {} home page announcement posts to migrate", postUrns.size());
+
+    if (postUrns.isEmpty()) {
+      log.info("No home page announcement posts found. Skipping migration.");
+      return;
+    }
+
+    // Step 2: Fetch the default home page template
+    Urn templateUrn = UrnUtils.getUrn(DEFAULT_HOME_PAGE_TEMPLATE_URN);
+    DataHubPageTemplateProperties templateProperties =
+        fetchPageTemplateProperties(systemOperationContext, templateUrn);
+
+    if (templateProperties == null) {
+      log.warn("Default home page template not found. Skipping migration.");
+      return;
+    }
+
+    // Step 3: Convert posts to page modules and create them
+    List<Urn> moduleUrns = convertPostsToPageModules(systemOperationContext, postUrns, auditStamp);
+    log.info("Created {} page modules from home page posts", moduleUrns.size());
+
+    if (moduleUrns.size() == 0) {
+      return;
+    }
+
+    // Step 4: Update the home page template with the new modules
+    updateHomePageTemplate(
+        systemOperationContext, templateUrn, templateProperties, moduleUrns, auditStamp);
+    log.info("Updated home page template with migrated modules");
+
+    log.info("Home page links migration completed successfully");
+  }
+
+  @Nonnull
+  @Override
+  public ExecutionMode getExecutionMode() {
+    return ExecutionMode.ASYNC;
+  }
+
+  private List<Urn> fetchPostUrns(@Nonnull OperationContext systemOperationContext) {
+    // There's no filtering for type, so we just need to get all posts
+    SearchResult searchResult =
+        _entitySearchService.search(
+            systemOperationContext.withSearchFlags(
+                flags ->
+                    flags.setFulltext(false).setSkipAggregates(true).setSkipHighlighting(true)),
+            List.of(Constants.POST_ENTITY_NAME),
+            "*",
+            null,
+            null,
+            0,
+            BATCH_SIZE);
+
+    return searchResult.getEntities().stream()
+        .map(SearchEntity::getEntity)
+        .collect(Collectors.toList());
+  }
+
+  private DataHubPageTemplateProperties fetchPageTemplateProperties(
+      @Nonnull OperationContext systemOperationContext, @Nonnull Urn templateUrn) {
+    try {
+      EntityResponse response =
+          entityService.getEntityV2(
+              systemOperationContext,
+              Constants.DATAHUB_PAGE_TEMPLATE_ENTITY_NAME,
+              templateUrn,
+              Collections.singleton(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME));
+
+      if (response != null
+          && response
+              .getAspects()
+              .containsKey(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME)) {
+        EnvelopedAspect aspect =
+            response.getAspects().get(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME);
+        return new DataHubPageTemplateProperties(aspect.getValue().data());
+      }
+    } catch (Exception e) {
+      log.error("Failed to fetch page template properties for urn: {}", templateUrn, e);
+    }
+    return null;
+  }
+
+  private List<Urn> convertPostsToPageModules(
+      @Nonnull OperationContext systemOperationContext,
+      @Nonnull List<Urn> postUrns,
+      @Nonnull AuditStamp auditStamp)
+      throws Exception {
+
+    List<Urn> moduleUrns = new ArrayList<>();
+
+    // Fetch all post info aspects
+    Map<Urn, EntityResponse> postResponses =
+        entityService.getEntitiesV2(
+            systemOperationContext,
+            Constants.POST_ENTITY_NAME,
+            postUrns.stream().collect(Collectors.toSet()),
+            Collections.singleton(Constants.POST_INFO_ASPECT_NAME));
+
+    for (Map.Entry<Urn, EntityResponse> entry : postResponses.entrySet()) {
+      Urn postUrn = entry.getKey();
+      EntityResponse response = entry.getValue();
+
+      if (response == null || !response.getAspects().containsKey(Constants.POST_INFO_ASPECT_NAME)) {
+        log.warn("Post {} has no postInfo aspect, skipping", postUrn);
+        continue;
+      }
+
+      EnvelopedAspect postInfoAspect = response.getAspects().get(Constants.POST_INFO_ASPECT_NAME);
+      PostInfo postInfo = new PostInfo(postInfoAspect.getValue().data());
+
+      // Only process posts with HOME_PAGE_ANNOUNCEMENT and LINK types
+      if (!PostType.HOME_PAGE_ANNOUNCEMENT.equals(postInfo.getType())
+          || !PostContentType.LINK.equals(postInfo.getContent().getType())
+          || postInfo.getContent().getLink() == null) {
+        continue;
+      }
+
+      // Create a page module from this post
+      String moduleId = postUrn.getEntityKey().get(0); // Use the same ID from the post URN
+      Urn moduleUrn =
+          UrnUtils.getUrn("urn:li:" + Constants.DATAHUB_PAGE_MODULE_ENTITY_NAME + ":" + moduleId);
+
+      DataHubPageModuleProperties moduleProperties = createModuleFromPost(postInfo, auditStamp);
+
+      final MetadataChangeProposal proposal = new MetadataChangeProposal();
+      proposal.setEntityUrn(moduleUrn);
+      proposal.setEntityType(Constants.DATAHUB_PAGE_MODULE_ENTITY_NAME);
+      proposal.setAspectName(Constants.DATAHUB_PAGE_MODULE_PROPERTIES_ASPECT_NAME);
+      proposal.setAspect(GenericRecordUtils.serializeAspect(moduleProperties));
+      proposal.setChangeType(ChangeType.UPSERT);
+
+      entityService.ingestProposal(
+          systemOperationContext,
+          AspectsBatchImpl.builder()
+              .mcps(
+                  List.of(proposal),
+                  new AuditStamp()
+                      .setActor(Urn.createFromString(Constants.SYSTEM_ACTOR))
+                      .setTime(System.currentTimeMillis()),
+                  systemOperationContext.getRetrieverContext())
+              .build(systemOperationContext),
+          false);
+
+      moduleUrns.add(moduleUrn);
+    }
+
+    return moduleUrns;
+  }
+
+  private DataHubPageModuleProperties createModuleFromPost(
+      @Nonnull PostInfo postInfo, @Nonnull AuditStamp auditStamp) {
+    DataHubPageModuleProperties properties = new DataHubPageModuleProperties();
+
+    // Set module name from post title
+    properties.setName(postInfo.getContent().getTitle());
+    properties.setType(DataHubPageModuleType.LINK);
+
+    // Set visibility
+    DataHubPageModuleVisibility visibility = new DataHubPageModuleVisibility();
+    visibility.setScope(PageModuleScope.GLOBAL);
+    properties.setVisibility(visibility);
+
+    // Set link parameters
+    DataHubPageModuleParams params = new DataHubPageModuleParams();
+    LinkModuleParams linkParams = new LinkModuleParams();
+
+    linkParams.setLinkUrl(postInfo.getContent().getLink().toString());
+    if (postInfo.getContent().getDescription() != null) {
+      linkParams.setDescription(postInfo.getContent().getDescription());
+    }
+    if (postInfo.getContent().getMedia() != null
+        && postInfo.getContent().getMedia().getLocation() != null) {
+      linkParams.setImageUrl(postInfo.getContent().getMedia().getLocation().toString());
+    }
+
+    params.setLinkParams(linkParams);
+    properties.setParams(params);
+
+    // Set audit stamps
+    properties.setCreated(auditStamp);
+    properties.setLastModified(auditStamp);
+
+    return properties;
+  }
+
+  private void updateHomePageTemplate(
+      @Nonnull OperationContext systemOperationContext,
+      @Nonnull Urn templateUrn,
+      @Nonnull DataHubPageTemplateProperties templateProperties,
+      @Nonnull List<Urn> moduleUrns,
+      @Nonnull AuditStamp auditStamp)
+      throws Exception {
+
+    // Create rows for the modules (max 3 modules per row)
+    List<DataHubPageTemplateRow> newRows = new ArrayList<>();
+    for (int i = 0; i < moduleUrns.size(); i += 3) {
+      DataHubPageTemplateRow row = new DataHubPageTemplateRow();
+      List<Urn> rowModules = moduleUrns.subList(i, Math.min(i + 3, moduleUrns.size()));
+      row.setModules(new UrnArray(rowModules));
+      newRows.add(row);
+    }
+
+    // Insert the new rows at the beginning of the existing rows
+    List<DataHubPageTemplateRow> existingRows =
+        templateProperties.getRows() != null
+            ? new ArrayList<>(templateProperties.getRows())
+            : new ArrayList<>();
+
+    newRows.addAll(existingRows);
+    templateProperties.setRows(new DataHubPageTemplateRowArray(newRows));
+    templateProperties.setLastModified(auditStamp);
+
+    final MetadataChangeProposal proposal = new MetadataChangeProposal();
+    proposal.setEntityUrn(templateUrn);
+    proposal.setEntityType(Constants.DATAHUB_PAGE_TEMPLATE_ENTITY_NAME);
+    proposal.setAspectName(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME);
+    proposal.setAspect(GenericRecordUtils.serializeAspect(templateProperties));
+    proposal.setChangeType(ChangeType.UPSERT);
+
+    entityService.ingestProposal(
+        systemOperationContext,
+        AspectsBatchImpl.builder()
+            .mcps(
+                List.of(proposal),
+                new AuditStamp()
+                    .setActor(Urn.createFromString(Constants.SYSTEM_ACTOR))
+                    .setTime(System.currentTimeMillis()),
+                systemOperationContext.getRetrieverContext())
+            .build(systemOperationContext),
+        false);
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/MigrateHomePageLinksStepTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/MigrateHomePageLinksStepTest.java
@@ -1,0 +1,356 @@
+package com.linkedin.metadata.boot.steps;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Media;
+import com.linkedin.common.MediaType;
+import com.linkedin.common.url.Url;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.IngestResult;
+import com.linkedin.metadata.entity.ebean.batch.AspectsBatchImpl;
+import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.post.PostContent;
+import com.linkedin.post.PostContentType;
+import com.linkedin.post.PostInfo;
+import com.linkedin.post.PostType;
+import com.linkedin.template.DataHubPageTemplateProperties;
+import com.linkedin.template.DataHubPageTemplateRowArray;
+import com.linkedin.template.DataHubPageTemplateSurface;
+import com.linkedin.template.DataHubPageTemplateVisibility;
+import com.linkedin.template.PageTemplateScope;
+import com.linkedin.template.PageTemplateSurfaceType;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Collections;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class MigrateHomePageLinksStepTest {
+
+  @Test
+  public void testConstructor() {
+    EntityService<?> entityService = Mockito.mock(EntityService.class);
+    EntitySearchService searchService = Mockito.mock(EntitySearchService.class);
+
+    MigrateHomePageLinksStep step = new MigrateHomePageLinksStep(entityService, searchService);
+
+    assertNotNull(step);
+  }
+
+  @Test
+  public void testExecutionMode() {
+    EntityService<?> entityService = Mockito.mock(EntityService.class);
+    EntitySearchService searchService = Mockito.mock(EntitySearchService.class);
+
+    MigrateHomePageLinksStep step = new MigrateHomePageLinksStep(entityService, searchService);
+
+    assertEquals(step.getExecutionMode(), MigrateHomePageLinksStep.ExecutionMode.ASYNC);
+  }
+
+  @Test
+  public void testUpgradeWithNoPosts() throws Exception {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    EntitySearchService mockSearchService = mock(EntitySearchService.class);
+    EntityRegistry testEntityRegistry = getTestEntityRegistry();
+    OperationContext mockContext =
+        TestOperationContexts.systemContextNoSearchAuthorization(testEntityRegistry);
+
+    // Mock search to return no posts
+    when(mockSearchService.search(
+            any(), eq(List.of(Constants.POST_ENTITY_NAME)), eq("*"), any(), any(), eq(0), eq(1000)))
+        .thenReturn(createEmptySearchResult());
+
+    MigrateHomePageLinksStep step =
+        new MigrateHomePageLinksStep(mockEntityService, mockSearchService);
+    step.upgrade(mockContext);
+
+    // Verify that no further processing happens when no posts are found
+    verify(mockEntityService, times(0)).getEntityV2(any(), any(), any(), anySet());
+    verify(mockEntityService, times(0)).ingestProposal(any(), any(), eq(false));
+  }
+
+  @Test
+  public void testUpgradeWithNoTemplate() throws Exception {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    EntitySearchService mockSearchService = mock(EntitySearchService.class);
+    EntityRegistry testEntityRegistry = getTestEntityRegistry();
+    OperationContext mockContext =
+        TestOperationContexts.systemContextNoSearchAuthorization(testEntityRegistry);
+
+    Urn postUrn = UrnUtils.getUrn("urn:li:post:test-post");
+    Urn templateUrn = UrnUtils.getUrn("urn:li:dataHubPageTemplate:home_default_1");
+
+    // Mock search to return posts
+    when(mockSearchService.search(
+            any(), eq(List.of(Constants.POST_ENTITY_NAME)), eq("*"), any(), any(), eq(0), eq(1000)))
+        .thenReturn(createSearchResultWithPosts(ImmutableList.of(postUrn)));
+
+    // Mock template fetch to return null (template not found)
+    when(mockEntityService.getEntityV2(
+            any(),
+            eq(Constants.DATAHUB_PAGE_TEMPLATE_ENTITY_NAME),
+            eq(templateUrn),
+            eq(Collections.singleton(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME))))
+        .thenReturn(null);
+
+    MigrateHomePageLinksStep step =
+        new MigrateHomePageLinksStep(mockEntityService, mockSearchService);
+    step.upgrade(mockContext);
+
+    // Verify template fetch was attempted but no ingestion happened
+    verify(mockEntityService, times(1))
+        .getEntityV2(
+            any(),
+            eq(Constants.DATAHUB_PAGE_TEMPLATE_ENTITY_NAME),
+            eq(templateUrn),
+            eq(Collections.singleton(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME)));
+    verify(mockEntityService, times(0)).ingestProposal(any(), any(), eq(false));
+  }
+
+  @Test
+  public void testUpgradeWithValidPostsAndTemplate() throws Exception {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    EntitySearchService mockSearchService = mock(EntitySearchService.class);
+    EntityRegistry testEntityRegistry = getTestEntityRegistry();
+    OperationContext mockContext =
+        TestOperationContexts.systemContextNoSearchAuthorization(testEntityRegistry);
+
+    Urn postUrn = UrnUtils.getUrn("urn:li:post:test-post");
+    Urn templateUrn = UrnUtils.getUrn("urn:li:dataHubPageTemplate:home_default_1");
+
+    // Mock search to return posts
+    when(mockSearchService.search(
+            any(), eq(List.of(Constants.POST_ENTITY_NAME)), eq("*"), any(), any(), eq(0), eq(1000)))
+        .thenReturn(createSearchResultWithPosts(ImmutableList.of(postUrn)));
+
+    // Mock template fetch
+    when(mockEntityService.getEntityV2(
+            any(),
+            eq(Constants.DATAHUB_PAGE_TEMPLATE_ENTITY_NAME),
+            eq(templateUrn),
+            eq(Collections.singleton(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME))))
+        .thenReturn(createTemplateResponse(templateUrn));
+
+    // Mock post info fetch
+    when(mockEntityService.getEntitiesV2(
+            any(),
+            eq(Constants.POST_ENTITY_NAME),
+            anySet(),
+            eq(Collections.singleton(Constants.POST_INFO_ASPECT_NAME))))
+        .thenReturn(ImmutableMap.of(postUrn, createValidPostResponse(postUrn)));
+
+    // Mock ingest to return successfully
+    when(mockEntityService.ingestProposal(
+            any(OperationContext.class), any(AspectsBatchImpl.class), eq(false)))
+        .thenReturn(ImmutableList.of(mock(IngestResult.class)));
+
+    MigrateHomePageLinksStep step =
+        new MigrateHomePageLinksStep(mockEntityService, mockSearchService);
+
+    // This should complete successfully if our business logic works
+    step.upgrade(mockContext);
+
+    // Verify that ingestion was attempted for the module and template
+    verify(mockEntityService, times(2))
+        .ingestProposal(any(OperationContext.class), any(AspectsBatchImpl.class), eq(false));
+  }
+
+  @Test
+  public void testUpgradeWithNoValidPosts() throws Exception {
+    EntityService<?> mockEntityService = mock(EntityService.class);
+    EntitySearchService mockSearchService = mock(EntitySearchService.class);
+    EntityRegistry testEntityRegistry = getTestEntityRegistry();
+    OperationContext mockContext =
+        TestOperationContexts.systemContextNoSearchAuthorization(testEntityRegistry);
+
+    Urn invalidPostUrn = UrnUtils.getUrn("urn:li:post:invalid-post");
+    Urn templateUrn = UrnUtils.getUrn("urn:li:dataHubPageTemplate:home_default_1");
+
+    // Mock search to return posts
+    when(mockSearchService.search(
+            any(), eq(List.of(Constants.POST_ENTITY_NAME)), eq("*"), any(), any(), eq(0), eq(1000)))
+        .thenReturn(createSearchResultWithPosts(ImmutableList.of(invalidPostUrn)));
+
+    // Mock template fetch
+    when(mockEntityService.getEntityV2(
+            any(),
+            eq(Constants.DATAHUB_PAGE_TEMPLATE_ENTITY_NAME),
+            eq(templateUrn),
+            eq(Collections.singleton(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME))))
+        .thenReturn(createTemplateResponse(templateUrn));
+
+    // Mock post info fetch - only invalid posts
+    when(mockEntityService.getEntitiesV2(
+            any(),
+            eq(Constants.POST_ENTITY_NAME),
+            anySet(),
+            eq(Collections.singleton(Constants.POST_INFO_ASPECT_NAME))))
+        .thenReturn(ImmutableMap.of(invalidPostUrn, createInvalidPostResponse(invalidPostUrn)));
+
+    // Mock ingest to return successfully (should not be called)
+    when(mockEntityService.ingestProposal(
+            any(OperationContext.class), any(AspectsBatchImpl.class), eq(false)))
+        .thenReturn(ImmutableList.of(mock(IngestResult.class)));
+
+    MigrateHomePageLinksStep step =
+        new MigrateHomePageLinksStep(mockEntityService, mockSearchService);
+
+    // This should complete successfully but not call ingest (no valid posts)
+    step.upgrade(mockContext);
+
+    // Verify that ingestion was NOT attempted (no valid posts)
+    verify(mockEntityService, times(0))
+        .ingestProposal(any(OperationContext.class), any(AspectsBatchImpl.class), eq(false));
+  }
+
+  // Helper methods
+
+  @NotNull
+  private ConfigEntityRegistry getTestEntityRegistry() {
+    PathSpecBasedSchemaAnnotationVisitor.class
+        .getClassLoader()
+        .setClassAssertionStatus(PathSpecBasedSchemaAnnotationVisitor.class.getName(), false);
+    return new ConfigEntityRegistry(
+        IngestDataPlatformInstancesStepTest.class
+            .getClassLoader()
+            .getResourceAsStream("test-entity-registry.yaml"));
+  }
+
+  private SearchResult createEmptySearchResult() {
+    SearchResult result = new SearchResult();
+    result.setEntities(new SearchEntityArray());
+    result.setNumEntities(0);
+    return result;
+  }
+
+  private SearchResult createSearchResultWithPosts(List<Urn> postUrns) {
+    SearchResult result = new SearchResult();
+    SearchEntityArray entities = new SearchEntityArray();
+
+    for (Urn urn : postUrns) {
+      SearchEntity entity = new SearchEntity();
+      entity.setEntity(urn);
+      entities.add(entity);
+    }
+
+    result.setEntities(entities);
+    result.setNumEntities(postUrns.size());
+    return result;
+  }
+
+  private EntityResponse createTemplateResponse(Urn templateUrn) {
+    DataHubPageTemplateProperties properties = new DataHubPageTemplateProperties();
+    properties.setRows(new DataHubPageTemplateRowArray());
+    DataHubPageTemplateVisibility visibility = new DataHubPageTemplateVisibility();
+    visibility.setScope(PageTemplateScope.GLOBAL);
+    properties.setVisibility(visibility);
+    AuditStamp created = new AuditStamp();
+    created.setTime(System.currentTimeMillis());
+    created.setActor(UrnUtils.getUrn("urn:li:corpuser:admin"));
+    properties.setCreated(created);
+    properties.setLastModified(created);
+    DataHubPageTemplateSurface surface = new DataHubPageTemplateSurface();
+    surface.setSurfaceType(PageTemplateSurfaceType.HOME_PAGE);
+    properties.setSurface(surface);
+
+    EntityResponse response = new EntityResponse();
+    response.setUrn(templateUrn);
+
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    EnvelopedAspect aspect = new EnvelopedAspect();
+    aspect.setValue(new Aspect(properties.data()));
+    aspectMap.put(Constants.DATAHUB_PAGE_TEMPLATE_PROPERTIES_ASPECT_NAME, aspect);
+    response.setAspects(aspectMap);
+
+    return response;
+  }
+
+  private EntityResponse createValidPostResponse(Urn postUrn) {
+    try {
+      // Create valid post content (HOME_PAGE_ANNOUNCEMENT + LINK)
+      PostContent content = new PostContent();
+      content.setType(PostContentType.LINK);
+      content.setTitle("Test Post");
+      content.setDescription("Test Description");
+      content.setLink(new Url("https://example.com"));
+
+      Media media = new Media();
+      media.setType(MediaType.IMAGE);
+      media.setLocation(new Url("https://example.com/image.png"));
+      content.setMedia(media);
+
+      PostInfo postInfo = new PostInfo();
+      postInfo.setType(PostType.HOME_PAGE_ANNOUNCEMENT);
+      postInfo.setContent(content);
+      postInfo.setCreated(System.currentTimeMillis());
+      postInfo.setLastModified(System.currentTimeMillis());
+
+      EntityResponse response = new EntityResponse();
+      response.setUrn(postUrn);
+
+      EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+      EnvelopedAspect aspect = new EnvelopedAspect();
+      aspect.setValue(new Aspect(postInfo.data()));
+      aspectMap.put(Constants.POST_INFO_ASPECT_NAME, aspect);
+      response.setAspects(aspectMap);
+
+      return response;
+    } catch (Exception e) {
+      throw new RuntimeException("Error creating test post response", e);
+    }
+  }
+
+  private EntityResponse createInvalidPostResponse(Urn postUrn) {
+    try {
+      // Create invalid post content (not HOME_PAGE_ANNOUNCEMENT or not LINK)
+      PostContent content = new PostContent();
+      content.setType(PostContentType.TEXT); // Not LINK
+      content.setTitle("Invalid Post");
+
+      PostInfo postInfo = new PostInfo();
+      postInfo.setType(PostType.ENTITY_ANNOUNCEMENT); // Not HOME_PAGE_ANNOUNCEMENT
+      postInfo.setContent(content);
+      postInfo.setCreated(System.currentTimeMillis());
+      postInfo.setLastModified(System.currentTimeMillis());
+
+      EntityResponse response = new EntityResponse();
+      response.setUrn(postUrn);
+
+      EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+      EnvelopedAspect aspect = new EnvelopedAspect();
+      aspect.setValue(new Aspect(postInfo.data()));
+      aspectMap.put(Constants.POST_INFO_ASPECT_NAME, aspect);
+      response.setAspects(aspectMap);
+
+      return response;
+    } catch (Exception e) {
+      throw new RuntimeException("Error creating test invalid post response", e);
+    }
+  }
+}

--- a/metadata-service/factories/src/test/resources/test-entity-registry.yaml
+++ b/metadata-service/factories/src/test/resources/test-entity-registry.yaml
@@ -30,3 +30,15 @@ entities:
       - dataTypeInfo
       - institutionalMemory
       - status
+  - name: dataHubPageModule
+    doc: A module within a DataHub page.
+    category: core
+    keyAspect: dataHubPageModuleKey
+    aspects:
+      - dataHubPageModuleProperties
+  - name: dataHubPageTemplate
+    doc: A template for a DataHub page.
+    category: core
+    keyAspect: dataHubPageTemplateKey
+    aspects:
+      - dataHubPageTemplateProperties


### PR DESCRIPTION
This PR adds a new upgrade step that will look for existing home page links and then converts them to module entities. We then add these module entities to the first row(s) of the default home page template. These rows will have max 3 modules and we can create multiple rows if there's more than 3 modules.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
