### PR TITLE
fix(customHomePage): fix not expandable glossary term when showing related entities

### DIFF
--- a/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/glossary/GlossaryTreeView.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/glossary/GlossaryTreeView.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 export default function GlossaryTreeView({ assetUrns, shouldShowRelatedEntities }: Props) {
-    const { tree, loading } = useGlossaryTree(assetUrns ?? []);
+    const { tree, loading } = useGlossaryTree(assetUrns ?? [], shouldShowRelatedEntities);
 
     const { parentValues, addParentValue, removeParentValue } = useParentValuesToLoadChildren();
 

--- a/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/glossary/hooks/useGlossaryTree.ts
+++ b/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/glossary/hooks/useGlossaryTree.ts
@@ -2,10 +2,14 @@ import useGlossaryNodesAndTermsByUrns from '@app/homeV3/modules/hierarchyViewMod
 import useTreeNodesFromGlossaryNodesAndTerms from '@app/homeV3/modules/hierarchyViewModule/components/glossary/hooks/useTreeNodesFromGlossaryNodesAndTerms';
 import useTree from '@app/homeV3/modules/hierarchyViewModule/treeView/useTree';
 
-export default function useGlossaryTree(glossaryNodesAndTermsUrns: string[]) {
+export default function useGlossaryTree(glossaryNodesAndTermsUrns: string[], shouldShowRelatedEntities: boolean) {
     const { glossaryNodes, glossaryTerms, loading } = useGlossaryNodesAndTermsByUrns(glossaryNodesAndTermsUrns);
 
-    const { treeNodes } = useTreeNodesFromGlossaryNodesAndTerms(glossaryNodes, glossaryTerms);
+    const { treeNodes } = useTreeNodesFromGlossaryNodesAndTerms(
+        glossaryNodes,
+        glossaryTerms,
+        shouldShowRelatedEntities,
+    );
 
     const tree = useTree(treeNodes);
 


### PR DESCRIPTION
<img width="1095" height="337" alt="image" src="https://github.com/user-attachments/assets/494102f3-f6af-40b8-808a-6ccfce0b2a71" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
