### PR TITLE
fix(ui/homepage): fix empty states of home page modules

### DIFF
--- a/datahub-web-react/src/app/homeV3/module/components/EmptyContent.tsx
+++ b/datahub-web-react/src/app/homeV3/module/components/EmptyContent.tsx
@@ -16,6 +16,11 @@ const Container = styled.div`
     flex-direction: column;
     justify-content: center;
     align-items: center;
+
+    p {
+        text-align: justify;
+        text-align-last: center;
+    }
 `;
 
 const IconWrapper = styled.div`

--- a/datahub-web-react/src/app/homeV3/modules/YourAssetsModule.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/YourAssetsModule.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useHistory } from 'react-router';
 
 import { useUserContext } from '@app/context/useUserContext';
 import { useGetAssetsYouOwn } from '@app/homeV2/reference/sections/assets/useGetAssetsYouOwn';
@@ -7,11 +8,17 @@ import EntityItem from '@app/homeV3/module/components/EntityItem';
 import LargeModule from '@app/homeV3/module/components/LargeModule';
 import { ModuleProps } from '@app/homeV3/module/types';
 import useSearchYourAssets from '@app/homeV3/modules/useSearchYourAssets';
+import { navigateToSearchUrl } from '@app/searchV2/utils/navigateToSearchUrl';
 
 export default function YourAssetsModule(props: ModuleProps) {
     const { user } = useUserContext();
     const { originEntities, loading } = useGetAssetsYouOwn(user);
     const searchForYourAssets = useSearchYourAssets();
+    const history = useHistory();
+
+    const navigateToSearch = useCallback(() => {
+        navigateToSearchUrl({ query: '*', history });
+    }, [history]);
 
     return (
         <LargeModule {...props} loading={loading} onClickViewAll={searchForYourAssets}>
@@ -20,8 +27,8 @@ export default function YourAssetsModule(props: ModuleProps) {
                     icon="User"
                     title="No Owned Assets"
                     description="Select an asset and add yourself as an owner to see the assets in this list"
-                    linkText="Discover assets to subscribe to"
-                    onLinkClick={() => {}}
+                    linkText="Discover the assets you want to own"
+                    onLinkClick={navigateToSearch}
                 />
             ) : (
                 originEntities.map((entity) => <EntityItem entity={entity} key={entity.urn} />)

--- a/datahub-web-react/src/app/homeV3/modules/link/LinkModal.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/link/LinkModal.tsx
@@ -25,11 +25,9 @@ export default function LinkModal() {
     const linkParams = initialState?.properties?.params?.linkParams;
     const urn = initialState?.urn;
 
-    /* TODO: Uncomment to validate and disable button once the Rich Text module PR is merged
-
-     const titleValue = Form.useWatch('title', form);
-     const linkUrlValue = Form.useWatch('link', form);
-     const isDisabled = !titleValue?.trim() || !linkUrlValue?.trim(); */
+    const nameValue = Form.useWatch('name', form);
+    const linkUrlValue = Form.useWatch('linkUrl', form);
+    const isDisabled = !nameValue?.trim() || !linkUrlValue?.trim();
 
     const handleUpsertDocumentationModule = () => {
         form.validateFields().then((values) => {
@@ -57,8 +55,7 @@ export default function LinkModal() {
             subtitle="Add links to your home page"
             onUpsert={handleUpsertDocumentationModule}
             width="40%"
-            /* TODO: Uncomment to validate and disable button once the Rich Text module PR is merged
-             submitButtonProps={{ disabled: isDisabled }} */
+            submitButtonProps={{ disabled: isDisabled }}
         >
             <ModalContent>
                 <ModuleDetailsForm form={form} formValues={{ name: currentName }} />


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-549/fix-broken-empty-state-of-all-modules

**Screenshot:**

<img width="1172" height="416" alt="Screenshot from 2025-07-24 20-21-00" src="https://github.com/user-attachments/assets/88bc6cf3-87b1-4692-94bc-18872ea0e158" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
