### PR TITLE
fix(sdk): make Filter type parsing more permissive

### DIFF
--- a/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
@@ -334,6 +334,15 @@ def test_tagged_union_error_messages() -> None:
     ):
         load_filters({"and": [{"unknown_field": 6}]})
 
+    # Test that we can load a filter from a string.
+    # Sometimes we get filters encoded as JSON, and we want to handle those gracefully.
+    filter_str = '{\n  "and": [\n    {"entity_type": ["dataset"]},\n    {"entity_subtype": ["Table"]},\n    {"platform": ["snowflake"]}\n  ]\n}'
+    assert load_filters(filter_str) == F.and_(
+        F.entity_type("dataset"),
+        F.entity_subtype("Table"),
+        F.platform("snowflake"),
+    )
+
 
 def test_invalid_filter() -> None:
     with pytest.raises(InvalidUrnError):

--- a/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
@@ -342,6 +342,13 @@ def test_tagged_union_error_messages() -> None:
         F.entity_subtype("Table"),
         F.platform("snowflake"),
     )
+    with pytest.raises(
+        ValidationError,
+        match=re.compile(
+            r"1 validation error.+Unable to extract tag using discriminator", re.DOTALL
+        ),
+    ):
+        load_filters("this is invalid json but should not raise a json error")
 
 
 def test_invalid_filter() -> None:


### PR DESCRIPTION
With sdk v2, we can now support raw strings in addition to proper objects.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
