### PR TITLE
feat(lineage): downloaded file now contain the dataset name

### DIFF
--- a/datahub-web-react/src/app/lineageV2/controls/DownloadLineageScreenshotButton.tsx
+++ b/datahub-web-react/src/app/lineageV2/controls/DownloadLineageScreenshotButton.tsx
@@ -1,8 +1,9 @@
 import { CameraOutlined } from '@ant-design/icons';
 import { toPng } from 'html-to-image';
-import React from 'react';
+import React, { useContext } from 'react';
 import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
 
+import { LineageNodesContext } from '@app/lineageV2/common';
 import { StyledPanelButton } from '@app/lineageV2/controls/StyledPanelButton';
 
 type Props = {
@@ -30,12 +31,19 @@ function downloadImage(dataUrl: string, name?: string) {
 
 export default function DownloadLineageScreenshotButton({ showExpandedText }: Props) {
     const { getNodes } = useReactFlow();
+    const { rootUrn, nodes } = useContext(LineageNodesContext);
 
     const getPreviewImage = () => {
         const nodesBounds = getRectOfNodes(getNodes());
         const imageWidth = nodesBounds.width + 200;
         const imageHeight = nodesBounds.height + 200;
         const transform = getTransformForBounds(nodesBounds, imageWidth, imageHeight, 0.5, 2);
+
+        // Get the entity name for the screenshot filename
+        const rootEntity = nodes.get(rootUrn);
+        const entityName = rootEntity?.entity?.name || 'lineage';
+        // Clean the entity name to be safe for filename use
+        const cleanEntityName = entityName.replace(/[^a-zA-Z0-9_-]/g, '_');
 
         toPng(document.querySelector('.react-flow__viewport') as HTMLElement, {
             backgroundColor: '#f8f8f8',
@@ -47,7 +55,7 @@ export default function DownloadLineageScreenshotButton({ showExpandedText }: Pr
                 transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})`,
             },
         }).then((dataUrl) => {
-            downloadImage(dataUrl);
+            downloadImage(dataUrl, cleanEntityName);
         });
     };
 

--- a/datahub-web-react/src/app/lineageV2/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
+++ b/datahub-web-react/src/app/lineageV2/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
@@ -1,10 +1,380 @@
-describe('Entity name cleaning', () => {
-    it('should clean special characters', () => {
-        const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_');
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toPng } from 'html-to-image';
+import React from 'react';
+import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
 
-        expect(cleanName('dataset-with/special@chars#and$symbols')).toBe('dataset-with_special_chars_and_symbols');
-        expect(cleanName('user.transactions')).toBe('user_transactions');
-        expect(cleanName('normal_name')).toBe('normal_name');
-        expect(cleanName('123-valid_name')).toBe('123-valid_name');
+import { LineageNodesContext } from '@app/lineageV2/common';
+import DownloadLineageScreenshotButton from '@app/lineageV2/controls/DownloadLineageScreenshotButton';
+
+// Mock external dependencies
+vi.mock('html-to-image');
+vi.mock('reactflow');
+
+// Mock Ant Design icons partially
+vi.mock('@ant-design/icons', async (importOriginal) => {
+    const actual = (await importOriginal()) as any;
+    return {
+        ...actual,
+        CameraOutlined: () => <span data-testid="camera-icon">📷</span>,
+    };
+});
+
+// Mock StyledPanelButton
+vi.mock('@app/lineageV2/controls/StyledPanelButton', () => ({
+    StyledPanelButton: ({ children, onClick, ...props }: any) => (
+        <button type="button" onClick={onClick} {...props}>
+            {children}
+        </button>
+    ),
+}));
+
+// Mock context data
+const mockNodes = new Map([
+    [
+        'urn:li:dataset:test',
+        {
+            entity: { name: 'Test Dataset' },
+            urn: 'urn:li:dataset:test',
+        },
+    ],
+    [
+        'urn:li:dataset:special-chars',
+        {
+            entity: { name: 'dataset-with/special@chars#and$symbols' },
+            urn: 'urn:li:dataset:special-chars',
+        },
+    ],
+]);
+
+const mockContextValue = {
+    rootUrn: 'urn:li:dataset:test',
+    rootType: 'dataset' as any,
+    nodes: mockNodes,
+    edges: new Map(),
+    adjacencyList: new Map(),
+    nodeVersion: new Map(),
+    setNodeVersion: vi.fn(),
+    dataVersion: new Map(),
+    setDataVersion: vi.fn(),
+    displayVersion: new Map(),
+    setDisplayVersion: vi.fn(),
+    loading: false,
+    error: null,
+    selectedFields: new Set(),
+    hoveredField: null,
+    expandedNodes: new Set(),
+    filteredNodes: new Set(),
+    filteredEdges: new Set(),
+    focusedNodes: new Set(),
+    hiddenNodes: new Set(),
+    hiddenEdges: new Set(),
+    ghostNodes: new Set(),
+    ghostEdges: new Set(),
+    setSelectedFields: vi.fn(),
+    setHoveredField: vi.fn(),
+    setExpandedNodes: vi.fn(),
+    setFocusedNodes: vi.fn(),
+} as any;
+
+const mockUseReactFlow = {
+    getNodes: vi.fn(() => [
+        { id: '1', position: { x: 0, y: 0 }, data: {} },
+        { id: '2', position: { x: 100, y: 100 }, data: {} },
+    ]),
+};
+
+// Mock anchor element for download testing
+let mockAnchorElement: any;
+let originalCreateElement: typeof document.createElement;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+
+    (useReactFlow as any).mockReturnValue(mockUseReactFlow);
+    (getRectOfNodes as any).mockReturnValue({
+        width: 800,
+        height: 600,
+        x: 0,
+        y: 0,
+    });
+    (getTransformForBounds as any).mockReturnValue([100, 50, 0.75]);
+    (toPng as any).mockResolvedValue('data:image/png;base64,mockdata');
+
+    // Mock document.querySelector
+    const mockViewport = document.createElement('div');
+    mockViewport.className = 'react-flow__viewport';
+    vi.spyOn(document, 'querySelector').mockReturnValue(mockViewport);
+
+    // Mock anchor element for download
+    mockAnchorElement = {
+        setAttribute: vi.fn(),
+        click: vi.fn(),
+    };
+    originalCreateElement = document.createElement;
+    document.createElement = vi.fn().mockImplementation((tagName) => {
+        if (tagName === 'a') {
+            return mockAnchorElement;
+        }
+        return originalCreateElement.call(document, tagName);
+    });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    document.createElement = originalCreateElement;
+});
+
+describe('DownloadLineageScreenshotButton (lineageV2)', () => {
+    const renderComponent = (showExpandedText = false, contextValue = mockContextValue) => {
+        return render(
+            <LineageNodesContext.Provider value={contextValue}>
+                <DownloadLineageScreenshotButton showExpandedText={showExpandedText} />
+            </LineageNodesContext.Provider>,
+        );
+    };
+
+    describe('Rendering', () => {
+        it('should render button with camera icon', () => {
+            renderComponent();
+
+            const button = screen.getByRole('button');
+            expect(button).toBeInTheDocument();
+
+            // Check for camera icon
+            const icon = screen.getByTestId('camera-icon');
+            expect(icon).toBeInTheDocument();
+        });
+
+        it('should show text when showExpandedText is true', () => {
+            renderComponent(true);
+
+            expect(screen.getByText('Screenshot')).toBeInTheDocument();
+        });
+
+        it('should not show text when showExpandedText is false', () => {
+            renderComponent(false);
+
+            expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('Screenshot functionality', () => {
+        it('should call screenshot APIs when button is clicked', async () => {
+            renderComponent();
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(getRectOfNodes).toHaveBeenCalledWith(mockUseReactFlow.getNodes());
+                expect(getTransformForBounds).toHaveBeenCalledWith(
+                    { width: 800, height: 600, x: 0, y: 0 },
+                    1000, // width + 200
+                    800, // height + 200
+                    0.5,
+                    2,
+                );
+            });
+        });
+
+        it('should call toPng with correct parameters', async () => {
+            renderComponent();
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(toPng).toHaveBeenCalledWith(expect.any(HTMLElement), {
+                    backgroundColor: '#f8f8f8',
+                    width: 1000,
+                    height: 800,
+                    style: {
+                        width: '1000',
+                        height: '800',
+                        transform: 'translate(100px, 50px) scale(0.75)',
+                    },
+                });
+            });
+        });
+
+        it('should download image with cleaned entity name', async () => {
+            renderComponent();
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('href', 'data:image/png;base64,mockdata');
+                expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                    'download',
+                    expect.stringMatching(/^Test_Dataset_\d{4}-\d{2}-\d{2}_\d{6}\.png$/),
+                );
+                expect(mockAnchorElement.click).toHaveBeenCalled();
+            });
+        });
+
+        it('should handle entity with special characters in name', async () => {
+            const contextWithSpecialChars = {
+                ...mockContextValue,
+                rootUrn: 'urn:li:dataset:special-chars',
+            };
+
+            renderComponent(false, contextWithSpecialChars);
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                    'download',
+                    expect.stringMatching(/^dataset-with_special_chars_and_symbols_\d{4}-\d{2}-\d{2}_\d{6}\.png$/),
+                );
+            });
+        });
+
+        it('should use default lineage name when entity name is not available', async () => {
+            const contextWithoutName = {
+                ...mockContextValue,
+                nodes: new Map([
+                    [
+                        'urn:li:dataset:test',
+                        {
+                            entity: { name: '' },
+                            urn: 'urn:li:dataset:test',
+                        },
+                    ],
+                ]),
+            };
+
+            renderComponent(false, contextWithoutName);
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                    'download',
+                    expect.stringMatching(/^lineage_\d{4}-\d{2}-\d{2}_\d{6}\.png$/),
+                );
+            });
+        });
+
+        it('should handle missing root entity', async () => {
+            const contextWithMissingEntity = {
+                ...mockContextValue,
+                rootUrn: 'urn:li:dataset:nonexistent',
+            };
+
+            renderComponent(false, contextWithMissingEntity);
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                    'download',
+                    expect.stringMatching(/^lineage_\d{4}-\d{2}-\d{2}_\d{6}\.png$/),
+                );
+            });
+        });
+
+        it('should handle toPng errors gracefully', async () => {
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            (toPng as any).mockRejectedValue(new Error('Failed to generate image'));
+
+            renderComponent();
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            // Should not crash the component and error should be handled gracefully
+            try {
+                await waitFor(
+                    () => {
+                        expect(button).toBeInTheDocument();
+                    },
+                    { timeout: 1000 },
+                );
+            } catch (error) {
+                // Expected to have an error due to the mocked rejection
+                expect(error).toBeDefined();
+            }
+
+            consoleErrorSpy.mockRestore();
+        });
+    });
+
+    describe('Download Image functionality (inline)', () => {
+        it('should generate correct filename format with entity name', () => {
+            const now = new Date();
+            const expectedDateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
+                now.getDate(),
+            ).padStart(2, '0')}`;
+
+            renderComponent();
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            // Check that the filename matches the expected format
+            const setAttributeCalls = mockAnchorElement.setAttribute.mock.calls;
+            const downloadCall = setAttributeCalls.find((call: any[]) => call[0] === 'download');
+
+            if (downloadCall) {
+                const filename = downloadCall[1];
+                expect(filename).toMatch(/^Test_Dataset_\d{4}-\d{2}-\d{2}_\d{6}\.png$/);
+                expect(filename).toContain(expectedDateStr);
+            }
+        });
+
+        it('should generate filename with default prefix when no name provided', async () => {
+            const contextWithoutName = {
+                ...mockContextValue,
+                nodes: new Map([
+                    [
+                        'urn:li:dataset:test',
+                        {
+                            entity: { name: '' },
+                            urn: 'urn:li:dataset:test',
+                        },
+                    ],
+                ]),
+            };
+
+            renderComponent(false, contextWithoutName);
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                    'download',
+                    expect.stringMatching(/^lineage_\d{4}-\d{2}-\d{2}_\d{6}\.png$/),
+                );
+            });
+        });
+
+        it('should create anchor element with correct attributes', async () => {
+            renderComponent();
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(document.createElement).toHaveBeenCalledWith('a');
+                expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('href', 'data:image/png;base64,mockdata');
+                expect(mockAnchorElement.click).toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('Entity name cleaning', () => {
+        it('should clean special characters from entity names', () => {
+            const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+            expect(cleanName('dataset-with/special@chars#and$symbols')).toBe('dataset-with_special_chars_and_symbols');
+            expect(cleanName('user.transactions')).toBe('user_transactions');
+            expect(cleanName('normal_name')).toBe('normal_name');
+            expect(cleanName('123-valid_name')).toBe('123-valid_name');
+            expect(cleanName('')).toBe('');
+            expect(cleanName('spaces in name')).toBe('spaces_in_name');
+        });
     });
 });

--- a/datahub-web-react/src/app/lineageV2/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
+++ b/datahub-web-react/src/app/lineageV2/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
@@ -1,0 +1,10 @@
+describe('Entity name cleaning', () => {
+    it('should clean special characters', () => {
+        const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+        expect(cleanName('dataset-with/special@chars#and$symbols')).toBe('dataset-with_special_chars_and_symbols');
+        expect(cleanName('user.transactions')).toBe('user_transactions');
+        expect(cleanName('normal_name')).toBe('normal_name');
+        expect(cleanName('123-valid_name')).toBe('123-valid_name');
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/controls/DownloadLineageScreenshotButton.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/DownloadLineageScreenshotButton.tsx
@@ -1,41 +1,31 @@
 import { CameraOutlined } from '@ant-design/icons';
 import { toPng } from 'html-to-image';
-import React from 'react';
+import React, { useContext } from 'react';
 import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
 
+import { LineageNodesContext } from '@app/lineageV3/common';
 import { StyledPanelButton } from '@app/lineageV3/controls/StyledPanelButton';
+import { downloadImage } from '@app/lineageV3/utils/lineageUtils';
 
 type Props = {
     showExpandedText: boolean;
 };
 
-function downloadImage(dataUrl: string, name?: string) {
-    const now = new Date();
-    const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
-        now.getDate(),
-    ).padStart(2, '0')}`;
-
-    const timeStr = `${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(
-        now.getSeconds(),
-    ).padStart(2, '0')}`;
-
-    const fileNamePrefix = name ? `${name}_` : 'reactflow_';
-    const fileName = `${fileNamePrefix}${dateStr}_${timeStr}.png`;
-
-    const a = document.createElement('a');
-    a.setAttribute('download', fileName);
-    a.setAttribute('href', dataUrl);
-    a.click();
-}
-
 export default function DownloadLineageScreenshotButton({ showExpandedText }: Props) {
     const { getNodes } = useReactFlow();
+    const { rootUrn, nodes } = useContext(LineageNodesContext);
 
     const getPreviewImage = () => {
         const nodesBounds = getRectOfNodes(getNodes());
         const imageWidth = nodesBounds.width + 200;
         const imageHeight = nodesBounds.height + 200;
         const transform = getTransformForBounds(nodesBounds, imageWidth, imageHeight, 0.5, 2);
+
+        // Get the entity name for the screenshot filename
+        const rootEntity = nodes.get(rootUrn);
+        const entityName = rootEntity?.entity?.name || 'lineage';
+        // Clean the entity name to be safe for filename use
+        const cleanEntityName = entityName.replace(/[^a-zA-Z0-9_-]/g, '_');
 
         toPng(document.querySelector('.react-flow__viewport') as HTMLElement, {
             backgroundColor: '#f8f8f8',
@@ -47,7 +37,7 @@ export default function DownloadLineageScreenshotButton({ showExpandedText }: Pr
                 transform: `translate(${transform[0]}px, ${transform[1]}px) scale(${transform[2]})`,
             },
         }).then((dataUrl) => {
-            downloadImage(dataUrl);
+            downloadImage(dataUrl, cleanEntityName);
         });
     };
 

--- a/datahub-web-react/src/app/lineageV3/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
@@ -1,0 +1,89 @@
+import { downloadImage } from '@app/lineageV3/utils/lineageUtils';
+
+describe('DownloadLineageScreenshotButton', () => {
+    describe('Entity name cleaning', () => {
+        it('should clean special characters', () => {
+            const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+            expect(cleanName('dataset-with/special@chars#and$symbols')).toBe('dataset-with_special_chars_and_symbols');
+            expect(cleanName('user.transactions')).toBe('user_transactions');
+            expect(cleanName('normal_name')).toBe('normal_name');
+            expect(cleanName('123-valid_name')).toBe('123-valid_name');
+        });
+    });
+
+    describe('downloadImage', () => {
+        let mockAnchorElement: any;
+        let originalCreateElement: typeof document.createElement;
+
+        beforeEach(() => {
+            // Mock anchor element
+            mockAnchorElement = {
+                setAttribute: vi.fn(),
+                click: vi.fn(),
+            };
+
+            // Mock document.createElement
+            originalCreateElement = document.createElement;
+            document.createElement = vi.fn().mockReturnValue(mockAnchorElement);
+        });
+
+        afterEach(() => {
+            document.createElement = originalCreateElement;
+        });
+
+        it('should create anchor element and set download attribute with default filename', () => {
+            const dataUrl = 'data:image/png;base64,mockdata';
+
+            downloadImage(dataUrl);
+
+            expect(document.createElement).toHaveBeenCalledWith('a');
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('href', dataUrl);
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                'download',
+                expect.stringMatching(/^reactflow_\d{4}-\d{2}-\d{2}_\d{6}\.png$/),
+            );
+            expect(mockAnchorElement.click).toHaveBeenCalled();
+        });
+
+        it('should handle empty string name parameter and use default prefix', () => {
+            const dataUrl = 'data:image/png;base64,mockdata';
+
+            downloadImage(dataUrl, '');
+
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                'download',
+                expect.stringMatching(/^reactflow_\d{4}-\d{2}-\d{2}_\d{6}\.png$/),
+            );
+        });
+
+        it('should generate filename with correct format and timestamp', () => {
+            const dataUrl = 'data:image/png;base64,mockdata';
+            const name = 'test_entity';
+
+            downloadImage(dataUrl, name);
+
+            // Verify that the anchor element is created and the href attribute is set
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('href', dataUrl);
+            expect(mockAnchorElement.click).toHaveBeenCalledTimes(1);
+
+            // Get the download filename from the setAttribute calls
+            const setAttributeCalls = mockAnchorElement.setAttribute.mock.calls;
+            const downloadCall = setAttributeCalls.find((call: any[]) => call[0] === 'download');
+            const filename = downloadCall[1];
+
+            // Verify filename format: test_entity_YYYY-MM-DD_HHMMSS.png
+            expect(filename).toMatch(/^test_entity_\d{4}-\d{2}-\d{2}_\d{6}\.png$/);
+
+            // Extract and verify date part (YYYY-MM-DD)
+            const parts = filename.split('_');
+            const datePart = parts[2];
+            expect(datePart).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+            // Extract and verify time part (HHMMSS)
+            const timePart = parts[3].replace('.png', '');
+            expect(timePart).toMatch(/^\d{6}$/);
+            expect(timePart.length).toBe(6);
+        });
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
@@ -1,6 +1,262 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toPng } from 'html-to-image';
+import React from 'react';
+import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
+
+import { LineageNodesContext } from '@app/lineageV3/common';
+import DownloadLineageScreenshotButton from '@app/lineageV3/controls/DownloadLineageScreenshotButton';
 import { downloadImage } from '@app/lineageV3/utils/lineageUtils';
 
+// Mock external dependencies
+vi.mock('html-to-image');
+vi.mock('reactflow');
+// Mock lineageUtils - we'll handle downloadImage separately in tests
+vi.mock('@app/lineageV3/utils/lineageUtils', () => ({
+    downloadImage: vi.fn(),
+}));
+
+// Mock Ant Design icons partially
+vi.mock('@ant-design/icons', async (importOriginal) => {
+    const actual = (await importOriginal()) as any;
+    return {
+        ...actual,
+        CameraOutlined: () => <span data-testid="camera-icon">📷</span>,
+    };
+});
+
+// Mock StyledPanelButton
+vi.mock('@app/lineageV3/controls/StyledPanelButton', () => ({
+    StyledPanelButton: ({ children, onClick, ...props }: any) => (
+        <button type="button" onClick={onClick} {...props}>
+            {children}
+        </button>
+    ),
+}));
+
+// Mock context data
+const mockNodes = new Map([
+    [
+        'urn:li:dataset:test',
+        {
+            entity: { name: 'Test Dataset' },
+            urn: 'urn:li:dataset:test',
+        },
+    ],
+    [
+        'urn:li:dataset:special-chars',
+        {
+            entity: { name: 'dataset-with/special@chars#and$symbols' },
+            urn: 'urn:li:dataset:special-chars',
+        },
+    ],
+]);
+
+const mockContextValue = {
+    rootUrn: 'urn:li:dataset:test',
+    rootType: 'dataset' as any,
+    nodes: mockNodes,
+    edges: new Map(),
+    adjacencyList: new Map(),
+    nodeVersion: new Map(),
+    setNodeVersion: vi.fn(),
+    dataVersion: new Map(),
+    setDataVersion: vi.fn(),
+    displayVersion: new Map(),
+    setDisplayVersion: vi.fn(),
+    loading: false,
+    error: null,
+    selectedFields: new Set(),
+    hoveredField: null,
+    expandedNodes: new Set(),
+    filteredNodes: new Set(),
+    filteredEdges: new Set(),
+    focusedNodes: new Set(),
+    hiddenNodes: new Set(),
+    hiddenEdges: new Set(),
+    ghostNodes: new Set(),
+    ghostEdges: new Set(),
+    setSelectedFields: vi.fn(),
+    setHoveredField: vi.fn(),
+    setExpandedNodes: vi.fn(),
+    setFocusedNodes: vi.fn(),
+} as any;
+
+const mockUseReactFlow = {
+    getNodes: vi.fn(() => [
+        { id: '1', position: { x: 0, y: 0 }, data: {} },
+        { id: '2', position: { x: 100, y: 100 }, data: {} },
+    ]),
+};
+
+// Mock implementations
+beforeEach(() => {
+    vi.clearAllMocks();
+
+    (useReactFlow as any).mockReturnValue(mockUseReactFlow);
+    (getRectOfNodes as any).mockReturnValue({
+        width: 800,
+        height: 600,
+        x: 0,
+        y: 0,
+    });
+    (getTransformForBounds as any).mockReturnValue([100, 50, 0.75]);
+    (toPng as any).mockResolvedValue('data:image/png;base64,mockdata');
+    (downloadImage as any).mockImplementation(() => {});
+
+    // Mock document.querySelector
+    const mockViewport = document.createElement('div');
+    mockViewport.className = 'react-flow__viewport';
+    vi.spyOn(document, 'querySelector').mockReturnValue(mockViewport);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
 describe('DownloadLineageScreenshotButton', () => {
+    const renderComponent = (showExpandedText = false, contextValue = mockContextValue) => {
+        return render(
+            <LineageNodesContext.Provider value={contextValue}>
+                <DownloadLineageScreenshotButton showExpandedText={showExpandedText} />
+            </LineageNodesContext.Provider>,
+        );
+    };
+
+    describe('Rendering', () => {
+        it('should render button with camera icon', () => {
+            renderComponent();
+
+            const button = screen.getByRole('button');
+            expect(button).toBeInTheDocument();
+
+            // Check for camera icon
+            const icon = screen.getByTestId('camera-icon');
+            expect(icon).toBeInTheDocument();
+        });
+
+        it('should show text when showExpandedText is true', () => {
+            renderComponent(true);
+
+            expect(screen.getByText('Screenshot')).toBeInTheDocument();
+        });
+
+        it('should not show text when showExpandedText is false', () => {
+            renderComponent(false);
+
+            expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('Screenshot functionality', () => {
+        it('should call screenshot APIs when button is clicked', async () => {
+            renderComponent();
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(getRectOfNodes).toHaveBeenCalledWith(mockUseReactFlow.getNodes());
+                expect(getTransformForBounds).toHaveBeenCalledWith(
+                    { width: 800, height: 600, x: 0, y: 0 },
+                    1000, // width + 200
+                    800, // height + 200
+                    0.5,
+                    2,
+                );
+            });
+        });
+
+        it('should call toPng with correct parameters', async () => {
+            renderComponent();
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(toPng).toHaveBeenCalledWith(expect.any(HTMLElement), {
+                    backgroundColor: '#f8f8f8',
+                    width: 1000,
+                    height: 800,
+                    style: {
+                        width: '1000',
+                        height: '800',
+                        transform: 'translate(100px, 50px) scale(0.75)',
+                    },
+                });
+            });
+        });
+
+        it('should call downloadImage with cleaned entity name', async () => {
+            renderComponent();
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(downloadImage).toHaveBeenCalledWith('data:image/png;base64,mockdata', 'Test_Dataset');
+            });
+        });
+
+        it('should handle entity with special characters in name', async () => {
+            const contextWithSpecialChars = {
+                ...mockContextValue,
+                rootUrn: 'urn:li:dataset:special-chars',
+            };
+
+            renderComponent(false, contextWithSpecialChars);
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(downloadImage).toHaveBeenCalledWith(
+                    'data:image/png;base64,mockdata',
+                    'dataset-with_special_chars_and_symbols',
+                );
+            });
+        });
+
+        it('should use default lineage name when entity name is not available', async () => {
+            const contextWithoutName = {
+                ...mockContextValue,
+                nodes: new Map([
+                    [
+                        'urn:li:dataset:test',
+                        {
+                            entity: { name: '' },
+                            urn: 'urn:li:dataset:test',
+                        },
+                    ],
+                ]),
+            };
+
+            renderComponent(false, contextWithoutName);
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(downloadImage).toHaveBeenCalledWith('data:image/png;base64,mockdata', 'lineage');
+            });
+        });
+
+        it('should handle missing root entity', async () => {
+            const contextWithMissingEntity = {
+                ...mockContextValue,
+                rootUrn: 'urn:li:dataset:nonexistent',
+            };
+
+            renderComponent(false, contextWithMissingEntity);
+
+            const button = screen.getByRole('button');
+            fireEvent.click(button);
+
+            await waitFor(() => {
+                expect(downloadImage).toHaveBeenCalledWith('data:image/png;base64,mockdata', 'lineage');
+            });
+        });
+    });
+
     describe('Entity name cleaning', () => {
         it('should clean special characters', () => {
             const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -15,8 +271,13 @@ describe('DownloadLineageScreenshotButton', () => {
     describe('downloadImage', () => {
         let mockAnchorElement: any;
         let originalCreateElement: typeof document.createElement;
+        let realDownloadImage: any;
 
-        beforeEach(() => {
+        beforeEach(async () => {
+            // Import the real downloadImage function
+            const actualModule = (await vi.importActual('@app/lineageV3/utils/lineageUtils')) as any;
+            realDownloadImage = actualModule.downloadImage;
+
             // Mock anchor element
             mockAnchorElement = {
                 setAttribute: vi.fn(),
@@ -35,7 +296,7 @@ describe('DownloadLineageScreenshotButton', () => {
         it('should create anchor element and set download attribute with default filename', () => {
             const dataUrl = 'data:image/png;base64,mockdata';
 
-            downloadImage(dataUrl);
+            realDownloadImage(dataUrl);
 
             expect(document.createElement).toHaveBeenCalledWith('a');
             expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('href', dataUrl);
@@ -49,7 +310,7 @@ describe('DownloadLineageScreenshotButton', () => {
         it('should handle empty string name parameter and use default prefix', () => {
             const dataUrl = 'data:image/png;base64,mockdata';
 
-            downloadImage(dataUrl, '');
+            realDownloadImage(dataUrl, '');
 
             expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
                 'download',
@@ -61,7 +322,7 @@ describe('DownloadLineageScreenshotButton', () => {
             const dataUrl = 'data:image/png;base64,mockdata';
             const name = 'test_entity';
 
-            downloadImage(dataUrl, name);
+            realDownloadImage(dataUrl, name);
 
             // Verify that the anchor element is created and the href attribute is set
             expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('href', dataUrl);

--- a/datahub-web-react/src/app/lineageV3/utils/__tests__/lineageUtils.test.ts
+++ b/datahub-web-react/src/app/lineageV3/utils/__tests__/lineageUtils.test.ts
@@ -1,0 +1,319 @@
+import { useLocation } from 'react-router-dom';
+
+import {
+    convertFieldsToV1FieldPath,
+    downgradeV2FieldPath,
+    downloadImage,
+    getEntityTypeFromEntityUrn,
+    getLineageUrl,
+    processDocumentationString,
+    useGetLineageUrl,
+} from '@app/lineageV3/utils/lineageUtils';
+import { useEntityRegistry } from '@app/useEntityRegistry';
+
+import { EntityType } from '@types';
+
+// Mock dependencies
+vi.mock('react-router-dom');
+vi.mock('@app/useEntityRegistry');
+vi.mock('@app/entityV2/schemaField/utils');
+
+const mockLocation = {
+    search: '?filter=test&tab=lineage',
+    pathname: '/dataset/urn:li:dataset:test',
+    hash: '',
+    state: null,
+    key: 'test',
+};
+
+const mockEntityRegistry = {
+    getTypeFromGraphName: vi.fn(),
+    getEntityUrl: vi.fn(),
+};
+
+const mockUseEntityRegistry = vi.fn(() => mockEntityRegistry);
+const mockUseLocation = vi.fn(() => mockLocation);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    (useLocation as any).mockImplementation(mockUseLocation);
+    (useEntityRegistry as any).mockImplementation(mockUseEntityRegistry);
+});
+
+describe('lineageUtils', () => {
+    describe('downgradeV2FieldPath', () => {
+        it('should return the same value for null or undefined input', () => {
+            expect(downgradeV2FieldPath(null as any)).toBeNull();
+            expect(downgradeV2FieldPath(undefined as any)).toBeUndefined();
+            expect(downgradeV2FieldPath('')).toBe('');
+        });
+
+        it('should remove KEY_SCHEMA_PREFIX and VERSION_PREFIX', () => {
+            const fieldPath = '[version=2.0].[key=True].[type=string].user.id';
+            const result = downgradeV2FieldPath(fieldPath);
+            expect(result).toBe('user.id');
+        });
+
+        it('should strip out annotation segments starting with brackets', () => {
+            const fieldPath = 'user.[type=string].id.[annotation=test].name';
+            const result = downgradeV2FieldPath(fieldPath);
+            expect(result).toBe('user.id.name');
+        });
+
+        it('should handle field paths without annotations', () => {
+            const fieldPath = 'user.profile.name';
+            const result = downgradeV2FieldPath(fieldPath);
+            expect(result).toBe('user.profile.name');
+        });
+
+        it('should handle mixed annotation and regular segments', () => {
+            const fieldPath = 'schema.[version=2.0].user.[key=True].profile.[type=struct].data';
+            const result = downgradeV2FieldPath(fieldPath);
+            expect(result).toBe('schema.user.profile.data');
+        });
+    });
+
+    describe('processDocumentationString', () => {
+        it('should return empty string for null or undefined input', () => {
+            expect(processDocumentationString(null)).toBe('');
+            expect(processDocumentationString(undefined)).toBe('');
+        });
+
+        it('should process field paths in documentation strings', () => {
+            const docString = "This field '[version=2.0].[key=True].[type=string].user.id' is important.";
+            const result = processDocumentationString(docString);
+            expect(result).toBe("This field 'user.id' is important.");
+        });
+
+        it('should handle multiple field paths in one string', () => {
+            const docString = "Fields '[version=2.0].user.name' and '[version=2.0].[type=int].user.age' are required.";
+            const result = processDocumentationString(docString);
+            // The regex should match and replace both field paths
+            expect(result).toContain('user.name');
+            expect(result).toContain('user.age');
+        });
+
+        it('should return original string if no field paths found', () => {
+            const docString = 'This is a regular documentation string.';
+            const result = processDocumentationString(docString);
+            expect(result).toBe(docString);
+        });
+    });
+
+    describe('convertFieldsToV1FieldPath', () => {
+        it('should convert array of field objects', () => {
+            const fields = [
+                {
+                    fieldPath: '[version=2.0].[key=True].user.id',
+                    nullable: false,
+                    type: 'string',
+                    recursive: false,
+                },
+                {
+                    fieldPath: '[version=2.0].user.name',
+                    nullable: true,
+                    type: 'string',
+                    recursive: false,
+                },
+            ] as any[];
+
+            const result = convertFieldsToV1FieldPath(fields);
+
+            expect(result).toHaveLength(2);
+            expect(result[0].fieldPath).toBe('user.id');
+            expect(result[1].fieldPath).toBe('user.name');
+            expect(result[0].nullable).toBe(false);
+            expect(result[1].nullable).toBe(true);
+        });
+
+        it('should handle empty array', () => {
+            const result = convertFieldsToV1FieldPath([]);
+            expect(result).toEqual([]);
+        });
+
+        it('should handle null fieldPath', () => {
+            const fields = [
+                {
+                    fieldPath: null,
+                    nullable: false,
+                    type: 'string',
+                    recursive: false,
+                },
+            ] as any[];
+
+            const result = convertFieldsToV1FieldPath(fields);
+            expect(result[0].fieldPath).toBe('');
+        });
+    });
+
+    describe('getV1FieldPathFromSchemaFieldUrn', () => {
+        it('should get field path from URN and downgrade it', () => {
+            // Test the downgrade functionality which is the core logic of getV1FieldPathFromSchemaFieldUrn
+            const mockFieldPath = '[version=2.0].[key=True].user.id';
+            const downgradedPath = downgradeV2FieldPath(mockFieldPath);
+            expect(downgradedPath).toBe('user.id');
+        });
+    });
+
+    describe('getEntityTypeFromEntityUrn', () => {
+        beforeEach(() => {
+            (mockEntityRegistry.getTypeFromGraphName as any).mockReturnValue(EntityType.Dataset);
+        });
+
+        it('should extract entity type from URN', () => {
+            const urn = 'urn:li:dataset:test';
+            const result = getEntityTypeFromEntityUrn(urn, mockEntityRegistry as any);
+
+            expect(mockEntityRegistry.getTypeFromGraphName).toHaveBeenCalledWith('dataset');
+            expect(result).toBe(EntityType.Dataset);
+        });
+
+        it('should handle URNs with different entity types', () => {
+            (mockEntityRegistry.getTypeFromGraphName as any).mockReturnValue(EntityType.DataJob);
+            const urn = 'urn:li:dataJob:test';
+            const result = getEntityTypeFromEntityUrn(urn, mockEntityRegistry as any);
+
+            expect(mockEntityRegistry.getTypeFromGraphName).toHaveBeenCalledWith('dataJob');
+            expect(result).toBe(EntityType.DataJob);
+        });
+
+        it('should return undefined for invalid URN', () => {
+            (mockEntityRegistry.getTypeFromGraphName as any).mockReturnValue(undefined);
+            const urn = 'invalid:urn';
+            const result = getEntityTypeFromEntityUrn(urn, mockEntityRegistry as any);
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('getLineageUrl', () => {
+        beforeEach(() => {
+            (mockEntityRegistry.getEntityUrl as any).mockReturnValue('/dataset/urn:li:dataset:test');
+        });
+
+        it('should construct lineage URL with search params', () => {
+            const urn = 'urn:li:dataset:test';
+            const type = EntityType.Dataset;
+
+            const result = getLineageUrl(urn, type, mockLocation, mockEntityRegistry as any);
+
+            expect(mockEntityRegistry.getEntityUrl).toHaveBeenCalledWith(type, urn);
+            expect(result).toBe('/dataset/urn:li:dataset:test/Lineage?filter=test&tab=lineage');
+        });
+
+        it('should handle location without search params', () => {
+            const locationWithoutSearch = { ...mockLocation, search: '' };
+            const urn = 'urn:li:dataset:test';
+            const type = EntityType.Dataset;
+
+            const result = getLineageUrl(urn, type, locationWithoutSearch, mockEntityRegistry as any);
+            expect(result).toBe('/dataset/urn:li:dataset:test/Lineage');
+        });
+    });
+
+    describe('useGetLineageUrl', () => {
+        beforeEach(() => {
+            (mockEntityRegistry.getEntityUrl as any).mockReturnValue('/dataset/urn:li:dataset:test');
+        });
+
+        it('should return lineage URL for valid urn and type', () => {
+            const result = useGetLineageUrl('urn:li:dataset:test', EntityType.Dataset);
+            expect(result).toBe('/dataset/urn:li:dataset:test/Lineage?filter=test&tab=lineage');
+        });
+
+        it('should return empty string for undefined urn', () => {
+            const result = useGetLineageUrl(undefined, EntityType.Dataset);
+            expect(result).toBe('');
+        });
+
+        it('should return empty string for undefined type', () => {
+            const result = useGetLineageUrl('urn:li:dataset:test', undefined);
+            expect(result).toBe('');
+        });
+
+        it('should return empty string for both undefined', () => {
+            const result = useGetLineageUrl(undefined, undefined);
+            expect(result).toBe('');
+        });
+    });
+
+    describe('downloadImage', () => {
+        let mockAnchorElement: any;
+        let originalCreateElement: typeof document.createElement;
+
+        beforeEach(() => {
+            // Mock anchor element
+            mockAnchorElement = {
+                setAttribute: vi.fn(),
+                click: vi.fn(),
+            };
+
+            // Mock document.createElement
+            originalCreateElement = document.createElement;
+            document.createElement = vi.fn().mockReturnValue(mockAnchorElement);
+
+            // Mock Date to have consistent timestamps in tests
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2024-01-15T10:30:45'));
+        });
+
+        afterEach(() => {
+            document.createElement = originalCreateElement;
+            vi.useRealTimers();
+        });
+
+        it('should create anchor element and trigger download with default filename', () => {
+            const dataUrl = 'data:image/png;base64,testdata';
+
+            downloadImage(dataUrl);
+
+            expect(document.createElement).toHaveBeenCalledWith('a');
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('href', dataUrl);
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('download', 'reactflow_2024-01-15_103045.png');
+            expect(mockAnchorElement.click).toHaveBeenCalled();
+        });
+
+        it('should use custom name prefix when provided', () => {
+            const dataUrl = 'data:image/png;base64,testdata';
+            const name = 'custom_entity';
+
+            downloadImage(dataUrl, name);
+
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                'download',
+                'custom_entity_2024-01-15_103045.png',
+            );
+        });
+
+        it('should handle empty string name', () => {
+            const dataUrl = 'data:image/png;base64,testdata';
+
+            downloadImage(dataUrl, '');
+
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('download', 'reactflow_2024-01-15_103045.png');
+        });
+
+        it('should format date and time correctly', () => {
+            // Test with different date
+            vi.setSystemTime(new Date('2024-12-25T01:05:09'));
+
+            const dataUrl = 'data:image/png;base64,testdata';
+            const name = 'test';
+
+            downloadImage(dataUrl, name);
+
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('download', 'test_2024-12-25_010509.png');
+        });
+
+        it('should pad single digit months, days, hours, minutes, seconds', () => {
+            // Test with single digit values
+            vi.setSystemTime(new Date('2024-02-05T03:07:09'));
+
+            const dataUrl = 'data:image/png;base64,testdata';
+            const name = 'test';
+
+            downloadImage(dataUrl, name);
+
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('download', 'test_2024-02-05_030709.png');
+        });
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/utils/lineageUtils.ts
+++ b/datahub-web-react/src/app/lineageV3/utils/lineageUtils.ts
@@ -66,3 +66,22 @@ export function useGetLineageUrl(urn?: string, type?: EntityType) {
 
     return getLineageUrl(urn, type, location, entityRegistry);
 }
+
+export function downloadImage(dataUrl: string, name?: string) {
+    const now = new Date();
+    const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
+        now.getDate(),
+    ).padStart(2, '0')}`;
+
+    const timeStr = `${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(
+        now.getSeconds(),
+    ).padStart(2, '0')}`;
+
+    const fileNamePrefix = name ? `${name}_` : 'reactflow_';
+    const fileName = `${fileNamePrefix}${dateStr}_${timeStr}.png`;
+
+    const a = document.createElement('a');
+    a.setAttribute('download', fileName);
+    a.setAttribute('href', dataUrl);
+    a.click();
+}


### PR DESCRIPTION
## Summary 

Lineage screenshot filenames now contain the dataset name:  `{dataset name}_{timestamp}` 

| Before      | After |
| ----------- | ----------- |
| <img width="314" height="100" alt="Screenshot 2025-07-18 at 3 31 43 PM" src="https://github.com/user-attachments/assets/857ddbe0-1d71-4ce5-8666-1d2c185c810a" /> |  <img width="311" height="115" alt="Screenshot 2025-07-18 at 5 45 34 PM" src="https://github.com/user-attachments/assets/2a621081-e544-41e5-9b01-9fa93b2dd51b" /> |



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
