### PR TITLE
fix(customHomePage): allow to add global link module to new row

### DIFF
--- a/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
+++ b/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
@@ -205,7 +205,7 @@ export default function useAddModuleMenu(position: ModulePositionInput, closeMen
                     <ModuleMenuItem
                         module={convertModuleToModuleInfo(module)}
                         isDisabled={
-                            (SMALL_MODULE_TYPES.includes(module.properties.type) && !isSmallModuleRow) ||
+                            (SMALL_MODULE_TYPES.includes(module.properties.type) && isLargeModuleRow) ||
                             (LARGE_MODULE_TYPES.includes(module.properties.type) && isSmallModuleRow)
                         }
                         isSmallModule={SMALL_MODULE_TYPES.includes(module.properties.type)}
@@ -213,7 +213,7 @@ export default function useAddModuleMenu(position: ModulePositionInput, closeMen
                 ),
                 onClick: () => handleAddExistingModule(module),
                 disabled:
-                    (SMALL_MODULE_TYPES.includes(module.properties.type) && !isSmallModuleRow) ||
+                    (SMALL_MODULE_TYPES.includes(module.properties.type) && isLargeModuleRow) ||
                     (LARGE_MODULE_TYPES.includes(module.properties.type) && isSmallModuleRow),
             }));
 


### PR DESCRIPTION

<img width="615" height="835" alt="image" src="https://github.com/user-attachments/assets/3def4d95-c1b8-410c-912a-a515aa2ec21e" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
