### PR TITLE
fix(cli): add try catch around sentry init

### DIFF
--- a/metadata-ingestion/src/datahub/telemetry/telemetry.py
+++ b/metadata-ingestion/src/datahub/telemetry/telemetry.py
@@ -272,7 +272,10 @@ class Telemetry:
         if self.sentry_enabled:
             import sentry_sdk
 
-            sentry_sdk.set_tags(properties)
+            try:
+                sentry_sdk.set_tags(properties)
+            except Exception as e:
+                logger.warning("Failed to update Sentry properties.", exc_info=e)
 
     def init_capture_exception(self) -> None:
         if self.sentry_enabled:


### PR DESCRIPTION
In case someone is using older versions of sentry then the method may not be available. In those cases we log an error and don't break everything for telemetry

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
