### PR TITLE
fix(ui/ingest): space between tabs row and search

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Tabs/Tabs.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Tabs/Tabs.tsx
@@ -14,13 +14,24 @@ const ScrollableTabsContainer = styled.div<{ $maxHeight?: string }>`
     position: relative;
 `;
 
-const StyledTabs = styled(AntTabs)<{
+const StyledTabsPrimary = styled(AntTabs)<{
+    $navMarginBottom?: number;
+    $navMarginTop?: number;
+    $containerHeight?: 'full' | 'auto';
     $addPaddingLeft?: boolean;
     $hideTabsHeader: boolean;
     $scrollable?: boolean;
     $stickyHeader?: boolean;
 }>`
-    ${({ $scrollable }) => !$scrollable && 'flex: 1;'}
+    ${({ $scrollable, $containerHeight }) => {
+        if (!$scrollable) {
+            if ($containerHeight === 'full') {
+                return 'height: 100%;';
+            }
+            return 'flex: 1;';
+        }
+        return '';
+    }}
     ${({ $scrollable }) => !$scrollable && 'overflow: hidden;'}
 
     .ant-tabs-tab {
@@ -79,7 +90,85 @@ const StyledTabs = styled(AntTabs)<{
     }
 
     .ant-tabs-nav {
-        margin-bottom: 0px;
+        margin-bottom: ${(props) => props.$navMarginBottom ?? 24}px;
+        margin-top: ${(props) => props.$navMarginTop ?? 0}px;
+    }
+`;
+
+const StyledTabsSecondary = styled(AntTabs)<{
+    $navMarginBottom?: number;
+    $navMarginTop?: number;
+    $containerHeight?: 'full' | 'auto';
+    $addPaddingLeft?: boolean;
+    $hideTabsHeader: boolean;
+    $scrollable?: boolean;
+    $stickyHeader?: boolean;
+}>`
+    ${(props) =>
+        props.$containerHeight === 'full'
+            ? `
+        height: 100%;
+    `
+            : `
+        flex: 1;
+    `}
+    overflow: hidden;
+
+    .ant-tabs-tab {
+        padding: 8px 8px;
+        border-radius: 4px;
+        font-size: 14px;
+        color: ${colors.gray[600]};
+    }
+
+    ${({ $addPaddingLeft }) =>
+        $addPaddingLeft
+            ? `
+            .ant-tabs-tab {
+                margin-left: 8px;
+            }
+            `
+            : `
+            .ant-tabs-tab + .ant-tabs-tab {
+                margin-left: 8px;
+            }
+        `}
+
+    ${({ $hideTabsHeader }) =>
+        $hideTabsHeader &&
+        `
+            .ant-tabs-nav {
+                display: none;
+            }
+        `}
+
+    .ant-tabs-tab-active {
+        background-color: ${(props) => props.theme.styles['primary-color-light']}80;
+    }
+
+    .ant-tabs-tab-active .ant-tabs-tab-btn {
+        color: ${(props) => props.theme.styles['primary-color']};
+        font-weight: 600;
+    }
+
+    .ant-tabs-ink-bar {
+        background-color: transparent;
+    }
+
+    .ant-tabs-content-holder {
+        display: flex;
+    }
+
+    .ant-tabs-tabpane {
+        height: 100%;
+    }
+
+    .ant-tabs-nav {
+        margin-bottom: ${(props) => props.$navMarginBottom ?? 0}px;
+        margin-top: ${(props) => props.$navMarginTop ?? 0}px;
+        &::before {
+            display: none;
+        }
     }
 
     ${({ $stickyHeader }) =>
@@ -126,7 +215,7 @@ function TabView({ tab }: { tab: Tab }) {
         <Tooltip title={tab.tooltip}>
             <TabViewWrapper id={tab.id} $disabled={tab.disabled} data-testid={tab.dataTestId}>
                 {tab.name}
-                {!!tab.count && <Pill label={`${tab.count}`} size="xs" color="violet" />}
+                {!!tab.count && <Pill label={`${tab.count}`} size="xs" color="primary" />}
             </TabViewWrapper>
         </Tooltip>
     );
@@ -152,6 +241,12 @@ export interface Props {
     onUrlChange?: (url: string) => void;
     defaultTab?: string;
     getCurrentUrl?: () => string;
+    secondary?: boolean;
+    styleOptions?: {
+        containerHeight?: 'full' | 'auto';
+        navMarginBottom?: number;
+        navMarginTop?: number;
+    };
     addPaddingLeft?: boolean;
     hideTabsHeader?: boolean;
     scrollToTopOnChange?: boolean;
@@ -167,6 +262,8 @@ export function Tabs({
     onUrlChange = (url) => window.history.replaceState({}, '', url),
     defaultTab,
     getCurrentUrl = () => window.location.pathname,
+    secondary,
+    styleOptions,
     addPaddingLeft,
     hideTabsHeader,
     scrollToTopOnChange = false,
@@ -208,6 +305,8 @@ export function Tabs({
         }
     }, [getCurrentUrl, onChange, onUrlChange, selectedTab, urlMap, urlToTabMap, defaultTab]);
 
+    const StyledTabs = secondary ? StyledTabsSecondary : StyledTabsPrimary;
+
     const tabsContent = (
         <StyledTabs
             activeKey={selectedTab}
@@ -217,6 +316,9 @@ export function Tabs({
                     onUrlChange(urlMap[key]);
                 }
             }}
+            $navMarginBottom={styleOptions?.navMarginBottom}
+            $navMarginTop={styleOptions?.navMarginTop}
+            $containerHeight={styleOptions?.containerHeight}
             $addPaddingLeft={addPaddingLeft}
             $hideTabsHeader={!!hideTabsHeader}
             $scrollable={scrollToTopOnChange}

--- a/datahub-web-react/src/app/ingestV2/executions/components/ExecutionDetailsModal.tsx
+++ b/datahub-web-react/src/app/ingestV2/executions/components/ExecutionDetailsModal.tsx
@@ -112,6 +112,7 @@ export const ExecutionDetailsModal = ({ urn, open, onClose }: Props) => {
                 maxHeight="80vh"
                 stickyHeader
                 addPaddingLeft
+                secondary
             />
         </Modal>
     );


### PR DESCRIPTION
before
<img width="1083" height="324" alt="Screenshot 2025-07-30 at 6 19 37 PM" src="https://github.com/user-attachments/assets/b7a16de2-76e9-4069-8718-7e754c09dc75" />

after
<img width="1085" height="346" alt="Screenshot 2025-07-30 at 6 19 42 PM" src="https://github.com/user-attachments/assets/eecc49f5-5de1-40e2-9cd8-72390814a3a6" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
