### PR TITLE
feat(datajobs): support dataplatform instance in datajobs

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -2461,6 +2461,16 @@ public class GmsGraphQLEngine {
                                   : null;
                             }))
                     .dataFetcher(
+                        "platform",
+                        new LoadableTypeResolver<>(
+                            dataPlatformType,
+                            (env) -> {
+                              final DataJob dataJob = env.getSource();
+                              return dataJob != null && dataJob.getPlatform() != null
+                                  ? dataJob.getPlatform().getUrn()
+                                  : null;
+                            }))
+                    .dataFetcher(
                         "container",
                         new LoadableTypeResolver<>(
                             containerType,

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/datajob/mappers/DataJobMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/datajob/mappers/DataJobMapper.java
@@ -113,8 +113,11 @@ public class DataJobMapper implements ModelMapper<EntityResponse, DataJob> {
               } else if (DEPRECATION_ASPECT_NAME.equals(name)) {
                 result.setDeprecation(DeprecationMapper.map(context, new Deprecation(data)));
               } else if (DATA_PLATFORM_INSTANCE_ASPECT_NAME.equals(name)) {
-                result.setDataPlatformInstance(
-                    DataPlatformInstanceAspectMapper.map(context, new DataPlatformInstance(data)));
+                DataPlatformInstance dataPlatformInstance = new DataPlatformInstance(data);
+                com.linkedin.datahub.graphql.generated.DataPlatformInstance value =
+                    DataPlatformInstanceAspectMapper.map(context, dataPlatformInstance);
+                result.setPlatform(value.getPlatform());
+                result.setDataPlatformInstance(value);
               } else if (CONTAINER_ASPECT_NAME.equals(name)) {
                 final com.linkedin.container.Container gmsContainer =
                     new com.linkedin.container.Container(data);

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -6799,6 +6799,11 @@ type DataJob implements EntityWithRelationships & Entity & BrowsableEntity {
   dataPlatformInstance: DataPlatformInstance
 
   """
+  Standardized platform urn where the data job is defined
+  """
+  platform: DataPlatform
+
+  """
   The parent container in which the entity resides
   """
   container: Container

--- a/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
@@ -38,7 +38,7 @@ import { GetDataJobQuery, useGetDataJobQuery, useUpdateDataJobMutation } from '@
 import { DataJob, DataProcessInstanceResult, EntityType, SearchResult } from '@types';
 
 const getPlatformForDataJob = (data?: DataJob) => {
-    return data?.dataPlatformInstance?.platform || data?.dataFlow?.platform;
+    return data?.platform || data?.dataFlow?.platform;
 };
 
 const getDataJobPlatformName = (data?: DataJob): string => {

--- a/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
@@ -37,11 +37,11 @@ import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import { GetDataJobQuery, useGetDataJobQuery, useUpdateDataJobMutation } from '@graphql/dataJob.generated';
 import { DataJob, DataProcessInstanceResult, EntityType, SearchResult } from '@types';
 
-const getPlatformForDataJob = (data?: DataJob) => {
+const getPlatformForDataJob = (data?: DataJob | null) => {
     return data?.platform || data?.dataFlow?.platform;
 };
 
-const getDataJobPlatformName = (data?: DataJob): string => {
+const getDataJobPlatformName = (data?: DataJob | null): string => {
     const platform = getPlatformForDataJob(data);
     return platform?.properties?.displayName || capitalizeFirstLetterOnly(platform?.name) || '';
 };

--- a/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
@@ -37,12 +37,13 @@ import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import { GetDataJobQuery, useGetDataJobQuery, useUpdateDataJobMutation } from '@graphql/dataJob.generated';
 import { DataJob, DataProcessInstanceResult, EntityType, SearchResult } from '@types';
 
+const getPlatformForDataJob = (data?: DataJob) => {
+    return data?.dataPlatformInstance?.platform || data?.dataFlow?.platform;
+};
+
 const getDataJobPlatformName = (data?: DataJob): string => {
-    return (
-        data?.dataFlow?.platform?.properties?.displayName ||
-        capitalizeFirstLetterOnly(data?.dataFlow?.platform?.name) ||
-        ''
-    );
+    const platform = getPlatformForDataJob(data);
+    return platform?.properties?.displayName || capitalizeFirstLetterOnly(platform?.name) || '';
 };
 
 const headerDropdownItems = new Set([
@@ -195,7 +196,7 @@ export class DataJobEntity implements Entity<DataJob> {
         return {
             name,
             externalUrl,
-            platform: dataJob?.dataFlow?.platform,
+            platform: getPlatformForDataJob(dataJob),
             lastRun: ((dataJob as any).lastRun as DataProcessInstanceResult)?.runs?.[0],
             lastRunEvent: ((dataJob as any).lastRun as DataProcessInstanceResult)?.runs?.[0]?.state?.[0],
         };
@@ -211,7 +212,7 @@ export class DataJobEntity implements Entity<DataJob> {
                 subtype={data.subTypes?.typeNames?.[0]}
                 description={data.editableProperties?.description || data.properties?.description}
                 platformName={getDataJobPlatformName(data)}
-                platformLogo={data?.dataFlow?.platform?.properties?.logoUrl || ''}
+                platformLogo={getPlatformForDataJob(data)?.properties?.logoUrl || ''}
                 owners={data.ownership?.owners}
                 globalTags={data.globalTags || null}
                 domain={data.domain?.domain}
@@ -235,7 +236,7 @@ export class DataJobEntity implements Entity<DataJob> {
                 subtype={data.subTypes?.typeNames?.[0]}
                 description={data.editableProperties?.description || data.properties?.description}
                 platformName={getDataJobPlatformName(data)}
-                platformLogo={data?.dataFlow?.platform?.properties?.logoUrl || ''}
+                platformLogo={getPlatformForDataJob(data)?.properties?.logoUrl || ''}
                 platformInstanceId={data.dataPlatformInstance?.instanceId}
                 owners={data.ownership?.owners}
                 globalTags={data.globalTags}
@@ -281,7 +282,7 @@ export class DataJobEntity implements Entity<DataJob> {
             name: this.displayName(entity),
             expandedName: this.getExpandedNameForDataJob(entity),
             type: EntityType.DataJob,
-            icon: entity?.dataFlow?.platform?.properties?.logoUrl || undefined, // eslint-disable-next-line @typescript-eslint/dot-notation
+            icon: getPlatformForDataJob(entity)?.properties?.logoUrl || undefined, // eslint-disable-next-line @typescript-eslint/dot-notation
             downstreamChildren: entity?.['downstream']?.relationships?.map(
                 (relationship) =>
                     ({
@@ -296,7 +297,7 @@ export class DataJobEntity implements Entity<DataJob> {
                         type: relationship.entity.type,
                     }) as EntityAndType,
             ),
-            platform: entity?.dataFlow?.platform,
+            platform: getPlatformForDataJob(entity),
         };
     };
 

--- a/datahub-web-react/src/app/lineage/utils/__tests__/extendAsyncEntities.test.ts
+++ b/datahub-web-react/src/app/lineage/utils/__tests__/extendAsyncEntities.test.ts
@@ -9,6 +9,7 @@ describe('extendColumnLineage', () => {
         const dataJobWithCLL = {
             ...dataJob1,
             name: '',
+            platform: dataJob1.dataFlow?.platform || undefined,
             fineGrainedLineages: [
                 {
                     upstreams: [{ urn: dataset1.urn, path: 'test1' }],

--- a/datahub-web-react/src/graphql/dataJob.graphql
+++ b/datahub-web-react/src/graphql/dataJob.graphql
@@ -26,6 +26,9 @@ query getDataJob($urn: String!) {
             ...browsePathV2Fields
         }
         ...notes
+        platform {
+            ...platformFields
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -532,6 +532,9 @@ fragment nonRecursiveDataJobFields on DataJob {
     subTypes {
         typeNames
     }
+    platform {
+        ...platformFields
+    }
 }
 
 fragment dataJobFields on DataJob {
@@ -603,6 +606,9 @@ fragment dataJobFields on DataJob {
     }
     dataTransformLogic {
         ...dataTransformLogicFields
+    }
+    platform {
+        ...platformFields
     }
 }
 


### PR DESCRIPTION
In the case that a datajob has a data platform instance, we should use that for platform name and logo rather than the data flow's. This allows for visualizing when an orchestrator executes a task within a different tool.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
