### PR TITLE
feat(lineage): downloaded filename contains entity name (#6268)

### DIFF
--- a/datahub-web-react/src/app/lineageV2/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
+++ b/datahub-web-react/src/app/lineageV2/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
@@ -1,0 +1,10 @@
+describe('Entity name cleaning', () => {
+    it('should clean special characters', () => {
+        const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+        expect(cleanName('dataset-with/special@chars#and$symbols')).toBe('dataset-with_special_chars_and_symbols');
+        expect(cleanName('user.transactions')).toBe('user_transactions');
+        expect(cleanName('normal_name')).toBe('normal_name');
+        expect(cleanName('123-valid_name')).toBe('123-valid_name');
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/controls/DownloadLineageScreenshotButton.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/DownloadLineageScreenshotButton.tsx
@@ -3,31 +3,13 @@ import { toPng } from 'html-to-image';
 import React, { useContext } from 'react';
 import { getRectOfNodes, getTransformForBounds, useReactFlow } from 'reactflow';
 
-import { LineageNodesContext } from '@app/lineageV2/common';
-import { StyledPanelButton } from '@app/lineageV2/controls/StyledPanelButton';
+import { LineageNodesContext } from '@app/lineageV3/common';
+import { StyledPanelButton } from '@app/lineageV3/controls/StyledPanelButton';
+import { downloadImage } from '@app/lineageV3/utils/lineageUtils';
 
 type Props = {
     showExpandedText: boolean;
 };
-
-function downloadImage(dataUrl: string, name?: string) {
-    const now = new Date();
-    const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
-        now.getDate(),
-    ).padStart(2, '0')}`;
-
-    const timeStr = `${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(
-        now.getSeconds(),
-    ).padStart(2, '0')}`;
-
-    const fileNamePrefix = name ? `${name}_` : 'reactflow_';
-    const fileName = `${fileNamePrefix}${dateStr}_${timeStr}.png`;
-
-    const a = document.createElement('a');
-    a.setAttribute('download', fileName);
-    a.setAttribute('href', dataUrl);
-    a.click();
-}
 
 export default function DownloadLineageScreenshotButton({ showExpandedText }: Props) {
     const { getNodes } = useReactFlow();

--- a/datahub-web-react/src/app/lineageV3/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/__tests__/DownloadLineageScreenshotButton.test.tsx
@@ -1,0 +1,89 @@
+import { downloadImage } from '@app/lineageV3/utils/lineageUtils';
+
+describe('DownloadLineageScreenshotButton', () => {
+    describe('Entity name cleaning', () => {
+        it('should clean special characters', () => {
+            const cleanName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+            expect(cleanName('dataset-with/special@chars#and$symbols')).toBe('dataset-with_special_chars_and_symbols');
+            expect(cleanName('user.transactions')).toBe('user_transactions');
+            expect(cleanName('normal_name')).toBe('normal_name');
+            expect(cleanName('123-valid_name')).toBe('123-valid_name');
+        });
+    });
+
+    describe('downloadImage', () => {
+        let mockAnchorElement: any;
+        let originalCreateElement: typeof document.createElement;
+
+        beforeEach(() => {
+            // Mock anchor element
+            mockAnchorElement = {
+                setAttribute: vi.fn(),
+                click: vi.fn(),
+            };
+
+            // Mock document.createElement
+            originalCreateElement = document.createElement;
+            document.createElement = vi.fn().mockReturnValue(mockAnchorElement);
+        });
+
+        afterEach(() => {
+            document.createElement = originalCreateElement;
+        });
+
+        it('should create anchor element and set download attribute with default filename', () => {
+            const dataUrl = 'data:image/png;base64,mockdata';
+
+            downloadImage(dataUrl);
+
+            expect(document.createElement).toHaveBeenCalledWith('a');
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('href', dataUrl);
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                'download',
+                expect.stringMatching(/^reactflow_\d{4}-\d{2}-\d{2}_\d{6}\.png$/),
+            );
+            expect(mockAnchorElement.click).toHaveBeenCalled();
+        });
+
+        it('should handle empty string name parameter and use default prefix', () => {
+            const dataUrl = 'data:image/png;base64,mockdata';
+
+            downloadImage(dataUrl, '');
+
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith(
+                'download',
+                expect.stringMatching(/^reactflow_\d{4}-\d{2}-\d{2}_\d{6}\.png$/),
+            );
+        });
+
+        it('should generate filename with correct format and timestamp', () => {
+            const dataUrl = 'data:image/png;base64,mockdata';
+            const name = 'test_entity';
+
+            downloadImage(dataUrl, name);
+
+            // Verify that the anchor element is created and the href attribute is set
+            expect(mockAnchorElement.setAttribute).toHaveBeenCalledWith('href', dataUrl);
+            expect(mockAnchorElement.click).toHaveBeenCalledTimes(1);
+
+            // Get the download filename from the setAttribute calls
+            const setAttributeCalls = mockAnchorElement.setAttribute.mock.calls;
+            const downloadCall = setAttributeCalls.find((call: any[]) => call[0] === 'download');
+            const filename = downloadCall[1];
+
+            // Verify filename format: test_entity_YYYY-MM-DD_HHMMSS.png
+            expect(filename).toMatch(/^test_entity_\d{4}-\d{2}-\d{2}_\d{6}\.png$/);
+
+            // Extract and verify date part (YYYY-MM-DD)
+            const parts = filename.split('_');
+            const datePart = parts[2];
+            expect(datePart).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+            // Extract and verify time part (HHMMSS)
+            const timePart = parts[3].replace('.png', '');
+            expect(timePart).toMatch(/^\d{6}$/);
+            expect(timePart.length).toBe(6);
+        });
+    });
+});

--- a/datahub-web-react/src/app/lineageV3/utils/lineageUtils.ts
+++ b/datahub-web-react/src/app/lineageV3/utils/lineageUtils.ts
@@ -1,0 +1,87 @@
+import { useLocation } from 'react-router-dom';
+
+import { KEY_SCHEMA_PREFIX, VERSION_PREFIX } from '@app/entity/dataset/profile/schema/utils/constants';
+import { getFieldPathFromSchemaFieldUrn } from '@app/entityV2/schemaField/utils';
+import { useEntityRegistry } from '@app/useEntityRegistry';
+import { EntityRegistry } from '@src/entityRegistryContext';
+
+import { EntityType, SchemaField } from '@types';
+
+export function downgradeV2FieldPath(fieldPath: string): string;
+export function downgradeV2FieldPath(fieldPath?: string | null) {
+    if (!fieldPath) {
+        return fieldPath;
+    }
+
+    const cleanedFieldPath = fieldPath.replace(KEY_SCHEMA_PREFIX, '').replace(VERSION_PREFIX, '');
+
+    // strip out all annotation segments
+    return cleanedFieldPath
+        .split('.')
+        .map((segment) => (segment.startsWith('[') ? null : segment))
+        .filter(Boolean)
+        .join('.');
+}
+
+export function processDocumentationString(docString): string {
+    if (!docString) {
+        return '';
+    }
+    const fieldRegex = /'(\[version=2\.0\](?:\.\[key=True\])?\.\[type=[^\]]+\]\.[^']+)'/g;
+    return docString.replace(fieldRegex, (_, fieldPath) => `'${downgradeV2FieldPath(fieldPath)}'`);
+}
+
+export function convertFieldsToV1FieldPath(fields: SchemaField[]) {
+    return fields.map((field) => ({
+        ...field,
+        fieldPath: downgradeV2FieldPath(field.fieldPath) || '',
+    }));
+}
+
+export function getV1FieldPathFromSchemaFieldUrn(schemaFieldUrn: string) {
+    return downgradeV2FieldPath(getFieldPathFromSchemaFieldUrn(schemaFieldUrn)) as string;
+}
+
+export function getEntityTypeFromEntityUrn(urn: string, registry: EntityRegistry): EntityType | undefined {
+    const [, , entityType] = urn.split(':');
+    return registry.getTypeFromGraphName(entityType);
+}
+
+export function getLineageUrl(
+    urn: string,
+    type: EntityType,
+    location: ReturnType<typeof useLocation>,
+    entityRegistry: EntityRegistry,
+) {
+    return `${entityRegistry.getEntityUrl(type, urn)}/Lineage${location.search}`;
+}
+
+export function useGetLineageUrl(urn?: string, type?: EntityType) {
+    const location = useLocation();
+    const entityRegistry = useEntityRegistry();
+
+    if (!urn || !type) {
+        return '';
+    }
+
+    return getLineageUrl(urn, type, location, entityRegistry);
+}
+
+export function downloadImage(dataUrl: string, name?: string) {
+    const now = new Date();
+    const dateStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
+        now.getDate(),
+    ).padStart(2, '0')}`;
+
+    const timeStr = `${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(
+        now.getSeconds(),
+    ).padStart(2, '0')}`;
+
+    const fileNamePrefix = name ? `${name}_` : 'reactflow_';
+    const fileName = `${fileNamePrefix}${dateStr}_${timeStr}.png`;
+
+    const a = document.createElement('a');
+    a.setAttribute('download', fileName);
+    a.setAttribute('href', dataUrl);
+    a.click();
+}


### PR DESCRIPTION
## Summary 

Lineage screenshot filenames now contain the dataset name:  `{dataset name}_{timestamp}` 

| Before      | After |
| ----------- | ----------- |
| <img width="314" height="100" alt="Screenshot 2025-07-18 at 3 31 43 PM" src="https://github.com/user-attachments/assets/857ddbe0-1d71-4ce5-8666-1d2c185c810a" /> |  <img width="311" height="115" alt="Screenshot 2025-07-18 at 5 45 34 PM" src="https://github.com/user-attachments/assets/2a621081-e544-41e5-9b01-9fa93b2dd51b" /> |



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
