### PR TITLE
feat(siblings): Fix siblings search to apply consistent ordering

### DIFF
--- a/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.test.ts
+++ b/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.test.ts
@@ -518,6 +518,233 @@ const searchResultWithGhostSiblings = [
     },
 ];
 
+// --- Test data for DBT/Snowflake sibling handling ---
+const dbtSnowflakeCommonName = 'dbt_plus_snowflake_asset';
+const dbtPlatformName = 'dbt';
+const snowflakePlatformName = 'snowflake';
+
+const dbtUrn = `urn:li:dataset:(urn:li:dataPlatform:${dbtPlatformName},${dbtSnowflakeCommonName},PROD)`;
+const snowflakeUrn = `urn:li:dataset:(urn:li:dataPlatform:${snowflakePlatformName},${dbtSnowflakeCommonName},PROD)`;
+
+const dbtSiblingEntityData = {
+    urn: dbtUrn,
+    exists: true,
+    type: 'DATASET',
+    name: dbtSnowflakeCommonName,
+    platform: {
+        urn: `urn:li:dataPlatform:${dbtPlatformName}`,
+        type: 'DATA_PLATFORM',
+        name: dbtPlatformName,
+        properties: {
+            type: 'OTHERS',
+            displayName: 'dbt',
+            datasetNameDelimiter: '.',
+            logoUrl: '/assets/platforms/dbtlogo.png',
+            __typename: 'DataPlatformProperties',
+        },
+        __typename: 'DataPlatform',
+    },
+    properties: { name: 'dbt_plus_snowflake_asset', __typename: 'DatasetProperties' }, // Simplified properties
+    __typename: 'Dataset',
+};
+
+const snowflakeSiblingEntityData = {
+    urn: snowflakeUrn,
+    exists: true,
+    type: 'DATASET',
+    name: dbtSnowflakeCommonName,
+    platform: {
+        urn: `urn:li:dataPlatform:${snowflakePlatformName}`,
+        type: 'DATA_PLATFORM',
+        name: snowflakePlatformName,
+        properties: {
+            type: 'WAREHOUSE',
+            displayName: 'Snowflake',
+            datasetNameDelimiter: '.',
+            logoUrl: '/assets/platforms/snowflakelogo.png',
+            __typename: 'DataPlatformProperties',
+        },
+        __typename: 'DataPlatform',
+    },
+    properties: { name: 'dbt_plus_snowflake_asset', __typename: 'DatasetProperties' }, // Simplified properties
+    __typename: 'Dataset',
+};
+
+const dbtSearchResultItem = {
+    entity: {
+        urn: dbtUrn,
+        exists: true,
+        type: 'DATASET',
+        name: dbtSnowflakeCommonName,
+        platform: {
+            urn: `urn:li:dataPlatform:${dbtPlatformName}`,
+            type: 'DATA_PLATFORM',
+            name: dbtPlatformName,
+            properties: {
+                type: 'OTHERS',
+                displayName: 'dbt',
+                datasetNameDelimiter: '.',
+                logoUrl: '/assets/platforms/dbtlogo.png',
+                __typename: 'DataPlatformProperties',
+            },
+            __typename: 'DataPlatform',
+        },
+        properties: { name: 'dbt_plus_snowflake_asset', __typename: 'DatasetProperties' },
+        siblingsSearch: {
+            searchResults: [{ entity: snowflakeSiblingEntityData }],
+        },
+        __typename: 'Dataset',
+    },
+    matchedFields: [{ name: 'name', value: dbtSnowflakeCommonName, __typename: 'MatchedField' }],
+    __typename: 'SearchResult',
+};
+
+const snowflakeSearchResultItem = {
+    entity: {
+        urn: snowflakeUrn,
+        exists: true,
+        type: 'DATASET',
+        name: dbtSnowflakeCommonName,
+        platform: {
+            urn: `urn:li:dataPlatform:${snowflakePlatformName}`,
+            type: 'DATA_PLATFORM',
+            name: snowflakePlatformName,
+            properties: {
+                type: 'WAREHOUSE',
+                displayName: 'Snowflake',
+                datasetNameDelimiter: '.',
+                logoUrl: '/assets/platforms/snowflakelogo.png',
+                __typename: 'DataPlatformProperties',
+            },
+            __typename: 'DataPlatform',
+        },
+        properties: { name: 'dbt_plus_snowflake_asset', __typename: 'DatasetProperties' },
+        siblingsSearch: {
+            searchResults: [{ entity: dbtSiblingEntityData }],
+        },
+        __typename: 'Dataset',
+    },
+    matchedFields: [{ name: 'name', value: dbtSnowflakeCommonName, __typename: 'MatchedField' }],
+    __typename: 'SearchResult',
+};
+
+const searchResultsDbtFirstSnowflakeSecond = [dbtSearchResultItem, snowflakeSearchResultItem];
+const searchResultsSnowflakeFirstDbtSecond = [snowflakeSearchResultItem, dbtSearchResultItem];
+// --- End of test data for DBT/Snowflake ---
+
+// --- Test data for non-DBT sibling handling ---
+const platformACommonName = 'platform_a_plus_platform_b_asset';
+const platformAName = 'platformA';
+const platformBName = 'platformB';
+
+const platformAUrn = `urn:li:dataset:(urn:li:dataPlatform:${platformAName},${platformACommonName},PROD)`;
+const platformBUrn = `urn:li:dataset:(urn:li:dataPlatform:${platformBName},${platformACommonName},PROD)`;
+
+const platformASiblingEntityData = {
+    urn: platformAUrn,
+    exists: true,
+    type: 'DATASET',
+    name: platformACommonName,
+    platform: {
+        urn: `urn:li:dataPlatform:${platformAName}`,
+        type: 'DATA_PLATFORM',
+        name: platformAName,
+        properties: {
+            type: 'OTHERS',
+            displayName: 'Platform A',
+            datasetNameDelimiter: '.',
+            logoUrl: '/assets/platforms/platformAlogo.png',
+            __typename: 'DataPlatformProperties',
+        },
+        __typename: 'DataPlatform',
+    },
+    properties: { name: platformACommonName, __typename: 'DatasetProperties' },
+    __typename: 'Dataset',
+};
+
+const platformBSiblingEntityData = {
+    urn: platformBUrn,
+    exists: true,
+    type: 'DATASET',
+    name: platformACommonName,
+    platform: {
+        urn: `urn:li:dataPlatform:${platformBName}`,
+        type: 'DATA_PLATFORM',
+        name: platformBName,
+        properties: {
+            type: 'OTHERS',
+            displayName: 'Platform B',
+            datasetNameDelimiter: '.',
+            logoUrl: '/assets/platforms/platformBlogo.png',
+            __typename: 'DataPlatformProperties',
+        },
+        __typename: 'DataPlatform',
+    },
+    properties: { name: platformACommonName, __typename: 'DatasetProperties' },
+    __typename: 'Dataset',
+};
+
+const platformASearchResultItem = {
+    entity: {
+        urn: platformAUrn,
+        exists: true,
+        type: 'DATASET',
+        name: platformACommonName,
+        platform: {
+            urn: `urn:li:dataPlatform:${platformAName}`,
+            type: 'DATA_PLATFORM',
+            name: platformAName,
+            properties: {
+                type: 'OTHERS',
+                displayName: 'Platform A',
+                datasetNameDelimiter: '.',
+                logoUrl: '/assets/platforms/platformAlogo.png',
+                __typename: 'DataPlatformProperties',
+            },
+            __typename: 'DataPlatform',
+        },
+        properties: { name: platformACommonName, __typename: 'DatasetProperties' },
+        siblingsSearch: {
+            searchResults: [{ entity: platformBSiblingEntityData }],
+        },
+        __typename: 'Dataset',
+    },
+    matchedFields: [{ name: 'name', value: platformACommonName, __typename: 'MatchedField' }],
+    __typename: 'SearchResult',
+};
+
+const platformBSearchResultItem = {
+    entity: {
+        urn: platformBUrn,
+        exists: true,
+        type: 'DATASET',
+        name: platformACommonName,
+        platform: {
+            urn: `urn:li:dataPlatform:${platformBName}`,
+            type: 'DATA_PLATFORM',
+            name: platformBName,
+            properties: {
+                type: 'OTHERS',
+                displayName: 'Platform B',
+                datasetNameDelimiter: '.',
+                logoUrl: '/assets/platforms/platformBlogo.png',
+                __typename: 'DataPlatformProperties',
+            },
+            __typename: 'DataPlatform',
+        },
+        properties: { name: platformACommonName, __typename: 'DatasetProperties' },
+        siblingsSearch: {
+            searchResults: [{ entity: platformASiblingEntityData }],
+        },
+        __typename: 'Dataset',
+    },
+    matchedFields: [{ name: 'name', value: platformACommonName, __typename: 'MatchedField' }],
+    __typename: 'SearchResult',
+};
+
+const searchResultsPlatformAFirstPlatformBSecond = [platformASearchResultItem, platformBSearchResultItem];
+// --- End of test data for non-DBT sibling handling ---
+
 describe('siblingUtils', () => {
     describe('combineSiblingsInSearchResults', () => {
         it('combines search results to deduplicate siblings', () => {
@@ -546,6 +773,135 @@ describe('siblingUtils', () => {
             expect(result?.[0]?.matchedEntities).toHaveLength(1);
 
             expect(result?.[0]?.matchedFields).toHaveLength(2);
+        });
+
+        describe('dbt and snowflake sibling handling', () => {
+            describe('when showSeparateSiblings is false (siblings combined)', () => {
+                it('handles DBT entity first, then Snowflake sibling: result uses Snowflake URN, DBT platform, includes both in matchedEntities', () => {
+                    const result = combineSiblingsInSearchResults(false, searchResultsDbtFirstSnowflakeSecond as any);
+
+                    expect(result).toHaveLength(1);
+                    expect((result[0] as any).entity.urn).toEqual(snowflakeUrn); // Combined entity uses Snowflake URN
+                    expect((result[0] as any).entity.platform?.name).toEqual(dbtPlatformName); // Platform is from the (modified) DBT entity
+                });
+
+                it('handles Snowflake entity first, then DBT sibling: result uses Snowflake URN and platform, includes both in matchedEntities', () => {
+                    const result = combineSiblingsInSearchResults(false, searchResultsSnowflakeFirstDbtSecond as any);
+
+                    expect(result).toHaveLength(1);
+                    expect((result[0] as any).entity.urn).toEqual(snowflakeUrn); // Combined entity uses Snowflake URN
+                    expect((result[0] as any).entity.platform?.name).toEqual(snowflakePlatformName); // Platform is from the Snowflake entity
+                });
+            });
+
+            describe('when showSeparateSiblings is true (siblings not combined)', () => {
+                it('handles DBT entity first, then Snowflake sibling: keeps both entities as is', () => {
+                    const result = combineSiblingsInSearchResults(true, searchResultsDbtFirstSnowflakeSecond as any);
+
+                    expect(result).toHaveLength(2);
+                    // First entity should be the original DBT entity
+                    expect((result[0] as any).urn).toEqual(dbtUrn);
+                    expect((result[0] as any).platform?.name).toEqual(dbtPlatformName);
+
+                    // Second entity should be the original Snowflake entity
+                    expect((result[1] as any).urn).toEqual(snowflakeUrn);
+                    expect((result[1] as any).platform?.name).toEqual(snowflakePlatformName);
+                });
+
+                it('handles Snowflake entity first, then DBT sibling: keeps both entities as is', () => {
+                    const result = combineSiblingsInSearchResults(true, searchResultsSnowflakeFirstDbtSecond as any);
+
+                    expect(result).toHaveLength(2);
+                    // First entity should be the original Snowflake entity
+                    expect((result[0] as any).urn).toEqual(snowflakeUrn);
+                    expect((result[0] as any).platform?.name).toEqual(snowflakePlatformName);
+
+                    // Second entity should be the original DBT entity
+                    expect((result[1] as any).urn).toEqual(dbtUrn);
+                    expect((result[1] as any).platform?.name).toEqual(dbtPlatformName);
+                });
+            });
+        });
+
+        describe('edge cases', () => {
+            it('handles entities with missing sibling URN gracefully', () => {
+                const searchResultWithMissingSibling = [{
+                    entity: {
+                        urn: dbtUrn,
+                        platform: { name: 'dbt' },
+                        siblingsSearch: {
+                            searchResults: [{ 
+                                entity: { 
+                                    // Missing urn property
+                                    platform: { name: 'snowflake' }
+                                }
+                            }]
+                        }
+                    },
+                    matchedFields: []
+                }];
+                
+                const result = combineSiblingsInSearchResults(false, searchResultWithMissingSibling as any);
+                // Should not crash and should process normally
+                expect(result).toHaveLength(1);
+                expect((result[0] as any).entity.urn).toEqual(dbtUrn);
+            });
+
+            it('handles entities with empty siblingsSearch gracefully', () => {
+                const searchResultWithEmptySiblings = [{
+                    entity: {
+                        urn: dbtUrn,
+                        platform: { name: 'dbt' },
+                        siblingsSearch: {
+                            searchResults: []
+                        }
+                    },
+                    matchedFields: []
+                }];
+                
+                const result = combineSiblingsInSearchResults(false, searchResultWithEmptySiblings as any);
+                // Should not crash and should process normally
+                expect(result).toHaveLength(1);
+                expect((result[0] as any).entity.urn).toEqual(dbtUrn);
+            });
+        });
+
+        describe('non-DBT sibling handling', () => {
+            it('combines two non-DBT siblings generically (no URN swapping) when showSeparateSiblings is false', () => {
+                const result = combineSiblingsInSearchResults(false, searchResultsPlatformAFirstPlatformBSecond as any);
+
+                expect(result).toHaveLength(1);
+                const combinedEntry = result[0] as any;
+
+                // Assuming platformA is chosen as the primary by the generic combine() because it's first in the input list
+                // The `entity` property of the result should be the main display entity.
+                expect(combinedEntry.entity.urn).toEqual(platformAUrn);
+                expect(combinedEntry.entity.platform?.name).toEqual(platformAName);
+
+                // Both original entities should be present in matchedEntities
+                expect(combinedEntry.matchedEntities).toHaveLength(2);
+                const entityAInMatched = combinedEntry.matchedEntities.find((e: any) => e.urn === platformAUrn);
+                const entityBInMatched = combinedEntry.matchedEntities.find((e: any) => e.urn === platformBUrn);
+
+                expect(entityAInMatched).toBeDefined();
+                expect(entityAInMatched.platform.name).toEqual(platformAName); // Verify no platform swapping
+                expect(entityBInMatched).toBeDefined();
+                expect(entityBInMatched.platform.name).toEqual(platformBName); // Verify no platform swapping
+            });
+
+            it('does not combine two non-DBT siblings when showSeparateSiblings is true', () => {
+                const result = combineSiblingsInSearchResults(true, searchResultsPlatformAFirstPlatformBSecond as any);
+
+                expect(result).toHaveLength(2);
+                // The structure for showSeparateSiblings: true currently spreads entity properties to the top level of the result item.
+                // First entity should be the original Platform A entity
+                expect((result[0] as any).urn).toEqual(platformAUrn);
+                expect((result[0] as any).platform?.name).toEqual(platformAName);
+
+                // Second entity should be the original Platform B entity
+                expect((result[1] as any).urn).toEqual(platformBUrn);
+                expect((result[1] as any).platform?.name).toEqual(platformBName);
+            });
         });
     });
 });

--- a/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
+++ b/datahub-web-react/src/app/searchV2/utils/combineSiblingsInSearchResults.ts
@@ -2,11 +2,18 @@ import { CombinedEntity, createSiblingEntityCombiner } from '@app/entity/shared/
 
 import { Entity, EntityPath, MatchedField } from '@types';
 
+type MaybeEntityWithPlatform = Entity & { platform?: { name?: string }; urn?: string };
+type MaybeEntityWithSiblings = Entity & { platform?: { name?: string }; urn?: string } & {
+    siblingsSearch?: { searchResults?: { entity?: MaybeEntityWithPlatform }[] };
+};
+
 type UncombinedSeaerchResults = {
-    entity: Entity;
+    entity: MaybeEntityWithSiblings;
     matchedFields: Array<MatchedField>;
     paths?: EntityPath[];
 };
+
+const DBT_PLATFORM = 'dbt';
 
 export type CombinedSearchResult = CombinedEntity &
     Pick<UncombinedSeaerchResults, 'matchedFields'> &
@@ -19,10 +26,50 @@ export function combineSiblingsInSearchResults(
     const combine = createSiblingEntityCombiner();
     const combinedSearchResults: Array<CombinedSearchResult> = [];
 
-    searchResults.forEach((searchResult) => {
-        const combinedResult = showSeparateSiblings
-            ? { combinedEntity: searchResult.entity, skipped: false }
-            : combine(searchResult.entity);
+    const originalUrnList = searchResults.map((result) => result.entity.urn);
+
+    // With usage propagation from snowflake to dbt, dbt and snowflake siblings do not rank
+    // consistently in search. in cases where they both show up in the same page, we should have
+    // the warehouse urn win for consistency.
+    searchResults.forEach((searchResult, index) => {
+        let entityToProcess = searchResult.entity;
+
+        // If showing separate siblings, skip the complex logic and just add the entity
+        if (showSeparateSiblings) {
+            combinedSearchResults.push({
+                ...searchResult,
+                ...entityToProcess,
+            });
+            return;
+        }
+
+        // properly handle cases where non-dbt and dbt siblings are both present in results.
+        const siblingUrn = entityToProcess?.siblingsSearch?.searchResults?.[0]?.entity?.urn || '';
+        const hasSiblingInList = originalUrnList.includes(siblingUrn);
+        const entityPlatform = entityToProcess?.platform?.name;
+        const siblingPlatform = entityToProcess?.siblingsSearch?.searchResults?.[0]?.entity?.platform?.name;
+        const isDbtAndWarehouseSibling = entityPlatform === DBT_PLATFORM && siblingPlatform !== DBT_PLATFORM;
+
+        const siblingIndex = siblingUrn ? originalUrnList.indexOf(siblingUrn) : -1;
+        const isSiblingAheadInTheList = siblingIndex !== -1 && siblingIndex < index;
+
+        if (hasSiblingInList && isDbtAndWarehouseSibling) {
+            // Skip if sibling is ahead in the list (already rendered or will be rendered with warehouse URN)
+            if (isSiblingAheadInTheList) {
+                return;
+            }
+            
+            // If this is a DBT entity and sibling is not ahead, use the warehouse URN
+            if (entityPlatform === DBT_PLATFORM) {
+                entityToProcess = {
+                    ...entityToProcess,
+                    urn: siblingUrn,
+                };
+            }
+            // Non-DBT entities render normally (no action needed)
+        }
+
+        const combinedResult = combine(entityToProcess);
         if (!combinedResult.skipped) {
             combinedSearchResults.push({
                 ...searchResult,


### PR DESCRIPTION
Compressed version of https://github.com/datahub-project/datahub/pull/13573 with fixes applied

With the addition of usage propagation from the warehouse to dbt, we reached a point of non-determinism where dbt and warehouse results will somewhat arbitrarily be ahead of each other in search results. Currently, our search will link the user to whichever result happened to be ranked higher. Rather than leaving things up to chance, in cases where both show up on the same page, we are changing the logic to consistently link to the warehouse. This lines up with the behavior before we added usage propagation to dbt, which was that the warehous was consistently ranked higher.

Test plan:

tested live
added unit tests

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
