### PR TITLE
fix(customHomePage): fix unnecessary expanding of selected nodes

### DIFF
--- a/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/domains/DomainsSelectableTreeView.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/domains/DomainsSelectableTreeView.tsx
@@ -65,8 +65,8 @@ export default function DomainsSelectableTreeView() {
                     loading={loading}
                     nodes={tree.nodes}
                     explicitlySelectParent
+                    expandParentNodesOfInitialSelectedValues
                     selectedValues={selectedValues}
-                    expandedValues={initialSelectedValues}
                     updateSelectedValues={updateSelectedValues}
                     loadChildren={startLoadingOfChildren}
                     renderNodeLabel={(nodeProps) => <DomainSelectableTreeNodeRenderer {...nodeProps} />}

--- a/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/glossary/GlossarySelectableTreeView.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/glossary/GlossarySelectableTreeView.tsx
@@ -64,10 +64,10 @@ export default function GlossarySelectableTreeView() {
                 <TreeView
                     selectable
                     explicitlySelectParent
+                    expandParentNodesOfInitialSelectedValues
                     loading={loading}
                     nodes={tree.nodes}
                     selectedValues={selectedValues}
-                    expandedValues={initialSelectedValues}
                     updateSelectedValues={updateSelectedValues}
                     loadChildren={startLoadingOfChildren}
                     renderNodeLabel={(nodeProps) => <GlossaryTreeNodeRenderer {...nodeProps} />}

--- a/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/treeView/types.ts
+++ b/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/treeView/types.ts
@@ -85,8 +85,8 @@ export interface TreeViewContextProviderProps {
     selectedValues?: string[];
     // Called when selection state changed (`values` is the full list of selected values)
     updateSelectedValues?: (values: string[]) => void;
-    // If enabled all
-    expandInitialSelectedNodes?: boolean;
+    // If enabled  it expands all parent nodes of initial selected values
+    expandParentNodesOfInitialSelectedValues?: boolean;
     // If enabled it prevents selecting of all children if parent was selected
     explicitlySelectChildren?: boolean;
     // If enabled it prevents unselecting of children if parent was unselected


### PR DESCRIPTION
Now when an user opens the hierarchy module with already selected values, only parent nodes of selected nodes will be expanded. Before this fix selected nodes would be expanded too.

<img width="1100" height="376" alt="image" src="https://github.com/user-attachments/assets/014f1b95-6d27-4681-a44b-8249337f61d6" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
