### PR TITLE
feat(meta-mapping): support meta mappings of lists

### DIFF
--- a/metadata-ingestion/docs/sources/dbt/dbt.md
+++ b/metadata-ingestion/docs/sources/dbt/dbt.md
@@ -78,6 +78,28 @@ Note:
 
 1. The dbt `meta_mapping` config works at the model level, while the `column_meta_mapping` config works at the column level. The `add_owner` operation is not supported at the column level.
 2. For string meta properties we support regex matching.
+3. **List support**: YAML lists are now supported in meta properties. Each item in the list that matches the regex pattern will be processed. For example:
+
+   ```yaml
+   meta:
+     owners:
+       - user1@company.com
+       - user2@company.com
+       - external@other.com
+   ```
+
+   With a meta mapping like:
+
+   ```yaml
+   meta_mapping:
+     owners:
+       match: ".*@company.com"
+       operation: "add_owner"
+       config:
+         owner_type: user
+   ```
+
+   This will create owners for `user1@company.com` and `user2@company.com` (matching the pattern) but skip `external@other.com` (not matching).
 
 With regex matching, you can also use the matched value to customize how you populate the tag, term or owner fields. Here are a few advanced examples:
 
@@ -174,6 +196,29 @@ meta_mapping:
 ```
 
 In the examples above, we show two ways of writing the matching regexes. In the first one, `^@(.*)` the first matching group (a.k.a. match.group(1)) is automatically inferred. In the second example, `^@(?P<owner>(.*))`, we use a named matching group (called owner, since we are matching an owner) to capture the string we want to provide to the ownership urn.
+
+#### Working with Lists
+
+YAML lists are fully supported in dbt meta properties. Each item in the list is evaluated against the match pattern, and only matching items are processed.
+
+```yaml
+meta:
+  owners:
+    - alice@company.com
+    - bob@company.com
+    - contractor@external.com
+```
+
+```yaml
+meta_mapping:
+  owners:
+    match: ".*@company.com"
+    operation: "add_owner"
+    config:
+      owner_type: user
+```
+
+This will add `alice@company.com` and `bob@company.com` as owners (matching `.*@company.com`) but skip `contractor@external.com` (doesn't match the pattern).
 
 ### dbt query_tag automated mappings
 

--- a/metadata-ingestion/docs/sources/dbt/dbt.md
+++ b/metadata-ingestion/docs/sources/dbt/dbt.md
@@ -78,28 +78,7 @@ Note:
 
 1. The dbt `meta_mapping` config works at the model level, while the `column_meta_mapping` config works at the column level. The `add_owner` operation is not supported at the column level.
 2. For string meta properties we support regex matching.
-3. **List support**: YAML lists are now supported in meta properties. Each item in the list that matches the regex pattern will be processed. For example:
-
-   ```yaml
-   meta:
-     owners:
-       - user1@company.com
-       - user2@company.com
-       - external@other.com
-   ```
-
-   With a meta mapping like:
-
-   ```yaml
-   meta_mapping:
-     owners:
-       match: ".*@company.com"
-       operation: "add_owner"
-       config:
-         owner_type: user
-   ```
-
-   This will create owners for `user1@company.com` and `user2@company.com` (matching the pattern) but skip `external@other.com` (not matching).
+3. **List support**: YAML lists are now supported in meta properties. Each item in the list that matches the regex pattern will be processed.
 
 With regex matching, you can also use the matched value to customize how you populate the tag, term or owner fields. Here are a few advanced examples:
 

--- a/metadata-ingestion/tests/unit/test_mapping.py
+++ b/metadata-ingestion/tests/unit/test_mapping.py
@@ -452,3 +452,65 @@ def test_validate_ownership_type_non_urn_invalid():
     # Non-urn input that is not valid should raise ValueError.
     with pytest.raises(ValueError):
         validate_ownership_type("invalid_type")
+
+
+def test_operation_processor_list_values():
+    """Test that list values are properly handled in operation definitions."""
+    raw_props = {
+        "owners_list": [
+            "owner1@company.com",
+            "owner2@company.com",
+            "owner3@company.com",
+        ],
+        "tags_list": ["tag1", "tag2", "tag3"],
+        "mixed_list": ["match1", "nomatch", "match2"],
+    }
+
+    processor = OperationProcessor(
+        operation_defs={
+            "owners_list": {
+                "match": ".*@company.com",
+                "operation": "add_owner",
+                "config": {"owner_type": "user"},
+            },
+            "tags_list": {
+                "match": "tag.*",
+                "operation": "add_tag",
+                "config": {"tag": "list_{{ $match }}"},
+            },
+            "mixed_list": {
+                "match": "match.*",
+                "operation": "add_term",
+                "config": {"term": "{{ $match }}"},
+            },
+        },
+        strip_owner_email_id=True,
+    )
+
+    aspect_map = processor.process(raw_props)
+
+    # Test owners from list
+    assert "add_owner" in aspect_map
+    ownership_aspect: OwnershipClass = aspect_map["add_owner"]
+    assert len(ownership_aspect.owners) == 3
+    owner_urns = {owner.owner for owner in ownership_aspect.owners}
+    expected_owners = {
+        "urn:li:corpuser:owner1",
+        "urn:li:corpuser:owner2",
+        "urn:li:corpuser:owner3",
+    }
+    assert owner_urns == expected_owners
+
+    # Test tags from list - note: tags use the match replacement but join with comma
+    assert "add_tag" in aspect_map
+    tag_aspect: GlobalTagsClass = aspect_map["add_tag"]
+    assert len(tag_aspect.tags) == 1
+    # The matched values get joined with comma, and commas get URL-encoded in URNs
+    assert tag_aspect.tags[0].tag == "urn:li:tag:list_tag1%2Ctag2%2Ctag3"
+
+    # Test terms from list - only matching items
+    assert "add_term" in aspect_map
+    term_aspect: GlossaryTermsClass = aspect_map["add_term"]
+    assert len(term_aspect.terms) == 1
+    # The matched values get joined with comma - terms don't get URL-encoded
+    assert term_aspect.terms[0].urn == "urn:li:glossaryTerm:match1,match2"


### PR DESCRIPTION
YAML lists are fully supported in dbt meta properties. Each item in the list is evaluated against the match pattern, and only matching items are processed.

```yaml
meta:
  owners:
    - alice@company.com
    - bob@company.com
    - contractor@external.com
```

```yaml
meta_mapping:
  owners:
    match: ".*@company.com"
    operation: "add_owner"
    config:
      owner_type: user
```


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
