### PR TITLE
fix(ingest): multi-database ingestion config supported by odbc connections

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -751,6 +751,7 @@ full_test_dev_requirements = {
             "mongodb",
             "slack",
             "mssql",
+            "mssql-odbc",
             "mysql",
             "mariadb",
             "redash",

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
@@ -160,9 +160,11 @@ class SQLServerConfig(BasicSQLAlchemyConfig):
             uri_opts=uri_opts,
         )
         if self.use_odbc:
-            uri_args = ({k:v for k,v in self.uri_args.items() if k.lower() != 'database'}
-                       if current_db else
-                       self.uri_args)
+            uri_args = (
+                {k: v for k, v in self.uri_args.items() if k.lower() != "database"}
+                if current_db
+                else self.uri_args
+            )
             uri = f"{uri}?{urllib.parse.urlencode(uri_args)}"
         return uri
 
@@ -954,7 +956,7 @@ class SQLServerSource(SQLAlchemySource):
                        'distribution' , 'reportserver', 'reportservertempdb'); "
             ).fetchall()
         return [db["name"] for db in databases]
-    
+
     def _inspector_for_database(self, db_name: str) -> Inspector:
         url = self.config.get_sql_alchemy_url(current_db=db_name)
         engine = create_engine(url, **self.config.options)

--- a/metadata-ingestion/tests/unit/test_mssql.py
+++ b/metadata-ingestion/tests/unit/test_mssql.py
@@ -311,13 +311,19 @@ def test_get_sql_alchemy_url_ignores_config_db_when_override_is_provided():
         username="test",
         password="test",
         use_odbc=True,
-        uri_args={'database': config_defined_db, 'driver': 'some_driver_value'},
+        uri_args={"database": config_defined_db, "driver": "some_driver_value"},
     )
 
     # Mock to avoid DB connections
-    with patch("datahub.ingestion.source.sql.sql_common.SQLAlchemySource.__init__"), \
-         patch("datahub.ingestion.source.sql.mssql.source.SQLServerSource._database_names_from_engine") as mock_db_names, \
-         patch("datahub.ingestion.source.sql.mssql.source.SQLServerSource._inspector_for_database"):
+    with (
+        patch("datahub.ingestion.source.sql.sql_common.SQLAlchemySource.__init__"),
+        patch(
+            "datahub.ingestion.source.sql.mssql.source.SQLServerSource._database_names_from_engine"
+        ) as mock_db_names,
+        patch(
+            "datahub.ingestion.source.sql.mssql.source.SQLServerSource._inspector_for_database"
+        ),
+    ):
         mock_db_names.return_value = [override_db]
         source = SQLServerSource(config, MagicMock())
 
@@ -329,6 +335,8 @@ def test_get_sql_alchemy_url_ignores_config_db_when_override_is_provided():
         assert override_db not in default_connection
 
         # assert that when overridden, the override database is used
-        override_db_connection = source.config.get_sql_alchemy_url(current_db=override_db)
+        override_db_connection = source.config.get_sql_alchemy_url(
+            current_db=override_db
+        )
         assert override_db in override_db_connection
         assert config_defined_db not in override_db_connection


### PR DESCRIPTION
Per the docs if the database field is omitted from the config then all databases are considered for ingestion. This was not the case as the metadata ingested into a datahub instance contained only the initial connection database contents

fixes https://github.com/datahub-project/datahub/issues/11185
