### PR TITLE
fix(lineage): Improve lineage logging (#6242)

### DIFF
--- a/datahub-web-react/src/app/analytics/__tests__/columnFilterAnalytics.test.ts
+++ b/datahub-web-react/src/app/analytics/__tests__/columnFilterAnalytics.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EventType } from '@app/analytics/event';
+
+// Mock analytics
+const mockAnalyticsEvent = vi.fn();
+vi.mock('@app/analytics', () => ({
+    default: {
+        event: mockAnalyticsEvent,
+    },
+}));
+
+/**
+ * Tests for enhanced column filter analytics that distinguish between:
+ * 1. User-applied fieldPaths filters (hasUserAppliedColumnFilter)
+ * 2. Schema field URN context from navigation (isSchemaFieldContext)
+ */
+describe('Enhanced Column Filter Analytics', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const baseEventProps = {
+        query: 'test query',
+        page: 1,
+        total: 100,
+        maxDegree: '3',
+    };
+
+    describe('User-Applied Column Filters', () => {
+        it('should track when user applies fieldPaths filter only', () => {
+            const mockEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true, // backward compatibility
+                hasUserAppliedColumnFilter: true,
+                isSchemaFieldContext: false,
+            };
+
+            // Simulate the analytics call
+            mockAnalyticsEvent(mockEvent);
+
+            expect(mockAnalyticsEvent).toHaveBeenCalledWith({
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true,
+                hasUserAppliedColumnFilter: true,
+                isSchemaFieldContext: false,
+            });
+        });
+
+        it('should track multiple field paths in user filter', () => {
+            const mockEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true,
+                hasUserAppliedColumnFilter: true, // User selected multiple columns
+                isSchemaFieldContext: false,
+            };
+
+            mockAnalyticsEvent(mockEvent);
+
+            expect(mockAnalyticsEvent).toHaveBeenCalledWith(mockEvent);
+        });
+    });
+
+    describe('Schema Field URN Context', () => {
+        it('should track when navigated from schema field URN only', () => {
+            const mockEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true, // backward compatibility
+                hasUserAppliedColumnFilter: false,
+                isSchemaFieldContext: true,
+            };
+
+            mockAnalyticsEvent(mockEvent);
+
+            expect(mockAnalyticsEvent).toHaveBeenCalledWith({
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true,
+                hasUserAppliedColumnFilter: false,
+                isSchemaFieldContext: true,
+            });
+        });
+
+        it('should distinguish schema field context from user filter', () => {
+            // First call: Schema field context only
+            const schemaFieldEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true,
+                hasUserAppliedColumnFilter: false,
+                isSchemaFieldContext: true,
+            };
+
+            mockAnalyticsEvent(schemaFieldEvent);
+
+            // Second call: User-applied filter only
+            const userFilterEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true,
+                hasUserAppliedColumnFilter: true,
+                isSchemaFieldContext: false,
+            };
+
+            mockAnalyticsEvent(userFilterEvent);
+
+            expect(mockAnalyticsEvent).toHaveBeenCalledTimes(2);
+            expect(mockAnalyticsEvent).toHaveBeenNthCalledWith(1, schemaFieldEvent);
+            expect(mockAnalyticsEvent).toHaveBeenNthCalledWith(2, userFilterEvent);
+        });
+    });
+
+    describe('Combined Scenarios', () => {
+        it('should track when both user filter and schema field context are present', () => {
+            const mockEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true, // backward compatibility
+                hasUserAppliedColumnFilter: true,
+                isSchemaFieldContext: true,
+            };
+
+            mockAnalyticsEvent(mockEvent);
+
+            expect(mockAnalyticsEvent).toHaveBeenCalledWith(mockEvent);
+        });
+
+        it('should track when neither filter type is present', () => {
+            const mockEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: false, // backward compatibility
+                hasUserAppliedColumnFilter: false,
+                isSchemaFieldContext: false,
+            };
+
+            mockAnalyticsEvent(mockEvent);
+
+            expect(mockAnalyticsEvent).toHaveBeenCalledWith(mockEvent);
+        });
+    });
+
+    describe('Backward Compatibility', () => {
+        it('should maintain hasColumnFilter for existing analytics', () => {
+            // Test that hasColumnFilter still works as expected
+            const testCases = [
+                {
+                    userFilter: false,
+                    schemaField: false,
+                    expectedHasColumnFilter: false,
+                },
+                {
+                    userFilter: true,
+                    schemaField: false,
+                    expectedHasColumnFilter: true,
+                },
+                {
+                    userFilter: false,
+                    schemaField: true,
+                    expectedHasColumnFilter: true,
+                },
+                {
+                    userFilter: true,
+                    schemaField: true,
+                    expectedHasColumnFilter: true,
+                },
+            ];
+
+            testCases.forEach(({ userFilter, schemaField, expectedHasColumnFilter }, index) => {
+                const mockEvent = {
+                    type: EventType.SearchAcrossLineageResultsViewEvent,
+                    ...baseEventProps,
+                    hasColumnFilter: expectedHasColumnFilter,
+                    hasUserAppliedColumnFilter: userFilter,
+                    isSchemaFieldContext: schemaField,
+                };
+
+                mockAnalyticsEvent(mockEvent);
+
+                expect(mockAnalyticsEvent).toHaveBeenNthCalledWith(index + 1, mockEvent);
+            });
+        });
+    });
+
+    describe('Real-world Usage Scenarios', () => {
+        it('should track user drilling down from table-level to column-level lineage', () => {
+            // Scenario: User starts at table lineage, then applies column filter
+            const tableLineageEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: false,
+                hasUserAppliedColumnFilter: false,
+                isSchemaFieldContext: false,
+            };
+
+            const columnLineageEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true,
+                hasUserAppliedColumnFilter: true, // User applied filter
+                isSchemaFieldContext: false,
+            };
+
+            mockAnalyticsEvent(tableLineageEvent);
+            mockAnalyticsEvent(columnLineageEvent);
+
+            expect(mockAnalyticsEvent).toHaveBeenCalledTimes(2);
+            expect(mockAnalyticsEvent).toHaveBeenNthCalledWith(1, tableLineageEvent);
+            expect(mockAnalyticsEvent).toHaveBeenNthCalledWith(2, columnLineageEvent);
+        });
+
+        it('should track navigation from schema tab to lineage', () => {
+            // Scenario: User clicks on column in schema tab, gets navigated to lineage
+            const schemaNavigationEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true,
+                hasUserAppliedColumnFilter: false,
+                isSchemaFieldContext: true, // Came from schema field navigation
+            };
+
+            mockAnalyticsEvent(schemaNavigationEvent);
+
+            expect(mockAnalyticsEvent).toHaveBeenCalledWith(schemaNavigationEvent);
+        });
+
+        it('should track progressive refinement: navigation + user filter', () => {
+            // Scenario: User navigates from schema field, then applies additional filters
+            const progressiveRefinementEvent = {
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                ...baseEventProps,
+                hasColumnFilter: true,
+                hasUserAppliedColumnFilter: true, // User added more filters
+                isSchemaFieldContext: true, // Still in schema field context
+            };
+
+            mockAnalyticsEvent(progressiveRefinementEvent);
+
+            expect(mockAnalyticsEvent).toHaveBeenCalledWith(progressiveRefinementEvent);
+        });
+    });
+
+    describe('Analytics Insights', () => {
+        it('should enable insights about user behavior patterns', () => {
+            // This test demonstrates the kind of insights we can now gather
+            const analyticsInsights = {
+                userDiscoveryPatterns: {
+                    explicitColumnFiltering: 'hasUserAppliedColumnFilter=true & isSchemaFieldContext=false',
+                    schemaFieldDrillDown: 'hasUserAppliedColumnFilter=false & isSchemaFieldContext=true',
+                    progressiveRefinement: 'hasUserAppliedColumnFilter=true & isSchemaFieldContext=true',
+                    tableLineageOnly: 'hasUserAppliedColumnFilter=false & isSchemaFieldContext=false',
+                },
+                migrationPath: {
+                    // Can still use hasColumnFilter for existing dashboards
+                    // while migrating to more granular fields
+                    legacy: 'hasColumnFilter',
+                    enhanced: 'hasUserAppliedColumnFilter + isSchemaFieldContext',
+                },
+            };
+
+            expect(analyticsInsights.userDiscoveryPatterns).toBeDefined();
+            expect(analyticsInsights.migrationPath).toBeDefined();
+        });
+    });
+});

--- a/datahub-web-react/src/app/analytics/__tests__/useTrackPageView.test.ts
+++ b/datahub-web-react/src/app/analytics/__tests__/useTrackPageView.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSameEntityTabNavigation } from '@app/analytics/useTrackPageView';
+
+describe('isSameEntityTabNavigation', () => {
+    // Test data using actual entity types
+    const sampleUrn = 'urn:li:dataset:(urn:li:dataPlatform:mysql,my_database.my_table,PROD)';
+    const encodedUrn = encodeURIComponent(sampleUrn);
+    const differentUrn = 'urn:li:dataset:(urn:li:dataPlatform:postgres,other_db.other_table,PROD)';
+    const encodedDifferentUrn = encodeURIComponent(differentUrn);
+
+    describe('same entity, different tabs', () => {
+        it('should return true when navigating between tabs of the same dataset', () => {
+            const prevPath = `/dataset/${encodedUrn}/Schema`;
+            const currentPath = `/dataset/${encodedUrn}/Properties`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+        });
+
+        it('should return true when navigating between tabs of the same dashboard', () => {
+            const dashboardUrn = 'urn:li:dashboard:(looker,my_dashboard)';
+            const encodedDashboardUrn = encodeURIComponent(dashboardUrn);
+            const prevPath = `/dashboard/${encodedDashboardUrn}/Charts`;
+            const currentPath = `/dashboard/${encodedDashboardUrn}/Properties`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+        });
+
+        it('should return true when navigating to entity root from a tab', () => {
+            const prevPath = `/dataset/${encodedUrn}/Schema`;
+            const currentPath = `/dataset/${encodedUrn}/Properties`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+        });
+
+        it('should return true with additional path segments', () => {
+            const prevPath = `/dataset/${encodedUrn}/Schema/field/my_field`;
+            const currentPath = `/dataset/${encodedUrn}/Properties/owners`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+        });
+
+        it('should return true with query parameters', () => {
+            const prevPath = `/dataset/${encodedUrn}/Schema?view=table`;
+            const currentPath = `/dataset/${encodedUrn}/Properties?mode=edit`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+        });
+    });
+
+    describe('different entities', () => {
+        it('should return false when navigating between different datasets', () => {
+            const prevPath = `/dataset/${encodedUrn}/Schema`;
+            const currentPath = `/dataset/${encodedDifferentUrn}/Schema`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+
+        it('should return false when navigating between different entity types', () => {
+            const prevPath = `/dataset/${encodedUrn}/Schema`;
+            const currentPath = `/dashboard/${encodedUrn}/Properties`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+
+        it('should return false when navigating from entity to completely different page', () => {
+            const prevPath = `/dataset/${encodedUrn}/Schema`;
+            const currentPath = '/search/datasets';
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+    });
+
+    describe('invalid or non-entity paths', () => {
+        it('should return false for root path', () => {
+            const prevPath = '/';
+            const currentPath = `/dataset/${encodedUrn}/Schema`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+
+        it('should return false for search results', () => {
+            const prevPath = '/search/datasets';
+            const currentPath = '/search/dashboards';
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+
+        it('should return false for browse paths', () => {
+            const prevPath = '/browse/dataset';
+            const currentPath = '/browse/dashboard';
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+
+        it('should return false when one path is too short', () => {
+            const prevPath = '/dataset';
+            const currentPath = `/dataset/${encodedUrn}/Schema`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+
+        it('should return false when both paths are too short', () => {
+            const prevPath = '/dataset';
+            const currentPath = '/dashboard';
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+
+        it('should return false for empty paths', () => {
+            expect(isSameEntityTabNavigation('', '')).toBe(false);
+        });
+
+        it('should return false when one path is empty', () => {
+            const currentPath = `/dataset/${encodedUrn}/Schema`;
+            expect(isSameEntityTabNavigation('', currentPath)).toBe(false);
+            expect(isSameEntityTabNavigation(currentPath, '')).toBe(false);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle URNs with special characters', () => {
+            const specialUrn = 'urn:li:dataset:(urn:li:dataPlatform:mysql,my-db.my_table_2023,PROD)';
+            const encodedSpecialUrn = encodeURIComponent(specialUrn);
+            const prevPath = `/dataset/${encodedSpecialUrn}/Schema`;
+            const currentPath = `/dataset/${encodedSpecialUrn}/Properties`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+        });
+
+        it('should handle long URNs', () => {
+            const longUrn =
+                'urn:li:dataset:(urn:li:dataPlatform:snowflake,very_long_database_name.very_long_schema_name.very_long_table_name_with_lots_of_details,PROD)';
+            const encodedLongUrn = encodeURIComponent(longUrn);
+            const prevPath = `/dataset/${encodedLongUrn}/Schema`;
+            const currentPath = `/dataset/${encodedLongUrn}/Lineage`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+        });
+
+        it('should be case sensitive for entity types', () => {
+            const prevPath = `/Dataset/${encodedUrn}/Schema`;
+            const currentPath = `/dataset/${encodedUrn}/Properties`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+
+        it('should be case sensitive for URNs', () => {
+            const upperUrn = sampleUrn.toUpperCase();
+            const encodedUpperUrn = encodeURIComponent(upperUrn);
+            const prevPath = `/dataset/${encodedUrn}/Schema`;
+            const currentPath = `/dataset/${encodedUpperUrn}/Properties`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+        });
+
+        it('should handle paths with trailing slashes', () => {
+            const prevPath = `/dataset/${encodedUrn}/Schema/`;
+            const currentPath = `/dataset/${encodedUrn}/Properties/`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+        });
+
+        it('should handle malformed URNs', () => {
+            const malformedUrn = 'not-a-valid-urn';
+            const prevPath = `/dataset/${malformedUrn}/Schema`;
+            const currentPath = `/dataset/${malformedUrn}/Properties`;
+
+            expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+        });
+    });
+
+    describe('real-world entity types', () => {
+        // Test with various actual entity types from the DataHub system
+        const testCases = [
+            { type: 'dataset', urn: 'urn:li:dataset:(urn:li:dataPlatform:mysql,db.table,PROD)' },
+            { type: 'dashboard', urn: 'urn:li:dashboard:(looker,my_dashboard)' },
+            { type: 'chart', urn: 'urn:li:chart:(looker,my_chart)' },
+            { type: 'pipeline', urn: 'urn:li:dataFlow:(airflow,dag_id,cluster)' },
+            { type: 'task', urn: 'urn:li:dataJob:(airflow,dag_id,task_id)' },
+            { type: 'glossaryTerm', urn: 'urn:li:glossaryTerm:my_term' },
+            { type: 'domain', urn: 'urn:li:domain:my_domain' },
+            { type: 'container', urn: 'urn:li:container:my_container' },
+            { type: 'user', urn: 'urn:li:corpuser:john.doe' },
+            { type: 'group', urn: 'urn:li:corpGroup:data_team' },
+        ];
+
+        testCases.forEach(({ type, urn }) => {
+            it(`should correctly handle ${type} entity navigation`, () => {
+                const encodedTestUrn = encodeURIComponent(urn);
+                const prevPath = `/${type}/${encodedTestUrn}/Properties`;
+                const currentPath = `/${type}/${encodedTestUrn}/Lineage`;
+
+                expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+            });
+
+            it(`should detect different ${type} entities`, () => {
+                const encodedTestUrn = encodeURIComponent(urn);
+                const differentTestUrn = encodeURIComponent(`${urn}_different`);
+                const prevPath = `/${type}/${encodedTestUrn}/Properties`;
+                const currentPath = `/${type}/${differentTestUrn}/Properties`;
+
+                expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(false);
+            });
+        });
+    });
+
+    describe('common tab names', () => {
+        const commonTabs = [
+            'Properties',
+            'Schema',
+            'Lineage',
+            'Documentation',
+            'Queries',
+            'Stats',
+            'Validations',
+            'Incidents',
+            'Ownership',
+            'Glossary Terms',
+            'Tags',
+            'Domains',
+        ];
+
+        commonTabs.forEach((fromTab) => {
+            commonTabs.forEach((toTab) => {
+                if (fromTab !== toTab) {
+                    it(`should return true when navigating from ${fromTab} to ${toTab}`, () => {
+                        const prevPath = `/dataset/${encodedUrn}/${fromTab}`;
+                        const currentPath = `/dataset/${encodedUrn}/${toTab}`;
+
+                        expect(isSameEntityTabNavigation(prevPath, currentPath)).toBe(true);
+                    });
+                }
+            });
+        });
+    });
+});

--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -440,7 +440,14 @@ export interface HomePageRecommendationClickEvent extends BaseEvent {
 
 export interface VisualLineageViewEvent extends BaseEvent {
     type: EventType.VisualLineageViewEvent;
-    entityType?: EntityType;
+    entityType: EntityType;
+    numUpstreams: number;
+    numDownstreams: number;
+    hasColumnLevelLineage: boolean;
+    hasExpandableUpstreamsV2?: boolean;
+    hasExpandableDownstreamsV2?: boolean;
+    hasExpandableUpstreamsV3?: boolean;
+    hasExpandableDownstreamsV3?: boolean;
 }
 
 export interface VisualLineageExpandGraphEvent extends BaseEvent {
@@ -463,6 +470,9 @@ export interface SearchAcrossLineageResultsViewEvent extends BaseEvent {
     page?: number;
     total: number;
     maxDegree?: string;
+    hasUserAppliedColumnFilter?: boolean;
+    /** Whether search is scoped to a specific schema field URN (from navigation) */
+    isSchemaFieldContext?: boolean;
 }
 
 export interface DownloadAsCsvEvent extends BaseEvent {

--- a/datahub-web-react/src/app/analytics/useTrackPageView.ts
+++ b/datahub-web-react/src/app/analytics/useTrackPageView.ts
@@ -7,13 +7,46 @@ import analytics from '@app/analytics/analytics';
 let prevPathname: string = document.referrer;
 
 /**
+ * Check if two paths represent navigation between tabs of the same entity:
+ *  /<entity-type>/<entity-urn>/<tab-name>
+ *
+ * @param prevPath - The previous path
+ * @param currentPath - The current path
+ * @returns true if both paths are for the same entity but different tabs
+ */
+export function isSameEntityTabNavigation(prevPath: string, currentPath: string): boolean {
+    const prevParts = prevPath.split('/');
+    const currentParts = currentPath.split('/');
+
+    // Entity URLs have format: ['', entity-type, entity-urn, tab-name, ...]
+    // We need at least 4 parts to be an entity tab URL
+    if (prevParts.length < 4 || currentParts.length < 4) {
+        return false;
+    }
+
+    // Compare entity type (index 1) and entity URN (index 2)
+    const prevEntityType = prevParts[1];
+    const prevEntityUrn = prevParts[2];
+    const currentEntityType = currentParts[1];
+    const currentEntityUrn = currentParts[2];
+
+    return prevEntityType === currentEntityType && prevEntityUrn === currentEntityUrn;
+}
+
+/**
  * Hook used for logging page view events.
+ * Excludes tab navigation within the same entity profile.
  */
 export const useTrackPageView = () => {
     const location = useLocation();
 
     return useEffect(() => {
-        analytics.page({ prevPathname });
-        prevPathname = location.pathname;
+        if (prevPathname !== location.pathname) {
+            // Don't fire PageViewEvent for tab navigation within the same entity
+            if (!isSameEntityTabNavigation(prevPathname, location.pathname)) {
+                analytics.page({ prevPathname });
+            }
+            prevPathname = location.pathname;
+        }
     }, [location]);
 };

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -281,16 +281,22 @@ export const EmbeddedListSearch = ({
     // used for logging impact anlaysis events
     const degreeFilter = filters.find((filter) => filter.field === DEGREE_FILTER_NAME);
 
+    // Stable values for analytics to prevent multiple events
+    const degreeValues = degreeFilter?.values || [];
+    const maxDegree = degreeValues.length > 0 ? degreeValues.sort().reverse()[0] || '1' : null;
+
     // we already have some lineage logging through Tab events, but this adds additional context, particularly degree
-    if (!loading && (degreeFilter?.values?.length || 0) > 0) {
-        analytics.event({
-            type: EventType.SearchAcrossLineageResultsViewEvent,
-            query,
-            page,
-            total: data?.total || 0,
-            maxDegree: degreeFilter?.values?.sort()?.reverse()[0] || '1',
-        });
-    }
+    useEffect(() => {
+        if (!loading && maxDegree && data?.total !== undefined) {
+            analytics.event({
+                type: EventType.SearchAcrossLineageResultsViewEvent,
+                query,
+                page,
+                total: data.total,
+                maxDegree,
+            });
+        }
+    }, [loading, data?.total, query, page, maxDegree]);
 
     const isServerOverloadError = [503, 500, 504].includes(serverError?.networkError?.response?.status);
 

--- a/datahub-web-react/src/app/lineage/LineageExplorer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageExplorer.tsx
@@ -87,10 +87,15 @@ export default function LineageExplorer({ urn, type }: Props) {
         setAsyncEntities(new Map());
         // this can also be our hook for emitting the tracking event
 
-        analytics.event({
-            type: EventType.VisualLineageViewEvent,
-            entityType: entityData?.type,
-        });
+        if (entityData?.type) {
+            analytics.event({
+                type: EventType.VisualLineageViewEvent,
+                entityType: entityData.type,
+                numUpstreams: 0,
+                numDownstreams: 0,
+                hasColumnLevelLineage: false,
+            });
+        }
     }, [isHideSiblingMode, startTimeMillis, endTimeMillis, entityData?.type]);
 
     useEffect(() => {

--- a/datahub-web-react/src/app/lineageV2/LineageExplorer.hooks.tsx
+++ b/datahub-web-react/src/app/lineageV2/LineageExplorer.hooks.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+
+import analytics, { EventType } from '@app/analytics';
+import { LineageEntity } from '@app/lineageV2/common';
+import { ColumnAsset, LineageAssetType } from '@app/lineageV2/types';
+
+import { EntityType, LineageDirection } from '@types';
+
+interface UseTrackLineageViewV2Props {
+    initialized: boolean;
+    urn: string;
+    type: EntityType;
+    adjacencyList: Record<LineageDirection, Map<string, Set<string>>>;
+    nodes: Map<string, LineageEntity>;
+    nodeVersion: number;
+}
+
+/**
+ * Custom hook to track visual lineage view analytics events for V2
+ */
+export function useTrackLineageViewV2({
+    initialized,
+    urn,
+    type,
+    adjacencyList,
+    nodes,
+    nodeVersion,
+}: UseTrackLineageViewV2Props) {
+    const [hasTracked, setHasTracked] = useState(false);
+
+    useEffect(() => {
+        if (!initialized) return;
+
+        // Reset tracking state when entity changes
+        setHasTracked(false);
+    }, [urn, initialized]);
+
+    useEffect(() => {
+        if (!initialized || hasTracked) return;
+
+        // Wait for some nodes to be loaded before tracking
+        if (nodeVersion === 0) return;
+
+        const upstreamNeighbors = adjacencyList[LineageDirection.Upstream].get(urn) || new Set<string>();
+        const downstreamNeighbors = adjacencyList[LineageDirection.Downstream].get(urn) || new Set<string>();
+
+        // Check if any loaded entities have column-level lineage data
+        const hasColumnLevelLineage = Array.from(nodes.values()).some((node) => {
+            const { entity } = node;
+            if (!entity) return false;
+
+            // Check for fine-grained lineage data
+            if (entity.fineGrainedLineages && entity.fineGrainedLineages.length > 0) return true;
+
+            // Check for input fields (chart -> dataset column relationships)
+            if (entity.inputFields && entity.inputFields.fields && entity.inputFields.fields.length > 0) return true;
+
+            // Check for lineage assets with column information
+            if (entity.lineageAssets && entity.lineageAssets.size > 0) {
+                return Array.from(entity.lineageAssets.values()).some((asset) => {
+                    // Type guard to ensure we have a ColumnAsset
+                    if (asset.type === LineageAssetType.Column) {
+                        const columnAsset = asset as ColumnAsset;
+                        return (columnAsset.numUpstream || 0) > 0 || (columnAsset.numDownstream || 0) > 0;
+                    }
+                    return false;
+                });
+            }
+
+            return false;
+        });
+
+        analytics.event({
+            type: EventType.VisualLineageViewEvent,
+            entityType: type,
+            numUpstreams: upstreamNeighbors.size,
+            numDownstreams: downstreamNeighbors.size,
+            hasColumnLevelLineage,
+            // set these both to false since it is difficult to fetch in V2 code and we are moving to V3 for default anyway.
+            hasExpandableUpstreamsV2: false,
+            hasExpandableDownstreamsV2: false,
+        });
+
+        setHasTracked(true);
+    }, [initialized, urn, type, adjacencyList, nodes, nodeVersion, hasTracked]);
+}

--- a/datahub-web-react/src/app/lineageV2/LineageExplorer.tsx
+++ b/datahub-web-react/src/app/lineageV2/LineageExplorer.tsx
@@ -3,6 +3,7 @@ import { ReactFlowProvider } from 'reactflow';
 
 import { useGetLineageTimeParams } from '@app/lineage/utils/useGetLineageTimeParams';
 import LineageDisplay from '@app/lineageV2/LineageDisplay';
+import { useTrackLineageViewV2 } from '@app/lineageV2/LineageExplorer.hooks';
 import {
     EdgeId,
     FetchStatus,
@@ -66,6 +67,8 @@ export default function LineageExplorer(props: Props) {
     };
 
     const initialized = useInitializeNodes(context, urn, type);
+
+    useTrackLineageViewV2({ initialized, urn, type, adjacencyList, nodes, nodeVersion });
 
     return (
         <LineageNodesContext.Provider value={context}>

--- a/datahub-web-react/src/app/lineageV3/LineageDisplay.hooks.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageDisplay.hooks.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+import analytics, { EventType } from '@app/analytics';
+import { FetchStatus, LineageEntity, LineageNode } from '@app/lineageV3/common';
+
+import { EntityType, LineageDirection } from '@types';
+
+interface UseTrackLineageViewProps {
+    initialized: boolean;
+    type: EntityType;
+    adjacencyList: Record<LineageDirection, Map<string, Set<string>>>;
+    rootUrn: string;
+    nodes: Map<string, LineageNode>;
+}
+
+/**
+ * Custom hook to track visual lineage view analytics events
+ */
+export function useTrackLineageView({ initialized, type, adjacencyList, rootUrn, nodes }: UseTrackLineageViewProps) {
+    const [hasTracked, setHasTracked] = useState(false);
+
+    useEffect(() => {
+        if (!initialized) return;
+
+        // Reset tracking state when entity changes
+        setHasTracked(false);
+    }, [rootUrn, initialized]);
+
+    useEffect(() => {
+        if (!initialized || hasTracked) return;
+
+        const upstreamNeighbors = adjacencyList[LineageDirection.Upstream].get(rootUrn) || new Set<string>();
+        const downstreamNeighbors = adjacencyList[LineageDirection.Downstream].get(rootUrn) || new Set<string>();
+
+        // Wait for nodes to have entity data before tracking
+        const allNodes = Array.from(nodes.values());
+        const entitiesLoaded =
+            allNodes.length > 0 &&
+            allNodes.every((node) => {
+                if (node.type === 'lineage-filter') return true;
+                const entity = node as LineageEntity;
+                return !!entity.entity; // Wait for entity data to be loaded
+            });
+
+        if (!entitiesLoaded) return;
+
+        // Check if there are expandable upstream entities
+        const hasExpandableUpstreams = Array.from(nodes.values()).some((node) => {
+            if (node.type === 'lineage-filter') return false;
+            const entity = node as LineageEntity;
+            const upstreamNotComplete = entity.fetchStatus[LineageDirection.Upstream] !== FetchStatus.COMPLETE;
+            return upstreamNotComplete && upstreamNeighbors.size > 0;
+        });
+
+        // Check if there are expandable downstream entities
+        const hasExpandableDownstreams = Array.from(nodes.values()).some((node) => {
+            if (node.type === 'lineage-filter') return false;
+            const entity = node as LineageEntity;
+            const downstreamNotComplete = entity.fetchStatus[LineageDirection.Downstream] !== FetchStatus.COMPLETE;
+            return downstreamNotComplete && downstreamNeighbors.size > 0;
+        });
+
+        // Check if any entities have column-level lineage
+        const hasColumnLevelLineage = Array.from(nodes.values()).some((node) => {
+            if (node.type === 'lineage-filter') return false;
+            const entity = node as LineageEntity;
+            return entity.entity?.fineGrainedLineages && entity.entity.fineGrainedLineages.length > 0;
+        });
+
+        analytics.event({
+            type: EventType.VisualLineageViewEvent,
+            entityType: type,
+            numUpstreams: upstreamNeighbors.size,
+            numDownstreams: downstreamNeighbors.size,
+            hasColumnLevelLineage: hasColumnLevelLineage || false,
+            hasExpandableUpstreamsV3: hasExpandableUpstreams,
+            hasExpandableDownstreamsV3: hasExpandableDownstreams,
+        });
+
+        setHasTracked(true);
+    }, [initialized, type, adjacencyList, rootUrn, nodes, hasTracked]);
+}

--- a/datahub-web-react/src/app/lineageV3/LineageDisplay.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { useReactFlow } from 'reactflow';
 
+import { useTrackLineageView } from '@app/lineageV3/LineageDisplay.hooks';
 import { LINEAGE_FILTER_NODE_NAME } from '@app/lineageV3/LineageFilterNode/LineageFilterNodeBasic';
 import LineageSidebar from '@app/lineageV3/LineageSidebar';
 import LineageVisualization from '@app/lineageV3/LineageVisualization';
@@ -12,10 +13,16 @@ import useComputeGraph from '@app/lineageV3/useComputeGraph/useComputeGraph';
 import useNodeHighlighting from '@app/lineageV3/useNodeHighlighting';
 
 type Props = {
-    initialized: boolean;
+    refetchCenterNode?: () => void;
+    dragToSelect?: boolean;
+    initialized?: boolean;
 };
 
-export default function LineageDisplay({ initialized }: Props) {
+export default function LineageDisplay({
+    refetchCenterNode: _refetchCenterNode,
+    dragToSelect: _dragToSelect,
+    initialized,
+}: Props) {
     const { getEdge, setNodes, setEdges } = useReactFlow();
 
     const [selectedColumn, setSelectedColumn] = useState<ColumnRef | null>(null);
@@ -31,13 +38,23 @@ export default function LineageDisplay({ initialized }: Props) {
     const refetchUrn = useBulkEntityLineage(shownUrns);
 
     const { highlightedNodes, highlightedEdges } = useNodeHighlighting(hoveredNode);
-
     const { cllHighlightedNodes, highlightedColumns } = useColumnHighlighting(
         selectedColumn,
         hoveredColumn,
         fineGrainedLineage.indirect,
         shownUrns,
     );
+
+    const { rootUrn, rootType, nodes, adjacencyList, nodeVersion } = useContext(LineageNodesContext);
+
+    // Track lineage view analytics
+    useTrackLineageView({
+        initialized: initialized !== undefined ? initialized && nodeVersion > 0 : nodeVersion > 0,
+        type: rootType,
+        adjacencyList,
+        rootUrn,
+        nodes,
+    });
 
     useEffect(() => {
         const newNodeMap = new Map(flowNodes.map((node) => [node.id, node]));
@@ -65,7 +82,7 @@ export default function LineageDisplay({ initialized }: Props) {
 
     useEffect(() => setEdges(flowEdges), [flowEdges, getEdge, setEdges]);
 
-    useFitView(initialized);
+    useFitView(initialized !== undefined ? initialized && nodeVersion > 0 : nodeVersion > 0);
 
     return (
         <LineageDisplayContext.Provider


### PR DESCRIPTION
# Improve Lineage Logging

Fixes for the following issues:
1. The lineage section view event doesn't include metadata like, # of upstreams, # of downstreams, whether CLL is present, or if those upstreams or downstreams are expandable. All of this is important context of the quality of the lineage graph - P0

* Added new fields to the event:
<img width="394" height="317" alt="Screenshot 2025-07-15 at 4 33 35 PM" src="https://github.com/user-attachments/assets/311d1ecd-dcb2-4a81-a7cb-e886077b1b88" />

2. Opening the lineage tab triggers a new section view event and page view event. It should just trigger a section view event - P1
* Emitting only two events (`EntitySectionViewEvent` and `VisualLineageViewEvent`):
<img width="548" height="353" alt="Screenshot 2025-07-16 at 11 13 49 AM" src="https://github.com/user-attachments/assets/537efb71-4f9c-4a52-b72e-f17a98e49d27" />

3. Impact Analysis- since column level lineage analysis is important- we should track in the SearchAcrossLineageResultsViewEvent if a column filter is applied, just like we do with maxDegree 

4. Impact Analysis - when opening the impact analysis tab, I see 3-4 "SearchAcrossLineageResultsViewEvent" events get fired at once. This should be just one, or our counts of engagement will be off.

5. Toggling between Impact Analysis Tab -> Explore doesn't consistently fire events, and after that first toggle more misses - Same as (1) above. -

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
- [ ] For any major SaaS specific change update [Updating DataHub SaaS](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub-saas.md)

-->
