### PR TITLE
fix(dbt-cloud): use correct node description for sources

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_cloud.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_cloud.py
@@ -370,7 +370,6 @@ class DBTCloudSource(DBTSourceBase, TestableSource):
             name = node["alias"]
 
         comment = node.get("comment", "")
-        description = node["description"]
         description = node["description"] or node.get("sourceDescription", "")
 
         if node["resourceType"] == "model":

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_cloud.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_cloud.py
@@ -370,6 +370,11 @@ class DBTCloudSource(DBTSourceBase, TestableSource):
             name = node["alias"]
 
         comment = node.get("comment", "")
+
+        # In dbt sources, there are two types of descriptions:
+        # - description: table-level description (specific to the source table)
+        # - sourceDescription: schema-level description (describes the overall source schema)
+        # The table-level description should take precedence since it's more specific.
         description = node["description"] or node.get("sourceDescription", "")
 
         if node["resourceType"] == "model":

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_cloud.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_cloud.py
@@ -371,8 +371,7 @@ class DBTCloudSource(DBTSourceBase, TestableSource):
 
         comment = node.get("comment", "")
         description = node["description"]
-        if node.get("sourceDescription"):
-            description = node["sourceDescription"]
+        description = node["description"] or node.get("sourceDescription", "")
 
         if node["resourceType"] == "model":
             materialization = node["materializedType"]

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Dict, List, TypedDict, Union
+from typing import Any, Dict, List, TypedDict, Union
 from unittest import mock
 
 import pytest
@@ -686,7 +686,7 @@ def test_dbt_cloud_source_description_precedence() -> None:
     source = DBTCloudSource(config, ctx)
 
     # Create mock node data representing a source with both descriptions
-    source_node_data = {
+    source_node_data: Dict[str, Any] = {
         "uniqueId": "source.my_project.my_schema.my_table",
         "name": "my_table",
         "description": "This is the table-level description for my_table",
@@ -740,7 +740,7 @@ def test_dbt_cloud_source_description_fallback() -> None:
     source = DBTCloudSource(config, ctx)
 
     # Create mock node data with empty table description but present schema description
-    source_node_data = {
+    source_node_data: Dict[str, Any] = {
         "uniqueId": "source.my_project.my_schema.my_table",
         "name": "my_table",
         "description": "",  # Empty table description

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -663,12 +663,6 @@ def test_drop_duplicate_sources() -> None:
 def test_dbt_cloud_source_description_precedence() -> None:
     """
     Test that dbt Cloud source prioritizes table-level description over schema-level sourceDescription.
-
-    In dbt sources, there are two types of descriptions:
-    - description: table-level description (specific to the source table)
-    - sourceDescription: schema-level description (describes the overall source schema)
-
-    The table-level description should take precedence since it's more specific.
     """
 
     config = DBTCloudConfig(

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -671,7 +671,6 @@ def test_dbt_cloud_source_description_precedence() -> None:
     The table-level description should take precedence since it's more specific.
     """
 
-    # Create a mock DBTCloudSource
     config = DBTCloudConfig(
         access_url="https://test.getdbt.com",
         token="dummy_token",
@@ -685,7 +684,6 @@ def test_dbt_cloud_source_description_precedence() -> None:
     ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-cloud-source")
     source = DBTCloudSource(config, ctx)
 
-    # Create mock node data representing a source with both descriptions
     source_node_data: Dict[str, Any] = {
         "uniqueId": "source.my_project.my_schema.my_table",
         "name": "my_table",
@@ -709,10 +707,8 @@ def test_dbt_cloud_source_description_precedence() -> None:
         "loader": None,
     }
 
-    # Parse the node using the DBTCloudSource method
     parsed_node = source._parse_into_dbt_node(source_node_data)
 
-    # Assert that the table-level description is used, not the schema-level sourceDescription
     assert parsed_node.description == "This is the table-level description for my_table"
     assert (
         parsed_node.description != "This is the schema-level description for my_schema"
@@ -739,7 +735,6 @@ def test_dbt_cloud_source_description_fallback() -> None:
     ctx = PipelineContext(run_id="test-run-id", pipeline_name="dbt-cloud-source")
     source = DBTCloudSource(config, ctx)
 
-    # Create mock node data with empty table description but present schema description
     source_node_data: Dict[str, Any] = {
         "uniqueId": "source.my_project.my_schema.my_table",
         "name": "my_table",
@@ -763,10 +758,8 @@ def test_dbt_cloud_source_description_fallback() -> None:
         "loader": None,
     }
 
-    # Parse the node using the DBTCloudSource method
     parsed_node = source._parse_into_dbt_node(source_node_data)
 
-    # Should fall back to sourceDescription when table description is empty
     assert (
         parsed_node.description == "This is the schema-level description for my_schema"
     )


### PR DESCRIPTION
### Fix dbt Cloud source description priority: use table-level over schema-level descriptions

Currently, dbt Cloud sources incorrectly prioritize schema-level `sourceDescription` over table-level `description` for source resources. This fix ensures table-level descriptions take precedence, with fallback to schema-level when table description is empty.

Added unit tests to validate the correct behavior and prevent regression.

#### Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)