### PR TITLE
feat(irc): report tblproperties via dataset properties

### DIFF
--- a/docs/iceberg-catalog.md
+++ b/docs/iceberg-catalog.md
@@ -509,9 +509,8 @@ Once you create tables in iceberg, each of those tables show up in DataHub as a 
   <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/cec184aa1e3cb15c087625ffc997b4345a858c8b/imgs/iceberg-dataset-schema.png"/>
 </p>
 
-Any Iceberg `TBLPROPERTIES` set via DDL show up in as DatasetProperties with a prefix `iceberg:` This is in addition to any additional metadata properties that may be
-added directly to the dataset via Datahub CLI/API. The iceberg table properties can only be set via DDL and shown in DatasetProperties with the `iceberg:` prefix for
-visibility, but this is a one way sync. Changes to iceberg properties via datahub APIs do not get written to the Iceberg table metadata.
+Some of the standard metadata fields are populated in the Dataset Properties. Additionally, any Iceberg `TBLPROPERTIES` set via DDL on tables or views are also shown in DatasetProperties with a prefix `iceberg:`
+The iceberg 'TBLPROPERTIES' can only be set via DDL and is a one way sync. Changes to iceberg `TBLPROPERTIES` properties via datahub APIs do not get written to the Iceberg table or view properties.
 
 ## Troubleshooting
 

--- a/docs/iceberg-catalog.md
+++ b/docs/iceberg-catalog.md
@@ -509,6 +509,10 @@ Once you create tables in iceberg, each of those tables show up in DataHub as a 
   <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/cec184aa1e3cb15c087625ffc997b4345a858c8b/imgs/iceberg-dataset-schema.png"/>
 </p>
 
+Any Iceberg `TBLPROPERTIES` set via DDL show up in as DatasetProperties with a prefix `iceberg:` This is in addition to any additional metadata properties that may be
+added directly to the dataset via Datahub CLI/API. The iceberg table properties can only be set via DDL and shown in DatasetProperties with the `iceberg:` prefix for
+visibility, but this is a one way sync. Changes to iceberg properties via datahub APIs do not get written to the Iceberg table metadata.
+
 ## Troubleshooting
 
 ### Q: How do I verify my warehouse was created successfully?

--- a/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/DataHubIcebergWarehouse.java
+++ b/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/DataHubIcebergWarehouse.java
@@ -39,6 +39,7 @@ public class DataHubIcebergWarehouse {
   public static final String DATAPLATFORM_INSTANCE_ICEBERG_WAREHOUSE_ASPECT_NAME =
       "icebergWarehouseInfo";
 
+  public static final String ICEBERG_PROPERTY_PREFIX = "iceberg:";
   private final EntityService entityService;
 
   private final SecretService secretService;
@@ -326,6 +327,14 @@ public class DataHubIcebergWarehouse {
         new DatasetProperties()
             .setName(toTableId.name())
             .setQualifiedName(fullTableName(platformInstance, toTableId));
+
+    RecordTemplate fromDatasetPropertiesRecord =
+        entityService.getLatestAspect(operationContext, datasetUrn, DATASET_PROPERTIES_ASPECT_NAME);
+    if (fromDatasetPropertiesRecord != null) {
+      DatasetProperties fromDatasetProperties =
+          new DatasetProperties(fromDatasetPropertiesRecord.data());
+      datasetProperties.setCustomProperties(fromDatasetProperties.getCustomProperties());
+    }
 
     IcebergBatch.EntityBatch datasetBatch =
         icebergBatch.updateEntity(datasetUrn, DATASET_ENTITY_NAME);

--- a/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/DataHubIcebergWarehouse.java
+++ b/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/DataHubIcebergWarehouse.java
@@ -334,6 +334,10 @@ public class DataHubIcebergWarehouse {
       DatasetProperties fromDatasetProperties =
           new DatasetProperties(fromDatasetPropertiesRecord.data());
       datasetProperties.setCustomProperties(fromDatasetProperties.getCustomProperties());
+    } else {
+      // For rename, this should never be null, because at minimum, the name and qualified name
+      // must be set via datasetProperties
+      log.error("Internal error: existing dataset properties not found for dataset {}", datasetUrn);
     }
 
     IcebergBatch.EntityBatch datasetBatch =

--- a/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/IcebergBatch.java
+++ b/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/IcebergBatch.java
@@ -25,6 +25,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 public class IcebergBatch {
+  // TODO: Support patch operations in IcebergBatch
   private List<MetadataChangeProposal> mcps = new ArrayList<>();
 
   @Getter private final AuditStamp auditStamp;

--- a/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/TableOrViewOpsDelegate.java
+++ b/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/TableOrViewOpsDelegate.java
@@ -2,15 +2,18 @@ package io.datahubproject.iceberg.catalog;
 
 import static com.linkedin.metadata.Constants.*;
 import static com.linkedin.metadata.utils.GenericRecordUtils.serializeAspect;
-import static io.datahubproject.iceberg.catalog.DataHubIcebergWarehouse.DATASET_ICEBERG_METADATA_ASPECT_NAME;
+import static io.datahubproject.iceberg.catalog.DataHubIcebergWarehouse.*;
 import static io.datahubproject.iceberg.catalog.Utils.*;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.linkedin.common.AuditStamp;
 import com.linkedin.common.SubTypes;
 import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.container.Container;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.dataset.DatasetProfile;
 import com.linkedin.dataset.DatasetProperties;
 import com.linkedin.dataset.IcebergCatalogInfo;
@@ -18,6 +21,7 @@ import com.linkedin.dataset.ViewProperties;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.aspect.batch.AspectsBatch;
+import com.linkedin.metadata.aspect.patch.builder.DatasetPropertiesPatchBuilder;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.validation.ValidationException;
@@ -29,6 +33,7 @@ import io.datahubproject.schematron.converters.avro.AvroSchemaConverter;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.iceberg.Snapshot;
@@ -196,7 +201,6 @@ abstract class TableOrViewOpsDelegate<M> {
     }
 
     additionalMcps(metadata.metadata(), datasetBatch);
-
     try {
       AspectsBatch aspectsBatch = icebergBatch.asAspectsBatch();
       entityService.ingestProposal(operationContext, aspectsBatch, false);
@@ -210,22 +214,12 @@ abstract class TableOrViewOpsDelegate<M> {
       }
     }
 
-    DatasetProfile datasetProfile =
-        getDataSetProfile(metadata.metadata())
-            .setTimestampMillis(icebergBatch.getAuditStamp().getTime());
-
-    MetadataChangeProposal datasetProfileMcp =
-        new MetadataChangeProposal()
-            .setEntityUrn(datasetUrn)
-            .setEntityType(DATASET_ENTITY_NAME)
-            .setAspectName(DATASET_PROFILE_ASPECT_NAME)
-            .setAspect(serializeAspect(datasetProfile))
-            .setChangeType(ChangeType.UPSERT);
-    entityService.ingestProposal(
-        operationContext, datasetProfileMcp, icebergBatch.getAuditStamp(), true);
+    additionalAsyncMcps(datasetUrn, metadata, icebergBatch.getAuditStamp());
   }
 
   protected abstract DatasetProfile getDataSetProfile(M metadata);
+
+  protected abstract StringMap getIcebergProperties(M metadata);
 
   FileIO io() {
     return io;
@@ -255,7 +249,56 @@ abstract class TableOrViewOpsDelegate<M> {
 
   abstract RuntimeException noSuchEntityException();
 
+  // Any additional MCPs that need to be stored in the same transaction.
   void additionalMcps(M metadata, IcebergBatch.EntityBatch datasetBatch) {}
+
+  // Any additional MCPs that can be ingested asynchronously (and hence outside the iceberg commit
+  // path)
+  void additionalAsyncMcps(
+      DatasetUrn datasetUrn, MetadataWrapper<M> metadata, AuditStamp auditStamp) {
+    DatasetProfile datasetProfile =
+        getDataSetProfile(metadata.metadata()).setTimestampMillis(auditStamp.getTime());
+
+    MetadataChangeProposal datasetProfileMcp =
+        new MetadataChangeProposal()
+            .setEntityUrn(datasetUrn)
+            .setEntityType(DATASET_ENTITY_NAME)
+            .setAspectName(DATASET_PROFILE_ASPECT_NAME)
+            .setAspect(serializeAspect(datasetProfile))
+            .setChangeType(ChangeType.UPSERT);
+    entityService.ingestProposal(operationContext, datasetProfileMcp, auditStamp, true);
+
+    RecordTemplate prevDatasetPropertiesData =
+        entityService.getLatestAspect(operationContext, datasetUrn, DATASET_PROPERTIES_ASPECT_NAME);
+    if (prevDatasetPropertiesData != null) {
+      DatasetProperties prevPropertiesAspect =
+          new DatasetProperties(prevDatasetPropertiesData.data());
+      StringMap prevPropertiesMap = prevPropertiesAspect.getCustomProperties();
+      Set<String> prevIcebergProperties =
+          prevPropertiesMap.keySet().stream()
+              .filter(key -> key.startsWith(ICEBERG_PROPERTY_PREFIX))
+              .collect(Collectors.toSet());
+
+      StringMap newIcebergProperties = getIcebergProperties(metadata.metadata());
+      Set<String> deletedIcebergProperties =
+          prevIcebergProperties.stream()
+              .filter(key -> !newIcebergProperties.containsKey(key))
+              .collect(Collectors.toSet());
+
+      DatasetPropertiesPatchBuilder patchBuilder =
+          new DatasetPropertiesPatchBuilder().urn(datasetUrn);
+      for (String deletedProperty : deletedIcebergProperties) {
+        patchBuilder.removeCustomProperty(deletedProperty);
+      }
+      for (String newProperty : newIcebergProperties.keySet()) {
+        patchBuilder.addCustomProperty(
+            ICEBERG_PROPERTY_PREFIX + newProperty, newIcebergProperties.get(newProperty));
+      }
+
+      MetadataChangeProposal datasetPropertiesMcp = patchBuilder.build();
+      entityService.ingestProposal(operationContext, datasetPropertiesMcp, auditStamp, true);
+    }
+  }
 }
 
 @Slf4j
@@ -326,6 +369,11 @@ class ViewOpsDelegate extends TableOrViewOpsDelegate<ViewMetadata> {
     datasetProfile.setColumnCount(columnCount);
     return datasetProfile;
   }
+
+  @Override
+  protected StringMap getIcebergProperties(ViewMetadata metadata) {
+    return new StringMap(metadata.properties());
+  }
 }
 
 class TableOpsDelegate extends TableOrViewOpsDelegate<TableMetadata> {
@@ -384,6 +432,11 @@ class TableOpsDelegate extends TableOrViewOpsDelegate<TableMetadata> {
   @Override
   RuntimeException noSuchEntityException() {
     return new NoSuchTableException("No such table %s", name());
+  }
+
+  @Override
+  protected StringMap getIcebergProperties(TableMetadata metadata) {
+    return new StringMap(metadata.properties());
   }
 }
 

--- a/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/DataHubIcebergWarehouseTest.java
+++ b/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/DataHubIcebergWarehouseTest.java
@@ -15,6 +15,7 @@ import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.dataplatforminstance.IcebergWarehouseInfo;
 import com.linkedin.dataset.DatasetProperties;
 import com.linkedin.dataset.IcebergCatalogInfo;
@@ -32,7 +33,6 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.services.SecretService;
 import java.util.*;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -563,7 +563,6 @@ public class DataHubIcebergWarehouseTest {
             FabricType.PROD);
 
     // Mock getDatasetUrn behavior for source table
-
     PlatformResourceInfo resourceInfo =
         new PlatformResourceInfo()
             .setPrimaryKey(existingDatasetUrn.toString())
@@ -575,6 +574,17 @@ public class DataHubIcebergWarehouseTest {
             eq(Set.of(STATUS_ASPECT_NAME, PLATFORM_RESOURCE_INFO_ASPECT_NAME)),
             eq(false)))
         .thenReturn(Map.of(fromResourceUrn, List.of(new Status().setRemoved(false), resourceInfo)));
+
+    // Mock existing dataset properties with custom properties
+    DatasetProperties existingProperties =
+        new DatasetProperties()
+            .setName(fromTableId.name())
+            .setQualifiedName(fullTableName(platformInstance, fromTableId))
+            .setCustomProperties(new StringMap(Map.of("key1", "value1", "key2", "value2")));
+
+    when(entityService.getLatestAspect(
+            same(operationContext), eq(existingDatasetUrn), eq(DATASET_PROPERTIES_ASPECT_NAME)))
+        .thenReturn(existingProperties);
 
     DataHubIcebergWarehouse warehouse =
         new DataHubIcebergWarehouse(
@@ -607,23 +617,58 @@ public class DataHubIcebergWarehouseTest {
             eq(PLATFORM_RESOURCE_ENTITY_NAME),
             eq(PLATFORM_RESOURCE_INFO_ASPECT_NAME),
             eq(resourceInfo));
-    verify(datasetUpdateBatch)
-        .aspect(
-            DATASET_PROPERTIES_ASPECT_NAME,
-            new DatasetProperties()
-                .setName(toTableId.name())
-                .setQualifiedName(fullTableName(platformInstance, toTableId)));
+
+    // Verify that the dataset properties are updated with preserved custom properties
+    DatasetProperties expectedProperties =
+        new DatasetProperties()
+            .setName(toTableId.name())
+            .setQualifiedName(fullTableName(platformInstance, toTableId))
+            .setCustomProperties(new StringMap(Map.of("key1", "value1", "key2", "value2")));
+
+    verify(datasetUpdateBatch).aspect(DATASET_PROPERTIES_ASPECT_NAME, expectedProperties);
     // no container aspect as rename is within same namespace
 
     verify(entityService).ingestProposal(same(operationContext), same(mockAspectsBatch), eq(false));
     verify(entityService).deleteUrn(eq(operationContext), eq(fromResourceUrn));
   }
 
-  @Test(expectedExceptions = NoSuchTableException.class)
-  public void testRenameDataset_SourceTableNotFound() throws Exception {
+  @Test
+  public void testRenameDataset_NoExistingCustomProperties() throws Exception {
     String platformInstance = "test-platform";
     TableIdentifier fromTableId = TableIdentifier.of("db", "oldTable");
     TableIdentifier toTableId = TableIdentifier.of("db", "newTable");
+    Urn fromResourceUrn =
+        Urn.createFromString("urn:li:platformResource:iceberg.test-platform.db.oldTable");
+    Urn toResourceUrn =
+        Urn.createFromString("urn:li:platformResource:iceberg.test-platform.db.newTable");
+    DatasetUrn existingDatasetUrn =
+        new DatasetUrn(
+            DataPlatformUrn.createFromString("urn:li:dataPlatform:iceberg"),
+            "test-dataset",
+            FabricType.PROD);
+
+    // Mock getDatasetUrn behavior for source table
+    PlatformResourceInfo resourceInfo =
+        new PlatformResourceInfo()
+            .setPrimaryKey(existingDatasetUrn.toString())
+            .setResourceType("icebergTable");
+
+    when(entityService.getLatestAspects(
+            same(operationContext),
+            eq(Set.of(fromResourceUrn)),
+            eq(Set.of(STATUS_ASPECT_NAME, PLATFORM_RESOURCE_INFO_ASPECT_NAME)),
+            eq(false)))
+        .thenReturn(Map.of(fromResourceUrn, List.of(new Status().setRemoved(false), resourceInfo)));
+
+    // Mock existing dataset properties without custom properties
+    DatasetProperties existingProperties =
+        new DatasetProperties()
+            .setName(fromTableId.name())
+            .setQualifiedName(fullTableName(platformInstance, fromTableId));
+
+    when(entityService.getLatestAspect(
+            same(operationContext), eq(existingDatasetUrn), eq(DATASET_PROPERTIES_ASPECT_NAME)))
+        .thenReturn(existingProperties);
 
     DataHubIcebergWarehouse warehouse =
         new DataHubIcebergWarehouse(
@@ -639,7 +684,34 @@ public class DataHubIcebergWarehouseTest {
           }
         };
 
-    // by default mock to return null on entity-service calls, so dataset should not be found
+    IcebergBatch.EntityBatch datasetUpdateBatch = mock(IcebergBatch.EntityBatch.class);
+    when(mockIcebergBatch.updateEntity(eq(existingDatasetUrn), eq(DATASET_ENTITY_NAME)))
+        .thenReturn(datasetUpdateBatch);
+
+    when(entityService.ingestProposal(same(operationContext), same(mockAspectsBatch), eq(false)))
+        .thenReturn(List.of());
+
     warehouse.renameDataset(fromTableId, toTableId, false);
+
+    verify(mockIcebergBatch)
+        .softDeleteEntity(eq(fromResourceUrn), eq(PLATFORM_RESOURCE_ENTITY_NAME));
+    verify(mockIcebergBatch)
+        .createEntity(
+            eq(toResourceUrn),
+            eq(PLATFORM_RESOURCE_ENTITY_NAME),
+            eq(PLATFORM_RESOURCE_INFO_ASPECT_NAME),
+            eq(resourceInfo));
+
+    // Verify that the dataset properties are updated with empty custom properties
+    DatasetProperties expectedProperties =
+        new DatasetProperties()
+            .setName(toTableId.name())
+            .setQualifiedName(fullTableName(platformInstance, toTableId))
+            .setCustomProperties(new StringMap());
+
+    verify(datasetUpdateBatch).aspect(DATASET_PROPERTIES_ASPECT_NAME, expectedProperties);
+
+    verify(entityService).ingestProposal(same(operationContext), same(mockAspectsBatch), eq(false));
+    verify(entityService).deleteUrn(eq(operationContext), eq(fromResourceUrn));
   }
 }

--- a/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/TableOpsDelegateTest.java
+++ b/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/TableOpsDelegateTest.java
@@ -120,6 +120,15 @@ public class TableOpsDelegateTest {
     TableMetadata metadata = mock(TableMetadata.class);
     when(metadata.schema()).thenReturn(schema);
     when(metadata.location()).thenReturn("s3://bucket/table");
+    when(metadata.formatVersion()).thenReturn(2);
+    when(metadata.uuid()).thenReturn("table-uuid-123");
+
+    // Mock current snapshot
+    Snapshot mockSnapshot = mock(Snapshot.class);
+    when(mockSnapshot.snapshotId()).thenReturn(12345L);
+    when(mockSnapshot.sequenceNumber()).thenReturn(1L);
+    when(mockSnapshot.manifestListLocation()).thenReturn("/path/to/manifest-list");
+    when(metadata.currentSnapshot()).thenReturn(mockSnapshot);
 
     // Simulating new table creation
     when(mockWarehouse.getIcebergMetadataEnveloped(identifier)).thenReturn(null);
@@ -222,6 +231,15 @@ public class TableOpsDelegateTest {
     TableMetadata metadata = mock(TableMetadata.class);
     when(metadata.location()).thenReturn("s3://bucket/table");
     when(metadata.currentSchemaId()).thenReturn(existingSchemaId);
+    when(metadata.formatVersion()).thenReturn(2);
+    when(metadata.uuid()).thenReturn("table-uuid-123");
+
+    // Mock current snapshot
+    Snapshot mockSnapshot = mock(Snapshot.class);
+    when(mockSnapshot.snapshotId()).thenReturn(12345L);
+    when(mockSnapshot.sequenceNumber()).thenReturn(1L);
+    when(mockSnapshot.manifestListLocation()).thenReturn("/path/to/manifest-list");
+    when(metadata.currentSnapshot()).thenReturn(mockSnapshot);
 
     TableMetadata base = mock(TableMetadata.class);
     when(base.metadataFileLocation()).thenReturn(existingLocation);
@@ -273,6 +291,15 @@ public class TableOpsDelegateTest {
     when(metadata.schema()).thenReturn(schema);
     when(metadata.location()).thenReturn("s3://bucket/table");
     when(metadata.currentSchemaId()).thenReturn(existingSchemaId + 1);
+    when(metadata.formatVersion()).thenReturn(2);
+    when(metadata.uuid()).thenReturn("table-uuid-123");
+
+    // Mock current snapshot
+    Snapshot mockSnapshot = mock(Snapshot.class);
+    when(mockSnapshot.snapshotId()).thenReturn(12345L);
+    when(mockSnapshot.sequenceNumber()).thenReturn(1L);
+    when(mockSnapshot.manifestListLocation()).thenReturn("/path/to/manifest-list");
+    when(metadata.currentSnapshot()).thenReturn(mockSnapshot);
 
     TableMetadata base = mock(TableMetadata.class);
     when(base.metadataFileLocation()).thenReturn(existingLocation);
@@ -524,6 +551,18 @@ public class TableOpsDelegateTest {
     newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property3", "new_value3");
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
 
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/table");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("table-uuid-123");
+
+    // Mock current snapshot
+    Snapshot mockSnapshot = mock(Snapshot.class);
+    when(mockSnapshot.snapshotId()).thenReturn(12345L);
+    when(mockSnapshot.sequenceNumber()).thenReturn(1L);
+    when(mockSnapshot.manifestListLocation()).thenReturn("/path/to/manifest-list");
+    when(mockMetadata.currentSnapshot()).thenReturn(mockSnapshot);
+
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -564,6 +603,18 @@ public class TableOpsDelegateTest {
     newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "value1");
     newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property2", "value2");
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/table");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("table-uuid-123");
+
+    // Mock current snapshot
+    Snapshot mockSnapshot = mock(Snapshot.class);
+    when(mockSnapshot.snapshotId()).thenReturn(12345L);
+    when(mockSnapshot.sequenceNumber()).thenReturn(1L);
+    when(mockSnapshot.manifestListLocation()).thenReturn("/path/to/manifest-list");
+    when(mockMetadata.currentSnapshot()).thenReturn(mockSnapshot);
 
     // Mock schema to prevent NullPointerException
     Schema schema =
@@ -614,6 +665,18 @@ public class TableOpsDelegateTest {
     TableMetadata mockMetadata = mock(TableMetadata.class);
     Map<String, String> newIcebergProperties = new HashMap<>();
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/table");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("table-uuid-123");
+
+    // Mock current snapshot
+    Snapshot mockSnapshot = mock(Snapshot.class);
+    when(mockSnapshot.snapshotId()).thenReturn(12345L);
+    when(mockSnapshot.sequenceNumber()).thenReturn(1L);
+    when(mockSnapshot.manifestListLocation()).thenReturn("/path/to/manifest-list");
+    when(mockMetadata.currentSnapshot()).thenReturn(mockSnapshot);
 
     Schema schema =
         new Schema(
@@ -666,6 +729,18 @@ public class TableOpsDelegateTest {
     newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "new_value1");
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
 
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/table");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("table-uuid-123");
+
+    // Mock current snapshot
+    Snapshot mockSnapshot = mock(Snapshot.class);
+    when(mockSnapshot.snapshotId()).thenReturn(12345L);
+    when(mockSnapshot.sequenceNumber()).thenReturn(1L);
+    when(mockSnapshot.manifestListLocation()).thenReturn("/path/to/manifest-list");
+    when(mockMetadata.currentSnapshot()).thenReturn(mockSnapshot);
+
     Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
@@ -712,6 +787,18 @@ public class TableOpsDelegateTest {
     TableMetadata mockMetadata = mock(TableMetadata.class);
     Map<String, String> newIcebergProperties = new HashMap<>();
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/table");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("table-uuid-123");
+
+    // Mock current snapshot
+    Snapshot mockSnapshot = mock(Snapshot.class);
+    when(mockSnapshot.snapshotId()).thenReturn(12345L);
+    when(mockSnapshot.sequenceNumber()).thenReturn(1L);
+    when(mockSnapshot.manifestListLocation()).thenReturn("/path/to/manifest-list");
+    when(mockMetadata.currentSnapshot()).thenReturn(mockSnapshot);
 
     // Mock schema to prevent NullPointerException
     Schema schema =

--- a/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/ViewOpsDelegateTest.java
+++ b/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/ViewOpsDelegateTest.java
@@ -3,6 +3,7 @@ package io.datahubproject.iceberg.catalog;
 import static com.linkedin.metadata.Constants.*;
 import static com.linkedin.metadata.utils.GenericRecordUtils.serializeAspect;
 import static io.datahubproject.iceberg.catalog.DataHubIcebergWarehouse.DATASET_ICEBERG_METADATA_ASPECT_NAME;
+import static io.datahubproject.iceberg.catalog.DataHubIcebergWarehouse.ICEBERG_PROPERTY_PREFIX;
 import static io.datahubproject.iceberg.catalog.Utils.containerUrn;
 import static io.datahubproject.iceberg.catalog.Utils.platformUrn;
 import static org.mockito.ArgumentMatchers.any;
@@ -16,6 +17,7 @@ import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.container.Container;
 import com.linkedin.data.template.StringArray;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.dataset.DatasetProfile;
 import com.linkedin.dataset.DatasetProperties;
 import com.linkedin.dataset.IcebergCatalogInfo;
@@ -33,7 +35,9 @@ import io.datahubproject.metadata.context.ActorContext;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.schematron.converters.avro.AvroSchemaConverter;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.iceberg.Schema;
@@ -423,5 +427,252 @@ public class ViewOpsDelegateTest {
   public void testRefreshNotFound() {
     when(mockWarehouse.getIcebergMetadata(identifier)).thenReturn(Optional.empty());
     assertNull(viewDelegate.refresh());
+  }
+
+  @Test
+  public void testAdditionalAsyncMcpsWithExistingDatasetProperties() {
+    // Create a real ViewOpsDelegate instance for testing
+    ViewOpsDelegate realViewDelegate =
+        new ViewOpsDelegate(
+            mockWarehouse, identifier, mockEntityService, mockOperationContext, mockFileIOFactory);
+
+    // Mock existing dataset properties with Iceberg properties
+    DatasetProperties existingProperties = new DatasetProperties();
+    StringMap existingCustomProperties = new StringMap();
+    existingCustomProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "old_value1");
+    existingCustomProperties.put(ICEBERG_PROPERTY_PREFIX + "property2", "old_value2");
+    existingCustomProperties.put("non_iceberg_property", "should_not_change");
+    existingProperties.setCustomProperties(existingCustomProperties);
+
+    // Mock entityService.getLatestAspect to return existing properties
+    when(mockEntityService.getLatestAspect(
+            eq(mockOperationContext), any(DatasetUrn.class), eq(DATASET_PROPERTIES_ASPECT_NAME)))
+        .thenReturn(existingProperties);
+
+    // Mock ViewMetadata with new Iceberg properties
+    ViewMetadata mockMetadata = mock(ViewMetadata.class);
+    Map<String, String> newIcebergProperties = new HashMap<>();
+    newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "new_value1");
+    newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property3", "new_value3");
+    when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock schema to prevent NullPointerException
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+    when(mockMetadata.schema()).thenReturn(schema);
+
+    // Mock AuditStamp
+    AuditStamp auditStamp = new AuditStamp().setTime(Instant.now().toEpochMilli());
+    when(mockIcebergBatch.getAuditStamp()).thenReturn(auditStamp);
+
+    // Create MetadataWrapper
+    MetadataWrapper<ViewMetadata> metadataWrapper = new MetadataWrapper<>(mockMetadata);
+    DatasetUrn datasetUrn = mock(DatasetUrn.class);
+
+    // Call the method directly since it's package-private
+    realViewDelegate.additionalAsyncMcps(datasetUrn, metadataWrapper, auditStamp);
+
+    // Verify that entityService.ingestProposal was called for dataset properties update
+    verify(mockEntityService, times(2))
+        .ingestProposal(
+            eq(mockOperationContext), any(MetadataChangeProposal.class), eq(auditStamp), eq(true));
+  }
+
+  @Test
+  public void testAdditionalAsyncMcpsWithNoExistingDatasetProperties() {
+    // Create a real ViewOpsDelegate instance for testing
+    ViewOpsDelegate realViewDelegate =
+        new ViewOpsDelegate(
+            mockWarehouse, identifier, mockEntityService, mockOperationContext, mockFileIOFactory);
+
+    // Mock entityService.getLatestAspect to return null (no existing properties)
+    when(mockEntityService.getLatestAspect(
+            eq(mockOperationContext), any(DatasetUrn.class), eq(DATASET_PROPERTIES_ASPECT_NAME)))
+        .thenReturn(null);
+
+    // Mock ViewMetadata with Iceberg properties
+    ViewMetadata mockMetadata = mock(ViewMetadata.class);
+    Map<String, String> newIcebergProperties = new HashMap<>();
+    newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "value1");
+    newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property2", "value2");
+    when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock schema to prevent NullPointerException
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+    when(mockMetadata.schema()).thenReturn(schema);
+
+    // Mock AuditStamp
+    AuditStamp auditStamp = new AuditStamp().setTime(Instant.now().toEpochMilli());
+    when(mockIcebergBatch.getAuditStamp()).thenReturn(auditStamp);
+
+    // Create MetadataWrapper
+    MetadataWrapper<ViewMetadata> metadataWrapper = new MetadataWrapper<>(mockMetadata);
+    DatasetUrn datasetUrn = mock(DatasetUrn.class);
+
+    // Call the method directly since it's package-private
+    realViewDelegate.additionalAsyncMcps(datasetUrn, metadataWrapper, auditStamp);
+
+    // Verify that entityService.ingestProposal was called twice (for dataset profile and dataset
+    // properties)
+    // The dataset properties update happens because there are new properties to add
+    verify(mockEntityService, times(2))
+        .ingestProposal(
+            eq(mockOperationContext), any(MetadataChangeProposal.class), eq(auditStamp), eq(true));
+  }
+
+  @Test
+  public void testAdditionalAsyncMcpsWithNoNewProperties() {
+    // Create a real ViewOpsDelegate instance for testing
+    ViewOpsDelegate realViewDelegate =
+        new ViewOpsDelegate(
+            mockWarehouse, identifier, mockEntityService, mockOperationContext, mockFileIOFactory);
+
+    // Mock existing dataset properties with Iceberg properties
+    DatasetProperties existingProperties = new DatasetProperties();
+    StringMap existingCustomProperties = new StringMap();
+    existingCustomProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "old_value1");
+    existingCustomProperties.put(ICEBERG_PROPERTY_PREFIX + "property2", "old_value2");
+    existingCustomProperties.put("non_iceberg_property", "should_not_change");
+    existingProperties.setCustomProperties(existingCustomProperties);
+
+    // Mock entityService.getLatestAspect to return existing properties
+    when(mockEntityService.getLatestAspect(
+            eq(mockOperationContext), any(DatasetUrn.class), eq(DATASET_PROPERTIES_ASPECT_NAME)))
+        .thenReturn(existingProperties);
+
+    // Mock ViewMetadata with no new Iceberg properties
+    ViewMetadata mockMetadata = mock(ViewMetadata.class);
+    Map<String, String> newIcebergProperties = new HashMap<>();
+    when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock schema to prevent NullPointerException
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+    when(mockMetadata.schema()).thenReturn(schema);
+
+    // Mock AuditStamp
+    AuditStamp auditStamp = new AuditStamp().setTime(Instant.now().toEpochMilli());
+    when(mockIcebergBatch.getAuditStamp()).thenReturn(auditStamp);
+
+    // Create MetadataWrapper
+    MetadataWrapper<ViewMetadata> metadataWrapper = new MetadataWrapper<>(mockMetadata);
+    DatasetUrn datasetUrn = mock(DatasetUrn.class);
+
+    // Call the method directly since it's package-private
+    realViewDelegate.additionalAsyncMcps(datasetUrn, metadataWrapper, auditStamp);
+
+    // Verify that entityService.ingestProposal was called twice (for dataset profile and dataset
+    // properties)
+    // The dataset properties update happens because there are properties to delete
+    verify(mockEntityService, times(2))
+        .ingestProposal(
+            eq(mockOperationContext), any(MetadataChangeProposal.class), eq(auditStamp), eq(true));
+  }
+
+  @Test
+  public void testAdditionalAsyncMcpsWithDeletedIcebergProperties() {
+    // Create a real ViewOpsDelegate instance for testing
+    ViewOpsDelegate realViewDelegate =
+        new ViewOpsDelegate(
+            mockWarehouse, identifier, mockEntityService, mockOperationContext, mockFileIOFactory);
+
+    // Mock existing dataset properties with Iceberg properties that should be deleted
+    DatasetProperties existingProperties = new DatasetProperties();
+    StringMap existingCustomProperties = new StringMap();
+    existingCustomProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "old_value1");
+    existingCustomProperties.put(ICEBERG_PROPERTY_PREFIX + "property2", "old_value2");
+    existingCustomProperties.put(ICEBERG_PROPERTY_PREFIX + "property3", "old_value3");
+    existingCustomProperties.put("non_iceberg_property", "should_not_change");
+    existingProperties.setCustomProperties(existingCustomProperties);
+
+    // Mock entityService.getLatestAspect to return existing properties
+    when(mockEntityService.getLatestAspect(
+            eq(mockOperationContext), any(DatasetUrn.class), eq(DATASET_PROPERTIES_ASPECT_NAME)))
+        .thenReturn(existingProperties);
+
+    // Mock ViewMetadata with fewer Iceberg properties (property2 and property3 should be deleted)
+    ViewMetadata mockMetadata = mock(ViewMetadata.class);
+    Map<String, String> newIcebergProperties = new HashMap<>();
+    newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "new_value1");
+    when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock schema to prevent NullPointerException
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+    when(mockMetadata.schema()).thenReturn(schema);
+
+    // Mock AuditStamp
+    AuditStamp auditStamp = new AuditStamp().setTime(Instant.now().toEpochMilli());
+    when(mockIcebergBatch.getAuditStamp()).thenReturn(auditStamp);
+
+    // Create MetadataWrapper
+    MetadataWrapper<ViewMetadata> metadataWrapper = new MetadataWrapper<>(mockMetadata);
+    DatasetUrn datasetUrn = mock(DatasetUrn.class);
+
+    // Call the method directly since it's package-private
+    realViewDelegate.additionalAsyncMcps(datasetUrn, metadataWrapper, auditStamp);
+
+    // Verify that entityService.ingestProposal was called for dataset properties update
+    verify(mockEntityService, times(2))
+        .ingestProposal(
+            eq(mockOperationContext), any(MetadataChangeProposal.class), eq(auditStamp), eq(true));
+  }
+
+  @Test
+  public void testAdditionalAsyncMcpsWithEmptyIcebergProperties() {
+    // Create a real ViewOpsDelegate instance for testing
+    ViewOpsDelegate realViewDelegate =
+        new ViewOpsDelegate(
+            mockWarehouse, identifier, mockEntityService, mockOperationContext, mockFileIOFactory);
+
+    // Mock existing dataset properties with Iceberg properties
+    DatasetProperties existingProperties = new DatasetProperties();
+    StringMap existingCustomProperties = new StringMap();
+    existingCustomProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "old_value1");
+    existingCustomProperties.put(ICEBERG_PROPERTY_PREFIX + "property2", "old_value2");
+    existingCustomProperties.put("non_iceberg_property", "should_not_change");
+    existingProperties.setCustomProperties(existingCustomProperties);
+
+    // Mock entityService.getLatestAspect to return existing properties
+    when(mockEntityService.getLatestAspect(
+            eq(mockOperationContext), any(DatasetUrn.class), eq(DATASET_PROPERTIES_ASPECT_NAME)))
+        .thenReturn(existingProperties);
+
+    // Mock ViewMetadata with no Iceberg properties (all should be deleted)
+    ViewMetadata mockMetadata = mock(ViewMetadata.class);
+    Map<String, String> newIcebergProperties = new HashMap<>();
+    when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock schema to prevent NullPointerException
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "data", Types.StringType.get()));
+    when(mockMetadata.schema()).thenReturn(schema);
+
+    // Mock AuditStamp
+    AuditStamp auditStamp = new AuditStamp().setTime(Instant.now().toEpochMilli());
+    when(mockIcebergBatch.getAuditStamp()).thenReturn(auditStamp);
+
+    // Create MetadataWrapper
+    MetadataWrapper<ViewMetadata> metadataWrapper = new MetadataWrapper<>(mockMetadata);
+    DatasetUrn datasetUrn = mock(DatasetUrn.class);
+
+    // Call the method directly since it's package-private
+    realViewDelegate.additionalAsyncMcps(datasetUrn, metadataWrapper, auditStamp);
+
+    // Verify that entityService.ingestProposal was called for dataset properties update
+    verify(mockEntityService, times(2))
+        .ingestProposal(
+            eq(mockOperationContext), any(MetadataChangeProposal.class), eq(auditStamp), eq(true));
   }
 }

--- a/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/ViewOpsDelegateTest.java
+++ b/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/ViewOpsDelegateTest.java
@@ -456,6 +456,11 @@ public class ViewOpsDelegateTest {
     newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property3", "new_value3");
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
 
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/view");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("view-uuid-123");
+
     // Mock schema to prevent NullPointerException
     Schema schema =
         new Schema(
@@ -498,6 +503,11 @@ public class ViewOpsDelegateTest {
     newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "value1");
     newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property2", "value2");
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/view");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("view-uuid-123");
 
     // Mock schema to prevent NullPointerException
     Schema schema =
@@ -549,6 +559,11 @@ public class ViewOpsDelegateTest {
     ViewMetadata mockMetadata = mock(ViewMetadata.class);
     Map<String, String> newIcebergProperties = new HashMap<>();
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/view");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("view-uuid-123");
 
     // Mock schema to prevent NullPointerException
     Schema schema =
@@ -603,6 +618,11 @@ public class ViewOpsDelegateTest {
     newIcebergProperties.put(ICEBERG_PROPERTY_PREFIX + "property1", "new_value1");
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
 
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/view");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("view-uuid-123");
+
     // Mock schema to prevent NullPointerException
     Schema schema =
         new Schema(
@@ -651,6 +671,11 @@ public class ViewOpsDelegateTest {
     ViewMetadata mockMetadata = mock(ViewMetadata.class);
     Map<String, String> newIcebergProperties = new HashMap<>();
     when(mockMetadata.properties()).thenReturn(newIcebergProperties);
+
+    // Mock metadata properties that will be added by addMetadataProperties
+    when(mockMetadata.location()).thenReturn("/path/to/view");
+    when(mockMetadata.formatVersion()).thenReturn(2);
+    when(mockMetadata.uuid()).thenReturn("view-uuid-123");
 
     // Mock schema to prevent NullPointerException
     Schema schema =


### PR DESCRIPTION
Add some of the standard metadata fields are populated in the Dataset Properties. Additionally, any Iceberg `TBLPROPERTIES` set via DDL on tables or views are also shown in DatasetProperties with a prefix `iceberg:`
The iceberg 'TBLPROPERTIES' can only be set via DDL and is a one way sync. Changes to iceberg `TBLPROPERTIES` properties via datahub APIs do not get written to the Iceberg table or view properties.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
