### PR TITLE
fix(openapi): Generic entities upsert applies all changes transaction…

### DIFF
--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/controller/EntityController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/controller/EntityController.java
@@ -470,23 +470,16 @@ public class EntityController
             .build(opContext);
     List<IngestResult> results = entityService.ingestProposal(opContext, batch, async);
 
-    if (!async) {
-      // Group results by entity type for response structure
-      Map<String, List<IngestResult>> resultsByEntityType = new HashMap<>();
-      for (IngestResult result : results) {
-        String entityType = result.getUrn().getEntityType();
-        resultsByEntityType.computeIfAbsent(entityType, k -> new ArrayList<>()).add(result);
-      }
+    // Group results by entity type for response structure
+    Map<String, List<IngestResult>> resultsByEntityType = new HashMap<>();
+    for (IngestResult result : results) {
+      String entityType = result.getUrn().getEntityType();
+      resultsByEntityType.computeIfAbsent(entityType, k -> new ArrayList<>()).add(result);
+    }
 
-      for (String entityName : entityTypes) {
-        List<IngestResult> entityResults = resultsByEntityType.getOrDefault(entityName, List.of());
-        response.put(entityName, buildEntityList(opContext, entityResults, withSystemMetadata));
-      }
-    } else {
-      // For async requests, return empty lists for each entity type
-      for (String entityName : entityTypes) {
-        response.put(entityName, List.of());
-      }
+    for (String entityName : entityTypes) {
+      List<IngestResult> entityResults = resultsByEntityType.getOrDefault(entityName, List.of());
+      response.put(entityName, buildEntityList(opContext, entityResults, withSystemMetadata));
     }
 
     return async ? ResponseEntity.accepted().body(response) : ResponseEntity.ok(response);


### PR DESCRIPTION
Wrap all changes in the generic entities upsert in a single aspect batch such that the entityService will apply a single transactional boundary across the entities