### PR TITLE
fix(build): incorrect tag for full variant of datahub-ingestion image

### DIFF
--- a/docker/datahub-ingestion/build.gradle
+++ b/docker/datahub-ingestion/build.gradle
@@ -41,7 +41,7 @@ docker {
 
     variants = [
         "slim": [suffix: "", args: [RELEASE_VERSION: python_docker_version, APP_ENV: "slim"]],
-        "full": [suffix: "full", args: [RELEASE_VERSION: python_docker_version, APP_ENV: "full"]]
+        "full": [suffix: "-full", args: [RELEASE_VERSION: python_docker_version, APP_ENV: "full"]]
         ]
     // This task is intended to build the slim image
     //target 'ingestion-base-slim' //Review if this needs to be handled by bake


### PR DESCRIPTION
Corrects tags, current published are `fa0edcdfull` instead of `fa0edcd-full`
https://hub.docker.com/r/acryldata/datahub-ingestion/tags
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
