### PR TITLE
fix(customHomePage): adjust icon colors of add module menu items

### DIFF
--- a/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/components/MenuItem.tsx
+++ b/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/components/MenuItem.tsx
@@ -45,10 +45,12 @@ export default function MenuItem({ icon, title, description, hasChildren, isDisa
         return 'Cannot add large widget to small widget row';
     }, [isDisabled, isSmallModule]);
 
+    const iconColorLevel = isDisabled ? 300 : 1800;
+
     const content = (
         <Wrapper>
             <IconWrapper>
-                <Icon icon={icon} source="phosphor" color="gray" size="2xl" />
+                <Icon icon={icon} source="phosphor" color="gray" colorLevel={iconColorLevel} size="2xl" />
             </IconWrapper>
 
             <Container>
@@ -62,7 +64,9 @@ export default function MenuItem({ icon, title, description, hasChildren, isDisa
 
             <SpaceFiller />
 
-            {hasChildren && <Icon icon="CaretRight" source="phosphor" color="gray" size="lg" />}
+            {hasChildren && (
+                <Icon icon="CaretRight" source="phosphor" color="gray" colorLevel={iconColorLevel} size="lg" />
+            )}
         </Wrapper>
     );
 


### PR DESCRIPTION
<img width="776" height="636" alt="image" src="https://github.com/user-attachments/assets/109274a1-0f49-4bac-a226-1daa8ae4203f" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
