### PR TITLE
fix(ingest): ensure docker image has all required deps

### DIFF
--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -129,14 +129,12 @@ USER datahub
 FROM ingestion-base-${APP_ENV} AS add-code
 
 COPY --chown=datahub ./metadata-ingestion /metadata-ingestion
-COPY --chown=datahub ./metadata-ingestion-modules/airflow-plugin /airflow-plugin
 
 ARG RELEASE_VERSION
 RUN test -n "$RELEASE_VERSION"  # RELEASE_VERSION is a required build arg
 RUN test -d /metadata-ingestion/src/datahub/metadata  # codegen must be run prior to building the image
 RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_updater.py \
-    python /version_updater.py --directory /metadata-ingestion/ --version "$RELEASE_VERSION" --expected-update-count 1 \
-    && python /version_updater.py --directory /airflow-plugin/ --version "$RELEASE_VERSION" --expected-update-count 1
+    python /version_updater.py --directory /metadata-ingestion/ --version "$RELEASE_VERSION" --expected-update-count 1
 
 FROM add-code AS install-slim
 
@@ -148,9 +146,8 @@ FROM add-code AS install-full
 
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000 \
     UV_LINK_MODE=copy uv pip install \
-        -e "/metadata-ingestion/[base,all]" \
-        -e "/airflow-plugin/[plugin-v2]" && \
-    datahub --version
+        -e "/metadata-ingestion/[all]" \
+    && datahub --version
 
 FROM install-${APP_ENV} AS final
 

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -987,11 +987,12 @@ See the [DataHub docs](https://docs.datahub.com/docs/metadata-ingestion).
         },
         "all": list(
             framework_common.union(
+                pydantic_no_v2,
                 *[
                     requirements
                     for plugin, requirements in plugins.items()
                     if plugin not in all_exclude_plugins
-                ]
+                ],
             )
         ),
         "cloud": ["acryl-datahub-cloud"],

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/models.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from datahub.configuration.pydantic_migration_helpers import PYDANTIC_VERSION_2
 from datahub.emitter.mcp_builder import ContainerKey
 
 # Grafana-specific type definitions for better type safety
@@ -105,6 +106,11 @@ class Folder(BaseModel):
     id: str
     title: str
     description: Optional[str] = ""
+
+    if PYDANTIC_VERSION_2:
+        from pydantic import ConfigDict
+
+        model_config = ConfigDict(coerce_numbers_to_str=True)  # type: ignore
 
 
 class FolderKey(ContainerKey):


### PR DESCRIPTION
The datahub-ingestion docker image was missing the dep on pydantic v1, resulting in an image that did not work as expected.

Also improves the grafana source to work with pydantic v2 for when we actually enable that in the future.

Fixes #14261

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
