### PR TITLE
fix(security): exclude docs-website from scans

### DIFF
--- a/.aikido
+++ b/.aikido
@@ -1,0 +1,3 @@
+exclude:
+  paths:
+    - docs-website/ 


### PR DESCRIPTION
Exclude docs-website from security scans with Aikido.
