### PR TITLE
fix(customHomePage): prevent default template deleting through API

### DIFF
--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageTemplateService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageTemplateService.java
@@ -33,6 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PageTemplateService {
   private final EntityClient entityClient;
+  private static final String DEFAULT_HOME_PAGE_TEMPLATE_URN =
+      "urn:li:dataHubPageTemplate:home_default_1";
 
   public PageTemplateService(@Nonnull EntityClient entityClient) {
     this.entityClient = entityClient;
@@ -200,6 +202,11 @@ public class PageTemplateService {
    */
   public void checkDeleteTemplatePermissions(
       @Nonnull OperationContext opContext, @Nonnull final Urn templateUrn) {
+
+    if (Objects.equals(templateUrn.toString(), DEFAULT_HOME_PAGE_TEMPLATE_URN)) {
+      throw new UnauthorizedException("Attempted to delete the default page template");
+    }
+
     DataHubPageTemplateProperties properties = getPageTemplateProperties(opContext, templateUrn);
 
     if (properties == null) {


### PR DESCRIPTION
This PR prevents default template deleting through API

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
