### PR TITLE
feat(sdk/patch): Support DataJob fine grained lineage patch

### DIFF
--- a/docs/advanced/patch.md
+++ b/docs/advanced/patch.md
@@ -11,7 +11,7 @@ To support these scenarios, DataHub supports `PATCH` operations to perform targe
 
 :::note
 
-Currently, PATCH support is only available for a selected set of aspects, so before pinning your hopes on using PATCH as a way to make modifications to aspect values, confirm whether your aspect supports PATCH semantics. The complete list of Aspects that are supported are maintained [here](https://github.com/datahub-project/datahub/blob/9588440549f3d99965085e97b214a7dabc181ed2/entity-registry/src/main/java/com/linkedin/metadata/models/registry/template/AspectTemplateEngine.java#L24).
+Currently, PATCH support is only available for a selected set of aspects, so before pinning your hopes on using PATCH as a way to make modifications to aspect values, confirm whether your aspect supports PATCH semantics. The complete list of Aspects that are supported are maintained by the `SUPPORTED_TEMPLATES` constant [here](https://github.com/datahub-project/datahub/blob/master/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/AspectTemplateEngine.java#L23).
 
 :::
 
@@ -104,10 +104,10 @@ The Java Patch builders are aspect-oriented and located in the [datahub-client](
 {{ inline /metadata-integration/java/examples/src/main/java/io/datahubproject/examples/DatasetCustomPropertiesAddRemove.java show_path_as_comment }}
 ```
 
-### Add Data Job Lineage
+### Add & Remove Data Job Lineage
 
-```java
-{{ inline /metadata-integration/java/examples/src/main/java/io/datahubproject/examples/DataJobLineageAdd.java show_path_as_comment }}
+```python
+{{ inline /metadata-ingestion/examples/library/patch_datajob_lineage.py show_path_as_comment }}
 ```
 
 </TabItem>

--- a/metadata-ingestion/examples/library/dataset_add_upstream_lineage_patch.py
+++ b/metadata-ingestion/examples/library/dataset_add_upstream_lineage_patch.py
@@ -31,7 +31,7 @@ patch_builder.add_upstream_lineage(
 upstream_field_to_add_urn = make_schema_field_urn(upstream_to_add_urn, "profile_id")
 downstream_field_to_add_urn = make_schema_field_urn(dataset_urn, "profile_id")
 
-patch_builder.add_fine_grained_upstream_lineage(
+patch_builder.add_fine_grained_lineage(
     FineGrainedLineageClass(
         FineGrainedLineageUpstreamTypeClass.FIELD_SET,
         FineGrainedLineageUpstreamTypeClass.FIELD_SET,
@@ -45,7 +45,7 @@ upstream_field_to_remove_urn = make_schema_field_urn(
 )
 downstream_field_to_remove_urn = make_schema_field_urn(dataset_urn, "profile_id")
 
-patch_builder.remove_fine_grained_upstream_lineage(
+patch_builder.remove_fine_grained_lineage(
     FineGrainedLineageClass(
         FineGrainedLineageUpstreamTypeClass.FIELD_SET,
         FineGrainedLineageUpstreamTypeClass.FIELD_SET,

--- a/metadata-ingestion/examples/library/patch_datajob_lineage.py
+++ b/metadata-ingestion/examples/library/patch_datajob_lineage.py
@@ -1,0 +1,73 @@
+from datahub.emitter import mce_builder
+from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
+from datahub.metadata.schema_classes import (
+    FineGrainedLineageClass as FineGrainedLineage,
+    FineGrainedLineageDownstreamTypeClass as FineGrainedLineageDownstreamType,
+    FineGrainedLineageUpstreamTypeClass as FineGrainedLineageUpstreamType,
+)
+from datahub.specific.datajob import DataJobPatchBuilder
+
+# Create DataJobPatchBuilder instance
+job_urn = mce_builder.make_data_job_urn("airflow", "data_pipeline", "transform_task")
+patch_builder = DataJobPatchBuilder(job_urn)
+
+# Add input and output datasets
+patch_builder.add_input_dataset(
+    mce_builder.make_dataset_urn("postgres", "raw_data.users")
+)
+patch_builder.add_output_dataset(
+    mce_builder.make_dataset_urn("postgres", "analytics.user_metrics")
+)
+
+# Add input data job dependency
+patch_builder.add_input_datajob(
+    mce_builder.make_data_job_urn("airflow", "data_pipeline", "extract_users")
+)
+
+# Add input/output fields
+patch_builder.add_input_dataset_field(
+    mce_builder.make_schema_field_urn(
+        mce_builder.make_dataset_urn("postgres", "raw_data.users"), "user_id"
+    )
+)
+patch_builder.add_output_dataset_field(
+    mce_builder.make_schema_field_urn(
+        mce_builder.make_dataset_urn("postgres", "analytics.user_metrics"), "user_id"
+    )
+)
+
+# Update column-level lineage through the Data Job
+lineage1 = FineGrainedLineage(
+    upstreamType=FineGrainedLineageUpstreamType.FIELD_SET,
+    upstreams=[
+        mce_builder.make_schema_field_urn(
+            mce_builder.make_dataset_urn("postgres", "raw_data.users"), "user_id"
+        )
+    ],
+    downstreamType=FineGrainedLineageDownstreamType.FIELD,
+    downstreams=[
+        mce_builder.make_schema_field_urn(
+            mce_builder.make_dataset_urn("postgres", "analytics.user_metrics"),
+            "user_id",
+        )
+    ],
+    transformOperation="IDENTITY",
+    confidenceScore=1.0,
+)
+patch_builder.add_fine_grained_lineage(lineage1)
+patch_builder.remove_fine_grained_lineage(lineage1)
+patch_builder.set_fine_grained_lineages(
+    [lineage1]
+)  # Replaces all existing fine-grained lineages
+
+# Remove entities
+patch_builder.remove_input_dataset(
+    mce_builder.make_dataset_urn("postgres", "raw_data.users")
+)
+
+# Create DataHub Client
+datahub_client = DataHubGraph(DataHubGraphConfig(server="http://localhost:8080"))
+
+# Emit patches
+for patch in patch_builder.build():
+    datahub_client.emit(patch)

--- a/metadata-ingestion/src/datahub/specific/aspect_helpers/fine_grained_lineage.py
+++ b/metadata-ingestion/src/datahub/specific/aspect_helpers/fine_grained_lineage.py
@@ -1,0 +1,76 @@
+from abc import abstractmethod
+from typing import List, Tuple
+
+from typing_extensions import Self
+
+from datahub.emitter.mcp_patch_builder import MetadataPatchProposal, PatchPath
+from datahub.metadata.schema_classes import (
+    FineGrainedLineageClass as FineGrainedLineage,
+)
+
+
+class HasFineGrainedLineagePatch(MetadataPatchProposal):
+    @abstractmethod
+    def _fine_grained_lineage_location(self) -> Tuple[str, PatchPath]:
+        """Return the aspect name where fine-grained lineage is stored."""
+        raise NotImplementedError("Subclasses must implement this method.")
+
+    @staticmethod
+    def _get_fine_grained_key(
+        fine_grained_lineage: FineGrainedLineage,
+    ) -> Tuple[str, str, str]:
+        downstreams = fine_grained_lineage.downstreams or []
+        if len(downstreams) != 1:
+            raise TypeError("Cannot patch with more or less than one downstream.")
+        transform_op = fine_grained_lineage.transformOperation or "NONE"
+        downstream_urn = downstreams[0]
+        query_id = fine_grained_lineage.query or "NONE"
+        return transform_op, downstream_urn, query_id
+
+    def add_fine_grained_lineage(
+        self, fine_grained_lineage: FineGrainedLineage
+    ) -> Self:
+        aspect_name, path = self._fine_grained_lineage_location()
+        (
+            transform_op,
+            downstream_urn,
+            query_id,
+        ) = self._get_fine_grained_key(fine_grained_lineage)
+        for upstream_urn in fine_grained_lineage.upstreams or []:
+            self._add_patch(
+                aspect_name,
+                "add",
+                path=(*path, transform_op, downstream_urn, query_id, upstream_urn),
+                value={"confidenceScore": fine_grained_lineage.confidenceScore},
+            )
+        return self
+
+    def remove_fine_grained_lineage(
+        self, fine_grained_lineage: FineGrainedLineage
+    ) -> Self:
+        aspect_name, path = self._fine_grained_lineage_location()
+        (
+            transform_op,
+            downstream_urn,
+            query_id,
+        ) = self._get_fine_grained_key(fine_grained_lineage)
+        for upstream_urn in fine_grained_lineage.upstreams or []:
+            self._add_patch(
+                aspect_name,
+                "remove",
+                path=(*path, transform_op, downstream_urn, query_id, upstream_urn),
+                value={},
+            )
+        return self
+
+    def set_fine_grained_lineages(
+        self, fine_grained_lineages: List[FineGrainedLineage]
+    ) -> Self:
+        aspect_name, path = self._fine_grained_lineage_location()
+        self._add_patch(
+            aspect_name,
+            "add",
+            path=path,
+            value=fine_grained_lineages,
+        )
+        return self

--- a/metadata-ingestion/src/datahub/specific/dataset.py
+++ b/metadata-ingestion/src/datahub/specific/dataset.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Generic, List, Optional, Tuple, TypeVar, Union
 
 from datahub.emitter.mcp_patch_builder import MetadataPatchProposal, PatchPath
@@ -17,6 +18,9 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.metadata.urns import DatasetUrn, TagUrn, Urn
 from datahub.specific.aspect_helpers.custom_properties import HasCustomPropertiesPatch
+from datahub.specific.aspect_helpers.fine_grained_lineage import (
+    HasFineGrainedLineagePatch,
+)
 from datahub.specific.aspect_helpers.ownership import HasOwnershipPatch
 from datahub.specific.aspect_helpers.structured_properties import (
     HasStructuredPropertiesPatch,
@@ -99,6 +103,7 @@ class DatasetPatchBuilder(
     HasStructuredPropertiesPatch,
     HasTagsPatch,
     HasTermsPatch,
+    HasFineGrainedLineagePatch,
     MetadataPatchProposal,
 ):
     def __init__(
@@ -114,6 +119,10 @@ class DatasetPatchBuilder(
     @classmethod
     def _custom_properties_location(cls) -> Tuple[str, PatchPath]:
         return DatasetProperties.ASPECT_NAME, ("customProperties",)
+
+    @classmethod
+    def _fine_grained_lineage_location(cls) -> Tuple[str, PatchPath]:
+        return UpstreamLineage.ASPECT_NAME, ("fineGrainedLineages",)
 
     def add_upstream_lineage(self, upstream: Upstream) -> "DatasetPatchBuilder":
         self._add_patch(
@@ -144,75 +153,44 @@ class DatasetPatchBuilder(
     def add_fine_grained_upstream_lineage(
         self, fine_grained_lineage: FineGrainedLineage
     ) -> "DatasetPatchBuilder":
-        (
-            transform_op,
-            downstream_urn,
-            query_id,
-        ) = DatasetPatchBuilder.get_fine_grained_key(fine_grained_lineage)
-        for upstream_urn in fine_grained_lineage.upstreams or []:
-            self._add_patch(
-                UpstreamLineage.ASPECT_NAME,
-                "add",
-                path=self._build_fine_grained_path(
-                    transform_op, downstream_urn, query_id, upstream_urn
-                ),
-                value={"confidenceScore": fine_grained_lineage.confidenceScore},
-            )
-        return self
-
-    @staticmethod
-    def get_fine_grained_key(
-        fine_grained_lineage: FineGrainedLineage,
-    ) -> Tuple[str, str, str]:
-        downstreams = fine_grained_lineage.downstreams or []
-        if len(downstreams) != 1:
-            raise TypeError("Cannot patch with more or less than one downstream.")
-        transform_op = fine_grained_lineage.transformOperation or "NONE"
-        downstream_urn = downstreams[0]
-        query_id = fine_grained_lineage.query or "NONE"
-        return transform_op, downstream_urn, query_id
-
-    @classmethod
-    def _build_fine_grained_path(
-        cls, transform_op: str, downstream_urn: str, query_id: str, upstream_urn: str
-    ) -> PatchPath:
-        return (
-            "fineGrainedLineages",
-            transform_op,
-            downstream_urn,
-            query_id,
-            upstream_urn,
+        """
+        Deprecated: Use `add_fine_grained_lineage` instead.
+        """
+        warnings.warn(
+            "add_fine_grained_upstream_lineage() is deprecated."
+            " Use add_fine_grained_lineage() instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
+        return self.add_fine_grained_lineage(fine_grained_lineage)
 
     def remove_fine_grained_upstream_lineage(
         self, fine_grained_lineage: FineGrainedLineage
     ) -> "DatasetPatchBuilder":
-        (
-            transform_op,
-            downstream_urn,
-            query_id,
-        ) = DatasetPatchBuilder.get_fine_grained_key(fine_grained_lineage)
-        for upstream_urn in fine_grained_lineage.upstreams or []:
-            self._add_patch(
-                UpstreamLineage.ASPECT_NAME,
-                "remove",
-                path=self._build_fine_grained_path(
-                    transform_op, downstream_urn, query_id, upstream_urn
-                ),
-                value={},
-            )
-        return self
+        """
+        Deprecated: Use `remove_fine_grained_lineage` instead.
+        """
+        warnings.warn(
+            "remove_fine_grained_upstream_lineage() is deprecated."
+            " Use remove_fine_grained_lineage() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.remove_fine_grained_lineage(fine_grained_lineage)
 
     def set_fine_grained_upstream_lineages(
         self, fine_grained_lineages: List[FineGrainedLineage]
     ) -> "DatasetPatchBuilder":
-        self._add_patch(
-            UpstreamLineage.ASPECT_NAME,
-            "add",
-            path=("fineGrainedLineages",),
-            value=fine_grained_lineages,
+        """
+        Deprecated: Use `set_fine_grained_lineages` instead.
+        """
+        warnings.warn(
+            "set_fine_grained_upstream_lineages() is deprecated."
+            " Use set_fine_grained_lineages() instead.",
+            DeprecationWarning,
+            stacklevel=2,
         )
-        return self
+        return self.set_fine_grained_lineages(fine_grained_lineages)
 
     def for_field(
         self, field_path: str, editable: bool = True

--- a/metadata-ingestion/tests/unit/patch/test_patch_builder.py
+++ b/metadata-ingestion/tests/unit/patch/test_patch_builder.py
@@ -80,7 +80,7 @@ def test_complex_dataset_patch(
                 type=DatasetLineageTypeClass.TRANSFORMED,
             )
         )
-        .add_fine_grained_upstream_lineage(
+        .add_fine_grained_lineage(
             fine_grained_lineage=FineGrainedLineageClass(
                 upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
                 downstreams=[
@@ -108,7 +108,7 @@ def test_complex_dataset_patch(
                 confidenceScore=1.0,
             )
         )
-        .add_fine_grained_upstream_lineage(
+        .add_fine_grained_lineage(
             fine_grained_lineage=FineGrainedLineageClass(
                 upstreamType=FineGrainedLineageUpstreamTypeClass.DATASET,
                 upstreams=[
@@ -251,21 +251,104 @@ def test_datajob_patch_builder(created_on, last_modified, expected_actor):
     job_urn = make_data_job_urn_with_flow(
         flow_urn, "5ca6fee7-0192-1000-f206-dfbc2b0d8bfb"
     )
-    patcher = DataJobPatchBuilder(job_urn)
 
+    patcher = DataJobPatchBuilder(job_urn)
     patcher.add_output_dataset(
         make_edge_or_urn(
             "urn:li:dataset:(urn:li:dataPlatform:s3,output-bucket/folder1,DEV)"
         )
-    )
-    patcher.add_output_dataset(
+    ).add_output_dataset(
         make_edge_or_urn(
             "urn:li:dataset:(urn:li:dataPlatform:s3,output-bucket/folder3,DEV)"
         )
-    )
-    patcher.add_output_dataset(
+    ).add_output_dataset(
         make_edge_or_urn(
             "urn:li:dataset:(urn:li:dataPlatform:s3,output-bucket/folder2,DEV)"
+        )
+    ).add_fine_grained_lineage(
+        fine_grained_lineage=FineGrainedLineageClass(
+            upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+            upstreams=[
+                make_schema_field_urn(
+                    make_dataset_urn(
+                        platform="hive",
+                        name="fct_users_created_upstream",
+                        env="PROD",
+                    ),
+                    field_path="bar",
+                )
+            ],
+            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+            downstreams=[
+                make_schema_field_urn(
+                    make_dataset_urn(
+                        platform="hive",
+                        name="fct_users_created",
+                        env="PROD",
+                    ),
+                    field_path="foo",
+                )
+            ],
+            transformOperation="TRANSFORM",
+            confidenceScore=1.0,
+        )
+    ).add_fine_grained_lineage(
+        fine_grained_lineage=FineGrainedLineageClass(
+            upstreamType=FineGrainedLineageUpstreamTypeClass.DATASET,
+            upstreams=[
+                make_schema_field_urn(
+                    make_dataset_urn(
+                        platform="s3",
+                        name="my-bucket/my-folder/my-file.txt",
+                        env="PROD",
+                    ),
+                    field_path="foo",
+                )
+            ],
+            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD_SET,
+            downstreams=[
+                make_schema_field_urn(
+                    make_dataset_urn(
+                        platform="hive",
+                        name="fct_users_created",
+                        env="PROD",
+                    ),
+                    field_path="foo",
+                )
+            ],
+        )
+    ).remove_fine_grained_lineage(
+        fine_grained_lineage=FineGrainedLineageClass(
+            upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+            upstreams=[
+                make_schema_field_urn(
+                    make_dataset_urn(
+                        platform="hive",
+                        name="fct_users_deprecated",
+                        env="PROD",
+                    ),
+                    field_path="users",
+                ),
+                make_schema_field_urn(
+                    make_dataset_urn(
+                        platform="hive",
+                        name="fct_users_deprecated",
+                        env="PROD",
+                    ),
+                    field_path="users_old",
+                ),
+            ],
+            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+            downstreams=[
+                make_schema_field_urn(
+                    make_dataset_urn(
+                        platform="hive",
+                        name="fct_users_created",
+                        env="PROD",
+                    ),
+                    field_path="users",
+                )
+            ],
         )
     )
 
@@ -298,6 +381,26 @@ def test_datajob_patch_builder(created_on, last_modified, expected_actor):
                             "value": get_edge_expectation(
                                 "urn:li:dataset:(urn:li:dataPlatform:s3,output-bucket/folder2,DEV)"
                             ),
+                        },
+                        {
+                            "op": "add",
+                            "path": "/fineGrainedLineages/TRANSFORM/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD),foo)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created_upstream,PROD),bar)",
+                            "value": {"confidenceScore": 1.0},
+                        },
+                        {
+                            "op": "add",
+                            "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD),foo)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket~1my-folder~1my-file.txt,PROD),foo)",
+                            "value": {"confidenceScore": 1.0},
+                        },
+                        {
+                            "op": "remove",
+                            "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD),users)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deprecated,PROD),users)",
+                            "value": {},
+                        },
+                        {
+                            "op": "remove",
+                            "path": "/fineGrainedLineages/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD),users)/NONE/urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deprecated,PROD),users_old)",
+                            "value": {},
                         },
                     ]
                 ).encode("utf-8"),

--- a/smoke-test/tests/patch/test_datajob_patches.py
+++ b/smoke-test/tests/patch/test_datajob_patches.py
@@ -13,10 +13,12 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.specific.datajob import DataJobPatchBuilder
 from tests.patch.common_patch_tests import (
+    helper_test_add_fine_grained_lineage,
     helper_test_custom_properties_patch,
     helper_test_dataset_tags_patch,
     helper_test_entity_terms_patch,
     helper_test_ownership_patch,
+    helper_test_set_fine_grained_lineages,
 )
 
 
@@ -255,3 +257,27 @@ def test_datajob_multiple_inputoutput_dataset_patch(request, client_fixture_name
 
     assert updated_lineage_aspect is not None
     assert updated_lineage_aspect.to_obj() == lineage_aspect.to_obj()
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name", ["graph_client", "openapi_graph_client"]
+)
+def test_datajob_add_fine_grained_lineage(request, client_fixture_name):
+    """Test that add_fine_grained_lineage works correctly for DataJobs."""
+    graph_client = request.getfixturevalue(client_fixture_name)
+    datajob_urn = _make_test_datajob_urn()
+    helper_test_add_fine_grained_lineage(
+        graph_client, datajob_urn, DataJobInputOutputClass, DataJobPatchBuilder
+    )
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name", ["graph_client", "openapi_graph_client"]
+)
+def test_datajob_set_fine_grained_lineages(request, client_fixture_name):
+    """Test setting fine-grained lineages with end-to-end DataHub integration."""
+    graph_client = request.getfixturevalue(client_fixture_name)
+    datajob_urn = _make_test_datajob_urn()
+    helper_test_set_fine_grained_lineages(
+        graph_client, datajob_urn, DataJobInputOutputClass, DataJobPatchBuilder
+    )

--- a/smoke-test/tests/patch/test_dataset_patches.py
+++ b/smoke-test/tests/patch/test_dataset_patches.py
@@ -18,10 +18,12 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.specific.dataset import DatasetPatchBuilder
 from tests.patch.common_patch_tests import (
+    helper_test_add_fine_grained_lineage,
     helper_test_custom_properties_patch,
     helper_test_dataset_tags_patch,
     helper_test_entity_terms_patch,
     helper_test_ownership_patch,
+    helper_test_set_fine_grained_lineages,
 )
 
 
@@ -353,3 +355,31 @@ def test_custom_properties_patch(request, client_fixture_name: DataHubGraph):
     assert custom_properties is not None
 
     assert custom_properties["test_description_property"] == "test_description_value"
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name", ["graph_client", "openapi_graph_client"]
+)
+def test_datajob_add_fine_grained_lineage(request, client_fixture_name):
+    """Test that add_fine_grained_lineage works correctly for DataJobs."""
+    graph_client = request.getfixturevalue(client_fixture_name)
+    datajob_urn = make_dataset_urn(
+        platform="hive", name=f"SampleHiveDataset{uuid.uuid4()}", env="PROD"
+    )
+    helper_test_add_fine_grained_lineage(
+        graph_client, datajob_urn, UpstreamLineageClass, DatasetPatchBuilder
+    )
+
+
+@pytest.mark.parametrize(
+    "client_fixture_name", ["graph_client", "openapi_graph_client"]
+)
+def test_datajob_set_fine_grained_lineages(request, client_fixture_name):
+    """Test setting fine-grained lineages with end-to-end DataHub integration."""
+    graph_client = request.getfixturevalue(client_fixture_name)
+    datajob_urn = make_dataset_urn(
+        platform="hive", name=f"SampleHiveDataset{uuid.uuid4()}", env="PROD"
+    )
+    helper_test_set_fine_grained_lineages(
+        graph_client, datajob_urn, UpstreamLineageClass, DatasetPatchBuilder
+    )


### PR DESCRIPTION
Refactors dataset fgl patch to have common code that can be reused. Also adds smoke tests.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
