### PR TITLE
fix(actions) Fix checking actions enabled via env vars

### DIFF
--- a/datahub-actions/src/datahub_actions/cli/actions.py
+++ b/datahub-actions/src/datahub_actions/cli/actions.py
@@ -143,6 +143,14 @@ def run(ctx: Any, config: List[str], debug: bool) -> None:
         try:
             # Now load the full config with variable expansion
             pipeline_config_dict = load_config_file(pipeline_config_file)
+
+            # double check whether config is enabled with variable expansion
+            if not is_pipeline_enabled(pipeline_config_dict):
+                logger.warning(
+                    f"Skipping pipeline {pipeline_config_dict.get('name') or pipeline_config_file} as it is not enabled"
+                )
+                continue
+
             pipelines.append(pipeline_config_to_pipeline(pipeline_config_dict))
         except UnboundVariable as e:
             if len(valid_configs) == 1:

--- a/datahub-actions/tests/unit/cli/test_actions.py
+++ b/datahub-actions/tests/unit/cli/test_actions.py
@@ -123,7 +123,7 @@ action:
 @pytest.fixture
 def disabled_config_file_env_var() -> Generator[str, None, None]:
     """Creates a temporary YAML config file with disabled pipeline."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
         f.write(
             """
 name: "disabled_pipeline"
@@ -137,11 +137,7 @@ action:
     type: "hello_world"
 """
         )
-        config_path = f.name
-
-    yield config_path
-    # Cleanup
-    os.unlink(config_path)
+        yield f.name
 
 
 @pytest.fixture

--- a/datahub-actions/tests/unit/cli/test_actions.py
+++ b/datahub-actions/tests/unit/cli/test_actions.py
@@ -123,7 +123,7 @@ action:
 @pytest.fixture
 def disabled_config_file_env_var() -> Generator[str, None, None]:
     """Creates a temporary YAML config file with disabled pipeline."""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
         f.write(
             """
 name: "disabled_pipeline"
@@ -137,7 +137,11 @@ action:
     type: "hello_world"
 """
         )
-        yield f.name
+        config_path = f.name
+
+    yield config_path
+    # Cleanup
+    os.unlink(config_path)
 
 
 @pytest.fixture

--- a/datahub-actions/tests/unit/cli/test_actions.py
+++ b/datahub-actions/tests/unit/cli/test_actions.py
@@ -73,6 +73,30 @@ action:
 
 
 @pytest.fixture
+def enabled_config_file_env_var() -> Generator[str, None, None]:
+    """Creates a temporary YAML config file for testing."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(
+            """
+name: "test_pipeline"
+enabled: ${PIPELINE_ENABLED:-true}
+datahub:
+    server: "https://test.datahub.io"
+    token: "test-token"
+source:
+    type: "datahub-cloud"
+action:
+    type: "hello_world"
+"""
+        )
+        config_path = f.name
+
+    yield config_path
+    # Cleanup
+    os.unlink(config_path)
+
+
+@pytest.fixture
 def disabled_config_file() -> Generator[str, None, None]:
     """Creates a temporary YAML config file with disabled pipeline."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
@@ -80,6 +104,30 @@ def disabled_config_file() -> Generator[str, None, None]:
             """
 name: "disabled_pipeline"
 enabled: false
+datahub:
+    server: "https://test.datahub.io"
+    token: "test-token"
+source:
+    type: "datahub-cloud"
+action:
+    type: "hello_world"
+"""
+        )
+        config_path = f.name
+
+    yield config_path
+    # Cleanup
+    os.unlink(config_path)
+
+
+@pytest.fixture
+def disabled_config_file_env_var() -> Generator[str, None, None]:
+    """Creates a temporary YAML config file with disabled pipeline."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(
+            """
+name: "disabled_pipeline"
+enabled: ${PIPELINE_ENABLED:-false}
 datahub:
     server: "https://test.datahub.io"
     token: "test-token"
@@ -138,6 +186,70 @@ def test_disabled_pipeline_exits(
     assert result.exit_code == 1
     assert any(
         "Skipping pipeline disabled_pipeline as it is not enabled" in record.message
+        for record in capture_logger.records
+    )
+
+
+def test_disabled_pipeline_with_env_var_exits(
+    disabled_config_file_env_var: str, capture_logger: pytest.LogCaptureFixture
+) -> None:
+    """Test that disabled pipelines cause program exit."""
+    runner = CliRunner()
+    result = runner.invoke(actions, ["run", "-c", disabled_config_file_env_var])
+
+    assert result.exit_code == 1
+    assert any(
+        "Skipping pipeline disabled_pipeline as it is not enabled" in record.message
+        for record in capture_logger.records
+    )
+
+
+def test_valid_config_enabled_env_var(
+    enabled_config_file_env_var: str,
+    capture_logger: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_pipeline: Mock,
+    mock_pipeline_manager: Mock,
+) -> None:
+    """Test debug mode with valid pipeline config."""
+
+    def mock_create_pipeline(config: dict) -> Pipeline:
+        """Mock implementation of pipeline creation."""
+        return mock_pipeline
+
+    sleep_count = 0
+
+    def mock_sleep(seconds: int) -> None:
+        """Mock sleep that raises KeyboardInterrupt after first call."""
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count > 1:  # Allow one sleep to ensure logs are captured
+            raise KeyboardInterrupt()
+
+    runner = CliRunner()
+
+    # Use local_monkeypatch for tighter control
+    with (
+        local_monkeypatch(
+            monkeypatch,
+            "datahub_actions.pipeline.pipeline.Pipeline.create",
+            mock_create_pipeline,
+        ),
+        local_monkeypatch(monkeypatch, "time.sleep", mock_sleep),
+        local_monkeypatch(
+            monkeypatch,
+            "datahub_actions.cli.actions.pipeline_manager",
+            mock_pipeline_manager,
+        ),
+    ):
+        result = runner.invoke(
+            actions,
+            ["run", "-c", enabled_config_file_env_var, "--debug"],
+        )
+
+    assert result.exit_code == 1
+    assert any(
+        "Action Pipeline with name 'test_pipeline' is now running." in record.message
         for record in capture_logger.records
     )
 


### PR DESCRIPTION
We had an issue where actions enabled or disabled via env vars were throwing exceptions instead of being skipped appropriately if they were disabled via an env var. This PR updates our check after we expand variables to double check the `enabled` field once we know their final values with env vars. Also update to add tests for this scenario.

This issue explains the situation very well: https://github.com/datahub-project/datahub/issues/14224

Fixes #14224

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
