### PR TITLE
feat(unity): update GE profiler to use native Databricks SQL connector

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -15,10 +15,8 @@ from datahub.configuration.source_common import (
 )
 from datahub.configuration.validate_field_removal import pydantic_removed_field
 from datahub.configuration.validate_field_rename import pydantic_renamed_field
-from datahub.ingestion.source.ge_data_profiler import DATABRICKS
 from datahub.ingestion.source.ge_profiling_config import GEProfilingConfig
 from datahub.ingestion.source.sql.sql_config import SQLCommonConfig
-from datahub.ingestion.source.sql.sqlalchemy_uri import make_sqlalchemy_uri
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StatefulStaleMetadataRemovalConfig,
 )
@@ -306,14 +304,14 @@ class UnityCatalogSourceConfig(
         # Format: databricks+connector://token:${DATABRICKS_TOKEN}@${DATABRICKS_SERVER_HOSTNAME}:443/${DATABRICKS_HTTP_PATH}
         hostname = urlparse(self.workspace_url).netloc
         http_path = f"/sql/1.0/warehouses/{self.warehouse_id}"
-        
+
         # Build the native Databricks SQL connector URL
         url = f"databricks+connector://token:{self.token}@{hostname}:443{http_path}"
-        
+
         # Add catalog if specified
         if database:
             url += f"?catalog={database}"
-            
+
         return url
 
     def is_profiling_enabled(self) -> bool:


### PR DESCRIPTION
Update Unity Catalog GE profiler to use native Databricks SQL connector format instead of SQLAlchemy URI format.

Changes:
- Update get_sql_alchemy_url() method in UnityCatalogSourceConfig to generate native Databricks SQL connector URLs
- Change URL format from SQLAlchemy URI to databricks+connector:// format
- Update scheme from "databricks" to "databricks+connector"
- Remove dependency on make_sqlalchemy_uri helper function
