### PR TITLE
fix(ui): Render descriptions for custom assertions

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
@@ -1,4 +1,4 @@
-import { Table } from 'antd';
+import { Table, Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -10,7 +10,7 @@ import { VolumeAssertionDescription } from '@app/entity/shared/tabs/Dataset/Vali
 import { DataContractAssertionStatus } from '@app/entity/shared/tabs/Dataset/Validations/contract/DataContractAssertionStatus';
 import { DataContractSummaryFooter } from '@app/entity/shared/tabs/Dataset/Validations/contract/DataContractSummaryFooter';
 
-import { Assertion, DataQualityContract, DatasetAssertionInfo } from '@types';
+import { Assertion, AssertionType, DataQualityContract, DatasetAssertionInfo } from '@types';
 
 const TitleText = styled.div`
     color: ${ANTD_GRAY[7]};
@@ -63,6 +63,9 @@ export const DataQualityContractSummary = ({ contracts, showAction = false }: Pr
                         <FieldAssertionDescription assertionInfo={assertion.info?.fieldAssertion} />
                     )}
                     {assertion.info?.sqlAssertion && <SqlAssertionDescription assertionInfo={assertion.info} />}
+                    {assertion.info?.type === AssertionType.Custom && (
+                        <Typography.Text>{assertion.info?.description}</Typography.Text>
+                    )}
                 </>
             ),
         },

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
@@ -1,4 +1,4 @@
-import { Table } from 'antd';
+import { Table, Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -10,7 +10,7 @@ import { VolumeAssertionDescription } from '@app/entityV2/shared/tabs/Dataset/Va
 import { DataContractAssertionStatus } from '@app/entityV2/shared/tabs/Dataset/Validations/contract/DataContractAssertionStatus';
 import { DataContractSummaryFooter } from '@app/entityV2/shared/tabs/Dataset/Validations/contract/DataContractSummaryFooter';
 
-import { Assertion, DataQualityContract, DatasetAssertionInfo } from '@types';
+import { Assertion, AssertionType, DataQualityContract, DatasetAssertionInfo } from '@types';
 
 const TitleText = styled.div`
     color: ${ANTD_GRAY[7]};
@@ -63,6 +63,9 @@ export const DataQualityContractSummary = ({ contracts, showAction = false }: Pr
                         <FieldAssertionDescription assertionInfo={assertion.info?.fieldAssertion} />
                     )}
                     {assertion.info?.sqlAssertion && <SqlAssertionDescription assertionInfo={assertion.info} />}
+                    {assertion.info?.type === AssertionType.Custom && (
+                        <Typography.Text>{assertion.info?.description}</Typography.Text>
+                    )}
                 </>
             ),
         },


### PR DESCRIPTION
Under Data Contracts we are not rendering anything for custom assertions, and it currently looks like this:
<img width="781" height="546" alt="Screenshot 2025-08-06 at 3 52 08 PM" src="https://github.com/user-attachments/assets/caeae299-d4af-4ac4-83c8-b43b186cbdbb" />

This fix will render the assertion description instead.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
