### PR TITLE
fix(ui): Remove text overlaps with custom links

### DIFF
--- a/datahub-web-react/src/app/entityV2/glossaryTerm/profile/RelatedTerm.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryTerm/profile/RelatedTerm.tsx
@@ -1,10 +1,10 @@
-import { CloseOutlined } from '@ant-design/icons';
 import { Button } from 'antd';
 import React from 'react';
 import styled from 'styled-components/macro';
 
 import { PreviewType } from '@app/entityV2/Entity';
 import useRemoveRelatedTerms from '@app/entityV2/glossaryTerm/profile/useRemoveRelatedTerms';
+import { SearchCardContext } from '@app/entityV2/shared/SearchCardContext';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { useGetGlossaryTermQuery } from '@graphql/glossaryTerm.generated';
@@ -69,14 +69,13 @@ function RelatedTerm(props: Props) {
 
     return (
         <ListItem>
-            <Profile>
-                {entityRegistry.renderPreview(EntityType.GlossaryTerm, PreviewType.PREVIEW, data?.glossaryTerm)}
-                {isEditable && (
-                    <TransparentButton size="small" onClick={onRemove}>
-                        <CloseOutlined size={5} /> Remove Relationship
-                    </TransparentButton>
-                )}
-            </Profile>
+            <SearchCardContext.Provider
+                value={{ showRemovalFromList: isEditable, removeText: 'Remove Relationship', onRemove }}
+            >
+                <Profile>
+                    {entityRegistry.renderPreview(EntityType.GlossaryTerm, PreviewType.PREVIEW, data?.glossaryTerm)}
+                </Profile>
+            </SearchCardContext.Provider>
         </ListItem>
     );
 }

--- a/datahub-web-react/src/app/entityV2/shared/SearchCardContext.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/SearchCardContext.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 
 interface SearchCardContextType {
     showRemovalFromList: boolean;
+    onRemove?: () => void;
+    removeText?: string;
 }
 
 const defaultContext: SearchCardContextType = {
     showRemovalFromList: false,
+    removeText: '',
 };
 
 export const SearchCardContext = React.createContext<SearchCardContextType>(defaultContext);

--- a/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
@@ -374,7 +374,7 @@ export default function DefaultPreviewCard({
 
 function useRemoveRelationship(entityType: EntityType) {
     const { setShouldRefetchEmbeddedListSearch } = useEntityContext();
-    const { showRemovalFromList } = useSearchCardContext();
+    const { showRemovalFromList, onRemove, removeText } = useSearchCardContext();
     const { removeDomain } = useRemoveDomainAssets(setShouldRefetchEmbeddedListSearch);
     const { removeTerm } = useRemoveGlossaryTermAssets(setShouldRefetchEmbeddedListSearch);
     const { removeDataProduct } = useRemoveDataProductAssets(setShouldRefetchEmbeddedListSearch);
@@ -385,21 +385,23 @@ function useRemoveRelationship(entityType: EntityType) {
 
     if (pageEntityType === EntityType.Domain) {
         return {
-            removeRelationship: () => removeDomain(previewData?.urn),
+            removeRelationship: () => (onRemove ? onRemove() : removeDomain(previewData?.urn)),
             removeButtonText:
-                showRemovalFromList && entityType !== EntityType.DataProduct ? 'Remove from Domain' : null,
+                showRemovalFromList && entityType !== EntityType.DataProduct
+                    ? removeText || 'Remove from Domain'
+                    : null,
         };
     }
     if (pageEntityType === EntityType.GlossaryTerm) {
         return {
-            removeRelationship: () => removeTerm(previewData, entityData.urn),
-            removeButtonText: showRemovalFromList ? 'Remove Glossary Term' : null,
+            removeRelationship: () => (onRemove ? onRemove() : removeTerm(previewData, entityData.urn)),
+            removeButtonText: showRemovalFromList ? removeText || 'Remove Glossary Term' : null,
         };
     }
     if (pageEntityType === EntityType.DataProduct) {
         return {
-            removeRelationship: () => removeDataProduct(previewData?.urn),
-            removeButtonText: showRemovalFromList ? 'Remove from Data Product' : null,
+            removeRelationship: () => (onRemove ? onRemove() : removeDataProduct(previewData?.urn)),
+            removeButtonText: showRemovalFromList ? removeText || 'Remove from Data Product' : null,
         };
     }
     return {


### PR DESCRIPTION
Before:

<img width="649" height="180" alt="image (2)" src="https://github.com/user-attachments/assets/7d42787d-5453-4b1d-bb58-768daf88907d" />

After:
<img width="798" height="242" alt="Screenshot 2025-08-07 at 8 55 31 AM" src="https://github.com/user-attachments/assets/e7e39361-c4d6-4368-8cc1-7381811b8e43" />

Reused the existing SearchCard context instead of handling it separately


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
