### PR TITLE
fix(ui): Add tooltips to Icons in Ingestion page

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Icon/Icon.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Icon/Icon.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@components';
 import React from 'react';
 
 import { IconWrapper } from '@components/components/Icon/components';
@@ -11,6 +12,7 @@ export const iconDefaults: IconPropsDefaults = {
     size: '4xl',
     color: 'inherit',
     rotate: '0',
+    tooltipText: '',
 };
 
 export const Icon = ({
@@ -22,6 +24,7 @@ export const Icon = ({
     colorLevel,
     rotate = iconDefaults.rotate,
     weight,
+    tooltipText,
     ...props
 }: IconProps) => {
     const { filled, outlined } = getIconNames();
@@ -53,14 +56,16 @@ export const Icon = ({
 
     return (
         <IconWrapper size={getFontSize(size)} rotate={getRotationTransform(rotate)} {...props}>
-            <IconComponent
-                sx={{
-                    fontSize: getFontSize(size),
-                    color: getColor(color, colorLevel),
-                }}
-                style={{ color: getColor(color, colorLevel) }}
-                weight={source === 'phosphor' ? weight : undefined} // Phosphor icons use 'weight' prop
-            />
+            <Tooltip title={tooltipText}>
+                <IconComponent
+                    sx={{
+                        fontSize: getFontSize(size),
+                        color: getColor(color, colorLevel),
+                    }}
+                    style={{ color: getColor(color, colorLevel) }}
+                    weight={source === 'phosphor' ? weight : undefined} // Phosphor icons use 'weight' prop
+                />
+            </Tooltip>
         </IconWrapper>
     );
 };

--- a/datahub-web-react/src/alchemy-components/components/Icon/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Icon/types.ts
@@ -31,6 +31,7 @@ export interface IconPropsDefaults {
     color: FontColorOptions;
     colorLevel?: FontColorLevelOptions;
     rotate: RotationOptions;
+    tooltipText?: string;
 }
 
 export interface IconProps extends Partial<IconPropsDefaults>, Omit<HTMLAttributes<HTMLElement>, 'color'> {

--- a/datahub-web-react/src/app/ingestV2/executions/components/columns/ActionsColumn.tsx
+++ b/datahub-web-react/src/app/ingestV2/executions/components/columns/ActionsColumn.tsx
@@ -53,7 +53,12 @@ export function ActionsColumn({ record, setFocusExecutionUrn, handleRollback, ha
             dropdownItems={items}
             extraActions={
                 record.status === EXECUTION_REQUEST_STATUS_SUCCESS && record.showRollback ? (
-                    <Icon icon="ArrowUUpLeft" source="phosphor" onClick={() => handleRollback(record.id)} />
+                    <Icon
+                        icon="ArrowUUpLeft"
+                        source="phosphor"
+                        onClick={() => handleRollback(record.id)}
+                        tooltipText="Rollback"
+                    />
                 ) : null
             }
         />

--- a/datahub-web-react/src/app/ingestV2/executions/components/columns/RollbackExecutionConfirmation.tsx
+++ b/datahub-web-react/src/app/ingestV2/executions/components/columns/RollbackExecutionConfirmation.tsx
@@ -13,9 +13,20 @@ export default function RollbackExecutionConfirmation({ isOpen, onConfirm, onCan
         <ConfirmationModal
             isOpen={isOpen}
             modalTitle="Confirm Rollback"
-            modalText="Are you sure you want to continue? 
-            Rolling back this ingestion run will remove any new data ingested during the run. This may
-            exclude data that was previously extracted, but did not change during this run."
+            modalText={
+                <>
+                    Are you sure you want to continue? Rolling back this ingestion run will remove any new data ingested
+                    during the run. This may exclude data that was previously extracted, but did not change during this
+                    run.{' '}
+                    <a
+                        href="https://docs.datahub.com/docs/how/delete-metadata#rollback-ingestion-run"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Learn more
+                    </a>
+                </>
+            }
             handleConfirm={onConfirm}
             handleClose={onCancel}
         />

--- a/datahub-web-react/src/app/ingestV2/source/IngestionSourceTableColumns.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestionSourceTableColumns.tsx
@@ -337,6 +337,7 @@ export function ActionsColumn({
                         e.stopPropagation();
                         onCancel(record.lastExecUrn, record.urn);
                     }}
+                    tooltipText="Stop Execution"
                 />
             );
         }
@@ -350,6 +351,7 @@ export function ActionsColumn({
                     e.stopPropagation();
                     onExecute(record.urn);
                 }}
+                tooltipText="Execute"
             />
         );
     };


### PR DESCRIPTION
- Add tootlipText prop to Icon component
- Add Tooltips to Ingestion page icons
- Add Documentation link to Rollback confirmation modal

- <img width="543" height="263" alt="Screenshot 2025-08-07 at 1 22 32 PM" src="https://github.com/user-attachments/assets/9001f161-bb84-4e33-a650-56e58ae102a2" />

- <img width="165" height="127" alt="Screenshot 2025-08-07 at 1 20 28 PM" src="https://github.com/user-attachments/assets/26c4b0f4-ff2e-4221-814b-8d7c6c669235" />
- <img width="127" height="106" alt="Screenshot 2025-08-07 at 1 09 03 PM" src="https://github.com/user-attachments/assets/ef1b8ace-6689-4ef4-9ad7-707cbb43323b" />
- <img width="107" height="95" alt="Screenshot 2025-08-07 at 1 08 34 PM" src="https://github.com/user-attachments/assets/292347c1-f262-4f51-a173-aee1ca86a9f6" />



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
