### PR TITLE
fix(ui): Show better strings for 10k+ csv download 

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/DownloadAsCsvModal.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/DownloadAsCsvModal.tsx
@@ -74,13 +74,17 @@ export default function DownloadAsCsvModal({
     );
     const entityRegistry = useEntityRegistry();
     const openNotification = (currentCount = 0, estimatedTimeRemaining?: number) => {
-        let description =
-            totalResults && currentCount < totalResults
-                ? `Downloading ${currentCount} of ${totalResults} entities...`
-                : 'Creating CSV to download';
+        // Scroll Across Entities gives max 10k as total but results can go further than that
+        const hasMoreThanLimit = totalResults === 10000;
+        let description = totalResults
+            ? `Downloading ${currentCount} of ${hasMoreThanLimit ? '10,000+' : totalResults} entities...`
+            : 'Creating CSV to download';
 
         if (estimatedTimeRemaining !== undefined) {
-            description += `\nEstimated time remaining: ${formatTime(estimatedTimeRemaining)}`;
+            // Show estimate only if the count is less than 10k entities
+            if (!hasMoreThanLimit) {
+                description += `\nEstimated time remaining: ${formatTime(estimatedTimeRemaining)}`;
+            }
         }
 
         notification.info({


### PR DESCRIPTION
When the download results are more than 10K (the max of scroll across api), the UI doesn't indicate proper messages.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
