### PR TITLE
feat(search): make usage fields searchable

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetUsageStatistics.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetUsageStatistics.pdl
@@ -14,12 +14,20 @@ record DatasetUsageStatistics includes TimeseriesAspectBase {
    * Unique user count
    */
   @TimeseriesField = {}
+  @Searchable = {
+    "fieldType": "COUNT",
+    "hasValuesFieldName": "hasUniqueUserCount"
+  }
   uniqueUserCount: optional int
 
   /**
    * Total SQL query count
    */
   @TimeseriesField = {}
+  @Searchable = {
+    "fieldType": "COUNT",
+    "hasValuesFieldName": "hasTotalSqlQueriesCount"
+  }
   totalSqlQueries: optional int
 
   /**


### PR DESCRIPTION
Similar to this https://github.com/datahub-project/datahub/pull/6455 making the timeseries field searchable so it is present on the entity index.

Doing this for ingestion validation work so doesn't really require a reindexing as new ingestions will handle it.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
