### PR TITLE
fix(irc): changing prefix for tblproperties

### DIFF
--- a/docs/iceberg-catalog.md
+++ b/docs/iceberg-catalog.md
@@ -509,7 +509,7 @@ Once you create tables in iceberg, each of those tables show up in DataHub as a 
   <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/cec184aa1e3cb15c087625ffc997b4345a858c8b/imgs/iceberg-dataset-schema.png"/>
 </p>
 
-Some of the standard metadata fields are populated in the Dataset Properties. Additionally, any Iceberg `TBLPROPERTIES` set via DDL on tables or views are also shown in DatasetProperties with a prefix `iceberg:`
+Some of the standard metadata fields are populated in the Dataset Properties. Additionally, any Iceberg `TBLPROPERTIES` set via DDL on tables or views are also shown in DatasetProperties with a prefix `TBLPROPERTIES:`
 The iceberg 'TBLPROPERTIES' can only be set via DDL and is a one way sync. Changes to iceberg `TBLPROPERTIES` properties via datahub APIs do not get written to the Iceberg table or view properties.
 
 ## Troubleshooting

--- a/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/DataHubIcebergWarehouse.java
+++ b/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/DataHubIcebergWarehouse.java
@@ -39,7 +39,7 @@ public class DataHubIcebergWarehouse {
   public static final String DATAPLATFORM_INSTANCE_ICEBERG_WAREHOUSE_ASPECT_NAME =
       "icebergWarehouseInfo";
 
-  public static final String ICEBERG_PROPERTY_PREFIX = "iceberg:";
+  public static final String ICEBERG_PROPERTY_PREFIX = "TBLPROPERTIES:";
   private final EntityService entityService;
 
   private final SecretService secretService;


### PR DESCRIPTION
Changing prefix from iceberg to TBLPROPERTIES since all the properties here are already iceberg, and the ones with this prefix are those set using the DDL `TBLPROPERTIES` - this is for [tables & views.](https://iceberg.apache.org/docs/latest/spark-ddl/#setting-and-removing-view-properties)  
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
