### PR TITLE
dev(cypress): gradle command `quickstartCypress`

### DIFF
--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -55,6 +55,18 @@ ext {
                             DATAHUB_LOCAL_ACTIONS_ENV: "${rootProject.project(':smoke-test').projectDir}/test_resources/actions/actions.env"
                     ]
             ],
+            'quickstartCypress': [
+                    profile: 'debug',
+                    modules: python_services_modules + backend_profile_modules + [':datahub-frontend', ':datahub-actions'],
+                    isDebug: true,
+                    additionalEnv: [
+                            DATAHUB_LOCAL_ACTIONS_ENV: "${rootProject.project(':smoke-test').projectDir}/test_resources/actions/actions.env"
+                    ],
+                    // Override project name for cypress dev environment
+                    additionalConfig: [
+                            projectName: 'dh-cypress'
+                    ]
+            ],
             'quickstartDebugMin': [
                     profile: 'debug-min',
                     modules: backend_profile_modules + [':datahub-frontend'],

--- a/docker/profiles/README.md
+++ b/docker/profiles/README.md
@@ -14,6 +14,15 @@ $ cd docker/profiles
 $ docker compose --profile <profile name> up
 ```
 
+Alternatively, you can use the gradle tasks defined in `docker/build.gradle`:
+
+```bash
+# Run from the project root
+./gradlew quickstart          # Uses the 'quickstart' profile
+./gradlew quickstartDebug     # Uses the 'debug' profile  
+./gradlew quickstartCypress   # Uses the 'debug' profile with custom project name 'dh-cypress'
+```
+
 Use Control-c (`^c`) to terminate the running system. This will automatically stop all running containers.
 
 To remove the containers use the following:
@@ -92,6 +101,18 @@ Run everything except for the `frontend` component. Useful for running just a lo
 ### `quickstart-frontend`
 
 Runs everything except for the GMS. Useful for running just a local (non-docker) GMS instance.
+
+### `quickstartCypress`
+
+Runs the same configuration as `debug` but uses a custom project name (`dh-cypress`) instead of the default `datahub` project name. This is useful for Cypress testing scenarios where you need to isolate the docker compose project from other running instances.
+
+To load test data for Cypress testing, you can use the `:smoke-test:cypressData` gradle task:
+
+```bash
+./gradlew :smoke-test:cypressData
+```
+
+This will populate the running DataHub instance with sample data suitable for Cypress testing scenarios.
 
 ### Development Profiles Table
 

--- a/docker/profiles/README.md
+++ b/docker/profiles/README.md
@@ -19,7 +19,7 @@ Alternatively, you can use the gradle tasks defined in `docker/build.gradle`:
 ```bash
 # Run from the project root
 ./gradlew quickstart          # Uses the 'quickstart' profile
-./gradlew quickstartDebug     # Uses the 'debug' profile  
+./gradlew quickstartDebug     # Uses the 'debug' profile
 ./gradlew quickstartCypress   # Uses the 'debug' profile with custom project name 'dh-cypress'
 ```
 


### PR DESCRIPTION
## Add custom project name support for quickstartCypress task

### Changes
- Modified `docker/build.gradle` to allow the `quickstartCypress` task to use a custom project name (`dh-cypress`) instead of the default `datahub` project name
- Updated `docker/profiles/README.md` to document the new `quickstartCypress` task and its purpose for Cypress testing scenarios
- Added documentation for the `:smoke-test:cypressData` gradle task for loading test data

### Purpose
This enables isolated Cypress testing environments by using a different docker compose project name, preventing conflicts with other running DataHub instances during testing.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
