### PR TITLE
chore(codeCov) Update FE code coverage to look at only .ts files for now

### DIFF
--- a/datahub-web-react/vite.config.ts
+++ b/datahub-web-react/vite.config.ts
@@ -134,7 +134,7 @@ export default defineConfig(async ({ mode }) => {
                 enabled: true,
                 provider: 'v8',
                 reporter: ['text', 'json', 'html'],
-                include: ['src/**/*'],
+                include: ['src/**/*.ts'],
                 reportsDirectory: '../build/coverage-reports/datahub-web-react/',
                 exclude: [],
             },


### PR DESCRIPTION
Since we don't typically write component unit tests but let our E2E frameworks like cypress and our UI diff framework in meticulous check these things, we should really be testing code coverage on `.ts` files where we store our utility functions writing logic (that should all be tested) and our custom hooks. These should have high code coverage while making tweaks to `.tsx` files for CSS or rearranging some stuff in the UI will not be covered by code coverage. Again, these are covered by meticulous and cypress.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
