### PR TITLE
fix(ui/lineage): Do not hide transformational nodes in cycles with their parent

### DIFF
--- a/datahub-web-react/src/app/lineageV2/useComputeGraph/getDisplayedNodes.ts
+++ b/datahub-web-react/src/app/lineageV2/useComputeGraph/getDisplayedNodes.ts
@@ -187,8 +187,10 @@ function getChildrenToFilter(
     for (let node = queue.pop(); node; node = queue.pop()) {
         const children = adjacencyList[direction].get(node.urn);
         // Include non-query transformational nodes if they have no children
+        // Have to also include non-query transformational nodes in cycles with their parent, because
+        // those are effectively leaves as well.
         if (
-            !children?.size &&
+            (!children?.size || (node.inCycle && children.has(parent.urn))) &&
             !isQuery(node) &&
             !(direction === LineageDirection.Downstream && isDbt(node) && node.entity?.subtype === SubType.DbtSource)
         ) {

--- a/datahub-web-react/src/app/lineageV3/useComputeGraph/getDisplayedNodes.ts
+++ b/datahub-web-react/src/app/lineageV3/useComputeGraph/getDisplayedNodes.ts
@@ -187,8 +187,10 @@ function getChildrenToFilter(
     for (let node = queue.pop(); node; node = queue.pop()) {
         const children = adjacencyList[direction].get(node.urn);
         // Include non-query transformational nodes if they have no children
+        // Have to also include non-query transformational nodes in cycles with their parent, because
+        // those are effectively leaves as well.
         if (
-            !children?.size &&
+            (!children?.size || (node.inCycle && children.has(parent.urn))) &&
             !isQuery(node) &&
             !(direction === LineageDirection.Downstream && isDbt(node) && node.entity?.subtype === SubType.DbtSource)
         ) {


### PR DESCRIPTION
Bug was as follows:

We only show transformational nodes if one of their children is shown -- they are supposed to behave like query nodes in that they're just extra information on the dataset -> dataset edge
We have a special case for transformational leaves, because without any children themselves they'll never get shown
In the bug's case, we have transformational nodes whose only children are their parent (a cycle of 2 nodes). They aren't considered leaves because they have children, but they never get shown because their parent isn't in the list of "shown children"
To fix, I'm counting transformational nodes who are in a cycle to their parent as "leaves" as well.