### PR TITLE
fix(ingest/unity): Add option to set databricks api page size

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -275,6 +275,17 @@ class UnityCatalogSourceConfig(
         hidden_from_docs=True,
     )
 
+    databricks_api_page_size: int = pydantic.Field(
+        default=0,
+        ge=0,
+        description=(
+            "Page size for Databricks API calls when listing resources (catalogs, schemas, tables, etc.). "
+            "When set to 0 (default), uses server-side configured page length (recommended). "
+            "When set to a positive value, the page length is the minimum of this value and the server configured value. "
+            "Must be a non-negative integer."
+        ),
+    )
+
     include_usage_statistics: bool = Field(
         default=True,
         description="Generate usage statistics.",

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/connection_test.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/connection_test.py
@@ -19,6 +19,7 @@ class UnityCatalogConnectionTest:
             self.config.token,
             self.config.profiling.warehouse_id,
             report=self.report,
+            databricks_api_page_size=self.config.databricks_api_page_size,
         )
 
     def get_connection_test(self) -> TestConnectionReport:

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -211,6 +211,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
             report=self.report,
             hive_metastore_proxy=self.hive_metastore_proxy,
             lineage_data_source=config.lineage_data_source,
+            databricks_api_page_size=config.databricks_api_page_size,
         )
 
         self.external_url_base = urljoin(self.config.workspace_url, "/explore/data")

--- a/metadata-ingestion/tests/unit/test_unity_catalog_config.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_config.py
@@ -155,3 +155,78 @@ def test_set_profiling_warehouse_id_from_global():
         }
     )
     assert config.profiling.warehouse_id == "my_global_warehouse_id"
+
+
+def test_databricks_api_page_size_default():
+    """Test that databricks_api_page_size defaults to 0."""
+    config = UnityCatalogSourceConfig.parse_obj(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+        }
+    )
+    assert config.databricks_api_page_size == 0
+
+
+def test_databricks_api_page_size_valid_values():
+    """Test that databricks_api_page_size accepts valid positive integers."""
+    config = UnityCatalogSourceConfig.parse_obj(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "databricks_api_page_size": 100,
+        }
+    )
+    assert config.databricks_api_page_size == 100
+
+    config = UnityCatalogSourceConfig.parse_obj(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "databricks_api_page_size": 1000,
+        }
+    )
+    assert config.databricks_api_page_size == 1000
+
+
+def test_databricks_api_page_size_zero_allowed():
+    """Test that databricks_api_page_size allows zero (default behavior)."""
+    config = UnityCatalogSourceConfig.parse_obj(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "databricks_api_page_size": 0,
+        }
+    )
+    assert config.databricks_api_page_size == 0
+
+
+def test_databricks_api_page_size_negative_invalid():
+    """Test that databricks_api_page_size rejects negative values."""
+    with pytest.raises(
+        ValueError, match="ensure this value is greater than or equal to 0"
+    ):
+        UnityCatalogSourceConfig.parse_obj(
+            {
+                "token": "token",
+                "workspace_url": "https://test.databricks.com",
+                "include_hive_metastore": False,
+                "databricks_api_page_size": -1,
+            }
+        )
+
+    with pytest.raises(
+        ValueError, match="ensure this value is greater than or equal to 0"
+    ):
+        UnityCatalogSourceConfig.parse_obj(
+            {
+                "token": "token",
+                "workspace_url": "https://test.databricks.com",
+                "include_hive_metastore": False,
+                "databricks_api_page_size": -100,
+            }
+        )

--- a/metadata-ingestion/tests/unit/test_unity_catalog_source.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_source.py
@@ -1,0 +1,143 @@
+from unittest.mock import patch
+
+import pytest
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.source.unity.config import UnityCatalogSourceConfig
+from datahub.ingestion.source.unity.source import UnityCatalogSource
+
+
+class TestUnityCatalogSource:
+    @pytest.fixture
+    def minimal_config(self):
+        """Create a minimal config for testing."""
+        return UnityCatalogSourceConfig.parse_obj(
+            {
+                "token": "test_token",
+                "workspace_url": "https://test.databricks.com",
+                "warehouse_id": "test_warehouse",
+                "include_hive_metastore": False,
+            }
+        )
+
+    @pytest.fixture
+    def config_with_page_size(self):
+        """Create a config with custom page size."""
+        return UnityCatalogSourceConfig.parse_obj(
+            {
+                "token": "test_token",
+                "workspace_url": "https://test.databricks.com",
+                "warehouse_id": "test_warehouse",
+                "include_hive_metastore": False,
+                "databricks_api_page_size": 75,
+            }
+        )
+
+    @patch("datahub.ingestion.source.unity.source.UnityCatalogApiProxy")
+    @patch("datahub.ingestion.source.unity.source.HiveMetastoreProxy")
+    def test_source_constructor_passes_default_page_size_to_proxy(
+        self, mock_hive_proxy, mock_unity_proxy, minimal_config
+    ):
+        """Test that UnityCatalogSource passes default databricks_api_page_size to proxy."""
+        # Create a mock context
+        ctx = PipelineContext(run_id="test_run")
+        source = UnityCatalogSource.create(minimal_config, ctx)
+
+        # Verify proxy was created with correct parameters including page size
+        mock_unity_proxy.assert_called_once_with(
+            minimal_config.workspace_url,
+            minimal_config.token,
+            minimal_config.warehouse_id,
+            report=source.report,
+            hive_metastore_proxy=source.hive_metastore_proxy,
+            lineage_data_source=minimal_config.lineage_data_source,
+            databricks_api_page_size=0,  # Default value
+        )
+
+    @patch("datahub.ingestion.source.unity.source.UnityCatalogApiProxy")
+    @patch("datahub.ingestion.source.unity.source.HiveMetastoreProxy")
+    def test_source_constructor_passes_custom_page_size_to_proxy(
+        self, mock_hive_proxy, mock_unity_proxy, config_with_page_size
+    ):
+        """Test that UnityCatalogSource passes custom databricks_api_page_size to proxy."""
+        ctx = PipelineContext(run_id="test_run")
+        source = UnityCatalogSource.create(config_with_page_size, ctx)
+
+        # Verify proxy was created with correct parameters including custom page size
+        mock_unity_proxy.assert_called_once_with(
+            config_with_page_size.workspace_url,
+            config_with_page_size.token,
+            config_with_page_size.warehouse_id,
+            report=source.report,
+            hive_metastore_proxy=source.hive_metastore_proxy,
+            lineage_data_source=config_with_page_size.lineage_data_source,
+            databricks_api_page_size=75,  # Custom value
+        )
+
+    @patch("datahub.ingestion.source.unity.source.UnityCatalogApiProxy")
+    @patch("datahub.ingestion.source.unity.source.HiveMetastoreProxy")
+    def test_source_config_page_size_available_to_source(
+        self, mock_hive_proxy, mock_unity_proxy, config_with_page_size
+    ):
+        """Test that UnityCatalogSource has access to databricks_api_page_size config."""
+        ctx = PipelineContext(run_id="test_run")
+        source = UnityCatalogSource.create(config_with_page_size, ctx)
+
+        # Verify the source has access to the configuration value
+        assert source.config.databricks_api_page_size == 75
+
+    @patch("datahub.ingestion.source.unity.source.UnityCatalogApiProxy")
+    @patch("datahub.ingestion.source.unity.source.HiveMetastoreProxy")
+    def test_source_with_hive_metastore_disabled(
+        self, mock_hive_proxy, mock_unity_proxy
+    ):
+        """Test that UnityCatalogSource works with hive metastore disabled."""
+        config = UnityCatalogSourceConfig.parse_obj(
+            {
+                "token": "test_token",
+                "workspace_url": "https://test.databricks.com",
+                "warehouse_id": "test_warehouse",
+                "include_hive_metastore": False,
+                "databricks_api_page_size": 200,
+            }
+        )
+
+        ctx = PipelineContext(run_id="test_run")
+        source = UnityCatalogSource.create(config, ctx)
+
+        # Verify proxy was created with correct page size even when hive metastore is disabled
+        mock_unity_proxy.assert_called_once_with(
+            config.workspace_url,
+            config.token,
+            config.warehouse_id,
+            report=source.report,
+            hive_metastore_proxy=None,  # Should be None when disabled
+            lineage_data_source=config.lineage_data_source,
+            databricks_api_page_size=200,
+        )
+
+    def test_test_connection_with_page_size_config(self):
+        """Test that test_connection properly handles databricks_api_page_size."""
+        config_dict = {
+            "token": "test_token",
+            "workspace_url": "https://test.databricks.com",
+            "warehouse_id": "test_warehouse",
+            "databricks_api_page_size": 300,
+        }
+
+        with patch(
+            "datahub.ingestion.source.unity.source.UnityCatalogConnectionTest"
+        ) as mock_connection_test:
+            mock_connection_test.return_value.get_connection_test.return_value = (
+                "test_report"
+            )
+
+            result = UnityCatalogSource.test_connection(config_dict)
+
+            # Verify connection test was created with correct config
+            assert result == "test_report"
+            mock_connection_test.assert_called_once()
+
+            # Get the config that was passed to UnityCatalogConnectionTest
+            connection_test_config = mock_connection_test.call_args[0][0]
+            assert connection_test_config.databricks_api_page_size == 300


### PR DESCRIPTION
Add option to set databricks api page size and use server-side paging by default.
Earlier this was not set which meant it tried to get the whole result at once which caused failure on large Databricks workspaces.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
