### PR TITLE
fix(ui): fix entity hover cards covering health popover

### DIFF
--- a/datahub-web-react/src/app/previewV2/HealthIcon.tsx
+++ b/datahub-web-react/src/app/previewV2/HealthIcon.tsx
@@ -23,6 +23,10 @@ const HealthyIcon = styled(CheckCircle)`
     font-size: 20px;
 `;
 
+const popoverStyles = {
+    zIndex: 1200,
+};
+
 interface Props {
     urn: string;
     health: Health[];
@@ -41,7 +45,12 @@ const HealthIcon = ({ urn, health, baseUrl, className }: Props) => {
     }
 
     return (
-        <Popover content={<HealthPopover health={health} baseUrl={baseUrl} />} placement="bottom" showArrow={false}>
+        <Popover
+            content={<HealthPopover health={health} baseUrl={baseUrl} />}
+            placement="bottom"
+            showArrow={false}
+            overlayStyle={popoverStyles}
+        >
             <IconContainer className={className} data-testid={`${urn}-health-icon`}>
                 {icon}
             </IconContainer>


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-651/bug-entity-hover-card-covers-the-cards-deprecation-tooltip

**Screenshot:**

<img width="463" height="239" alt="image" src="https://github.com/user-attachments/assets/c93a7f47-42c7-413d-b66e-b84403f40de6" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
