### PR TITLE
fix(ui): fix unicode character always ellipsis when editable EntityName

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/header/EntityName.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/header/EntityName.tsx
@@ -107,7 +107,6 @@ function EntityName(props: Props) {
                 onStart: handleStartEditing,
             }}
             $showEntityLink={showEntityLink}
-
         >
             {updatedName}
         </EntityTitle>

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/header/EntityName.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/header/EntityName.tsx
@@ -107,9 +107,7 @@ function EntityName(props: Props) {
                 onStart: handleStartEditing,
             }}
             $showEntityLink={showEntityLink}
-            ellipsis={{
-                tooltip: { showArrow: false, color: 'white', overlayInnerStyle: { color: colors.gray[1700] } },
-            }}
+
         >
             {updatedName}
         </EntityTitle>


### PR DESCRIPTION
Before:
<img width="1249" height="441" alt="image" src="https://github.com/user-attachments/assets/1f788a89-76d9-4576-b7d5-0d57b5774919" />

After:
<img width="1255" height="437" alt="image" src="https://github.com/user-attachments/assets/ea591e6e-fb73-41dc-8195-7bfacb643fba" />


In the currently applied version of "antd", typography.Text is displayed as "..." for the Unicode string when the editable property and ellipsis are used simultaneously.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
