### PR TITLE
fix(ui/ingest): always show scroll bar on summary tab

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -120,7 +120,7 @@
         "format-check-file": "prettier --check",
         "lint-fix-file": "eslint --ext .ts,.tsx --quiet --fix",
         "format-check": "prettier --check src",
-        "format": "prettier --write src",
+        "format": "prettier --write src --list-different",
         "format-file": "prettier --write",
         "type-check": "tsc --noEmit",
         "type-watch": "tsc -w --noEmit",

--- a/datahub-web-react/src/app/ingestV2/executions/components/BaseTab.tsx
+++ b/datahub-web-react/src/app/ingestV2/executions/components/BaseTab.tsx
@@ -34,12 +34,12 @@ export const ScrollableDetailsContainer = styled(DetailsContainer)`
         max-height: 300px;
         overflow-y: scroll;
     }
-    
+
     pre::-webkit-scrollbar-track {
         background: rgba(193, 196, 208, 0.3) !important;
         border-radius: 10px;
     }
-    
+
     pre::-webkit-scrollbar-thumb {
         background: rgba(193, 196, 208, 0.8) !important;
         border-radius: 10px;

--- a/datahub-web-react/src/app/ingestV2/executions/components/BaseTab.tsx
+++ b/datahub-web-react/src/app/ingestV2/executions/components/BaseTab.tsx
@@ -32,5 +32,16 @@ export const DetailsContainer = styled.div`
 export const ScrollableDetailsContainer = styled(DetailsContainer)`
     pre {
         max-height: 300px;
+        overflow-y: scroll;
+    }
+    
+    pre::-webkit-scrollbar-track {
+        background: rgba(193, 196, 208, 0.3) !important;
+        border-radius: 10px;
+    }
+    
+    pre::-webkit-scrollbar-thumb {
+        background: rgba(193, 196, 208, 0.8) !important;
+        border-radius: 10px;
     }
 `;


### PR DESCRIPTION
- also change yarnLintFix to only print file names that `prettier` changed not all files which makes the log very large

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
