### PR TITLE
feat(ui/summary): add new summary tab on the required entities

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryNode/GlossaryNodeEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryNode/GlossaryNodeEntity.tsx
@@ -12,6 +12,8 @@ import SidebarStructuredPropsSection from '@app/entity/shared/containers/profile
 import { getDataForEntityType } from '@app/entity/shared/containers/profile/utils';
 import { DocumentationTab } from '@app/entity/shared/tabs/Documentation/DocumentationTab';
 import { PropertiesTab } from '@app/entity/shared/tabs/Properties/PropertiesTab';
+import SummaryTab from '@app/entityV2/summary/SummaryTab';
+import { useShowAssetSummaryPage } from '@app/entityV2/summary/useShowAssetSummaryPage';
 
 import { useGetGlossaryNodeQuery } from '@graphql/glossaryNode.generated';
 import { EntityType, GlossaryNode, SearchResult } from '@types';
@@ -63,23 +65,7 @@ class GlossaryNodeEntity implements Entity<GlossaryNode> {
                 getOverrideProperties={this.getOverridePropertiesFromEntity}
                 isNameEditable
                 hideBrowseBar
-                tabs={[
-                    {
-                        name: 'Contents',
-                        component: ChildrenTab,
-                    },
-                    {
-                        name: 'Documentation',
-                        component: DocumentationTab,
-                        properties: {
-                            hideLinksButton: true,
-                        },
-                    },
-                    {
-                        name: 'Properties',
-                        component: PropertiesTab,
-                    },
-                ]}
+                tabs={this.getProfileTabs()}
                 sidebarSections={this.getSidebarSections()}
                 headerDropdownItems={
                     new Set([
@@ -107,6 +93,40 @@ class GlossaryNodeEntity implements Entity<GlossaryNode> {
             component: SidebarStructuredPropsSection,
         },
     ];
+
+    getProfileTabs = () => {
+        const showSummaryTab = useShowAssetSummaryPage();
+
+        return [
+            ...(showSummaryTab
+                ? [
+                      {
+                          name: 'Summary',
+                          component: SummaryTab,
+                      },
+                  ]
+                : []),
+            {
+                name: 'Contents',
+                component: ChildrenTab,
+            },
+            ...(!showSummaryTab
+                ? [
+                      {
+                          name: 'Documentation',
+                          component: DocumentationTab,
+                          properties: {
+                              hideLinksButton: true,
+                          },
+                      },
+                  ]
+                : []),
+            {
+                name: 'Properties',
+                component: PropertiesTab,
+            },
+        ];
+    };
 
     displayName = (data: GlossaryNode) => {
         return data.properties?.name || data.urn;

--- a/datahub-web-react/src/app/entityV2/dataProduct/DataProductEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataProduct/DataProductEntity.tsx
@@ -31,6 +31,9 @@ import SidebarNotesSection from '@app/entityV2/shared/sidebarSection/SidebarNote
 import SidebarStructuredProperties from '@app/entityV2/shared/sidebarSection/SidebarStructuredProperties';
 import { DocumentationTab } from '@app/entityV2/shared/tabs/Documentation/DocumentationTab';
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';
+import { EntityTab } from '@app/entityV2/shared/types';
+import SummaryTab from '@app/entityV2/summary/SummaryTab';
+import { useShowAssetSummaryPage } from '@app/entityV2/summary/useShowAssetSummaryPage';
 
 import { useGetDataProductQuery } from '@graphql/dataProduct.generated';
 import { GetDatasetQuery } from '@graphql/dataset.generated';
@@ -100,32 +103,7 @@ export class DataProductEntity implements Entity<DataProduct> {
             headerActionItems={new Set([EntityActionItem.BATCH_ADD_DATA_PRODUCT])}
             headerDropdownItems={headerDropdownItems}
             isNameEditable
-            tabs={[
-                {
-                    id: EntityProfileTab.SUMMARY_TAB,
-                    name: 'Summary',
-                    component: DataProductSummaryTab,
-                    icon: ReadOutlined,
-                },
-                {
-                    name: 'Documentation',
-                    component: DocumentationTab,
-                    icon: FileOutlined,
-                },
-                {
-                    name: 'Assets',
-                    getCount: (entityData, _) => {
-                        return entityData?.entities?.total;
-                    },
-                    component: DataProductEntitiesTab,
-                    icon: AppstoreOutlined,
-                },
-                {
-                    name: 'Properties',
-                    component: PropertiesTab,
-                    icon: UnorderedListOutlined,
-                },
-            ]}
+            tabs={this.getProfileTabs()}
             sidebarSections={this.getSidebarSections()}
             sidebarTabs={this.getSidebarTabs()}
         />
@@ -174,6 +152,41 @@ export class DataProductEntity implements Entity<DataProduct> {
             component: StatusSection,
         },
     ];
+
+    getProfileTabs = (): EntityTab[] => {
+        const showSummaryTab = useShowAssetSummaryPage();
+
+        return [
+            {
+                id: EntityProfileTab.SUMMARY_TAB,
+                name: 'Summary',
+                component: showSummaryTab ? SummaryTab : DataProductSummaryTab,
+                icon: ReadOutlined,
+            },
+            ...(!showSummaryTab
+                ? [
+                      {
+                          name: 'Documentation',
+                          component: DocumentationTab,
+                          icon: FileOutlined,
+                      },
+                  ]
+                : []),
+            {
+                name: 'Assets',
+                getCount: (entityData, _) => {
+                    return entityData?.entities?.total;
+                },
+                component: DataProductEntitiesTab,
+                icon: AppstoreOutlined,
+            },
+            {
+                name: 'Properties',
+                component: PropertiesTab,
+                icon: UnorderedListOutlined,
+            },
+        ];
+    };
 
     getSidebarTabs = () => [
         {

--- a/datahub-web-react/src/app/entityV2/domain/DomainEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/domain/DomainEntity.tsx
@@ -23,6 +23,9 @@ import SidebarStructuredProperties from '@app/entityV2/shared/sidebarSection/Sid
 import { SUMMARY_TAB_ICON } from '@app/entityV2/shared/summary/HeaderComponents';
 import { DocumentationTab } from '@app/entityV2/shared/tabs/Documentation/DocumentationTab';
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';
+import { EntityTab } from '@app/entityV2/shared/types';
+import SummaryTab from '@app/entityV2/summary/SummaryTab';
+import { useShowAssetSummaryPage } from '@app/entityV2/summary/useShowAssetSummaryPage';
 
 import { useGetDomainQuery } from '@graphql/domain.generated';
 import { Domain, EntityType, SearchResult } from '@types';
@@ -93,43 +96,7 @@ export class DomainEntity implements Entity<Domain> {
             isNameEditable
             isIconEditable
             isColorEditable
-            tabs={[
-                {
-                    id: EntityProfileTab.SUMMARY_TAB,
-                    name: 'Summary',
-                    component: DomainSummaryTab,
-                    icon: SUMMARY_TAB_ICON,
-                },
-                {
-                    id: EntityProfileTab.DOMAIN_ENTITIES_TAB,
-                    name: 'Assets',
-                    getCount: (entityData, _) => {
-                        return entityData?.entities?.total;
-                    },
-                    component: DomainEntitiesTab,
-                    icon: AppstoreOutlined,
-                },
-                {
-                    id: EntityProfileTab.DOCUMENTATION_TAB,
-                    name: 'Documentation',
-                    component: DocumentationTab,
-                    icon: FileOutlined,
-                },
-                {
-                    id: EntityProfileTab.DATA_PRODUCTS_TAB,
-                    name: 'Data Products',
-                    getCount: (entityData, _) => {
-                        return entityData?.dataProducts?.total;
-                    },
-                    component: DataProductsTab,
-                    icon: FileDoneOutlined,
-                },
-                {
-                    name: 'Properties',
-                    component: PropertiesTab,
-                    icon: UnorderedListOutlined,
-                },
-            ]}
+            tabs={this.getProfileTabs()}
             sidebarSections={this.getSidebarSections()}
             sidebarTabs={this.getSidebarTabs()}
         />
@@ -167,6 +134,51 @@ export class DomainEntity implements Entity<Domain> {
             icon: ListBullets,
         },
     ];
+
+    getProfileTabs = (): EntityTab[] => {
+        const showSummaryTab = useShowAssetSummaryPage();
+        return [
+            {
+                id: EntityProfileTab.SUMMARY_TAB,
+                name: 'Summary',
+                component: showSummaryTab ? SummaryTab : DomainSummaryTab,
+                icon: SUMMARY_TAB_ICON,
+            },
+            {
+                id: EntityProfileTab.DOMAIN_ENTITIES_TAB,
+                name: 'Assets',
+                getCount: (entityData, _) => {
+                    return entityData?.entities?.total;
+                },
+                component: DomainEntitiesTab,
+                icon: AppstoreOutlined,
+            },
+            ...(!showSummaryTab
+                ? [
+                      {
+                          id: EntityProfileTab.DOCUMENTATION_TAB,
+                          name: 'Documentation',
+                          component: DocumentationTab,
+                          icon: FileOutlined,
+                      },
+                  ]
+                : []),
+            {
+                id: EntityProfileTab.DATA_PRODUCTS_TAB,
+                name: 'Data Products',
+                getCount: (entityData, _) => {
+                    return entityData?.dataProducts?.total;
+                },
+                component: DataProductsTab,
+                icon: FileDoneOutlined,
+            },
+            {
+                name: 'Properties',
+                component: PropertiesTab,
+                icon: UnorderedListOutlined,
+            },
+        ];
+    };
 
     renderPreview = (previewType: PreviewType, data: Domain) => {
         const genericProperties = this.getGenericEntityProperties(data);

--- a/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
@@ -25,6 +25,9 @@ import SidebarStructuredProperties from '@app/entityV2/shared/sidebarSection/Sid
 import { SchemaTab } from '@app/entityV2/shared/tabs/Dataset/Schema/SchemaTab';
 import { DocumentationTab } from '@app/entityV2/shared/tabs/Documentation/DocumentationTab';
 import { PropertiesTab } from '@app/entityV2/shared/tabs/Properties/PropertiesTab';
+import { EntityTab } from '@app/entityV2/shared/types';
+import SummaryTab from '@app/entityV2/summary/SummaryTab';
+import { useShowAssetSummaryPage } from '@app/entityV2/summary/useShowAssetSummaryPage';
 import { FetchedEntity } from '@app/lineage/types';
 
 import { GetGlossaryTermQuery, useGetGlossaryTermQuery } from '@graphql/glossaryTerm.generated';
@@ -98,49 +101,7 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
                 headerActionItems={new Set([EntityActionItem.BATCH_ADD_GLOSSARY_TERM])}
                 headerDropdownItems={headerDropdownItems}
                 isNameEditable
-                tabs={[
-                    {
-                        name: 'Documentation',
-                        component: DocumentationTab,
-                        icon: FileOutlined,
-                    },
-                    {
-                        name: 'Related Assets',
-                        getCount: useGlossaryRelatedAssetsTabCount,
-                        component: GlossaryRelatedEntity,
-                        icon: AppstoreOutlined,
-                    },
-                    {
-                        name: 'Schema',
-                        component: SchemaTab,
-                        icon: LayoutOutlined,
-                        properties: {
-                            editMode: false,
-                        },
-                        display: {
-                            visible: (_, glossaryTerm: GetGlossaryTermQuery) =>
-                                glossaryTerm?.glossaryTerm?.schemaMetadata !== null,
-                            enabled: (_, glossaryTerm: GetGlossaryTermQuery) =>
-                                glossaryTerm?.glossaryTerm?.schemaMetadata !== null,
-                        },
-                    },
-                    {
-                        name: 'Related Terms',
-                        getCount: (entityData, _, loading) => {
-                            const totalRelatedTerms = Object.keys(RelatedTermTypes).reduce((acc, curr) => {
-                                return acc + (entityData?.[curr]?.total || 0);
-                            }, 0);
-                            return !loading ? totalRelatedTerms : undefined;
-                        },
-                        component: GlossayRelatedTerms,
-                        icon: () => <BookmarkSimple style={{ marginRight: 6 }} />,
-                    },
-                    {
-                        name: 'Properties',
-                        component: PropertiesTab,
-                        icon: UnorderedListOutlined,
-                    },
-                ]}
+                tabs={this.getProfileTabs()}
                 sidebarSections={this.getSidebarSections()}
                 getOverrideProperties={this.getOverridePropertiesFromEntity}
                 sidebarTabs={this.getSidebarTabs()}
@@ -177,6 +138,66 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
             component: StatusSection,
         },
     ];
+
+    getProfileTabs = (): EntityTab[] => {
+        const showSummaryTab = useShowAssetSummaryPage();
+
+        return [
+            ...(showSummaryTab
+                ? [
+                      {
+                          name: 'Summary',
+                          component: SummaryTab,
+                      },
+                  ]
+                : []),
+            ...(!showSummaryTab
+                ? [
+                      {
+                          name: 'Documentation',
+                          component: DocumentationTab,
+                          icon: FileOutlined,
+                      },
+                  ]
+                : []),
+            {
+                name: 'Related Assets',
+                getCount: useGlossaryRelatedAssetsTabCount,
+                component: GlossaryRelatedEntity,
+                icon: AppstoreOutlined,
+            },
+            {
+                name: 'Schema',
+                component: SchemaTab,
+                icon: LayoutOutlined,
+                properties: {
+                    editMode: false,
+                },
+                display: {
+                    visible: (_, glossaryTerm: GetGlossaryTermQuery) =>
+                        glossaryTerm?.glossaryTerm?.schemaMetadata !== null,
+                    enabled: (_, glossaryTerm: GetGlossaryTermQuery) =>
+                        glossaryTerm?.glossaryTerm?.schemaMetadata !== null,
+                },
+            },
+            {
+                name: 'Related Terms',
+                getCount: (entityData, _, loading) => {
+                    const totalRelatedTerms = Object.keys(RelatedTermTypes).reduce((acc, curr) => {
+                        return acc + (entityData?.[curr]?.total || 0);
+                    }, 0);
+                    return !loading ? totalRelatedTerms : undefined;
+                },
+                component: GlossayRelatedTerms,
+                icon: () => <BookmarkSimple style={{ marginRight: 6 }} />,
+            },
+            {
+                name: 'Properties',
+                component: PropertiesTab,
+                icon: UnorderedListOutlined,
+            },
+        ];
+    };
 
     getSidebarTabs = () => [
         {

--- a/datahub-web-react/src/app/entityV2/summary/SummaryTab.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/SummaryTab.tsx
@@ -1,0 +1,30 @@
+import { colors } from '@components';
+import { Divider } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+
+import AboutSection from '@app/entityV2/summary/documentation/AboutSection';
+import PropertiesHeader from '@app/entityV2/summary/properties/PropertiesHeader';
+
+const SummaryWrapper = styled.div`
+    padding: 16px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+`;
+
+const StyledDivider = styled(Divider)`
+    margin: 0;
+    color: ${colors.gray[100]};
+`;
+
+export default function SummaryTab() {
+    return (
+        <SummaryWrapper>
+            <PropertiesHeader />
+            <StyledDivider />
+            <AboutSection />
+            <StyledDivider />
+        </SummaryWrapper>
+    );
+}

--- a/datahub-web-react/src/app/entityV2/summary/__tests__/useShowAssetSummaryPage.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/__tests__/useShowAssetSummaryPage.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { MockedFunction, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useShowAssetSummaryPage } from '@app/entityV2/summary/useShowAssetSummaryPage';
+import { useAppConfig } from '@app/useAppConfig';
+
+vi.mock('@app/useAppConfig', () => ({
+    useAppConfig: vi.fn(),
+}));
+
+const mockedUseAppConfig = useAppConfig as MockedFunction<typeof useAppConfig>;
+
+describe('useShowAssetSummaryPage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should return true when loaded is true and flag is true', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: true,
+            config: { featureFlags: { assetSummaryPageV1: true } },
+        } as any);
+
+        const { result } = renderHook(() => useShowAssetSummaryPage());
+        expect(result.current).toBe(true);
+    });
+
+    it('should return false when loaded is true and flag is false', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: true,
+            config: { featureFlags: { assetSummaryPageV1: false } },
+        } as any);
+
+        const { result } = renderHook(() => useShowAssetSummaryPage());
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false when loaded is false regardless of the flag', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: false,
+            config: { featureFlags: { assetSummaryPageV1: true } },
+        } as any);
+
+        const { result } = renderHook(() => useShowAssetSummaryPage());
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false when loaded is true but flag is missing', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: true,
+            config: { featureFlags: { assetSummaryPageV1: false } },
+        } as any);
+
+        const { result } = renderHook(() => useShowAssetSummaryPage());
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false when loaded is false and flag is missing', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: false,
+            config: { featureFlags: { assetSummaryPageV1: false } },
+        } as any);
+
+        const { result } = renderHook(() => useShowAssetSummaryPage());
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false when appConfig is undefined', () => {
+        mockedUseAppConfig.mockReturnValue(undefined as any);
+
+        const { result } = renderHook(() => useShowAssetSummaryPage());
+        expect(result.current).toBe(false);
+    });
+});

--- a/datahub-web-react/src/app/entityV2/summary/documentation/AboutSection.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/documentation/AboutSection.tsx
@@ -1,0 +1,12 @@
+import { Text } from '@components';
+import React from 'react';
+
+export default function AboutSection() {
+    return (
+        <>
+            <Text weight="bold" color="gray" colorLevel={600}>
+                About
+            </Text>
+        </>
+    );
+}

--- a/datahub-web-react/src/app/entityV2/summary/properties/PropertiesHeader.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/properties/PropertiesHeader.tsx
@@ -1,0 +1,12 @@
+import { Text } from '@components';
+import React from 'react';
+
+export default function PropertiesHeader() {
+    return (
+        <>
+            <Text weight="bold" color="gray" colorLevel={600}>
+                Properties
+            </Text>
+        </>
+    );
+}

--- a/datahub-web-react/src/app/entityV2/summary/useShowAssetSummaryPage.ts
+++ b/datahub-web-react/src/app/entityV2/summary/useShowAssetSummaryPage.ts
@@ -2,7 +2,8 @@ import { useAppConfig } from '@app/useAppConfig';
 
 export function useShowAssetSummaryPage() {
     const appConfig = useAppConfig();
-    const showSummary = appConfig.config.featureFlags.assetSummaryPageV1;
-
-    return showSummary;
+    if (appConfig?.loaded) {
+        return appConfig.config.featureFlags.assetSummaryPageV1;
+    }
+    return false;
 }

--- a/datahub-web-react/src/app/entityV2/summary/useShowAssetSummaryPage.ts
+++ b/datahub-web-react/src/app/entityV2/summary/useShowAssetSummaryPage.ts
@@ -1,0 +1,8 @@
+import { useAppConfig } from '@app/useAppConfig';
+
+export function useShowAssetSummaryPage() {
+    const appConfig = useAppConfig();
+    const showSummary = appConfig.config.featureFlags.assetSummaryPageV1;
+
+    return showSummary;
+}


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-667/skeleton-for-the-new-summary-tab-on-required-entities

**Screenshots:**

<img width="1366" height="583" alt="image" src="https://github.com/user-attachments/assets/ed65c0f5-ce71-434c-8dcb-a747012e489c" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
