### PR TITLE
fix(docs): Add new access workflow event fields

### DIFF
--- a/docs/actions/events/entity-change-event.md
+++ b/docs/actions/events/entity-change-event.md
@@ -604,7 +604,7 @@ This event is emitted when a structured property association is proposed for an 
 }
 ```
 
-### Approval Workflow Request Create Event
+### Approval Workflow Request Create Event (Data Access Workflows)
 
 This event is emitted when a new approval workflow form request is submitted on DataHub.
 
@@ -632,13 +632,18 @@ submitted the approval request form. It contains a serialized JSON object that m
       "workflowUrn": "urn:li:actionWorkflow:7a6e7a24-7525-4f1e-8d9b-08ba562399d0",
       "expiresAtMs": 1756680611743,
       "fields": "{\"reason\":[\"Building Tableau Dashboard Q2\"],\"privileges\":[\"SELECT\"],\"projects\":[\"Orders Dashboard Q2\"],\"tags\":[\"urn:li:tag:__default_gold\"]}",
-      "workflowId": "7a6e7a24-7525-4f1e-8d9b-08ba562399d0"
+      "workflowId": "7a6e7a24-7525-4f1e-8d9b-08ba562399d0",
+      "entityType": "dataset",
+      "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,example.table,PROD)",
+      "entityName": "table",
+      "qualifiedName": "example.table",
+      "entityPlatformName": "Snowflake"
     }
   }
 }
 ```
 
-### Approval Workflow Request Step Complete Event
+### Approval Workflow Request Step Complete Event (Data Access Workflows)
 
 This event is emitted when an approval step within a workflow request has been completed (approved, rejected, or requires more information).
 
@@ -668,13 +673,18 @@ submitted the approval request form. It contains a serialized JSON object that m
       "expiresAtMs": 1754002407730,
       "stepResult": "ACCEPTED",
       "fields": "{\"reason\":[\"Test\"],\"privileges\":[\"SELECT\"],\"tags\":[\"urn:li:tag:NeedsDocumentation\"]}",
-      "workflowId": "7a6e7a24-7525-4f1e-8d9b-08ba562399d0"
+      "workflowId": "7a6e7a24-7525-4f1e-8d9b-08ba562399d0",
+      "entityType": "dataset",
+      "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,example.table,PROD)",
+      "entityName": "table",
+      "qualifiedName": "example.table",
+      "entityPlatformName": "Snowflake"
     }
   }
 }
 ```
 
-### Approval Workflow Request Complete Event
+### Approval Workflow Request Complete Event (Data Access Workflows)
 
 This event is emitted when an approval workflow request has been fully completed - either approved through all steps or rejected at any step.
 
@@ -704,7 +714,12 @@ submitted the approval request form. It contains a serialized JSON object that m
       "expiresAtMs": 1756335474418,
       "fields": "{\"reason\":[\"test\"],\"privileges\":[\"SELECT\"],\"projects\":[\"test\"],\"tags\":[\"urn:li:tag:NeedsDocumentation\"]}",
       "operation": "COMPLETE",
-      "workflowId": "7a6e7a24-7525-4f1e-8d9b-08ba562399d0"
+      "workflowId": "7a6e7a24-7525-4f1e-8d9b-08ba562399d0",
+      "entityType": "dataset",
+      "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,example.table,PROD)",
+      "entityName": "table",
+      "qualifiedName": "example.table",
+      "entityPlatformName": "Snowflake"
     }
   }
 }


### PR DESCRIPTION
We recently added some new fields to access workflow events, to provide additional context like entity name, urn, and more.

This PR adds those to our documentation.



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
