### PR TITLE
fix(ui/browse): Fix bug where browse would not paginate when leaving a nested container

### DIFF
--- a/datahub-web-react/src/app/searchV2/sidebar/BrowseNode.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/BrowseNode.tsx
@@ -1,4 +1,5 @@
 import { FolderOutlined } from '@ant-design/icons';
+import { Loader } from '@components';
 import { Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
@@ -71,7 +72,7 @@ const BrowseNode = () => {
         trackSelectNodeEvent(isNowSelected ? 'select' : 'deselect', 'browse');
     };
 
-    const { error, groups, loaded, observable, path, retry } = useBrowsePagination({
+    const { error, groups, loading, loaded, observable, path, retry } = useBrowsePagination({
         skip: !isOpen || !browseResultGroup.hasSubGroups,
     });
 
@@ -118,6 +119,7 @@ const BrowseNode = () => {
                             <BrowseNode />
                         </BrowseProvider>
                     ))}
+                    {loading && <Loader size="sm" />}
                     {error && <SidebarLoadingError onClickRetry={retry} />}
                     {observable}
                 </ExpandableNode.Body>

--- a/datahub-web-react/src/app/searchV2/sidebar/PlatformNode.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/PlatformNode.tsx
@@ -1,3 +1,4 @@
+import { Loader } from '@components';
 import { Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
@@ -82,7 +83,7 @@ const PlatformNode = ({ iconSize = 20, hasOnlyOnePlatform = false, toggleCollaps
         trackSelectNodeEvent(isNowPlatformOnlySelected ? 'select' : 'deselect', 'platform');
     };
 
-    const { error, groups, loaded, observable, path, retry } = useBrowsePagination({ skip: !isOpen });
+    const { error, groups, loading, loaded, observable, path, retry } = useBrowsePagination({ skip: !isOpen });
 
     const color = REDESIGN_COLORS.TEXT_HEADING;
 
@@ -169,6 +170,7 @@ const PlatformNode = ({ iconSize = 20, hasOnlyOnePlatform = false, toggleCollaps
                             <BrowseNode />
                         </BrowseProvider>
                     ))}
+                    {loading && <Loader size="sm" />}
                     {error && <SidebarLoadingError onClickRetry={retry} />}
                     {observable}
                 </ExpandableNode.Body>

--- a/datahub-web-react/src/app/searchV2/sidebar/useBrowsePagination.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/useBrowsePagination.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { useBrowsePath, useEntityType } from '@app/searchV2/sidebar/BrowseContext';
 import { BROWSE_LOAD_MORE_MARGIN, BROWSE_PAGE_SIZE } from '@app/searchV2/sidebar/constants';

--- a/datahub-web-react/src/app/searchV2/sidebar/useBrowsePagination.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/useBrowsePagination.tsx
@@ -5,7 +5,7 @@ import { BROWSE_LOAD_MORE_MARGIN, BROWSE_PAGE_SIZE } from '@app/searchV2/sidebar
 import { useSidebarFilters } from '@app/searchV2/sidebar/useSidebarFilters';
 import useIntersect from '@app/shared/useIntersect';
 
-import { GetBrowseResultsV2Query, useGetBrowseResultsV2LazyQuery } from '@graphql/browseV2.generated';
+import { GetBrowseResultsV2Query, useGetBrowseResultsV2Query } from '@graphql/browseV2.generated';
 
 type Props = {
     skip: boolean;
@@ -33,62 +33,49 @@ const useBrowsePagination = ({ skip }: Props) => {
     const total = latestData?.browseV2?.total ?? -1;
     const done = !!latestData && groups.length >= total;
 
-    const [getBrowseResultsV2, { data, error, refetch }] = useGetBrowseResultsV2LazyQuery({
+    const [start, setStart] = useState(0);
+    const { loading, error, refetch } = useGetBrowseResultsV2Query({
+        skip,
         fetchPolicy: 'cache-first',
+        variables: {
+            input: {
+                type,
+                path,
+                start,
+                count: BROWSE_PAGE_SIZE,
+                orFilters: sidebarFilters.orFilters,
+                viewUrn: sidebarFilters.viewUrn,
+                query: sidebarFilters.query,
+            },
+        },
+        onCompleted: (data) => {
+            const newStart = data?.browseV2?.start ?? -1;
+            if (newStart === 0) initializing.current = false;
+            if (initializing.current || !data || newStart < 0) return;
+
+            setStartToBrowseMap((previousMap) => {
+                const newMap: typeof previousMap = { [newStart]: data };
+
+                Object.keys(previousMap)
+                    .map(Number)
+                    .forEach((previousStart) => {
+                        if (previousStart < newStart) newMap[previousStart] = previousMap[previousStart];
+                    });
+
+                return newMap;
+            });
+        },
     });
 
     const retry = () => {
         if (refetch) refetch();
     };
 
-    const getBrowseResultsV2WithDeps = useCallback(
-        (start: number) => {
-            if (skip) return;
-            getBrowseResultsV2({
-                variables: {
-                    input: {
-                        type,
-                        path,
-                        start,
-                        count: BROWSE_PAGE_SIZE,
-                        orFilters: sidebarFilters.orFilters,
-                        viewUrn: sidebarFilters.viewUrn,
-                        query: sidebarFilters.query,
-                    },
-                },
-            });
-        },
-        [getBrowseResultsV2, path, sidebarFilters.orFilters, sidebarFilters.query, sidebarFilters.viewUrn, skip, type],
-    );
-
-    useEffect(() => {
-        initializing.current = true;
-        getBrowseResultsV2WithDeps(0);
-    }, [getBrowseResultsV2WithDeps]);
-
-    useEffect(() => {
-        const newStart = data?.browseV2?.start ?? -1;
-        if (newStart === 0) initializing.current = false;
-        if (initializing.current || !data || newStart < 0) return;
-
-        setStartToBrowseMap((previousMap) => {
-            const newMap: typeof previousMap = { [newStart]: data };
-
-            Object.keys(previousMap)
-                .map(Number)
-                .forEach((previousStart) => {
-                    if (previousStart < newStart) newMap[previousStart] = previousMap[previousStart];
-                });
-
-            return newMap;
-        });
-    }, [data]);
-
     const advancePage = useCallback(() => {
         const newStart = latestStart + BROWSE_PAGE_SIZE;
         if (initializing.current || error || done || latestStart < 0 || total <= 0 || newStart >= total) return;
-        getBrowseResultsV2WithDeps(newStart);
-    }, [done, error, getBrowseResultsV2WithDeps, latestStart, total]);
+        setStart(newStart);
+    }, [done, error, latestStart, total]);
 
     const { observableRef } = useIntersect({
         skip,
@@ -97,6 +84,7 @@ const useBrowsePagination = ({ skip }: Props) => {
     });
 
     return {
+        loading: start > 0 && loading, // Don't display loading indicator for first page
         loaded: !!latestData || !!error,
         error,
         groups,


### PR DESCRIPTION
When leaving the nested folder, we'd have 2 pages of results but the internal component state would think we only had one and fetch the second page, getting no new results. I couldn't reason about the existing code so I cleaned it up. A consequence of the refactor is that after selecting a folder, we're no longer hiding other loaded folders in the same platform. I think this is a better experience anyway so seems like an improvement. I also added a loading state to improve UX.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
