### PR TITLE
feat(datahub-actions): Adding support for Metadata Change Log in DataHub Cloud Events Source

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/source/acryl/constants.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/acryl/constants.py
@@ -1,2 +1,4 @@
 PLATFORM_EVENT_TOPIC_NAME = "PlatformEvent_v1"
+METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME = "MetadataChangeLog_Versioned_v1"
+METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME = "MetadataChangeLog_Timeseries_v1"
 ENTITY_CHANGE_EVENT_NAME = "entityChangeEvent"

--- a/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_event_source.py
@@ -45,6 +45,7 @@ def build_entity_change_event(payload: GenericPayloadClass) -> EntityChangeEvent
     except Exception as e:
         raise ValueError("Failed to parse into EntityChangeEvent") from e
 
+
 def build_metadata_change_log_event(msg: ExternalEvent) -> MetadataChangeLogEvent:
     try:
         return cast(MetadataChangeLogEvent, MetadataChangeLogEvent.from_json(msg.value))
@@ -141,13 +142,13 @@ class DataHubEventSource(EventSource):
                 # Poll events from all topics
                 all_events = []
                 total_events = 0
-                
+
                 for topic in self.topics_list:
                     events_response = self.datahub_events_consumer.poll_events(
                         topic=topic, poll_timeout_seconds=2
                     )
                     total_events += len(events_response.events)
-                    
+
                     # Process events from this topic
                     for msg in events_response.events:
                         all_events.append((topic, msg))
@@ -182,11 +183,16 @@ class DataHubEventSource(EventSource):
 
         logger.info("DataHub Events consumer exiting main loop")
 
-    def _route_event_by_topic(self, topic: str, msg: ExternalEvent) -> Iterable[EventEnvelope]:
+    def _route_event_by_topic(
+        self, topic: str, msg: ExternalEvent
+    ) -> Iterable[EventEnvelope]:
         """Route events to appropriate handlers based on topic type."""
         if topic == PLATFORM_EVENT_TOPIC_NAME:
             yield from self.handle_pe(msg)
-        elif topic in [METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME, METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME]:
+        elif topic in [
+            METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME,
+            METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME,
+        ]:
             yield from self.handle_mcl(msg)
         else:
             logger.warning(f"Unknown topic: {topic}, skipping event")

--- a/datahub-actions/tests/unit/plugin/source/acryl/test_datahub_cloud_event_source.py
+++ b/datahub-actions/tests/unit/plugin/source/acryl/test_datahub_cloud_event_source.py
@@ -1,5 +1,7 @@
 # test_datahub_event_source.py
 
+import base64
+import json
 from typing import List, cast
 from unittest.mock import MagicMock, patch
 
@@ -8,7 +10,9 @@ import pytest
 from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.event.event_registry import (
     ENTITY_CHANGE_EVENT_V1_TYPE,
+    METADATA_CHANGE_LOG_EVENT_V1_TYPE,
     EntityChangeEvent,
+    MetadataChangeLogEvent,
 )
 from datahub_actions.pipeline.pipeline_context import PipelineContext
 
@@ -16,6 +20,7 @@ from datahub_actions.pipeline.pipeline_context import PipelineContext
 from datahub_actions.plugin.source.acryl.datahub_cloud_event_source import (
     DataHubEventSource,
     DataHubEventsSourceConfig,
+    build_metadata_change_log_event,
 )
 from datahub_actions.plugin.source.acryl.datahub_cloud_events_ack_manager import (
     AckManager,
@@ -24,6 +29,11 @@ from datahub_actions.plugin.source.acryl.datahub_cloud_events_consumer import (
     DataHubEventsConsumer,
     ExternalEvent,
     ExternalEventsResponse,
+)
+from datahub_actions.plugin.source.acryl.constants import (
+    METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME,
+    METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME,
+    PLATFORM_EVENT_TOPIC_NAME,
 )
 
 
@@ -50,7 +60,7 @@ def base_config_dict() -> dict:
     We will parse this into DataHubEventsSourceConfig in each test.
     """
     return {
-        "topic": "PlatformEvent_v1",
+        "topics": "PlatformEvent_v1",
         "lookback_days": None,
         "reset_offsets": False,
         "kill_after_idle_timeout": True,
@@ -88,7 +98,7 @@ def test_source_initialization(
     """
     Validate that DataHubEventSource constructor sets up DataHubEventsConsumer and AckManager.
     """
-    config_model = DataHubEventsSourceConfig.parse_obj(base_config_dict)
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
     source = DataHubEventSource(config_model, mock_pipeline_context)
     assert source.consumer_id == "urn:li:dataHubAction:test-pipeline"
     assert isinstance(source.datahub_events_consumer, DataHubEventsConsumer)
@@ -101,7 +111,7 @@ def test_events_with_no_events(
 ) -> None:
     base_config_dict["idle_timeout_duration_seconds"] = 1
     base_config_dict["kill_after_idle_timeout"] = True
-    config_model = DataHubEventsSourceConfig.parse_obj(base_config_dict)
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
     source = DataHubEventSource(config_model, mock_pipeline_context)
 
     mock_consumer = MagicMock(spec=DataHubEventsConsumer)
@@ -130,7 +140,7 @@ def test_events_with_some_events(
     """
     If poll_events returns events, verify that the source yields them and resets idle timer.
     """
-    config_model = DataHubEventsSourceConfig.parse_obj(base_config_dict)
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
     source = DataHubEventSource(config_model, mock_pipeline_context)
 
     mock_consumer = MagicMock(spec=DataHubEventsConsumer)
@@ -177,7 +187,7 @@ def test_outstanding_acks_timeout(
     due to event_processing_time_max_duration_seconds.
     """
     base_config_dict["event_processing_time_max_duration_seconds"] = 2
-    config_model = DataHubEventsSourceConfig.parse_obj(base_config_dict)
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
     source = DataHubEventSource(config_model, mock_pipeline_context)
 
     mock_ack_manager = MagicMock(spec=AckManager)
@@ -223,7 +233,7 @@ def test_ack(mock_pipeline_context: PipelineContext, base_config_dict: dict) -> 
     """
     Verify that ack() calls ack_manager.ack with the event's metadata.
     """
-    config_model = DataHubEventsSourceConfig.parse_obj(base_config_dict)
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
     source = DataHubEventSource(config_model, mock_pipeline_context)
 
     mock_ack_manager = MagicMock(spec=AckManager)
@@ -242,7 +252,7 @@ def test_close(mock_pipeline_context: PipelineContext, base_config_dict: dict) -
     """
     Verify that close() stops the source, commits offsets, and calls consumer.close().
     """
-    config_model = DataHubEventsSourceConfig.parse_obj(base_config_dict)
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
     source = DataHubEventSource(config_model, mock_pipeline_context)
 
     mock_consumer = MagicMock(spec=DataHubEventsConsumer)
@@ -263,7 +273,7 @@ def test_should_idle_timeout(
     Verify the idle timeout logic in _should_idle_timeout().
     """
     base_config_dict["idle_timeout_duration_seconds"] = 5
-    config_model = DataHubEventsSourceConfig.parse_obj(base_config_dict)
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
     source = DataHubEventSource(config_model, mock_pipeline_context)
 
     # If events > 0 => always False
@@ -288,3 +298,152 @@ def test_should_idle_timeout(
             is True
         )
         assert source.running is False
+
+
+def test_multiple_topics_config(
+    mock_pipeline_context: PipelineContext, base_config_dict: dict
+) -> None:
+    """
+    Test that the source properly handles multiple topics configuration.
+    """
+    # Test with list of topics
+    base_config_dict["topics"] = [
+        PLATFORM_EVENT_TOPIC_NAME,
+        METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME,
+        METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME,
+    ]
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
+    source = DataHubEventSource(config_model, mock_pipeline_context)
+    
+    assert source.topics_list == [
+        PLATFORM_EVENT_TOPIC_NAME,
+        METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME,
+        METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME,
+    ]
+
+
+def test_single_topic_config_as_string(
+    mock_pipeline_context: PipelineContext, base_config_dict: dict
+) -> None:
+    """
+    Test that the source properly handles single topic configuration as string.
+    """
+    # topics config as string should be converted to list
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
+    source = DataHubEventSource(config_model, mock_pipeline_context)
+    
+    assert source.topics_list == [PLATFORM_EVENT_TOPIC_NAME]
+
+
+def test_handle_mcl() -> None:
+    """
+    Test that handle_mcl properly processes MetadataChangeLogEvent with proper aspect encoding.
+    """
+    # Create a realistic MCL event based on the documented format
+    mcl_value = {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)",
+        "entityKeyAspect": None,
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "value": '{"tags":[{"tag":"urn:li:tag:pii"}]}',  # JSON string as per API format
+            "contentType": "application/json"
+        },
+        "systemMetadata": {
+            "lastObserved": 1651516475595,
+            "runId": "test-run-id",
+            "registryName": "testRegistry",
+            "registryVersion": "1.0.0",
+            "properties": None
+        },
+        "previousAspectValue": None,
+        "previousSystemMetadata": None,
+        "created": {
+            "time": 1651516475594,
+            "actor": "urn:li:corpuser:datahub",
+            "impersonator": None
+        }
+    }
+    
+    msg = ExternalEvent(contentType="application/json", value=json.dumps(mcl_value))
+    
+    envelopes: List[EventEnvelope] = list(DataHubEventSource.handle_mcl(msg))
+    assert len(envelopes) == 1
+    assert envelopes[0].event_type == METADATA_CHANGE_LOG_EVENT_V1_TYPE
+    assert isinstance(envelopes[0].event, MetadataChangeLogEvent)
+    
+    # Verify the event was parsed correctly
+    mcl_event = envelopes[0].event
+    assert mcl_event.entityUrn == "urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)"
+    assert mcl_event.entityType == "dataset"
+    assert mcl_event.aspectName == "globalTags"
+    assert mcl_event.changeType == "UPSERT"
+
+
+def test_route_event_by_topic(
+    mock_pipeline_context: PipelineContext, base_config_dict: dict
+) -> None:
+    """
+    Test that _route_event_by_topic properly routes events based on topic.
+    """
+    config_model = DataHubEventsSourceConfig.model_validate(base_config_dict)
+    source = DataHubEventSource(config_model, mock_pipeline_context)
+    
+    # Test platform event routing
+    pe_value = '{"header":{"timestampMillis":1737170481713},"name":"entityChangeEvent","payload":{"value":"{\\"auditStamp\\":{\\"actor\\":\\"urn:li:corpuser:test\\",\\"time\\":1737170481713},\\"entityUrn\\":\\"urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)\\",\\"entityType\\":\\"dataset\\",\\"modifier\\":\\"urn:li:tag:test\\",\\"category\\":\\"TAG\\",\\"operation\\":\\"ADD\\",\\"version\\":0}","contentType":"application/json"}}'
+    pe_msg = ExternalEvent(contentType="application/json", value=pe_value)
+    
+    pe_envelopes = list(source._route_event_by_topic(PLATFORM_EVENT_TOPIC_NAME, pe_msg))
+    assert len(pe_envelopes) == 1
+    assert pe_envelopes[0].event_type == ENTITY_CHANGE_EVENT_V1_TYPE
+    
+    # Test MCL event routing with mocked handler
+    mcl_msg = ExternalEvent(contentType="application/json", value='{"test": "mcl"}')
+    
+    with patch.object(source, 'handle_mcl') as mock_handle_mcl:
+        mock_envelope = EventEnvelope(METADATA_CHANGE_LOG_EVENT_V1_TYPE, MagicMock(), {})
+        mock_handle_mcl.return_value = [mock_envelope]
+        
+        mcl_envelopes = list(source._route_event_by_topic(METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME, mcl_msg))
+        assert len(mcl_envelopes) == 1
+        assert mcl_envelopes[0].event_type == METADATA_CHANGE_LOG_EVENT_V1_TYPE
+        mock_handle_mcl.assert_called_once_with(mcl_msg)
+    
+    # Test unknown topic (should return no events)
+    unknown_envelopes = list(source._route_event_by_topic("unknown_topic", pe_msg))
+    assert len(unknown_envelopes) == 0
+
+
+def test_build_metadata_change_log_event() -> None:
+    """
+    Test that build_metadata_change_log_event properly creates MetadataChangeLogEvent.
+    """
+    # Create a realistic MCL event based on documented format
+    mcl_value = {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,test_dataset,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "datasetProfile",
+        "aspect": {
+            "value": '{"rowCount": 1000, "columnCount": 5}',  # JSON string
+            "contentType": "application/json"
+        },
+        "systemMetadata": {
+            "lastObserved": 1651516475595,
+            "runId": "test-run"
+        },
+        "created": {
+            "time": 1651516475594,
+            "actor": "urn:li:corpuser:datahub"
+        }
+    }
+    
+    msg = ExternalEvent(contentType="application/json", value=json.dumps(mcl_value))
+    event = build_metadata_change_log_event(msg)
+    
+    assert isinstance(event, MetadataChangeLogEvent)
+    assert event.entityUrn == "urn:li:dataset:(urn:li:dataPlatform:hive,test_dataset,PROD)"
+    assert event.entityType == "dataset"
+    assert event.aspectName == "datasetProfile"
+    assert event.changeType == "UPSERT"

--- a/metadata-service/events-service/src/main/java/io/datahubproject/event/ExternalEventsService.java
+++ b/metadata-service/events-service/src/main/java/io/datahubproject/event/ExternalEventsService.java
@@ -28,7 +28,16 @@ import org.apache.kafka.common.TopicPartition;
 public class ExternalEventsService {
 
   public static final String PLATFORM_EVENT_TOPIC_NAME = "PlatformEvent_v1";
-  private static final Set<String> ALLOWED_TOPICS = Set.of(PLATFORM_EVENT_TOPIC_NAME);
+  public static final String METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME =
+      "MetadataChangeLog_Versioned_v1";
+  public static final String METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME =
+      "MetadataChangeLog_Timeseries_v1";
+
+  private static final Set<String> ALLOWED_TOPICS =
+      Set.of(
+          PLATFORM_EVENT_TOPIC_NAME,
+          METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME,
+          METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME);
   private final KafkaConsumerPool consumerPool;
   private final ObjectMapper objectMapper;
   private final Map<String, String>

--- a/metadata-service/events-service/src/main/java/io/datahubproject/event/ExternalEventsService.java
+++ b/metadata-service/events-service/src/main/java/io/datahubproject/event/ExternalEventsService.java
@@ -100,7 +100,6 @@ public class ExternalEventsService {
           getPartitionOffsets(finalTopic, offsetId, consumer, partitions, lookbackWindowDays);
 
       for (Map.Entry<TopicPartition, Long> entry : partitionOffsets.entrySet()) {
-        System.out.println(String.format("Seeking to topic is %s", entry.getKey().topic()));
         consumer.seek(entry.getKey(), entry.getValue());
       }
 

--- a/metadata-service/events-service/src/main/java/io/datahubproject/event/ExternalEventsService.java
+++ b/metadata-service/events-service/src/main/java/io/datahubproject/event/ExternalEventsService.java
@@ -89,6 +89,8 @@ public class ExternalEventsService {
     long timeout =
         (pollTimeoutSeconds != null ? pollTimeoutSeconds : defaultPollTimeoutSeconds) * 1000L;
 
+    System.out.println(String.format("Final topic is %s", finalTopic));
+
     try {
       List<TopicPartition> partitions =
           consumer.partitionsFor(finalTopic).stream()
@@ -97,9 +99,10 @@ public class ExternalEventsService {
       consumer.assign(partitions);
 
       Map<TopicPartition, Long> partitionOffsets =
-          getPartitionOffsets(topic, offsetId, consumer, partitions, lookbackWindowDays);
+          getPartitionOffsets(finalTopic, offsetId, consumer, partitions, lookbackWindowDays);
 
       for (Map.Entry<TopicPartition, Long> entry : partitionOffsets.entrySet()) {
+        System.out.println(String.format("Seeking to topic is %s", entry.getKey().topic()));
         consumer.seek(entry.getKey(), entry.getValue());
       }
 

--- a/metadata-service/events-service/src/main/java/io/datahubproject/event/ExternalEventsService.java
+++ b/metadata-service/events-service/src/main/java/io/datahubproject/event/ExternalEventsService.java
@@ -89,8 +89,6 @@ public class ExternalEventsService {
     long timeout =
         (pollTimeoutSeconds != null ? pollTimeoutSeconds : defaultPollTimeoutSeconds) * 1000L;
 
-    System.out.println(String.format("Final topic is %s", finalTopic));
-
     try {
       List<TopicPartition> partitions =
           consumer.partitionsFor(finalTopic).stream()

--- a/metadata-service/events-service/src/test/java/io/datahubproject/event/ExternalEventsServiceTest.java
+++ b/metadata-service/events-service/src/test/java/io/datahubproject/event/ExternalEventsServiceTest.java
@@ -37,6 +37,12 @@ public class ExternalEventsServiceTest {
     MockitoAnnotations.initMocks(this);
     when(consumerPool.borrowConsumer()).thenReturn(kafkaConsumer);
     topicNames.put(ExternalEventsService.PLATFORM_EVENT_TOPIC_NAME, "CustomerSpecificTopicName");
+    topicNames.put(
+        ExternalEventsService.METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME,
+        "CustomerSpecificVersionedTopicName");
+    topicNames.put(
+        ExternalEventsService.METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME,
+        "CustomerSpecificTimeseriesTopicName");
     service = new ExternalEventsService(consumerPool, objectMapper, topicNames, 10, 100);
 
     // Setup to simulate fetching records from Kafka
@@ -93,6 +99,38 @@ public class ExternalEventsServiceTest {
     // Execute
     ExternalEvents events =
         service.poll(ExternalEventsService.PLATFORM_EVENT_TOPIC_NAME, null, 10, 5, null);
+
+    // Validate
+    assertNotNull(events);
+    verify(kafkaConsumer, atLeastOnce()).poll(any());
+  }
+
+  @Test
+  public void testPollValidMetadataChangeLogVersionedTopic() throws Exception {
+    // Mocking Kafka and ObjectMapper behaviors
+    when(kafkaConsumer.partitionsFor(anyString())).thenReturn(Collections.emptyList());
+    when(objectMapper.writeValueAsString(any())).thenReturn("encodedString");
+
+    // Execute
+    ExternalEvents events =
+        service.poll(
+            ExternalEventsService.METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME, null, 10, 5, null);
+
+    // Validate
+    assertNotNull(events);
+    verify(kafkaConsumer, atLeastOnce()).poll(any());
+  }
+
+  @Test
+  public void testPollValidMetadataChangeLogTimeseriesTopic() throws Exception {
+    // Mocking Kafka and ObjectMapper behaviors
+    when(kafkaConsumer.partitionsFor(anyString())).thenReturn(Collections.emptyList());
+    when(objectMapper.writeValueAsString(any())).thenReturn("encodedString");
+
+    // Execute
+    ExternalEvents events =
+        service.poll(
+            ExternalEventsService.METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME, null, 10, 5, null);
 
     // Validate
     assertNotNull(events);

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/event/ExternalEventsServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/event/ExternalEventsServiceFactory.java
@@ -1,5 +1,7 @@
 package com.linkedin.gms.factory.event;
 
+import static io.datahubproject.event.ExternalEventsService.METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME;
+import static io.datahubproject.event.ExternalEventsService.METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME;
 import static io.datahubproject.event.ExternalEventsService.PLATFORM_EVENT_TOPIC_NAME;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -39,6 +41,12 @@ public class ExternalEventsServiceFactory {
   private Map<String, String> buildTopicNameMappings() {
     final Map<String, String> topicNames = new HashMap<>();
     topicNames.put(PLATFORM_EVENT_TOPIC_NAME, topicConvention.getPlatformEventTopicName());
+    topicNames.put(
+        METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME,
+        topicConvention.getMetadataChangeLogVersionedTopicName());
+    topicNames.put(
+        METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME,
+        topicConvention.getMetadataChangeLogTimeseriesTopicName());
     return topicNames;
   }
 }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/event/ExternalEventsController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v1/event/ExternalEventsController.java
@@ -80,7 +80,7 @@ public class ExternalEventsController {
               name = "topic",
               required = true,
               description =
-                  "The topic to read events for. Currently only supports PlatformEvent_v1, which provides Platform Events such as EntityChangeEvent and NotificationRequestEvent.")
+                  "The topic to read events for. Currently only supports PlatformEvent_v1, which provides Platform Events such as EntityChangeEvent and NotificationRequestEvents and MetadataChangeLog_v1, which provides all aspect updates.")
           @RequestParam(name = "topic", required = true)
           String topic,
       @Parameter(name = "offsetId", description = "The offset to start reading the topic from")
@@ -142,6 +142,12 @@ public class ExternalEventsController {
       @Nonnull final OperationContext opContext, @Nonnull final String topic) {
     if (Topics.PLATFORM_EVENT.equals(topic)) {
       return AuthUtil.isAPIAuthorized(opContext, PoliciesConfig.GET_PLATFORM_EVENTS_PRIVILEGE);
+    }
+    if (Topics.METADATA_CHANGE_LOG_VERSIONED.equals(topic)) {
+      return AuthUtil.isAPIAuthorized(opContext, PoliciesConfig.GET_METADATA_CHANGE_LOG_EVENTS);
+    }
+    if (Topics.METADATA_CHANGE_LOG_TIMESERIES.equals(topic)) {
+      return AuthUtil.isAPIAuthorized(opContext, PoliciesConfig.GET_METADATA_CHANGE_LOG_EVENTS);
     }
     return false;
   }

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/event/ExternalEventsControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v1/event/ExternalEventsControllerTest.java
@@ -1,5 +1,7 @@
 package io.datahubproject.openapi.v1.event;
 
+import static io.datahubproject.event.ExternalEventsService.METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME;
+import static io.datahubproject.event.ExternalEventsService.METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME;
 import static io.datahubproject.event.ExternalEventsService.PLATFORM_EVENT_TOPIC_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -297,6 +299,250 @@ public class ExternalEventsControllerTest extends AbstractTestNGSpringContextTes
                 .param("pollTimeoutSeconds", "10")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void testPollMetadataChangeLogVersionedTopic() throws Exception {
+    // Setup mock authorization
+    when(mockAuthorizerChain.authorize(any(AuthorizationRequest.class)))
+        .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+
+    // Setup mock response
+    List<ExternalEvent> events = new ArrayList<>();
+    ExternalEvent event = new ExternalEvent();
+    event.setValue(TEST_CONTENT);
+    event.setContentType(TEST_CONTENT_TYPE);
+    events.add(event);
+
+    ExternalEvents externalEvents = new ExternalEvents();
+    externalEvents.setEvents(events);
+    externalEvents.setOffsetId(TEST_OFFSET_ID);
+    externalEvents.setCount(1L);
+
+    when(mockEventsService.poll(
+            eq(METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME),
+            nullable(String.class),
+            anyInt(),
+            anyInt(),
+            nullable(Integer.class)))
+        .thenReturn(externalEvents);
+
+    // Execute test
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/v1/events/poll")
+                .param("topic", METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME)
+                .param("limit", "100")
+                .param("pollTimeoutSeconds", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.count").value(1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.offsetId").value(TEST_OFFSET_ID))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.events[0].value").value(TEST_CONTENT))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.events[0].contentType").value(TEST_CONTENT_TYPE));
+  }
+
+  @Test
+  public void testPollMetadataChangeLogTimeseriesTopic() throws Exception {
+    // Setup mock authorization
+    when(mockAuthorizerChain.authorize(any(AuthorizationRequest.class)))
+        .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+
+    // Setup mock response
+    List<ExternalEvent> events = new ArrayList<>();
+    ExternalEvent event = new ExternalEvent();
+    event.setValue(TEST_CONTENT);
+    event.setContentType(TEST_CONTENT_TYPE);
+    events.add(event);
+
+    ExternalEvents externalEvents = new ExternalEvents();
+    externalEvents.setEvents(events);
+    externalEvents.setOffsetId(TEST_OFFSET_ID);
+    externalEvents.setCount(1L);
+
+    when(mockEventsService.poll(
+            eq(METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME),
+            nullable(String.class),
+            anyInt(),
+            anyInt(),
+            nullable(Integer.class)))
+        .thenReturn(externalEvents);
+
+    // Execute test
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/v1/events/poll")
+                .param("topic", METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME)
+                .param("limit", "100")
+                .param("pollTimeoutSeconds", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.count").value(1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.offsetId").value(TEST_OFFSET_ID))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.events[0].value").value(TEST_CONTENT))
+        .andExpect(
+            MockMvcResultMatchers.jsonPath("$.events[0].contentType").value(TEST_CONTENT_TYPE));
+  }
+
+  @Test
+  public void testPollMetadataChangeLogVersionedTopicWithOffset() throws Exception {
+    // Setup mock authorization
+    when(mockAuthorizerChain.authorize(any(AuthorizationRequest.class)))
+        .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+
+    // Setup mock response
+    List<ExternalEvent> events = new ArrayList<>();
+    ExternalEvent event = new ExternalEvent();
+    event.setValue(TEST_CONTENT);
+    event.setContentType(TEST_CONTENT_TYPE);
+    events.add(event);
+
+    ExternalEvents externalEvents = new ExternalEvents();
+    externalEvents.setEvents(events);
+    externalEvents.setOffsetId("new-offset-id");
+    externalEvents.setCount(1L);
+
+    when(mockEventsService.poll(
+            eq(METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME),
+            eq(TEST_OFFSET_ID),
+            anyInt(),
+            anyInt(),
+            nullable(Integer.class)))
+        .thenReturn(externalEvents);
+
+    // Execute test
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/v1/events/poll")
+                .param("topic", METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME)
+                .param("offsetId", TEST_OFFSET_ID)
+                .param("limit", "100")
+                .param("pollTimeoutSeconds", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.count").value(1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.offsetId").value("new-offset-id"));
+  }
+
+  @Test
+  public void testPollMetadataChangeLogTimeseriesTopicWithOffset() throws Exception {
+    // Setup mock authorization
+    when(mockAuthorizerChain.authorize(any(AuthorizationRequest.class)))
+        .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+
+    // Setup mock response
+    List<ExternalEvent> events = new ArrayList<>();
+    ExternalEvent event = new ExternalEvent();
+    event.setValue(TEST_CONTENT);
+    event.setContentType(TEST_CONTENT_TYPE);
+    events.add(event);
+
+    ExternalEvents externalEvents = new ExternalEvents();
+    externalEvents.setEvents(events);
+    externalEvents.setOffsetId("new-offset-id");
+    externalEvents.setCount(1L);
+
+    when(mockEventsService.poll(
+            eq(METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME),
+            eq(TEST_OFFSET_ID),
+            anyInt(),
+            anyInt(),
+            nullable(Integer.class)))
+        .thenReturn(externalEvents);
+
+    // Execute test
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/v1/events/poll")
+                .param("topic", METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME)
+                .param("offsetId", TEST_OFFSET_ID)
+                .param("limit", "100")
+                .param("pollTimeoutSeconds", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.count").value(1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.offsetId").value("new-offset-id"));
+  }
+
+  @Test
+  public void testPollMetadataChangeLogVersionedTopicWithLookbackWindow() throws Exception {
+    // Setup mock authorization
+    when(mockAuthorizerChain.authorize(any(AuthorizationRequest.class)))
+        .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+
+    // Setup mock response
+    List<ExternalEvent> events = new ArrayList<>();
+    ExternalEvent event = new ExternalEvent();
+    event.setValue(TEST_CONTENT);
+    event.setContentType(TEST_CONTENT_TYPE);
+    events.add(event);
+
+    ExternalEvents externalEvents = new ExternalEvents();
+    externalEvents.setEvents(events);
+    externalEvents.setOffsetId(TEST_OFFSET_ID);
+    externalEvents.setCount(1L);
+
+    when(mockEventsService.poll(
+            eq(METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME),
+            nullable(String.class),
+            anyInt(),
+            anyInt(),
+            eq(7)))
+        .thenReturn(externalEvents);
+
+    // Execute test
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/v1/events/poll")
+                .param("topic", METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME)
+                .param("lookbackWindowDays", "7")
+                .param("limit", "100")
+                .param("pollTimeoutSeconds", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.count").value(1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.offsetId").value(TEST_OFFSET_ID));
+  }
+
+  @Test
+  public void testPollMetadataChangeLogTimeseriesTopicWithLookbackWindow() throws Exception {
+    // Setup mock authorization
+    when(mockAuthorizerChain.authorize(any(AuthorizationRequest.class)))
+        .thenReturn(new AuthorizationResult(null, AuthorizationResult.Type.ALLOW, ""));
+
+    // Setup mock response
+    List<ExternalEvent> events = new ArrayList<>();
+    ExternalEvent event = new ExternalEvent();
+    event.setValue(TEST_CONTENT);
+    event.setContentType(TEST_CONTENT_TYPE);
+    events.add(event);
+
+    ExternalEvents externalEvents = new ExternalEvents();
+    externalEvents.setEvents(events);
+    externalEvents.setOffsetId(TEST_OFFSET_ID);
+    externalEvents.setCount(1L);
+
+    when(mockEventsService.poll(
+            eq(METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME),
+            nullable(String.class),
+            anyInt(),
+            anyInt(),
+            eq(7)))
+        .thenReturn(externalEvents);
+
+    // Execute test
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.get("/openapi/v1/events/poll")
+                .param("topic", METADATA_CHANGE_LOG_TIMESERIES_TOPIC_NAME)
+                .param("lookbackWindowDays", "7")
+                .param("limit", "100")
+                .param("pollTimeoutSeconds", "10")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.count").value(1))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.offsetId").value(TEST_OFFSET_ID));
   }
 
   @Test

--- a/metadata-service/war/src/main/resources/boot/policies.json
+++ b/metadata-service/war/src/main/resources/boot/policies.json
@@ -41,7 +41,8 @@
         "MANAGE_FEATURES",
         "MANAGE_SYSTEM_OPERATIONS",
         "GET_PLATFORM_EVENTS",
-        "MANAGE_HOME_PAGE_TEMPLATES"
+        "MANAGE_HOME_PAGE_TEMPLATES",
+        "GET_METADATA_CHANGE_LOG_EVENTS"
       ],
       "displayName": "Root User - All Platform Privileges",
       "description": "Grants all platform privileges to root user.",
@@ -198,7 +199,19 @@
         "MANAGE_FEATURES",
         "MANAGE_SYSTEM_OPERATIONS",
         "GET_PLATFORM_EVENTS",
+<<<<<<< HEAD
         "MANAGE_HOME_PAGE_TEMPLATES"
+=======
+        "MANAGE_HOME_PAGE_TEMPLATES",
+        "GET_METADATA_CHANGE_LOG_EVENTS",
+        "VIEW_DOCUMENTATION_FORMS_PAGE",
+        "MANAGE_CONNECTIONS",
+        "MANAGE_MONITORS",
+        "MANAGE_ORGANIZATION_DISPLAY_PREFERENCES",
+        "PROPOSE_CREATE_GLOSSARY_TERM",
+        "PROPOSE_CREATE_GLOSSARY_NODE",
+        "MANAGE_ACTION_WORKFLOWS"
+>>>>>>> d267df5dbd (updating for 1 consumer per each topic)
       ],
       "displayName": "Admins - Platform Policy",
       "description": "Admins have all platform privileges.",

--- a/metadata-service/war/src/main/resources/boot/policies.json
+++ b/metadata-service/war/src/main/resources/boot/policies.json
@@ -199,19 +199,8 @@
         "MANAGE_FEATURES",
         "MANAGE_SYSTEM_OPERATIONS",
         "GET_PLATFORM_EVENTS",
-<<<<<<< HEAD
-        "MANAGE_HOME_PAGE_TEMPLATES"
-=======
         "MANAGE_HOME_PAGE_TEMPLATES",
-        "GET_METADATA_CHANGE_LOG_EVENTS",
-        "VIEW_DOCUMENTATION_FORMS_PAGE",
-        "MANAGE_CONNECTIONS",
-        "MANAGE_MONITORS",
-        "MANAGE_ORGANIZATION_DISPLAY_PREFERENCES",
-        "PROPOSE_CREATE_GLOSSARY_TERM",
-        "PROPOSE_CREATE_GLOSSARY_NODE",
-        "MANAGE_ACTION_WORKFLOWS"
->>>>>>> d267df5dbd (updating for 1 consumer per each topic)
+        "GET_METADATA_CHANGE_LOG_EVENTS"
       ],
       "displayName": "Admins - Platform Policy",
       "description": "Admins have all platform privileges.",

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -212,6 +212,12 @@ public class PoliciesConfig {
           "Get Platform Events",
           "The ability to use the Events API to read Platform Events - Entity Change Events and Notification Request Events.");
 
+  public static final Privilege GET_METADATA_CHANGE_LOG_EVENTS =
+      Privilege.of(
+          "GET_METADATA_CHANGE_LOG_EVENTS",
+          "Get Metadata Change Log Events",
+          "The ability to use the Events API to read Metadata Change Log, or all low-level Metadata Change Events.");
+
   public static final Privilege MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE =
       Privilege.of(
           "MANAGE_HOME_PAGE_TEMPLATES",
@@ -256,6 +262,7 @@ public class PoliciesConfig {
           MANAGE_FEATURES_PRIVILEGE,
           MANAGE_SYSTEM_OPERATIONS_PRIVILEGE,
           GET_PLATFORM_EVENTS_PRIVILEGE,
+          GET_METADATA_CHANGE_LOG_EVENTS,
           MANAGE_HOME_PAGE_TEMPLATES_PRIVILEGE);
 
   // Resource Privileges //


### PR DESCRIPTION
# Summary

Adding support for MCLs in DataHub server external events API. This will unblock DataHub Actions support for MCLs from DataHub Cloud and DataHub OSS

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
