### PR TITLE
fix(ui) Add roles to avatar stack component

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Avatar/Avatar.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Avatar/Avatar.tsx
@@ -6,6 +6,8 @@ import getAvatarColor, { getNameInitials } from '@components/components/Avatar/u
 import { AvatarType } from '@components/components/AvatarStack/types';
 import { Icon } from '@components/components/Icon';
 
+import { mapRoleIcon } from '@app/identity/user/UserUtils';
+
 export const avatarDefaults: AvatarProps = {
     name: 'User name',
     size: 'default',
@@ -39,6 +41,11 @@ export const Avatar = ({
             {type === AvatarType.group && !imageUrl && (
                 <AvatarImageWrapper $color={getAvatarColor(name)} $size={size} $isOutlined={isOutlined}>
                     <Icon icon="UsersThree" source="phosphor" variant="filled" size="lg" />
+                </AvatarImageWrapper>
+            )}
+            {type === AvatarType.role && !imageUrl && (
+                <AvatarImageWrapper $color={getAvatarColor(name)} $size={size} $isOutlined={isOutlined}>
+                    {mapRoleIcon(name)}
                 </AvatarImageWrapper>
             )}
             {showInPill && <AvatarText $size={size}>{name}</AvatarText>}

--- a/datahub-web-react/src/alchemy-components/components/AvatarStack/AvatarStackWithHover.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AvatarStack/AvatarStackWithHover.tsx
@@ -24,9 +24,11 @@ const AvatarStackWithHover = ({
     showRemainingNumber = true,
     maxToShow = 4,
     entityRegistry,
+    title = 'Owners',
 }: Props) => {
-    const users = avatars.filter((avatar) => avatar.type === AvatarType.user);
-    const groups = avatars.filter((avatar) => avatar.type === AvatarType.group);
+    const users = avatars?.filter((avatar) => avatar.type === AvatarType.user) || [];
+    const groups = avatars?.filter((avatar) => avatar.type === AvatarType.group) || [];
+    const roles = avatars?.filter((avatar) => avatar.type === AvatarType.role) || [];
 
     const renderTitle = (headerText, count) => (
         <HeaderContainer>
@@ -41,7 +43,7 @@ const AvatarStackWithHover = ({
         <StopPropagationWrapper>
             <StructuredPopover
                 width={280}
-                title="Owners"
+                title={title}
                 sections={[
                     ...(users.length > 0
                         ? [
@@ -67,6 +69,21 @@ const AvatarStackWithHover = ({
                                           entityRegistry={entityRegistry}
                                           size={size}
                                           type={AvatarType.group}
+                                      />
+                                  ),
+                              },
+                          ]
+                        : []),
+                    ...(roles.length > 0
+                        ? [
+                              {
+                                  title: renderTitle('Roles', roles.length),
+                                  content: (
+                                      <HoverSectionContent
+                                          avatars={roles}
+                                          entityRegistry={entityRegistry}
+                                          size={size}
+                                          type={AvatarType.role}
                                       />
                                   ),
                               },

--- a/datahub-web-react/src/alchemy-components/components/AvatarStack/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/AvatarStack/types.ts
@@ -3,6 +3,7 @@ import { AvatarSizeOptions } from '@src/alchemy-components/theme/config';
 export enum AvatarType {
     user,
     group,
+    role,
 }
 export interface AvatarItemProps {
     name: string;
@@ -16,4 +17,5 @@ export type AvatarStackProps = {
     size?: AvatarSizeOptions;
     showRemainingNumber?: boolean;
     maxToShow?: number;
+    title?: string;
 };

--- a/datahub-web-react/src/app/identity/user/UserUtils.tsx
+++ b/datahub-web-react/src/app/identity/user/UserUtils.tsx
@@ -1,6 +1,12 @@
 import { EditOutlined, ReadOutlined, SettingOutlined, UserOutlined } from '@ant-design/icons';
 import React from 'react';
 
+import { capitalizeFirstLetter } from '@app/shared/textUtil';
+
+export const getRoleNameFromUrn = (roleUrn: string) => {
+    return capitalizeFirstLetter(roleUrn.replace('urn:li:dataHubRole:', ''));
+};
+
 export const mapRoleIcon = (roleName) => {
     let icon = <UserOutlined />;
     if (roleName === 'Admin') {

--- a/datahub-web-react/src/app/identity/user/__tests__/UserUtils.test.ts
+++ b/datahub-web-react/src/app/identity/user/__tests__/UserUtils.test.ts
@@ -1,0 +1,186 @@
+import { EditOutlined, ReadOutlined, SettingOutlined, UserOutlined } from '@ant-design/icons';
+
+import { getRoleNameFromUrn, mapRoleIcon, shouldShowGlossary } from '@app/identity/user/UserUtils';
+
+describe('UserUtils', () => {
+    describe('getRoleNameFromUrn', () => {
+        it('should convert Admin role URN to Admin', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:admin');
+            expect(result).toEqual('Admin');
+        });
+
+        it('should convert Editor role URN to Editor', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:editor');
+            expect(result).toEqual('Editor');
+        });
+
+        it('should convert Reader role URN to Reader', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:reader');
+            expect(result).toEqual('Reader');
+        });
+
+        it('should handle uppercase role names', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:ADMIN');
+            expect(result).toEqual('Admin');
+        });
+
+        it('should handle mixed case role names', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:EdItOr');
+            expect(result).toEqual('Editor');
+        });
+
+        it('should handle custom role names', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:customRole');
+            expect(result).toEqual('Customrole');
+        });
+
+        it('should handle role names with underscores', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:custom_role');
+            expect(result).toEqual('Custom_role');
+        });
+
+        it('should handle role names with hyphens', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:custom-role');
+            expect(result).toEqual('Custom-role');
+        });
+
+        it('should handle empty role name after prefix', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:');
+            expect(result).toEqual(undefined);
+        });
+
+        it('should handle single character role names', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:a');
+            expect(result).toEqual('A');
+        });
+
+        it('should handle numeric role names', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:123');
+            expect(result).toEqual('123');
+        });
+
+        it('should handle role names with spaces (edge case)', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:custom role');
+            expect(result).toEqual('Custom role');
+        });
+
+        it('should handle role names with special characters', () => {
+            const result = getRoleNameFromUrn('urn:li:dataHubRole:role@123');
+            expect(result).toEqual('Role@123');
+        });
+
+        it('should handle malformed URNs (missing prefix)', () => {
+            const result = getRoleNameFromUrn('admin');
+            expect(result).toEqual('Admin');
+        });
+
+        it('should handle URNs with different prefix', () => {
+            const result = getRoleNameFromUrn('urn:li:role:admin');
+            expect(result).toEqual('Urn:li:role:admin');
+        });
+    });
+
+    describe('mapRoleIcon', () => {
+        it('should return SettingOutlined for Admin role', () => {
+            const result = mapRoleIcon('Admin');
+            expect(result.type).toEqual(SettingOutlined);
+        });
+
+        it('should return EditOutlined for Editor role', () => {
+            const result = mapRoleIcon('Editor');
+            expect(result.type).toEqual(EditOutlined);
+        });
+
+        it('should return ReadOutlined for Reader role', () => {
+            const result = mapRoleIcon('Reader');
+            expect(result.type).toEqual(ReadOutlined);
+        });
+
+        it('should return UserOutlined for unknown role names', () => {
+            const result = mapRoleIcon('CustomRole');
+            expect(result.type).toEqual(UserOutlined);
+        });
+
+        it('should return UserOutlined for empty role name', () => {
+            const result = mapRoleIcon('');
+            expect(result.type).toEqual(UserOutlined);
+        });
+
+        it('should return UserOutlined for null role name', () => {
+            const result = mapRoleIcon(null);
+            expect(result.type).toEqual(UserOutlined);
+        });
+
+        it('should return UserOutlined for undefined role name', () => {
+            const result = mapRoleIcon(undefined);
+            expect(result.type).toEqual(UserOutlined);
+        });
+
+        it('should be case-sensitive for role matching', () => {
+            const result = mapRoleIcon('admin'); // lowercase
+            expect(result.type).toEqual(UserOutlined);
+        });
+
+        it('should handle numeric role names', () => {
+            const result = mapRoleIcon('123');
+            expect(result.type).toEqual(UserOutlined);
+        });
+
+        it('should handle role names with special characters', () => {
+            const result = mapRoleIcon('Admin@123');
+            expect(result.type).toEqual(UserOutlined);
+        });
+    });
+
+    describe('shouldShowGlossary', () => {
+        it('should return true when canManageGlossary is true and hideGlossary is false', () => {
+            const result = shouldShowGlossary(true, false);
+            expect(result).toEqual(true);
+        });
+
+        it('should return true when canManageGlossary is true and hideGlossary is true', () => {
+            const result = shouldShowGlossary(true, true);
+            expect(result).toEqual(true);
+        });
+
+        it('should return true when canManageGlossary is false and hideGlossary is false', () => {
+            const result = shouldShowGlossary(false, false);
+            expect(result).toEqual(true);
+        });
+
+        it('should return false when canManageGlossary is false and hideGlossary is true', () => {
+            const result = shouldShowGlossary(false, true);
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('integration tests', () => {
+        it('should properly handle the complete flow from URN to icon for Admin', () => {
+            const roleName = getRoleNameFromUrn('urn:li:dataHubRole:admin');
+            const icon = mapRoleIcon(roleName);
+            expect(roleName).toEqual('Admin');
+            expect(icon.type).toEqual(SettingOutlined);
+        });
+
+        it('should properly handle the complete flow from URN to icon for Editor', () => {
+            const roleName = getRoleNameFromUrn('urn:li:dataHubRole:editor');
+            const icon = mapRoleIcon(roleName);
+            expect(roleName).toEqual('Editor');
+            expect(icon.type).toEqual(EditOutlined);
+        });
+
+        it('should properly handle the complete flow from URN to icon for Reader', () => {
+            const roleName = getRoleNameFromUrn('urn:li:dataHubRole:reader');
+            const icon = mapRoleIcon(roleName);
+            expect(roleName).toEqual('Reader');
+            expect(icon.type).toEqual(ReadOutlined);
+        });
+
+        it('should properly handle the complete flow from URN to icon for custom role', () => {
+            const roleName = getRoleNameFromUrn('urn:li:dataHubRole:customRole');
+            const icon = mapRoleIcon(roleName);
+            expect(roleName).toEqual('Customrole');
+            expect(icon.type).toEqual(UserOutlined);
+        });
+    });
+});

--- a/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
+++ b/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
@@ -1,5 +1,5 @@
 import { Button, Tooltip } from '@components';
-import { Empty, Pagination, Typography, message } from 'antd';
+import { Avatar, Empty, Pagination, Typography, message } from 'antd';
 import * as QueryString from 'query-string';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router';
@@ -177,16 +177,29 @@ export const ManageRoles = () => {
             dataIndex: 'users',
             key: 'users',
             render: (_: any, record: any) => {
+                const numberOfUsers = record?.totalUsers || 0;
                 return (
                     <>
-                        {(record?.users?.length && (
-                            <AvatarsGroup
-                                users={record?.users}
-                                groups={record?.resolvedGroups}
-                                entityRegistry={entityRegistry}
-                                maxCount={3}
-                                size={28}
-                            />
+                        {(!!numberOfUsers && (
+                            <>
+                                <AvatarsGroup
+                                    users={record?.users
+                                        ?.filter((u) => u.urn?.startsWith('urn:li:corpuser'))
+                                        .slice(0, 5)}
+                                    groups={record?.users
+                                        ?.filter((u) => u.urn?.startsWith('urn:li:corpGroup'))
+                                        .slice(0, 5)}
+                                    entityRegistry={entityRegistry}
+                                    maxCount={5}
+                                    size={28}
+                                />
+                                {numberOfUsers > 5 && (
+                                    // Keeping the color same as the avatar component indicator
+                                    <Avatar size={28} style={{ backgroundColor: 'rgb(204,204,204)' }}>
+                                        +{numberOfUsers - 5}
+                                    </Avatar>
+                                )}
+                            </>
                         )) || <Typography.Text type="secondary">No assigned users</Typography.Text>}
                     </>
                 );
@@ -222,6 +235,7 @@ export const ManageRoles = () => {
         description: role?.description,
         name: role?.name,
         users: role?.users?.relationships?.map((relationship) => relationship.entity as CorpUser),
+        totalUsers: role?.users?.total,
         policies: role?.policies?.relationships?.map((relationship) => relationship.entity as DataHubPolicy),
     }));
 

--- a/datahub-web-react/src/graphql/role.graphql
+++ b/datahub-web-react/src/graphql/role.graphql
@@ -14,6 +14,8 @@ query listRoles($input: ListRolesInput!) {
                 total
                 relationships {
                     entity {
+                        urn
+                        type
                         ... on CorpUser {
                             urn
                             type
@@ -32,6 +34,7 @@ query listRoles($input: ListRolesInput!) {
                                 pictureLink
                             }
                         }
+                        ...entityDisplayNameFields
                     }
                 }
             }


### PR DESCRIPTION
This PR adds the option to display roles in the avatar stack with hover component for other use cases where this makes sense.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
