### PR TITLE
fix(ui) Allow empty strings for sibling values

### DIFF
--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -29,7 +29,7 @@ export function stripSiblingsFromEntity(entity: any) {
     };
 }
 
-function cleanHelper(obj, visited) {
+export function cleanHelper(obj, visited) {
     if (visited.has(obj)) return obj;
     visited.add(obj);
 
@@ -38,7 +38,7 @@ function cleanHelper(obj, visited) {
         if (v && typeof v === 'object') {
             cleanHelper(v, visited);
         }
-        if ((v && typeof v === 'object' && !Object.keys(v).length) || v === null || v === undefined || v === '') {
+        if ((v && typeof v === 'object' && !Object.keys(v).length) || v === null || v === undefined) {
             if (Array.isArray(object)) {
                 // do nothing
             } else if (Object.getOwnPropertyDescriptor(object, k)?.configurable) {


### PR DESCRIPTION
Currently if someone wants to clear a description on a schema field (or dataset or what have you) but the sibling has a description, we just always show the sibling's description. This is a frustrating experience for our users.

So now I modify the function that removes fields with empty strings to be overwritten when merging siblings. This should solve the immediate issue but may cause other issues. Will review meticulous to see what else gets impacted.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
