### PR TITLE
fix(ui) Fix merge siblings function to handle multiple ownership types

### DIFF
--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -1,5 +1,5 @@
 import merge from 'deepmerge';
-import { keyBy, unionBy, values } from 'lodash';
+import { keyBy, unionBy, uniqWith, values } from 'lodash';
 import * as QueryString from 'query-string';
 import { useLocation } from 'react-router-dom';
 
@@ -125,8 +125,13 @@ const mergeStructuredProperties = (destinationArray, sourceArray, _options) => {
     return unionBy(sourceArray, destinationArray, 'structuredProperty.urn');
 };
 
-const mergeOwners = (destinationArray, sourceArray, _options) => {
-    return unionBy(destinationArray, sourceArray, 'owner.urn');
+export const mergeOwners = (destinationArray, sourceArray, _options) => {
+    console.log("HERE", { destinationArray, sourceArray})
+    return uniqWith(
+        [...destinationArray, ...sourceArray],
+        (ownerA, ownerB) =>
+            ownerA.owner.urn === ownerB.owner.urn && ownerA.ownershipType?.urn === ownerB.ownershipType?.urn,
+    );
 };
 
 const mergeFields = (destinationArray, sourceArray, _options) => {


### PR DESCRIPTION
We recently discovered a bug where merging owners between siblings would only merge based on the owner urn as the unique factor, which means that if there were two owners with the same owner entity urn (ie. urn:li:corpuser:admin) but different ownership type urn, then we only show one of them when we should show both because you can have the same owner twice with two different ownership types.

Most of the diff are tests for the few line logic change.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
