### PR TITLE
fix(web): assertion summary card has right subtitles

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/AssertionList/AcrylAssertionListConstants.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/AssertionList/AcrylAssertionListConstants.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { NO_RUNNING_STATE } from '@app/entityV2/shared/tabs/Dataset/Validations/AssertionList/constant';
-import { AssertionResultType } from '@src/types.generated';
+import { AssertionResultType, AssertionType } from '@src/types.generated';
 
 const StyledCardTitle = styled.div<{ background: string; color: string }>`
     background: ${({ background }) => background};
@@ -16,6 +16,18 @@ const StyledCardTitle = styled.div<{ background: string; color: string }>`
     align-items: center;
     font-size: 12px;
 `;
+
+
+export const ASSERITON_TYPE_TO_HEADER_SUBTITLE: Record<AssertionType, string> = {
+    [AssertionType.Freshness]: "Verifies when this dataset should be updated.",
+    [AssertionType.Volume]: "Verifies the row count of this dataset.",
+    [AssertionType.Field]: "Verifies the validity of a column.",
+    [AssertionType.DataSchema]: "Verifies the schema of this dataset.",
+    [AssertionType.Custom]: "A custom externally reported assertion.",
+    [AssertionType.Sql]: "Verifies using custom SQL rules.",
+    [AssertionType.Dataset]: "An external assertion.",
+};
+
 
 export const ASSERTION_SUMMARY_CARD_HEADER_BY_STATUS = {
     passing: {

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/AssertionList/Summary/AcrylAssertionSummaryCard.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/AssertionList/Summary/AcrylAssertionSummaryCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { ASSERTION_SUMMARY_CARD_HEADER_BY_STATUS } from '@app/entityV2/shared/tabs/Dataset/Validations/AssertionList/AcrylAssertionListConstants';
+import { ASSERITON_TYPE_TO_HEADER_SUBTITLE, ASSERTION_SUMMARY_CARD_HEADER_BY_STATUS } from '@app/entityV2/shared/tabs/Dataset/Validations/AssertionList/AcrylAssertionListConstants';
 import {
     AcrylAssertionProgressBar,
     AssertionProgressSummary,
@@ -110,6 +110,7 @@ export const AcrylAssertionSummaryCard: React.FC<Props> = ({ group }) => {
 
     const status = ASSERTION_SUMMARY_CARD_STATUSES.find((key) => group.summary[key]) || NO_RUNNING_STATE;
     const headerTitle = status ? ASSERTION_SUMMARY_CARD_HEADER_BY_STATUS[status].headerComponent : null;
+    const headerSubtitle = group.type ? ASSERITON_TYPE_TO_HEADER_SUBTITLE[group.type] : null;
 
     const handleCardClick = (type: AssertionType, event: React.MouseEvent) => {
         event.stopPropagation(); // Prevent parent click handlers from being triggered
@@ -130,7 +131,7 @@ export const AcrylAssertionSummaryCard: React.FC<Props> = ({ group }) => {
                 <AssertionIconWrapper>{icon}</AssertionIconWrapper>
                 <AssertionTypeDetailsContainer>
                     <AssertionTitle>{name}</AssertionTitle>
-                    <AssertionTextContainer>Verifies when this dataset should be updated.</AssertionTextContainer>
+                    <AssertionTextContainer>{headerSubtitle}</AssertionTextContainer>
                 </AssertionTypeDetailsContainer>
             </AssertionDetailsContainer>
 


### PR DESCRIPTION

<img width="939" height="602" alt="Screenshot 2025-08-22 at 3 36 35 PM" src="https://github.com/user-attachments/assets/623f6554-acd0-4bee-9dd4-8cf9679cca2c" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
