### PR TITLE
test: Add test case for JSON Schema recursive  performance issue (#14358)

### DIFF
--- a/metadata-ingestion/tests/unit/schema/test_data/test_json_schema_complex_recursive_refs_with_oneof.json
+++ b/metadata-ingestion/tests/unit/schema/test_data/test_json_schema_complex_recursive_refs_with_oneof.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schema.com/schema/1.0",
+  "type": "object",
+  "properties": {
+    "group": {
+      "type": "object",
+      "properties": {
+        "filter": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/condition"},
+          "minItems": 1
+        }
+      },
+      "required": ["filter"]
+    }
+  },
+  "required": ["group"],
+  "definitions": {
+    "condition": {
+      "type": "object",
+      "properties": {
+        "operator": {
+          "description": "Condition operator",
+          "type": "string",
+          "enum": [
+            "EXISTS",
+            "GREATERTHAN", 
+            "LESSTHAN",
+            "EQUALS",
+            "MATCHES",
+            "CONTAINS",
+            "IN",
+            "BETWEEN",
+            "NOT",
+            "AND",
+            "OR",
+            "XOR"
+          ]
+        },
+        "condition": {
+          "description": "negated condition",
+          "$ref": "#/definitions/condition"
+        },
+        "conditions": {
+          "description": "array of conditions (logical expressions)",
+          "type": "array",
+          "items": {"$ref": "#/definitions/condition"},
+          "minItems": 2
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "operator": {
+              "enum": ["GREATERTHAN", "LESSTHAN", "EQUALS"]
+            }
+          },
+          "required": ["operator"],
+          "oneOf": [
+            {
+              "properties": {"numberValue": {}},
+              "required": ["numberValue"]
+            },
+            {
+              "properties": {"booleanValue": {}},
+              "required": ["booleanValue"]
+            },
+            {
+              "properties": {"stringValue": {}},
+              "required": ["stringValue"]
+            },
+            {
+              "properties": {"referenceValue": {}},
+              "required": ["referenceValue"]
+            }
+          ]
+        },
+        {
+          "description": "negation logical filter condition",
+          "properties": {
+            "operator": {"enum": ["NOT"]},
+            "condition": {}
+          },
+          "required": ["operator", "condition"]
+        },
+        {
+          "description": "logical filter condition",
+          "properties": {
+            "operator": {"enum": ["AND", "OR", "XOR"]},
+            "conditions": {}
+          },
+          "required": ["operator", "conditions"]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add comprehensive test case for issue datahub-project/datahub#14358 that reproduces the performance issue with complex recursive JSON schemas containing nested oneOf structures.

## What this PR does

* **Reproduces the issue**: Creates test that demonstrates explosive field growth (200k+ fields)
* **Identifies root cause**: Complex interaction between recursive $ref and nested oneOf structures
* **Performance analysis**: Shows processing time of \~67 seconds (not infinite loop)
* **Maintainable test**: Loads schema from external JSON file for better organization
* **Robust assertions**: Tests field structure patterns rather than timing to avoid flaky tests

## Root Cause Analysis

The performance issue is caused by:

1. **Recursive $ref references** (`condition -> condition`)
2. **Nested oneOf structures** within the recursive definition
3. **Multiple reference paths** (both `condition` property and `conditions` array)

This creates **combinatorial explosion** before recursion detection kicks in:

* Simple recursion: \~2 fields, completes in 0.14s
* Complex recursion with oneOf: 200k+ fields, takes \~67s

The current recursion detection uses full schema string comparison, but oneOf branches create many "different" schema variations that pass the recursion check until very deep nesting.

## Testing

```bash
# Run the new test (takes ~67 seconds)
pytest tests/unit/schema/test_json_schema_util.py::test_json_schema_complex_recursive_refs_with_oneof -v

# Compare with simple recursion test (takes ~0.14 seconds)  
pytest tests/unit/schema/test_json_schema_util.py::test_json_schema_ref_loop_in_definitions -v
```

## Next Steps

This test establishes a baseline for measuring improvements to:

1. **Depth limiting**: Add maximum recursion depth parameter
2. **Better recursion detection**: Use pattern matching vs full schema comparison
3. **oneOf optimization**: Limit expansion of nested oneOf structures
4. **Field count limiting**: Add safety nets with warnings

## Related

* Addresses issue datahub-project/datahub#14358
* Test files: `tests/unit/schema/test_json_schema_util.py` and `tests/unit/schema/test_data/`

🤖 Generated with [Claude Code](<https://claude.ai/code>)