### PR TITLE
Update run history with timestamp tooltip

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -198,5 +198,6 @@
         "prosemirror-state": "1.3.2",
         "prosemirror-transform": "1.2.2",
         "prosemirror-view": "1.13.4"
-    }
+    },
+    "packageManager": "yarn@3.6.4+sha512.e70835d4d6d62c07be76b3c1529cb640c7443f0fe434ef4b6478a5a399218cbaf1511b396b3c56eb03bc86424cff2320f6167ad2fde273aa0df6e60b7754029f"
 }

--- a/datahub-web-react/src/app/ingestV2/executions/components/ExecutionsTable.tsx
+++ b/datahub-web-react/src/app/ingestV2/executions/components/ExecutionsTable.tsx
@@ -12,7 +12,7 @@ import RollbackExecutionConfirmation from '@app/ingestV2/executions/components/c
 import SourceColumn from '@app/ingestV2/executions/components/columns/SourceColumn';
 import { ExecutionCancelInfo, ExecutionRequestRecord } from '@app/ingestV2/executions/types';
 import TableFooter from '@app/ingestV2/shared/components/TableFooter';
-import DateTimeColumn from '@app/ingestV2/shared/components/columns/DateTimeColumn';
+import DateTimeColumn, { wrapDateTimeColumnWithHoverFromField } from '@app/ingestV2/shared/components/columns/DateTimeColumn';
 import DurationColumn from '@app/ingestV2/shared/components/columns/DurationColumn';
 import { StatusColumn } from '@app/ingestV2/shared/components/columns/StatusColumn';
 import { getIngestionSourceStatus } from '@app/ingestV2/source/utils';
@@ -92,6 +92,7 @@ export default function ExecutionsTable({
             title: 'Started At',
             key: 'startedAt',
             render: (record) => <DateTimeColumn time={record.startedAt} showRelative />,
+            cellWrapper: wrapDateTimeColumnWithHoverFromField('startedAt'),
             width: '15%',
         },
         {

--- a/datahub-web-react/src/app/ingestV2/shared/components/columns/DateTimeColumn.tsx
+++ b/datahub-web-react/src/app/ingestV2/shared/components/columns/DateTimeColumn.tsx
@@ -67,3 +67,27 @@ export function wrapDateTimeColumnWithHover(content: React.ReactNode, record: an
         </Tooltip>
     );
 }
+
+/**
+ * Factory to create a cell wrapper that shows a tooltip with the absolute
+ * date/time for a given timestamp field on the record.
+ */
+export function wrapDateTimeColumnWithHoverFromField(
+    fieldName: string,
+): (content: React.ReactNode, record: any) => React.ReactNode {
+    return (content: React.ReactNode, record: any): React.ReactNode => {
+        const time = record?.[fieldName];
+
+        if (!isPresent(time) || time === 0) {
+            return content;
+        }
+
+        const formattedDateTime = dayjs(time).format(DEFAULT_DATETIME_FORMAT);
+
+        return (
+            <Tooltip title={formattedDateTime}>
+                <DateTimeCellWrapper>{content}</DateTimeCellWrapper>
+            </Tooltip>
+        );
+    };
+}


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

feat(ingestion): Add precise datetime tooltip to Run History 'Started At' column

This PR addresses the request to display precise date and time information when hovering over the "Started At" column in the Run History tab.

It leverages and generalizes an existing `DateTimeColumn` hover pattern to provide a tooltip with the exact local date and time (e.g., "2025-08-28 07:37:46") when hovering over relative time strings (e.g., "2 weeks ago"). This improves user experience and consistency.

**Related Issue:** GRO-309


---
[Slack Thread](https://datahub.slack.com/archives/C08TM65PLRW/p1756366666348919?thread_ts=1756366666.348919&cid=C08TM65PLRW)

<a href="https://cursor.com/background-agent?bcId=bc-4ecb661d-92cc-43a2-ade1-4ad2578daf5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ecb661d-92cc-43a2-ade1-4ad2578daf5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

