### PR TITLE
feat: Upgrade OpenSearch to 2.17 and add search score field

### DIFF
--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -692,6 +692,13 @@ type SearchResult {
   Additional properties about the search result. Used for rendering in the UI
   """
   extraProperties: [ExtraProperty!]
+
+  """
+  Search score for this result.
+  For keyword search, this is the BM25 score (unbounded).
+  For semantic search, this is the cosine similarity score normalized to [0, 1].
+  """
+  score: Float
 }
 
 """

--- a/docker/elasticsearch/env/docker.env
+++ b/docker/elasticsearch/env/docker.env
@@ -1,2 +1,3 @@
 ES_JAVA_OPTS="-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
-OPENSEARCH_JAVA_OPTS="-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
+OPENSEARCH_JAVA_OPTS="-Xms768m -Xmx1024m -Dlog4j2.formatMsgNoLookups=true"
+DISABLE_SECURITY_PLUGIN="true"

--- a/docker/profiles/docker-compose.prerequisites.yml
+++ b/docker/profiles/docker-compose.prerequisites.yml
@@ -317,13 +317,13 @@ services:
   opensearch:
     profiles: *opensearch-profiles
     hostname: search
-    image: ${DATAHUB_SEARCH_IMAGE:-opensearchproject/opensearch}:${DATAHUB_SEARCH_TAG:-2.11.0}
+    image: ${DATAHUB_SEARCH_IMAGE:-opensearchproject/opensearch}:${DATAHUB_SEARCH_TAG:-2.17.0}
     ports:
       - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
     env_file: elasticsearch/env/docker.env
     environment:
       - discovery.type=single-node
-      - ${XPACK_SECURITY_ENABLED:-plugins.security.disabled=true}
+      - DISABLE_SECURITY_PLUGIN=true
     deploy:
       resources:
         limits:

--- a/docker/quickstart/docker-compose-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-m1.quickstart.yml
@@ -163,7 +163,8 @@ services:
     - discovery.type=single-node
     - ${XPACK_SECURITY_ENABLED:-xpack.security.enabled=false}
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
-    - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
+    - OPENSEARCH_JAVA_OPTS=-Xms768m -Xmx1024m -Dlog4j2.formatMsgNoLookups=true
+    - DISABLE_SECURITY_PLUGIN=true
     healthcheck:
       interval: 1s
       retries: 3

--- a/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
@@ -156,7 +156,8 @@ services:
     - discovery.type=single-node
     - ${XPACK_SECURITY_ENABLED:-xpack.security.enabled=false}
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
-    - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
+    - OPENSEARCH_JAVA_OPTS=-Xms768m -Xmx1024m -Dlog4j2.formatMsgNoLookups=true
+    - DISABLE_SECURITY_PLUGIN=true
     healthcheck:
       interval: 1s
       retries: 3

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -156,7 +156,8 @@ services:
     - discovery.type=single-node
     - ${XPACK_SECURITY_ENABLED:-xpack.security.enabled=false}
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
-    - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
+    - OPENSEARCH_JAVA_OPTS=-Xms768m -Xmx1024m -Dlog4j2.formatMsgNoLookups=true
+    - DISABLE_SECURITY_PLUGIN=true
     healthcheck:
       interval: 1s
       retries: 3

--- a/docker/quickstart/docker-compose.quickstart-profile.yml
+++ b/docker/quickstart/docker-compose.quickstart-profile.yml
@@ -302,9 +302,10 @@ services:
           memory: '1073741824'
     environment:
       ES_JAVA_OPTS: -Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
-      OPENSEARCH_JAVA_OPTS: -Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
+      OPENSEARCH_JAVA_OPTS: -Xms768m -Xmx1024m -Dlog4j2.formatMsgNoLookups=true
       discovery.type: single-node
       plugins.security.disabled: 'true'
+      DISABLE_SECURITY_PLUGIN: 'true'
     hostname: search
     healthcheck:
       test:

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -163,7 +163,8 @@ services:
     - discovery.type=single-node
     - ${XPACK_SECURITY_ENABLED:-xpack.security.enabled=false}
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
-    - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
+    - OPENSEARCH_JAVA_OPTS=-Xms768m -Xmx1024m -Dlog4j2.formatMsgNoLookups=true
+    - DISABLE_SECURITY_PLUGIN=true
     healthcheck:
       interval: 1s
       retries: 3

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/search/SearchResultMetadata.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/search/SearchResultMetadata.pdl
@@ -17,4 +17,9 @@ record SearchResultMetadata {
    */
   suggestions: array[SearchSuggestion] = []
 
+  /**
+   * The scoring method used for ranking results
+   */
+  scoringMethod: optional string
+
 }


### PR DESCRIPTION
This minimal PR provides infrastructure and GraphQL improvements:

1. OpenSearch Upgrade: 2.11.0 to 2.17.0 for bug fixes and performance
2. Memory Optimization: Increases heap memory to 768m-1024m
3. Search Score: Adds score field to GraphQL SearchResult
4. Metadata: Search result metadata enhancements

Changes (11 files):
- Infrastructure: 7 docker-compose files with OpenSearch/memory updates
- GraphQL: MapperUtils score field + schema + test (3 files)
- Metadata: SearchResultMetadata.pdl

All changes are backward compatible with no breaking changes.

