### PR TITLE
feat(ingest/bigquery): Set user-agent for bigquery connections

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_connection.py
@@ -2,14 +2,21 @@ import logging
 import os
 from typing import Any, Dict, Optional
 
+from google.api_core.client_info import ClientInfo
 from google.cloud import bigquery, datacatalog_v1, resourcemanager_v3
 from google.cloud.logging_v2.client import Client as GCPLoggingClient
 from pydantic import Field, PrivateAttr
 
+from datahub._version import nice_version_name
 from datahub.configuration.common import ConfigModel
 from datahub.ingestion.source.common.gcp_credentials_config import GCPCredential
 
 logger = logging.getLogger(__name__)
+
+
+def _get_bigquery_client_info() -> ClientInfo:
+    """Get ClientInfo with DataHub user-agent for BigQuery client identification"""
+    return ClientInfo(user_agent=f"datahub/{nice_version_name()}")
 
 
 class BigQueryConnectionConfig(ConfigModel):
@@ -41,7 +48,11 @@ class BigQueryConnectionConfig(ConfigModel):
 
     def get_bigquery_client(self) -> bigquery.Client:
         client_options = self.extra_client_options
-        return bigquery.Client(self.project_on_behalf, **client_options)
+        return bigquery.Client(
+            self.project_on_behalf,
+            client_info=_get_bigquery_client_info(),
+            **client_options,
+        )
 
     def get_projects_client(self) -> resourcemanager_v3.ProjectsClient:
         return resourcemanager_v3.ProjectsClient()

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_connection.py
@@ -7,7 +7,7 @@ from google.cloud import bigquery, datacatalog_v1, resourcemanager_v3
 from google.cloud.logging_v2.client import Client as GCPLoggingClient
 from pydantic import Field, PrivateAttr
 
-from datahub._version import nice_version_name
+from datahub._version import __version__
 from datahub.configuration.common import ConfigModel
 from datahub.ingestion.source.common.gcp_credentials_config import GCPCredential
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def _get_bigquery_client_info() -> ClientInfo:
     """Get ClientInfo with DataHub user-agent for BigQuery client identification"""
-    return ClientInfo(user_agent=f"datahub/{nice_version_name()}")
+    return ClientInfo(user_agent=f"datahub/{__version__}")
 
 
 class BigQueryConnectionConfig(ConfigModel):


### PR DESCRIPTION
⏺ Summary

  Added automatic user-agent identification for BigQuery client connections to improve observability and client tracking.

  Changes:
  - BigQuery: Added ClientInfo with user-agent format datahub/{version} to all BigQuery client connections
    - Imported ClientInfo from google.api_core.client_info and nice_version_name from datahub._version
    - Created _get_bigquery_client_info() helper function that returns ClientInfo(user_agent=f"datahub/{__version__()}")
    - Updated get_bigquery_client() method to include client_info=_get_bigquery_client_info() parameter

  Benefits:
  - Enables Google Cloud to identify DataHub client requests in BigQuery logs and monitoring
  - Follows Google's recommended best practices for client identification using ClientInfo
  - Consistent with existing patterns in Unity Catalog source which already uses similar client identification
  - Uses semantic versioning format (datahub/1.0.0) for proper client analytics


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
