### PR TITLE
fix(cypress) Fix flaky modules.js cypress test

### DIFF
--- a/datahub-web-react/src/app/homeV3/context/hooks/useTemplateOperations.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useTemplateOperations.ts
@@ -207,6 +207,7 @@ export function useTemplateOperations(
                     showToast(
                         'You’ve edited your home page',
                         `To reset your home page click "Reset to Organization Default"`,
+                        'edited-home-page-toast',
                     );
                 }
             });

--- a/datahub-web-react/src/app/homeV3/toast/useShowToast.tsx
+++ b/datahub-web-react/src/app/homeV3/toast/useShowToast.tsx
@@ -14,10 +14,10 @@ const notificationStyles = {
 };
 
 export default function useShowToast() {
-    function showToast(title: string, description?: string) {
+    function showToast(title: string, description?: string, dataTestId?: string) {
         notification.open({
             message: (
-                <Text color="blue" colorLevel={1000} weight="semiBold" lineHeight="sm">
+                <Text color="blue" colorLevel={1000} weight="semiBold" lineHeight="sm" data-testid={dataTestId}>
                     {title}
                 </Text>
             ),

--- a/smoke-test/tests/cypress/cypress/e2e/homeV3/modules.js
+++ b/smoke-test/tests/cypress/cypress/e2e/homeV3/modules.js
@@ -93,6 +93,7 @@ describe("home page modules", () => {
 
   it("remove default module", () => {
     addYourAssetsModule();
+    cy.ensureElementWithTestIdPresent("edited-home-page-toast");
     removeFirstModuleWithTestId("your-assets-module");
     cy.getWithTestId("your-assets-module").should("have.length.lessThan", 2);
     cy.getWithTestId("your-assets-module").should("have.length", 1);


### PR DESCRIPTION
This test was flaking pretty frequently because we were making our second edit before the first edit's request succeeded and updated state so that we were editing the wrong module - an issue of cypress moving much more quickly than a human could.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
