### PR TITLE
fix(spark-smoke-test): debian13 deprecated software-properties-common

### DIFF
--- a/metadata-integration/java/spark-lineage-legacy/spark-smoke-test/docker/SparkBase.Dockerfile
+++ b/metadata-integration/java/spark-lineage-legacy/spark-smoke-test/docker/SparkBase.Dockerfile
@@ -11,8 +11,9 @@ ARG spark_version=3.2.0
 ARG hadoop_version=2.7
 
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends curl gnupg software-properties-common && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
+    apt-get install -y --no-install-recommends curl gnupg && \
+    curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list && \
     curl https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb -o /tmp/zulu-repo_1.0.0-3_all.deb && \
     apt-get install /tmp/zulu-repo_1.0.0-3_all.deb && \
     apt-get update && \


### PR DESCRIPTION
python:3.9 moved to debian 13 last week which no longer has software-properties-common. 

https://docs.azul.com/core/install/linux-ca-deb

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
