### PR TITLE
fix(ingestion/nifi): Change Zookeeper image to bitnamilegacy version in test

### DIFF
--- a/metadata-ingestion/tests/integration/nifi/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/nifi/docker-compose.yml
@@ -40,7 +40,7 @@ services:
   nifi_zookeeper:
     hostname: nifi_zookeeper
     container_name: nifi_zookeeper
-    image: 'bitnami/zookeeper:latest'
+    image: 'bitnamilegacy/zookeeper:latest'
     environment:
       - ALLOW_ANONYMOUS_LOGIN=yes
       - ZOO_PORT_NUMBER=52181


### PR DESCRIPTION
Change Zookeeper image to bitnamilegacy version in test

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
