### PR TITLE
feat(ui/summary-tab): use permissions for documentation and links in the summary tab

### DIFF
--- a/datahub-web-react/src/app/entityV2/summary/documentation/AboutContent.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/documentation/AboutContent.tsx
@@ -2,6 +2,7 @@ import { Editor } from '@components';
 import React from 'react';
 import styled from 'styled-components';
 
+import { useEntityData } from '@app/entity/shared/EntityContext';
 import DescriptionActionsBar from '@app/entityV2/summary/documentation/DescriptionActionsBar';
 import DescriptionViewer from '@app/entityV2/summary/documentation/DescriptionViewer';
 import EmptyDescription from '@app/entityV2/summary/documentation/EmptyDescription';
@@ -46,6 +47,8 @@ export default function AboutContent() {
         handleCancel,
         emptyDescriptionText,
     } = useDescriptionUtils();
+    const { entityData } = useEntityData();
+    const canEditDescription = !!entityData?.privileges?.canEditDescription;
 
     let content;
 
@@ -71,7 +74,15 @@ export default function AboutContent() {
     }
     return (
         <>
-            <DescriptionContainer onClick={() => setIsEditing(true)}>{content}</DescriptionContainer>
+            <DescriptionContainer
+                onClick={() => {
+                    if (canEditDescription) {
+                        setIsEditing(true);
+                    }
+                }}
+            >
+                {content}
+            </DescriptionContainer>
             {isEditing && (
                 <DescriptionActionsBar
                     onCancel={handleCancel}

--- a/datahub-web-react/src/app/entityV2/summary/links/LinkItem.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/links/LinkItem.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import AvatarPillWithLinkAndHover from '@components/components/Avatar/AvatarPillWithLinkAndHover';
 
 import { formatDateString } from '@app/entityV2/shared/containers/profile/utils';
+import { useGetLinkPermissions } from '@app/entityV2/summary/links/useGetLinkPermissions';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 
 import { InstitutionalMemoryMetadata } from '@types';
@@ -44,6 +45,8 @@ type Props = {
 
 export default function LinkItem({ link, setSelectedLink, setShowConfirmDelete }: Props) {
     const entityRegistry = useEntityRegistryV2();
+    const hasLinkPermissions = useGetLinkPermissions();
+
     const createdBy = link.actor;
 
     return (
@@ -60,18 +63,22 @@ export default function LinkItem({ link, setSelectedLink, setShowConfirmDelete }
                         Added {formatDateString(link.created.time)} by{' '}
                     </Text>
                     <AvatarPillWithLinkAndHover user={createdBy} size="sm" entityRegistry={entityRegistry} />
-                    <StyledIcon icon="PencilSimpleLine" source="phosphor" color="gray" size="md" />
-                    <StyledIcon
-                        icon="Trash"
-                        source="phosphor"
-                        color="red"
-                        size="md"
-                        onClick={(e) => {
-                            e.preventDefault();
-                            setSelectedLink(link);
-                            setShowConfirmDelete(true);
-                        }}
-                    />
+                    {hasLinkPermissions && (
+                        <>
+                            <StyledIcon icon="PencilSimpleLine" source="phosphor" color="gray" size="md" />
+                            <StyledIcon
+                                icon="Trash"
+                                source="phosphor"
+                                color="red"
+                                size="md"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    setSelectedLink(link);
+                                    setShowConfirmDelete(true);
+                                }}
+                            />
+                        </>
+                    )}
                 </RightSection>
             </LinkContainer>
         </a>

--- a/datahub-web-react/src/app/entityV2/summary/links/Links.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/links/Links.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import AddLinkButton from '@app/entityV2/summary/links/AddLinkButton';
 import LinksList from '@app/entityV2/summary/links/LinksList';
+import { useGetLinkPermissions } from '@app/entityV2/summary/links/useGetLinkPermissions';
 
 const LinksSection = styled.div`
     display: flex;
@@ -11,10 +12,12 @@ const LinksSection = styled.div`
 `;
 
 export default function Links() {
+    const hasLinkPermissions = useGetLinkPermissions();
+
     return (
         <LinksSection>
             <LinksList />
-            <AddLinkButton />
+            {hasLinkPermissions && <AddLinkButton />}
         </LinksSection>
     );
 }

--- a/datahub-web-react/src/app/entityV2/summary/links/__tests__/useGetLinkPermissions.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/links/__tests__/useGetLinkPermissions.test.ts
@@ -1,0 +1,118 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserContext } from '@app/context/useUserContext';
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import { useGetLinkPermissions } from '@app/entityV2/summary/links/useGetLinkPermissions';
+
+import { EntityType } from '@types';
+
+// Mocking the hooks
+vi.mock('@app/entity/shared/EntityContext', () => ({
+    useEntityData: vi.fn(),
+}));
+
+vi.mock('@app/context/useUserContext', () => ({
+    useUserContext: vi.fn(),
+}));
+
+describe('useGetLinkPermissions', () => {
+    const setup = (entityDataProps, userProps, entityType) => {
+        (useEntityData as unknown as any).mockReturnValue({
+            entityData: entityDataProps,
+            entityType,
+        });
+        (useUserContext as unknown as any).mockReturnValue(userProps);
+        return renderHook(() => useGetLinkPermissions());
+    };
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('should return true when canEditLinks is true regardless of other permissions or entity type', () => {
+        const { result } = setup(
+            { privileges: { canEditLinks: true, canManageChildren: false } },
+            { platformPrivileges: { manageGlossaries: false } },
+            EntityType.Dataset,
+        );
+        expect(result.current).toBe(true);
+    });
+
+    it('should return true when entityType is GlossaryNode and user can manage glossaries', () => {
+        const { result } = setup(
+            { privileges: { canEditLinks: false, canManageChildren: false } },
+            { platformPrivileges: { manageGlossaries: true } },
+            EntityType.GlossaryNode,
+        );
+        expect(result.current).toBe(true);
+    });
+
+    it('should return true when entityType is GlossaryTerm and user can manage glossaries', () => {
+        const { result } = setup(
+            { privileges: { canEditLinks: false, canManageChildren: false } },
+            { platformPrivileges: { manageGlossaries: true } },
+            EntityType.GlossaryTerm,
+        );
+        expect(result.current).toBe(true);
+    });
+
+    it('should return true when entityType is GlossaryNode and canManageChildren is true', () => {
+        const { result } = setup(
+            { privileges: { canEditLinks: false, canManageChildren: true } },
+            { platformPrivileges: { manageGlossaries: false } },
+            EntityType.GlossaryNode,
+        );
+        expect(result.current).toBe(true);
+    });
+
+    it('should return true when entityType is GlossaryTerm and canManageChildren is true', () => {
+        const { result } = setup(
+            { privileges: { canEditLinks: false, canManageChildren: true } },
+            { platformPrivileges: { manageGlossaries: false } },
+            EntityType.GlossaryTerm,
+        );
+        expect(result.current).toBe(true);
+    });
+
+    it('should return false when none of the permissions are granted', () => {
+        const { result } = setup(
+            { privileges: { canEditLinks: false, canManageChildren: false } },
+            { platformPrivileges: { manageGlossaries: false } },
+            EntityType.Dataset,
+        );
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false for non-glossary entity types when only canManageChildren is true', () => {
+        const { result } = setup(
+            { privileges: { canEditLinks: false, canManageChildren: true } },
+            { platformPrivileges: { manageGlossaries: false } },
+            EntityType.Dataset,
+        );
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false when entityData is missing', () => {
+        const { result } = setup(undefined, { platformPrivileges: { manageGlossaries: true } }, EntityType.Dataset);
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false when user context is missing', () => {
+        const { result } = setup(
+            { privileges: { canEditLinks: false, canManageChildren: false } },
+            undefined,
+            EntityType.GlossaryNode,
+        );
+        expect(result.current).toBe(false);
+    });
+
+    it('should return true when both canEditLinks and glossary permissions are true', () => {
+        const { result } = setup(
+            { privileges: { canEditLinks: true, canManageChildren: true } },
+            { platformPrivileges: { manageGlossaries: true } },
+            EntityType.GlossaryNode,
+        );
+        expect(result.current).toBe(true);
+    });
+});

--- a/datahub-web-react/src/app/entityV2/summary/links/useGetLinkPermissions.ts
+++ b/datahub-web-react/src/app/entityV2/summary/links/useGetLinkPermissions.ts
@@ -1,0 +1,24 @@
+import { useUserContext } from '@app/context/useUserContext';
+import { useEntityData } from '@app/entity/shared/EntityContext';
+
+import { EntityType } from '@types';
+
+export function useGetLinkPermissions() {
+    const { entityData, entityType } = useEntityData();
+    const user = useUserContext();
+
+    // Edit links permission
+    const canEditLinks = !!entityData?.privileges?.canEditLinks;
+
+    const canManageGlossaries = !!user?.platformPrivileges?.manageGlossaries;
+    const canManageChildren = !!entityData?.privileges?.canManageChildren;
+
+    // Manage Glossary or manage children permission for Glossary terms and Glossary nodes
+    const canUpdateGlossaryEntity =
+        (entityType === EntityType.GlossaryNode || entityType === EntityType.GlossaryTerm) &&
+        (canManageGlossaries || canManageChildren);
+
+    const hasLinkPermissions = canEditLinks || canUpdateGlossaryEntity;
+
+    return hasLinkPermissions;
+}


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-708/check-permissions-for-documentation-and-links-section

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
