### PR TITLE
chore(kafka): fixes lower bound version for confluent_kafka dep in ingestion

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -75,7 +75,8 @@ kafka_common = {
     # With the release of 2.8.1, confluent-kafka only released a source distribution,
     # and no prebuilt wheels.
     # See https://github.com/confluentinc/confluent-kafka-python/issues/1927
-    "confluent_kafka[schemaregistry,avro]>=1.9.0, != 2.8.1",
+    # RegisteredSchema#guid is being used and was introduced in 2.10.1 https://github.com/confluentinc/confluent-kafka-python/pull/1978
+    "confluent_kafka[schemaregistry,avro]>=1.9.0, != 2.8.1, >=2.10.1",
     # We currently require both Avro libraries. The codegen uses avro-python3 (above)
     # schema parsers at runtime for generating and reading JSON into Python objects.
     # At the same time, we use Kafka's AvroSerializer, which internally relies on


### PR DESCRIPTION
This PR fixes the exception below, which occurs when running tests locally with `confluent-kafka==2.10.0`.

The issue does not appear in CI because 2.11.0 is being picked up there.

Updated lower bounds to be precise and correct. Even if the new lower bound supersedes existing version restrictions, I’ve kept the historic explicit for clarity.

```
FAILED tests/unit/test_confluent_schema_registry.py::ConfluentSchemaRegistryTest::test_get_schema_str_replace_confluent_ref_avro - TypeError: RegisteredSchema.__init__() got an unexpected keyword argument 'guid'
FAILED tests/unit/test_kafka_source.py::test_kafka_ignore_warnings_on_schema_type[ignore_warnings_on_schema_type-TRUE] - TypeError: RegisteredSchema.__init__() got an unexpected keyword argument 'guid'
FAILED tests/unit/test_kafka_source.py::test_kafka_source_topic_meta_mappings - TypeError: RegisteredSchema.__init__() got an unexpected keyword argument 'guid'
FAILED tests/unit/test_kafka_source.py::test_kafka_source_workunits_schema_registry_subject_name_strategies - TypeError: RegisteredSchema.__init__() got an unexpected keyword argument 'guid'
FAILED tests/unit/test_kafka_source.py::test_kafka_ignore_warnings_on_schema_type[ignore_warnings_on_schema_type-FALSE] - TypeError: RegisteredSchema.__init__() got an unexpected keyword argument 'guid'
```
