### PR TITLE
docs: Update docs banner to promote Context event

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -100,7 +100,7 @@ module.exports = {
     announcementBar: {
       id: "announcement-3",
       content:
-        '<div class="shimmer-banner"><p><strong>Town Hall August 21:</strong> The Latest in DataHub Lineage</p><a href="https://events.datahub.com/august-town-hall-2025?utm_source=webinar&utm_medium=&utm_campaign=17099074-FY25-Q3-Town-Hall" target="_blank" class="button"><div>Save your spot<span> →</span></div></a></div>',
+        '<div class="shimmer-banner"><p><strong>CONTEXT:</strong> The Metadata and AI Summit 10/29</p><a href="https://datahub.com/context/?utm_source=event&utm_medium=&utm_campaign=16839686-FY25-Q4-EVENT-CONTEXT-MAIS&utm_term=docs" target="_blank" class="button"><div>Register<span> →</span></div></a></div>',
       backgroundColor: "transparent",
       textColor: "#ffffff",
       isCloseable: false,


### PR DESCRIPTION
this is to promote our 1 day virtual summit per Jen Atherly's request: https://app.asana.com/1/1203979157792006/project/1210127569658102/task/1211185547599558?focus=true

-  [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
-  [X] Links to related issues (if applicable)

[NA] Tests for the changes have been added/updated (if applicable)
[NA] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
[NA] For any breaking changes
