### PR TITLE
fix(ui) Fix weird indents on schema table descriptions

### DIFF
--- a/datahub-web-react/src/app/entityV2/dataset/profile/schema/components/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entityV2/dataset/profile/schema/components/SchemaDescriptionField.tsx
@@ -98,6 +98,7 @@ const StyledViewer = styled(Editor)`
 const DescriptionWrapper = styled.span`
     display: inline-flex;
     align-items: center;
+    width: 100%;
 `;
 
 const AddModalWrapper = styled.div``;

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/CompactMarkdownViewer.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/CompactMarkdownViewer.tsx
@@ -16,6 +16,7 @@ const ShowMoreWrapper = styled.div`
 const MarkdownContainer = styled.div<{ lineLimit?: number | null }>`
     max-width: 100%;
     position: relative;
+    flex: 1;
     ${(props) =>
         props.lineLimit &&
         props.lineLimit <= 1 &&
@@ -36,6 +37,7 @@ const MarkdownViewContainer = styled.div<{ scrollableY: boolean }>`
     word-wrap: break-word;
     overflow-x: hidden;
     overflow-y: ${(props) => (props.scrollableY ? 'auto' : 'hidden')};
+    flex: 1;
 `;
 
 const CompactEditor = styled(Editor)<{ limit: number | null; customStyle?: React.CSSProperties }>`


### PR DESCRIPTION
Fixes a minor situation on the schema table with the markdown viewer where we can have "View more" all at different locations depending on the width of the full content. Now, always have the markdown viewer just take up all of its given space.

**Before:**
<img width="1184" height="668" alt="Screenshot 2025-09-03 at 11 45 18 AM" src="https://github.com/user-attachments/assets/82275d37-1012-4a96-9a2c-d4d72f7b60f8" />

**After**
<img width="1184" height="575" alt="Screenshot 2025-09-03 at 11 45 44 AM" src="https://github.com/user-attachments/assets/1d95d581-7d8e-4be2-b185-028ff7f313fa" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
