### PR TITLE
feat(summary-tab): support assets module on the summary pages

### DIFF
--- a/datahub-graphql-core/src/main/resources/module.graphql
+++ b/datahub-graphql-core/src/main/resources/module.graphql
@@ -231,6 +231,10 @@ enum DataHubPageModuleType {
   Module displaying the top domains
   """
   DOMAINS
+  """
+  Module displaying the assets of parent entities
+  """
+  ASSETS
 }
 
 """

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/AssetsModule.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/AssetsModule.tsx
@@ -15,12 +15,12 @@ export default function AssetsModule(props: ModuleProps) {
     const { loading, fetchAssets, total, navigateToAssetsTab } = useGetAssets();
 
     return (
-        <LargeModule {...props} loading={loading} onClickViewAll={navigateToAssetsTab} dataTestId="your-assets-module">
-            <div data-testid="user-owned-entities">
+        <LargeModule {...props} loading={loading} onClickViewAll={navigateToAssetsTab} dataTestId="assets-module">
+            <div data-testid="entity-assets">
                 <InfiniteScrollList<Entity>
                     fetchData={fetchAssets}
                     renderItem={(entity) => (
-                        <EntityItem entity={entity} key={entity.urn} moduleType={DataHubPageModuleType.OwnedAssets} />
+                        <EntityItem entity={entity} key={entity.urn} moduleType={DataHubPageModuleType.Assets} />
                     )}
                     pageSize={DEFAULT_PAGE_SIZE}
                     emptyState={

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/AssetsModule.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/AssetsModule.tsx
@@ -1,0 +1,40 @@
+import { InfiniteScrollList } from '@components';
+import React from 'react';
+
+import { useGetAssets } from '@app/entityV2/summary/modules/assets/useGetAssets';
+import EmptyContent from '@app/homeV3/module/components/EmptyContent';
+import EntityItem from '@app/homeV3/module/components/EntityItem';
+import LargeModule from '@app/homeV3/module/components/LargeModule';
+import { ModuleProps } from '@app/homeV3/module/types';
+
+import { DataHubPageModuleType, Entity } from '@types';
+
+const DEFAULT_PAGE_SIZE = 10;
+
+export default function AssetsModule(props: ModuleProps) {
+    const { loading, fetchAssets, total, navigateToAssetsTab } = useGetAssets();
+
+    return (
+        <LargeModule {...props} loading={loading} onClickViewAll={navigateToAssetsTab} dataTestId="your-assets-module">
+            <div data-testid="user-owned-entities">
+                <InfiniteScrollList<Entity>
+                    fetchData={fetchAssets}
+                    renderItem={(entity) => (
+                        <EntityItem entity={entity} key={entity.urn} moduleType={DataHubPageModuleType.OwnedAssets} />
+                    )}
+                    pageSize={DEFAULT_PAGE_SIZE}
+                    emptyState={
+                        <EmptyContent
+                            icon="Database"
+                            title="No Assets"
+                            description="Add assets to the parent entity to view them"
+                            linkText="Add assets"
+                            onLinkClick={navigateToAssetsTab}
+                        />
+                    }
+                    totalItemCount={total}
+                />
+            </div>
+        </LargeModule>
+    );
+}

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/__tests__/useGetAssets.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/__tests__/useGetAssets.test.ts
@@ -1,0 +1,97 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import { useGetAssets } from '@app/entityV2/summary/modules/assets/useGetAssets';
+import { useGetDataProductAssets } from '@app/entityV2/summary/modules/assets/useGetDataProductAssets';
+import { useGetDomainAssets } from '@app/entityV2/summary/modules/assets/useGetDomainAssets';
+import { useGetTermAssets } from '@app/entityV2/summary/modules/assets/useGetTermAssets';
+
+import { EntityType } from '@types';
+
+// Mock dependencies
+vi.mock('@app/entity/shared/EntityContext', () => ({
+    useEntityData: vi.fn(),
+}));
+vi.mock('@app/entityV2/summary/modules/assets/useGetDomainAssets', () => ({
+    useGetDomainAssets: vi.fn(),
+}));
+vi.mock('@app/entityV2/summary/modules/assets/useGetDataProductAssets', () => ({
+    useGetDataProductAssets: vi.fn(),
+}));
+vi.mock('@app/entityV2/summary/modules/assets/useGetTermAssets', () => ({
+    useGetTermAssets: vi.fn(),
+}));
+
+describe('useGetAssets', () => {
+    const mockDomain = {
+        loading: false,
+        fetchAssets: vi.fn(),
+        total: 3,
+        navigateToAssetsTab: vi.fn(),
+    };
+    const mockDataProduct = {
+        loading: true,
+        fetchAssets: vi.fn(),
+        total: 8,
+        navigateToAssetsTab: vi.fn(),
+    };
+    const mockTerm = {
+        loading: false,
+        fetchAssets: vi.fn(),
+        total: 5,
+        navigateToAssetsTab: vi.fn(),
+    };
+
+    const setup = (entityType) => {
+        (useEntityData as unknown as any).mockReturnValue({ entityType });
+        (useGetDomainAssets as unknown as any).mockReturnValue(mockDomain);
+        (useGetDataProductAssets as unknown as any).mockReturnValue(mockDataProduct);
+        (useGetTermAssets as unknown as any).mockReturnValue(mockTerm);
+        return renderHook(() => useGetAssets());
+    };
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('should return domain assets info when entity type is Domain', () => {
+        const { result } = setup(EntityType.Domain);
+        expect(result.current.fetchAssets).toBe(mockDomain.fetchAssets);
+        expect(result.current.loading).toBe(mockDomain.loading);
+        expect(result.current.total).toBe(mockDomain.total);
+        expect(result.current.navigateToAssetsTab).toBe(mockDomain.navigateToAssetsTab);
+    });
+
+    it('should return data product assets info when entity type is DataProduct', () => {
+        const { result } = setup(EntityType.DataProduct);
+        expect(result.current.fetchAssets).toBe(mockDataProduct.fetchAssets);
+        expect(result.current.loading).toBe(mockDataProduct.loading);
+        expect(result.current.total).toBe(mockDataProduct.total);
+        expect(result.current.navigateToAssetsTab).toBe(mockDataProduct.navigateToAssetsTab);
+    });
+
+    it('should return term assets info when entity type is GlossaryTerm', () => {
+        const { result } = setup(EntityType.GlossaryTerm);
+        expect(result.current.fetchAssets).toBe(mockTerm.fetchAssets);
+        expect(result.current.loading).toBe(mockTerm.loading);
+        expect(result.current.total).toBe(mockTerm.total);
+        expect(result.current.navigateToAssetsTab).toBe(mockTerm.navigateToAssetsTab);
+    });
+
+    it('should return undefineds when entity type is not mapped', () => {
+        const { result } = setup(EntityType.Dataset);
+        expect(result.current.fetchAssets).toBeUndefined();
+        expect(result.current.loading).toBeUndefined();
+        expect(result.current.total).toBeUndefined();
+        expect(result.current.navigateToAssetsTab).toBeUndefined();
+    });
+
+    it('should return undefineds when entity type is missing', () => {
+        const { result } = setup(undefined);
+        expect(result.current.fetchAssets).toBeUndefined();
+        expect(result.current.loading).toBeUndefined();
+        expect(result.current.total).toBeUndefined();
+        expect(result.current.navigateToAssetsTab).toBeUndefined();
+    });
+});

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/__tests__/useGetDataProductAssets.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/__tests__/useGetDataProductAssets.test.ts
@@ -1,0 +1,156 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useHistory } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import { useGetDataProductAssets } from '@app/entityV2/summary/modules/assets/useGetDataProductAssets';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+import { useListDataProductAssetsQuery } from '@graphql/search.generated';
+import { EntityType } from '@types';
+
+vi.mock('@app/entity/shared/EntityContext', () => ({
+    useEntityData: vi.fn(),
+}));
+vi.mock('@graphql/search.generated', () => ({
+    useListDataProductAssetsQuery: vi.fn(),
+}));
+vi.mock('@app/useEntityRegistry', () => ({
+    useEntityRegistryV2: vi.fn(),
+}));
+vi.mock('react-router', () => ({
+    useHistory: vi.fn(),
+}));
+
+describe('useGetDataProductAssets', () => {
+    const urn = 'urn:li:dataProduct:dataProduct1';
+    const entityType = EntityType.DataProduct;
+    const mockHistory = { push: vi.fn() };
+    const mockRegistry = {
+        getGenericEntityProperties: vi.fn().mockImplementation((type, entity) => ({ ...entity, type })),
+        getEntityUrl: vi.fn(),
+    };
+
+    beforeEach(() => {
+        mockRegistry.getEntityUrl.mockReturnValue('/entity/url');
+        (useEntityData as unknown as any).mockReturnValue({ urn, entityType });
+        (useHistory as unknown as any).mockReturnValue(mockHistory);
+        (useEntityRegistryV2 as unknown as any).mockReturnValue(mockRegistry);
+        (useListDataProductAssetsQuery as unknown as any).mockReturnValue({
+            loading: false,
+            data: {
+                listDataProductAssets: {
+                    searchResults: [
+                        { entity: { urn: 'urn:li:dataProduct:dataProduct1', type: 'DataProduct' } },
+                        { entity: { urn: 'urn:li:dataProduct:dataProduct2', type: 'DataProduct' } },
+                    ],
+                    total: 2,
+                },
+            },
+            error: undefined,
+            refetch: vi.fn().mockResolvedValue({
+                data: {
+                    listDataProductAssets: {
+                        searchResults: [{ entity: { urn: 'urn:li:dataProduct:dataProduct3', type: 'DataProduct' } }],
+                    },
+                },
+            }),
+        });
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const setup = () => renderHook(() => useGetDataProductAssets());
+
+    it('should return entities, originEntities, total and not loading', () => {
+        const { result } = setup();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.total).toBe(2);
+        expect(result.current.originEntities.length).toBe(2);
+        expect(result.current.entities[0]?.urn).toBe('urn:li:dataProduct:dataProduct1');
+        expect(result.current.entities[1]?.urn).toBe('urn:li:dataProduct:dataProduct2');
+    });
+
+    it('should return loading true if searchLoading is true', () => {
+        (useListDataProductAssetsQuery as unknown as any).mockReturnValueOnce({
+            loading: true,
+            data: undefined,
+            error: undefined,
+            refetch: vi.fn(),
+        });
+        const { result } = setup();
+        expect(result.current.loading).toBe(true);
+    });
+
+    it('should return loading true when no data yet', () => {
+        (useListDataProductAssetsQuery as unknown as any).mockReturnValueOnce({
+            loading: true,
+            data: undefined,
+            error: undefined,
+            refetch: vi.fn(),
+        });
+        const { result } = setup();
+        expect(result.current.loading).toBe(true);
+    });
+
+    it('should return error if there is an error', () => {
+        const mockError = new Error('Test error');
+        (useListDataProductAssetsQuery as unknown as any).mockReturnValueOnce({
+            loading: false,
+            data: undefined,
+            error: mockError,
+            refetch: vi.fn(),
+        });
+        const { result } = setup();
+        expect(result.current.error).toBe(mockError);
+    });
+
+    it('should fetch paginated assets for non-zero start', async () => {
+        const refetchMock = vi.fn().mockResolvedValue({
+            data: {
+                listDataProductAssets: {
+                    searchResults: [{ entity: { urn: 'urn:li:dataProduct:dataProduct3', type: 'DataProduct' } }],
+                },
+            },
+        });
+        (useListDataProductAssetsQuery as unknown as any).mockReturnValueOnce({
+            loading: false,
+            data: {
+                listDataProductAssets: {
+                    searchResults: [{ entity: { urn: 'urn:li:dataProduct:dataProduct1', type: 'DataProduct' } }],
+                    total: 1,
+                },
+            },
+            error: undefined,
+            refetch: refetchMock,
+        });
+
+        const { result } = setup();
+        let assets;
+        await act(async () => {
+            assets = await result.current.fetchAssets(10, 5);
+        });
+        expect(assets.length).toBe(1);
+        expect(assets[0].urn).toBe('urn:li:dataProduct:dataProduct3');
+        expect(refetchMock).toHaveBeenCalled();
+    });
+
+    it('should return origin entities when paginating from start=0', async () => {
+        const { result } = setup();
+        let assets;
+        await act(async () => {
+            assets = await result.current.fetchAssets(0, 10);
+        });
+        expect(assets.length).toBe(2);
+        expect(assets[0].urn).toBe('urn:li:dataProduct:dataProduct1');
+    });
+
+    it('should navigate to Assets Tab with correct URL', () => {
+        const { result } = setup();
+        result.current.navigateToAssetsTab();
+        expect(mockHistory.push).toHaveBeenCalledWith('/entity/url/Assets');
+        expect(mockRegistry.getEntityUrl).toHaveBeenCalledWith(entityType, urn);
+    });
+});

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/__tests__/useGetDomainAssets.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/__tests__/useGetDomainAssets.test.ts
@@ -1,0 +1,156 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useHistory } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import { useGetDomainAssets } from '@app/entityV2/summary/modules/assets/useGetDomainAssets';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
+import { EntityType } from '@types';
+
+vi.mock('@app/entity/shared/EntityContext', () => ({
+    useEntityData: vi.fn(),
+}));
+vi.mock('@graphql/search.generated', () => ({
+    useGetSearchResultsForMultipleQuery: vi.fn(),
+}));
+vi.mock('@app/useEntityRegistry', () => ({
+    useEntityRegistryV2: vi.fn(),
+}));
+vi.mock('react-router', () => ({
+    useHistory: vi.fn(),
+}));
+
+describe('useGetDomainAssets', () => {
+    const urn = 'urn:li:domain:marketing';
+    const entityType = EntityType.Domain;
+    const mockHistory = { push: vi.fn() };
+    const mockRegistry = {
+        getGenericEntityProperties: vi.fn().mockImplementation((type, entity) => ({ ...entity, type })),
+        getEntityUrl: vi.fn(),
+    };
+
+    beforeEach(() => {
+        mockRegistry.getEntityUrl.mockReturnValue('/entity/url');
+        (useEntityData as unknown as any).mockReturnValue({ urn, entityType });
+        (useHistory as unknown as any).mockReturnValue(mockHistory);
+        (useEntityRegistryV2 as unknown as any).mockReturnValue(mockRegistry);
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValue({
+            loading: false,
+            data: {
+                searchAcrossEntities: {
+                    searchResults: [
+                        { entity: { urn: 'urn:li:domain:marketing', type: 'Domain' } },
+                        { entity: { urn: 'urn:li:domain:finance', type: 'Domain' } },
+                    ],
+                    total: 2,
+                },
+            },
+            error: undefined,
+            refetch: vi.fn().mockResolvedValue({
+                data: {
+                    searchAcrossEntities: {
+                        searchResults: [{ entity: { urn: 'urn:li:domain:operations', type: 'Domain' } }],
+                    },
+                },
+            }),
+        });
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const setup = () => renderHook(() => useGetDomainAssets());
+
+    it('should return entities, originEntities, total and not loading', () => {
+        const { result } = setup();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.total).toBe(2);
+        expect(result.current.originEntities.length).toBe(2);
+        expect(result.current.entities[0]?.urn).toBe('urn:li:domain:marketing');
+        expect(result.current.entities[1]?.urn).toBe('urn:li:domain:finance');
+    });
+
+    it('should return loading true if searchLoading is true', () => {
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValueOnce({
+            loading: true,
+            data: undefined,
+            error: undefined,
+            refetch: vi.fn(),
+        });
+        const { result } = setup();
+        expect(result.current.loading).toBe(true);
+    });
+
+    it('should return loading true when no data yet', () => {
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValueOnce({
+            loading: true,
+            data: undefined,
+            error: undefined,
+            refetch: vi.fn(),
+        });
+        const { result } = setup();
+        expect(result.current.loading).toBe(true);
+    });
+
+    it('should return error if there is an error', () => {
+        const mockError = new Error('Test error');
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValueOnce({
+            loading: false,
+            data: undefined,
+            error: mockError,
+            refetch: vi.fn(),
+        });
+        const { result } = setup();
+        expect(result.current.error).toBe(mockError);
+    });
+
+    it('should fetch paginated assets for non-zero start', async () => {
+        const refetchMock = vi.fn().mockResolvedValue({
+            data: {
+                searchAcrossEntities: {
+                    searchResults: [{ entity: { urn: 'urn:li:domain:operations', type: 'Domain' } }],
+                },
+            },
+        });
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValueOnce({
+            loading: false,
+            data: {
+                searchAcrossEntities: {
+                    searchResults: [{ entity: { urn: 'urn:li:domain:marketing', type: 'Domain' } }],
+                    total: 1,
+                },
+            },
+            error: undefined,
+            refetch: refetchMock,
+        });
+
+        const { result } = setup();
+        let assets;
+        await act(async () => {
+            assets = await result.current.fetchAssets(10, 5);
+        });
+        expect(assets.length).toBe(1);
+        expect(assets[0].urn).toBe('urn:li:domain:operations');
+        expect(refetchMock).toHaveBeenCalled();
+    });
+
+    it('should return origin entities when paginating from start=0', async () => {
+        const { result } = setup();
+        let assets;
+        await act(async () => {
+            assets = await result.current.fetchAssets(0, 10);
+        });
+        expect(assets.length).toBe(2);
+        expect(assets[0].urn).toBe('urn:li:domain:marketing');
+    });
+
+    it('should navigate to Assets Tab with correct URL', () => {
+        const { result } = setup();
+        result.current.navigateToAssetsTab();
+        expect(mockHistory.push).toHaveBeenCalledWith('/entity/url/Assets');
+        expect(mockRegistry.getEntityUrl).toHaveBeenCalledWith(entityType, urn);
+    });
+});

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/__tests__/useGetTermAssets.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/__tests__/useGetTermAssets.test.ts
@@ -1,0 +1,156 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useHistory } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import { useGetTermAssets } from '@app/entityV2/summary/modules/assets/useGetTermAssets';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
+import { EntityType } from '@types';
+
+vi.mock('@app/entity/shared/EntityContext', () => ({
+    useEntityData: vi.fn(),
+}));
+vi.mock('@graphql/search.generated', () => ({
+    useGetSearchResultsForMultipleQuery: vi.fn(),
+}));
+vi.mock('@app/useEntityRegistry', () => ({
+    useEntityRegistryV2: vi.fn(),
+}));
+vi.mock('react-router', () => ({
+    useHistory: vi.fn(),
+}));
+
+describe('useGetTermAssets', () => {
+    const urn = 'urn:li:glossaryTerm:term1';
+    const entityType = EntityType.GlossaryTerm;
+    const mockHistory = { push: vi.fn() };
+    const mockRegistry = {
+        getGenericEntityProperties: vi.fn().mockImplementation((type, entity) => ({ ...entity, type })),
+        getEntityUrl: vi.fn(),
+    };
+
+    beforeEach(() => {
+        mockRegistry.getEntityUrl.mockReturnValue('/entity/url');
+        (useEntityData as unknown as any).mockReturnValue({ urn, entityType });
+        (useHistory as unknown as any).mockReturnValue(mockHistory);
+        (useEntityRegistryV2 as unknown as any).mockReturnValue(mockRegistry);
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValue({
+            loading: false,
+            data: {
+                searchAcrossEntities: {
+                    searchResults: [
+                        { entity: { urn: 'urn:li:glossaryTerm:term1', type: 'GlossaryTerm' } },
+                        { entity: { urn: 'urn:li:glossaryTerm:term2', type: 'GlossaryTerm' } },
+                    ],
+                    total: 2,
+                },
+            },
+            error: undefined,
+            refetch: vi.fn().mockResolvedValue({
+                data: {
+                    searchAcrossEntities: {
+                        searchResults: [{ entity: { urn: 'urn:li:glossaryTerm:term3', type: 'GlossaryTerm' } }],
+                    },
+                },
+            }),
+        });
+    });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+    });
+
+    const setup = () => renderHook(() => useGetTermAssets());
+
+    it('should return entities, originEntities, total and not loading', () => {
+        const { result } = setup();
+        expect(result.current.loading).toBe(false);
+        expect(result.current.total).toBe(2);
+        expect(result.current.originEntities.length).toBe(2);
+        expect(result.current.entities[0]?.urn).toBe('urn:li:glossaryTerm:term1');
+        expect(result.current.entities[1]?.urn).toBe('urn:li:glossaryTerm:term2');
+    });
+
+    it('should return loading true if searchLoading is true', () => {
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValueOnce({
+            loading: true,
+            data: undefined,
+            error: undefined,
+            refetch: vi.fn(),
+        });
+        const { result } = setup();
+        expect(result.current.loading).toBe(true);
+    });
+
+    it('should return loading true when no data yet', () => {
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValueOnce({
+            loading: true,
+            data: undefined,
+            error: undefined,
+            refetch: vi.fn(),
+        });
+        const { result } = setup();
+        expect(result.current.loading).toBe(true);
+    });
+
+    it('should return error if there is an error', () => {
+        const mockError = new Error('Test error');
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValueOnce({
+            loading: false,
+            data: undefined,
+            error: mockError,
+            refetch: vi.fn(),
+        });
+        const { result } = setup();
+        expect(result.current.error).toBe(mockError);
+    });
+
+    it('should fetch paginated assets for non-zero start', async () => {
+        const refetchMock = vi.fn().mockResolvedValue({
+            data: {
+                searchAcrossEntities: {
+                    searchResults: [{ entity: { urn: 'urn:li:glossaryTerm:term3', type: 'GlossaryTerm' } }],
+                },
+            },
+        });
+        (useGetSearchResultsForMultipleQuery as unknown as any).mockReturnValueOnce({
+            loading: false,
+            data: {
+                searchAcrossEntities: {
+                    searchResults: [{ entity: { urn: 'urn:li:glossaryTerm:term1', type: 'GlossaryTerm' } }],
+                    total: 1,
+                },
+            },
+            error: undefined,
+            refetch: refetchMock,
+        });
+
+        const { result } = setup();
+        let assets;
+        await act(async () => {
+            assets = await result.current.fetchAssets(10, 5);
+        });
+        expect(assets.length).toBe(1);
+        expect(assets[0].urn).toBe('urn:li:glossaryTerm:term3');
+        expect(refetchMock).toHaveBeenCalled();
+    });
+
+    it('should return origin entities when paginating from start=0', async () => {
+        const { result } = setup();
+        let assets;
+        await act(async () => {
+            assets = await result.current.fetchAssets(0, 10);
+        });
+        expect(assets.length).toBe(2);
+        expect(assets[0].urn).toBe('urn:li:glossaryTerm:term1');
+    });
+
+    it('should navigate to Assets Tab with correct URL', () => {
+        const { result } = setup();
+        result.current.navigateToAssetsTab();
+        expect(mockHistory.push).toHaveBeenCalledWith('/entity/url/Related Assets');
+        expect(mockRegistry.getEntityUrl).toHaveBeenCalledWith(entityType, urn);
+    });
+});

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetAssets.ts
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetAssets.ts
@@ -1,0 +1,48 @@
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import { useGetDataProductAssets } from '@app/entityV2/summary/modules/assets/useGetDataProductAssets';
+import { useGetDomainAssets } from '@app/entityV2/summary/modules/assets/useGetDomainAssets';
+
+import { EntityType } from '@types';
+
+const NUMBER_OF_ASSETS_TO_FETCH = 10;
+
+export function useGetAssets() {
+    const { entityType } = useEntityData();
+
+    const {
+        loading: domainAssetsLoading,
+        fetchAssets: fetchDomainAssets,
+        total: domainAssetsTotal,
+        navigateToAssetsTab: navigateToDomainAssetsTab,
+    } = useGetDomainAssets(NUMBER_OF_ASSETS_TO_FETCH);
+    const {
+        loading: dataProductAssetsLoading,
+        fetchAssets: fetchDataProductAssets,
+        total: dataProductAssetsTotal,
+        navigateToAssetsTab: navigateToDataProductAssetsTab,
+    } = useGetDataProductAssets(NUMBER_OF_ASSETS_TO_FETCH);
+
+    let fetchAssets;
+    let loading;
+    let total;
+    let navigateToAssetsTab;
+
+    switch (entityType) {
+        case EntityType.Domain:
+            fetchAssets = fetchDomainAssets;
+            loading = domainAssetsLoading;
+            total = domainAssetsTotal;
+            navigateToAssetsTab = navigateToDomainAssetsTab;
+            break;
+        case EntityType.DataProduct:
+            fetchAssets = fetchDataProductAssets;
+            loading = dataProductAssetsLoading;
+            total = dataProductAssetsTotal;
+            navigateToAssetsTab = navigateToDataProductAssetsTab;
+            break;
+        default:
+            break;
+    }
+
+    return { fetchAssets, loading, total, navigateToAssetsTab };
+}

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetAssets.ts
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetAssets.ts
@@ -1,6 +1,7 @@
 import { useEntityData } from '@app/entity/shared/EntityContext';
 import { useGetDataProductAssets } from '@app/entityV2/summary/modules/assets/useGetDataProductAssets';
 import { useGetDomainAssets } from '@app/entityV2/summary/modules/assets/useGetDomainAssets';
+import { useGetTermAssets } from '@app/entityV2/summary/modules/assets/useGetTermAssets';
 
 import { EntityType } from '@types';
 
@@ -22,6 +23,13 @@ export function useGetAssets() {
         navigateToAssetsTab: navigateToDataProductAssetsTab,
     } = useGetDataProductAssets(NUMBER_OF_ASSETS_TO_FETCH);
 
+    const {
+        loading: termAssetsLoading,
+        fetchAssets: fetchTermAssets,
+        total: termAssetsTotal,
+        navigateToAssetsTab: navigateToTermAssetsTab,
+    } = useGetTermAssets(NUMBER_OF_ASSETS_TO_FETCH);
+
     let fetchAssets;
     let loading;
     let total;
@@ -39,6 +47,12 @@ export function useGetAssets() {
             loading = dataProductAssetsLoading;
             total = dataProductAssetsTotal;
             navigateToAssetsTab = navigateToDataProductAssetsTab;
+            break;
+        case EntityType.GlossaryTerm:
+            fetchAssets = fetchTermAssets;
+            loading = termAssetsLoading;
+            total = termAssetsTotal;
+            navigateToAssetsTab = navigateToTermAssetsTab;
             break;
         default:
             break;

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetDataProductAssets.ts
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetDataProductAssets.ts
@@ -1,0 +1,69 @@
+import { useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+import { useListDataProductAssetsQuery } from '@graphql/search.generated';
+import { Entity, EntityType } from '@types';
+
+const NUMBER_OF_ASSETS_TO_FETCH = 10;
+
+export const useGetDataProductAssets = (initialCount = NUMBER_OF_ASSETS_TO_FETCH) => {
+    const { urn, entityType } = useEntityData();
+    const history = useHistory();
+
+    const getInputVariables = useCallback(
+        (start: number, count: number) => ({
+            urn,
+            input: {
+                query: '*',
+                start,
+                count,
+                searchFlags: { skipCache: true },
+            },
+        }),
+        [urn],
+    );
+
+    const {
+        loading: searchLoading,
+        data,
+        error,
+        refetch,
+    } = useListDataProductAssetsQuery({
+        variables: getInputVariables(0, initialCount),
+        skip: entityType !== EntityType.DataProduct,
+        fetchPolicy: 'cache-first',
+    });
+
+    const entityRegistry = useEntityRegistryV2();
+    const originEntities = useMemo(
+        () => data?.listDataProductAssets?.searchResults?.map((result) => result.entity) || [],
+        [data?.listDataProductAssets?.searchResults],
+    );
+    const entities =
+        originEntities.map((entity) => entityRegistry.getGenericEntityProperties(entity.type, entity)) || [];
+    const total = data?.listDataProductAssets?.total || 0;
+    const loading = searchLoading || !data;
+
+    // For fetching paginated entities based on start and count
+    const fetchAssets = useCallback(
+        async (start: number, count: number): Promise<Entity[]> => {
+            if (start === 0) {
+                return originEntities;
+            }
+
+            const result = await refetch(getInputVariables(start, count));
+
+            return result.data?.listDataProductAssets?.searchResults?.map((res) => res.entity) || [];
+        },
+        [refetch, getInputVariables, originEntities],
+    );
+
+    const navigateToAssetsTab = () => {
+        history.push(`${entityRegistry.getEntityUrl(entityType, urn)}/Assets`);
+    };
+
+    return { originEntities, entities, loading, error, total, fetchAssets, navigateToAssetsTab };
+};

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetDomainAssets.ts
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetDomainAssets.ts
@@ -1,0 +1,76 @@
+import { useCallback, useMemo } from 'react';
+import { useHistory } from 'react-router';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import { navigateToDomainEntities } from '@app/entityV2/shared/containers/profile/sidebar/Domain/utils';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
+import { Entity, EntityType } from '@types';
+
+const NUMBER_OF_ASSETS_TO_FETCH = 10;
+
+export const useGetDomainAssets = (initialCount = NUMBER_OF_ASSETS_TO_FETCH) => {
+    const { urn, entityType } = useEntityData();
+    const history = useHistory();
+
+    const getInputVariables = useCallback(
+        (start: number, count: number) => ({
+            input: {
+                query: '*',
+                start,
+                count,
+                filters: [
+                    { field: '_entityType', values: ['DATA_PRODUCT'], value: 'DATA_PRODUCT', negated: true },
+                    {
+                        field: 'domains',
+                        values: [urn],
+                    },
+                ],
+                searchFlags: { skipCache: true },
+            },
+        }),
+        [urn],
+    );
+
+    const {
+        loading: searchLoading,
+        data,
+        error,
+        refetch,
+    } = useGetSearchResultsForMultipleQuery({
+        variables: getInputVariables(0, initialCount),
+        skip: entityType !== EntityType.Domain,
+        fetchPolicy: 'cache-first',
+    });
+
+    const entityRegistry = useEntityRegistryV2();
+    const originEntities = useMemo(
+        () => data?.searchAcrossEntities?.searchResults?.map((result) => result.entity) || [],
+        [data?.searchAcrossEntities?.searchResults],
+    );
+    const entities =
+        originEntities.map((entity) => entityRegistry.getGenericEntityProperties(entity.type, entity)) || [];
+    const total = data?.searchAcrossEntities?.total || 0;
+    const loading = searchLoading || !data;
+
+    // For fetching paginated entities based on start and count
+    const fetchAssets = useCallback(
+        async (start: number, count: number): Promise<Entity[]> => {
+            if (start === 0) {
+                return originEntities;
+            }
+
+            const result = await refetch(getInputVariables(start, count));
+
+            return result.data?.searchAcrossEntities?.searchResults?.map((res) => res.entity) || [];
+        },
+        [refetch, getInputVariables, originEntities],
+    );
+
+    const navigateToAssetsTab = () => {
+        navigateToDomainEntities(urn, entityType, history, entityRegistry);
+    };
+
+    return { originEntities, entities, loading, error, total, fetchAssets, navigateToAssetsTab };
+};

--- a/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetTermAssets.ts
+++ b/datahub-web-react/src/app/entityV2/summary/modules/assets/useGetTermAssets.ts
@@ -2,8 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useHistory } from 'react-router';
 
 import { useEntityData } from '@app/entity/shared/EntityContext';
-import { navigateToDomainEntities } from '@app/entityV2/shared/containers/profile/sidebar/Domain/utils';
-import { DOMAINS_FILTER_NAME, ENTITY_FILTER_NAME } from '@app/searchV2/utils/constants';
+import { FIELD_GLOSSARY_TERMS_FILTER_NAME, GLOSSARY_TERMS_FILTER_NAME } from '@app/searchV2/utils/constants';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 
 import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
@@ -11,7 +10,7 @@ import { Entity, EntityType } from '@types';
 
 const NUMBER_OF_ASSETS_TO_FETCH = 10;
 
-export const useGetDomainAssets = (initialCount = NUMBER_OF_ASSETS_TO_FETCH) => {
+export const useGetTermAssets = (initialCount = NUMBER_OF_ASSETS_TO_FETCH) => {
     const { urn, entityType } = useEntityData();
     const history = useHistory();
 
@@ -23,13 +22,11 @@ export const useGetDomainAssets = (initialCount = NUMBER_OF_ASSETS_TO_FETCH) => 
                 count,
                 filters: [
                     {
-                        field: ENTITY_FILTER_NAME,
-                        values: [EntityType.DataProduct],
-                        value: EntityType.DataProduct,
-                        negated: true,
+                        field: GLOSSARY_TERMS_FILTER_NAME,
+                        values: [urn],
                     },
                     {
-                        field: DOMAINS_FILTER_NAME,
+                        field: FIELD_GLOSSARY_TERMS_FILTER_NAME,
                         values: [urn],
                     },
                 ],
@@ -46,7 +43,7 @@ export const useGetDomainAssets = (initialCount = NUMBER_OF_ASSETS_TO_FETCH) => 
         refetch,
     } = useGetSearchResultsForMultipleQuery({
         variables: getInputVariables(0, initialCount),
-        skip: entityType !== EntityType.Domain,
+        skip: entityType !== EntityType.GlossaryTerm,
         fetchPolicy: 'cache-first',
     });
 
@@ -75,7 +72,7 @@ export const useGetDomainAssets = (initialCount = NUMBER_OF_ASSETS_TO_FETCH) => 
     );
 
     const navigateToAssetsTab = () => {
-        navigateToDomainEntities(urn, entityType, history, entityRegistry);
+        history.push(`${entityRegistry.getEntityUrl(entityType, urn)}/Related Assets`);
     };
 
     return { originEntities, entities, loading, error, total, fetchAssets, navigateToAssetsTab };

--- a/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.test.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.test.ts
@@ -27,7 +27,7 @@ describe('getDefaultSummaryPageTemplate', () => {
         });
 
         // Verify modules array has content (but don't test specific content since it will change)
-        expect(result.properties.rows[0].modules).toHaveLength(1);
+        expect(result.properties.rows[0].modules).toHaveLength(2);
     });
 
     it('should return correct template for DataProduct entity type', () => {
@@ -57,7 +57,7 @@ describe('getDefaultSummaryPageTemplate', () => {
         });
 
         // Verify modules array has content (but don't test specific content since it will change)
-        expect(result.properties.rows[0].modules).toHaveLength(1);
+        expect(result.properties.rows[0].modules).toHaveLength(2);
     });
 
     it('should return correct template for GlossaryTerm entity type', () => {
@@ -85,7 +85,7 @@ describe('getDefaultSummaryPageTemplate', () => {
         });
 
         // Verify modules array has content (but don't test specific content since it will change)
-        expect(result.properties.rows[0].modules).toHaveLength(1);
+        expect(result.properties.rows[0].modules).toHaveLength(2);
     });
 
     it('should return correct template for GlossaryNode entity type', () => {

--- a/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.ts
@@ -22,6 +22,19 @@ const domainsModule: PageModuleFragment = {
     },
 };
 
+const asssetsModule: PageModuleFragment = {
+    urn: 'urn:li:dataHubPageModule:assets',
+    type: EntityType.DatahubPageModule,
+    properties: {
+        name: 'Assets',
+        type: DataHubPageModuleType.Assets,
+        visibility: {
+            scope: PageModuleScope.Global,
+        },
+        params: {},
+    },
+};
+
 const CREATED = { elementType: SummaryElementType.Created };
 const OWNERS = { elementType: SummaryElementType.Owners };
 const DOMAIN = { elementType: SummaryElementType.Domain };
@@ -35,15 +48,15 @@ export function getDefaultSummaryPageTemplate(entityType: EntityType): PageTempl
 
     switch (entityType) {
         case EntityType.Domain:
-            modules = [domainsModule];
+            modules = [domainsModule, asssetsModule];
             summaryElements = [CREATED, OWNERS];
             break;
         case EntityType.DataProduct:
-            modules = [domainsModule];
+            modules = [domainsModule, asssetsModule];
             summaryElements = [CREATED, OWNERS, DOMAIN, TAGS, GLOSSARY_TERMS];
             break;
         case EntityType.GlossaryTerm:
-            modules = [domainsModule];
+            modules = [domainsModule, asssetsModule];
             summaryElements = [CREATED, OWNERS, DOMAIN];
             break;
         case EntityType.GlossaryNode:

--- a/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.ts
@@ -1,3 +1,5 @@
+import { ASSETS_MODULE } from '@app/homeV3/template/components/addModuleMenu/useAddModuleMenu';
+
 import { PageModuleFragment, PageTemplateFragment } from '@graphql/template.generated';
 import {
     DataHubPageModuleType,
@@ -22,19 +24,6 @@ const domainsModule: PageModuleFragment = {
     },
 };
 
-const asssetsModule: PageModuleFragment = {
-    urn: 'urn:li:dataHubPageModule:assets',
-    type: EntityType.DatahubPageModule,
-    properties: {
-        name: 'Assets',
-        type: DataHubPageModuleType.Assets,
-        visibility: {
-            scope: PageModuleScope.Global,
-        },
-        params: {},
-    },
-};
-
 const CREATED = { elementType: SummaryElementType.Created };
 const OWNERS = { elementType: SummaryElementType.Owners };
 const DOMAIN = { elementType: SummaryElementType.Domain };
@@ -48,15 +37,15 @@ export function getDefaultSummaryPageTemplate(entityType: EntityType): PageTempl
 
     switch (entityType) {
         case EntityType.Domain:
-            modules = [domainsModule, asssetsModule];
+            modules = [domainsModule, ASSETS_MODULE];
             summaryElements = [CREATED, OWNERS];
             break;
         case EntityType.DataProduct:
-            modules = [domainsModule, asssetsModule];
+            modules = [domainsModule, ASSETS_MODULE];
             summaryElements = [CREATED, OWNERS, DOMAIN, TAGS, GLOSSARY_TERMS];
             break;
         case EntityType.GlossaryTerm:
-            modules = [domainsModule, asssetsModule];
+            modules = [domainsModule, ASSETS_MODULE];
             summaryElements = [CREATED, OWNERS, DOMAIN];
             break;
         case EntityType.GlossaryNode:

--- a/datahub-web-react/src/app/homeV3/module/Module.tsx
+++ b/datahub-web-react/src/app/homeV3/module/Module.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useMemo } from 'react';
 
+import AssetsModule from '@app/entityV2/summary/modules/assets/AssetsModule';
 import ModuleErrorBoundary from '@app/homeV3/module/components/ModuleErrorBoundary';
 import { ModuleProps } from '@app/homeV3/module/types';
 import SampleLargeModule from '@app/homeV3/modules/SampleLargeModule';
@@ -23,6 +24,7 @@ function Module(props: ModuleProps) {
         if (module.properties.type === DataHubPageModuleType.Link) return LinkModule;
         if (module.properties.type === DataHubPageModuleType.RichText) return DocumentationModule;
         if (module.properties.type === DataHubPageModuleType.Hierarchy) return HierarchyViewModule;
+        if (module.properties.type === DataHubPageModuleType.Assets) return AssetsModule;
 
         // TODO: remove the sample large module once we have other modules to fill this out
         console.error(`Issue finding module with type ${module.properties.type}`);

--- a/datahub-web-react/src/app/homeV3/modules/constants.ts
+++ b/datahub-web-react/src/app/homeV3/modules/constants.ts
@@ -29,6 +29,7 @@ export const DEFAULT_MODULE_URNS = [
     'urn:li:dataHubPageModule:your_assets',
     'urn:li:dataHubPageModule:your_subscriptions',
     'urn:li:dataHubPageModule:top_domains',
+    'urn:li:dataHubPageModule:assets',
 ];
 
 export const DEFAULT_TEMPLATE_URN = 'urn:li:dataHubPageTemplate:home_default_1';
@@ -57,6 +58,7 @@ export const LARGE_MODULE_TYPES: DataHubPageModuleType[] = [
     DataHubPageModuleType.AssetCollection,
     DataHubPageModuleType.Hierarchy,
     DataHubPageModuleType.RichText,
+    DataHubPageModuleType.Assets,
 ];
 
 export const SMALL_MODULE_TYPES: DataHubPageModuleType[] = [DataHubPageModuleType.Link];

--- a/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/__tests__/useAddModuleMenu.test.tsx
+++ b/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/__tests__/useAddModuleMenu.test.tsx
@@ -140,7 +140,7 @@ describe('useAddModuleMenu', () => {
         // Check "Default by DataHub" group
         expect(items?.[1]).toHaveProperty('key', 'customLargeModulesGroup');
         // @ts-expect-error SubMenuItem should have children
-        expect(items?.[1]?.children).toHaveLength(2);
+        expect(items?.[1]?.children).toHaveLength(3);
         // @ts-expect-error SubMenuItem should have children
         expect(items?.[1]?.children?.[0]).toHaveProperty('key', 'your-assets');
         // @ts-expect-error SubMenuItem should have children

--- a/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
+++ b/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
@@ -37,7 +37,7 @@ const DOMAINS_MODULE: PageModuleFragment = {
     },
 };
 
-const ASSETS_MODULE: PageModuleFragment = {
+export const ASSETS_MODULE: PageModuleFragment = {
     urn: 'urn:li:dataHubPageModule:assets',
     type: EntityType.DatahubPageModule,
     properties: {

--- a/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
+++ b/datahub-web-react/src/app/homeV3/template/components/addModuleMenu/useAddModuleMenu.tsx
@@ -37,6 +37,17 @@ const DOMAINS_MODULE: PageModuleFragment = {
     },
 };
 
+const ASSETS_MODULE: PageModuleFragment = {
+    urn: 'urn:li:dataHubPageModule:assets',
+    type: EntityType.DatahubPageModule,
+    properties: {
+        name: 'Assets',
+        type: DataHubPageModuleType.Assets,
+        visibility: { scope: PageModuleScope.Global },
+        params: {},
+    },
+};
+
 export default function useAddModuleMenu(position: ModulePositionInput, closeMenu: () => void) {
     const {
         addModule,
@@ -168,11 +179,28 @@ export default function useAddModuleMenu(position: ModulePositionInput, closeMen
             'data-testid': 'add-domains-module',
         };
 
+        const assets = {
+            name: 'Assets',
+            key: 'assets',
+            label: (
+                <MenuItem
+                    description="Related Assets tagged with the parent entity"
+                    title="Assets"
+                    icon="Database"
+                    isSmallModule={false}
+                />
+            ),
+            onClick: () => {
+                handleAddExistingModule(ASSETS_MODULE);
+            },
+            'data-testid': 'add-assets-module',
+        };
+
         items.push({
             key: 'customLargeModulesGroup',
             label: <GroupItem title="Default" />,
             type: 'group',
-            children: [yourAssets, domains],
+            children: [yourAssets, domains, assets],
         });
 
         // Add global custom modules if available

--- a/metadata-models/src/main/pegasus/com/linkedin/module/DataHubPageModuleType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/module/DataHubPageModuleType.pdl
@@ -28,4 +28,8 @@ enum DataHubPageModuleType {
    * Module displaying the top domains
    */
   DOMAINS
+  /**
+   * Module displaying the assets of parent entity
+   */
+  ASSETS
 }

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -44,7 +44,7 @@ bootstrap:
       mcps_location: "bootstrap_mcps/roles.yaml"
 
     - name: page-modules
-      version: v3
+      version: v4
       blocking: true
       async: false
       mcps_location: "bootstrap_mcps/page-modules.yaml"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-modules.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/page-modules.yaml
@@ -25,3 +25,15 @@
     params: {}
     created: {{&auditStamp}}
     lastModified: {{&auditStamp}}
+- entityUrn: urn:li:dataHubPageModule:assets
+  entityType: dataHubPageModule
+  aspectName: dataHubPageModuleProperties
+  changeType: UPSERT
+  aspect:
+    name: "Assets"
+    type: ASSETS
+    visibility:
+      scope: GLOBAL
+    params: {}
+    created: {{&auditStamp}}
+    lastModified: {{&auditStamp}}

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageModuleService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/PageModuleService.java
@@ -37,7 +37,8 @@ public class PageModuleService {
       List.of(
           "urn:li:dataHubPageModule:your_assets",
           "urn:li:dataHubPageModule:your_subscriptions",
-          "urn:li:dataHubPageModule:top_domains");
+          "urn:li:dataHubPageModule:top_domains",
+          "urn:li:dataHubPageModule:assets");
 
   public PageModuleService(@Nonnull EntityClient entityClient) {
     this.entityClient = entityClient;

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/PageModuleServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/PageModuleServiceTest.java
@@ -272,7 +272,8 @@ public class PageModuleServiceTest {
     String[] defaultModuleUrns = {
       "urn:li:dataHubPageModule:your_assets",
       "urn:li:dataHubPageModule:your_subscriptions",
-      "urn:li:dataHubPageModule:top_domains"
+      "urn:li:dataHubPageModule:top_domains",
+      "urn:li:dataHubPageModule:assets"
     };
 
     for (String defaultModuleUrn : defaultModuleUrns) {


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-722/support-assets-module-on-summary-pages

Description:

Supports Asset module on summary pages for domain and data products.

TODO: 
- Add support on glossary term pages
- Do not show this module item in add menu on home page


**Screenshots:**

<img width="1512" height="858" alt="image" src="https://github.com/user-attachments/assets/6c8c8c83-3b12-42cb-bdaa-5a7584dd05b9" />

<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/d91cc42f-a61e-4e2e-8fff-a318efc0b1ae" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
