### PR TITLE
fix(docs): update usage_stats optionality

### DIFF
--- a/metadata-ingestion/docs/sources/redshift/redshift_pre.md
+++ b/metadata-ingestion/docs/sources/redshift/redshift_pre.md
@@ -107,7 +107,7 @@ shows up correctly after datashare consumer namespace is ingested.
 
 ### Profiling
 
-Profiling runs sql queries on the redshift cluster to get statistics about the tables. To be able to do that, the user needs to have read access to the tables that should be profiled.
+Profiling runs sql queries on the redshift cluster to get statistics about the tables. In order to do that, the user needs to have read access on the tables that should be profiled.
 
 If you don't want to grant read access to the tables you can enable table level profiling which will get table statistics without reading the data.
 

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -143,7 +143,7 @@ logger: logging.Logger = logging.getLogger(__name__)
 @capability(SourceCapability.SCHEMA_METADATA, "Enabled by default")
 @capability(
     SourceCapability.USAGE_STATS,
-    "Enabled by default, can be disabled via configuration `include_usage_statistics`",
+    "Optionally enabled via `include_usage_statistics`",
 )
 @capability(
     SourceCapability.DELETION_DETECTION, "Enabled by default via stateful ingestion"


### PR DESCRIPTION
Dataset Usage not actually enabled by default for redshift.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
