### PR TITLE
Fix asset count mismatch in domain summary

### DIFF
--- a/datahub-web-react/src/app/entityV2/domain/summary/ContentsSection.tsx
+++ b/datahub-web-react/src/app/entityV2/domain/summary/ContentsSection.tsx
@@ -38,7 +38,7 @@ export const ContentsSection = () => {
     const { entityState } = useEntityContext();
     const history = useHistory();
     const entityRegistry = useEntityRegistry();
-    const { urn, entityType } = useEntityData();
+    const { urn, entityType, entityData } = useEntityData();
     const { data, loading, refetch } = useGetDomainEntitySummaryQuery({
         variables: {
             urn,
@@ -46,7 +46,9 @@ export const ContentsSection = () => {
     });
 
     const contentsSummary = data?.aggregateAcrossEntities && getContentsSummary(data.aggregateAcrossEntities as any);
-    const contentsCount = contentsSummary?.total || 0;
+    // Use the direct entity count from entityData instead of aggregated facet count to ensure consistency
+    // This ensures the count matches what's shown in other parts of the UI like tabs and preview cards
+    const contentsCount = (entityData as any)?.entities?.total || 0;
     const hasContents = contentsCount > 0;
 
     const shouldRefetch = entityState?.shouldRefetchContents;

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Container/SidebarContentsSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Container/SidebarContentsSection.tsx
@@ -40,7 +40,7 @@ const ViewAllButton = styled.div`
 `;
 
 const SidebarContentsSection = () => {
-    const { urn, entityType } = useEntityData();
+    const { urn, entityType, entityData } = useEntityData();
     const entityRegistry = useEntityRegistry();
     const history = useHistory();
     const { data, loading } = useGetContainerEntitySummaryQuery({
@@ -51,7 +51,9 @@ const SidebarContentsSection = () => {
     });
 
     const contentsSummary = data?.aggregateAcrossEntities && getContentsSummary(data.aggregateAcrossEntities as any);
-    const contentsCount = contentsSummary?.total || 0;
+    // Use the direct entity count from entityData instead of aggregated facet count to ensure consistency
+    // This ensures the count matches what's shown in other parts of the UI like tabs and preview cards
+    const contentsCount = (entityData as any)?.entities?.total || 0;
     const hasContents = contentsCount > 0;
 
     return (

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Domain/SidebarEntitiesSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Domain/SidebarEntitiesSection.tsx
@@ -40,7 +40,7 @@ const ViewAllButton = styled.div`
 `;
 
 const SidebarEntitiesSection = () => {
-    const { urn, entityType } = useEntityData();
+    const { urn, entityType, entityData } = useEntityData();
     const entityRegistry = useEntityRegistry();
     const { entityState } = useEntityContext();
     const history = useHistory();
@@ -59,7 +59,9 @@ const SidebarEntitiesSection = () => {
     }, [shouldRefetch, entityState, refetch]);
 
     const contentsSummary = data?.aggregateAcrossEntities && getContentsSummary(data.aggregateAcrossEntities as any);
-    const contentsCount = contentsSummary?.total || 0;
+    // Use the direct entity count from entityData instead of aggregated facet count to ensure consistency
+    // This ensures the count matches what's shown in other parts of the UI like tabs and preview cards
+    const contentsCount = (entityData as any)?.entities?.total || 0;
     const hasContents = contentsCount > 0;
 
     return (


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
**[BUG] Fix inconsistent asset counts in Domain and Container summaries**

**WHY**:
The Domain and Container summary and sidebar sections displayed an incorrect asset count. This discrepancy arose because these components were using aggregated facet counts from the `aggregateAcrossEntities` GraphQL query, which could sometimes be inconsistent or inaccurate. This led to a mismatch with the correct counts displayed in other UI elements, such as entity tabs and preview cards, which rely on direct entity counts.

**WHAT**:
This PR modifies three frontend components to consistently use the direct entity count (`entityData?.entities?.total`) instead of the aggregated facet counts:
1.  `datahub-web-react/src/app/entityV2/domain/summary/ContentsSection.tsx`
2.  `datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Container/SidebarContentsSection.tsx`
3.  `datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Domain/SidebarEntitiesSection.tsx`

**IMPACT**:
Ensures accurate and consistent asset counts across the DataHub UI for Domain and Container entities, resolving the reported discrepancy (OSS-306).

**Related Issue**:
[OSS-306](https://linear.app/acryl-data/issue/OSS-306)

---
Linear Issue: [OSS-306](https://linear.app/acryl-data/issue/OSS-306/the-number-of-assets-in-the-summary-doesnt-match-the-actual-number-of)

<a href="https://cursor.com/background-agent?bcId=bc-5c4c413c-0bcf-4ca2-bc3d-c49138da1aab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c4c413c-0bcf-4ca2-bc3d-c49138da1aab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

