### PR TITLE
fix(ingest/path_spec): make dir_allowed work with tables_filter_pattern

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
@@ -221,9 +221,9 @@ class PathSpec(ConfigModel):
                 ):
                     return False
 
-        file_name_pattern = self.include.rsplit("/", 1)[1]
+        dummy_rest_of_path = self.include.split("/")[path_slash:]
         table_name, _ = self.extract_table_name_and_path(
-            os.path.join(path, file_name_pattern)
+            os.path.join(path, *dummy_rest_of_path)
         )
         if not self.tables_filter_pattern.allowed(table_name):
             return False

--- a/metadata-ingestion/tests/integration/s3/golden-files/gcs/golden_mces_allow_table.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/gcs/golden_mces_allow_table.json
@@ -8,13 +8,13 @@
         "json": {
             "customProperties": {
                 "schema_inferred_from": "gs://my-test-bucket/folder_a/folder_aa/folder_aaa/folder_aaaa/pokemon_abilities_yearwise_2021/month=march/part2.json",
-                "number_of_partitions": "6"
+                "number_of_partitions": "1"
             },
             "externalUrl": "https://console.cloud.google.com/storage/browser/my-test-bucket/folder_a/folder_aa/folder_aaa/folder_aaaa",
             "name": "folder_aaaa",
             "description": "",
             "created": {
-                "time": 1586847680000
+                "time": 1586847780000
             },
             "lastModified": {
                 "time": 1586847790000
@@ -628,9 +628,9 @@
     "aspect": {
         "json": {
             "minPartition": {
-                "partition": "partition_0=pokemon_abilities_yearwise_2019/partition_1=month=feb",
-                "createdTime": 1586847680000,
-                "lastModifiedTime": 1586847690000
+                "partition": "partition_0=pokemon_abilities_yearwise_2021/partition_1=month=march",
+                "createdTime": 1586847780000,
+                "lastModifiedTime": 1586847790000
             },
             "maxPartition": {
                 "partition": "partition_0=pokemon_abilities_yearwise_2021/partition_1=month=march",

--- a/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_allow_table.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_allow_table.json
@@ -8,13 +8,13 @@
         "json": {
             "customProperties": {
                 "schema_inferred_from": "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/folder_aaaa/pokemon_abilities_yearwise_2021/month=march/part2.json",
-                "number_of_partitions": "6"
+                "number_of_partitions": "1"
             },
             "externalUrl": "https://us-east-1.console.aws.amazon.com/s3/buckets/my-test-bucket?prefix=folder_a/folder_aa/folder_aaa/folder_aaaa",
             "name": "folder_aaaa",
             "description": "",
             "created": {
-                "time": 1586847680000
+                "time": 1586847780000
             },
             "lastModified": {
                 "time": 1586847790000
@@ -628,9 +628,9 @@
     "aspect": {
         "json": {
             "minPartition": {
-                "partition": "partition_0=pokemon_abilities_yearwise_2019/partition_1=month=feb",
-                "createdTime": 1586847680000,
-                "lastModifiedTime": 1586847690000
+                "partition": "partition_0=pokemon_abilities_yearwise_2021/partition_1=month=march",
+                "createdTime": 1586847780000,
+                "lastModifiedTime": 1586847790000
             },
             "maxPartition": {
                 "partition": "partition_0=pokemon_abilities_yearwise_2021/partition_1=month=march",

--- a/metadata-ingestion/tests/unit/data_lake/test_path_spec.py
+++ b/metadata-ingestion/tests/unit/data_lake/test_path_spec.py
@@ -331,6 +331,25 @@ def test_dir_allowed_with_debug_logging() -> None:
     assert result is True
 
 
+@pytest.mark.parametrize(
+    "include, allowed",
+    [
+        ("s3://bucket/{table}/1/*.json", "s3://bucket/table/1/"),
+        ("s3://bucket/{table}/1/*/*.json", "s3://bucket/table/1/"),
+        ("s3://bucket/{table}/1/*/*.json", "s3://bucket/table/1/2/"),
+    ],
+)
+def test_dir_allowed_with_table_filter_pattern(include: str, allowed: str) -> None:
+    """Test dir_allowed method with table filter patterns."""
+    path_spec = PathSpec(
+        include=include,
+        tables_filter_pattern=AllowDenyPattern(
+            allow=["^table$"],
+        ),
+    )
+    assert path_spec.dir_allowed(allowed) is True
+
+
 # Tests for get_parsable_include classmethod
 @pytest.mark.parametrize(
     "include, expected",


### PR DESCRIPTION
Also includes a change to `allow_table` test because it was relying on the broken behavior to traverse all partitions, since the partition listing logic would disallow the partition folders and just return the base table path.