### PR TITLE
feat(s3/ingest): performance improvements for get_dir_to_process and get_folder_info

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/s3_boto_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/s3_boto_utils.py
@@ -126,7 +126,10 @@ def list_folders_path(
 
 
 def list_objects_recursive_path(
-    s3_uri: str, *, startswith: str, aws_config: Optional[AwsConnectionConfig]
+    s3_uri: str,
+    *,
+    startswith: str = "",
+    aws_config: Optional[AwsConnectionConfig] = None,
 ) -> Iterable["ObjectSummary"]:
     """
     Given an S3 URI to a folder or bucket, return all objects underneath that URI, optionally

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
@@ -221,9 +221,9 @@ class PathSpec(ConfigModel):
                 ):
                     return False
 
-        file_name_pattern = self.include.rsplit("/", 1)[1]
+        dummy_rest_of_path = self.include.split("/")[path_slash:]
         table_name, _ = self.extract_table_name_and_path(
-            os.path.join(path, file_name_pattern)
+            os.path.join(path, *dummy_rest_of_path)
         )
         if not self.tables_filter_pattern.allowed(table_name):
             return False

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake_common/path_spec.py
@@ -194,6 +194,9 @@ class PathSpec(ConfigModel):
         return True
 
     def dir_allowed(self, path: str) -> bool:
+        if not path.endswith("/"):
+            path += "/"
+
         if self.glob_include.endswith("**"):
             return self.allowed(path, ignore_ext=True)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -878,9 +878,6 @@ class S3Source(StatefulIngestionSourceBase):
         protocol: str,
         min: bool = False,
     ) -> List[str]:
-        # if len(path_spec.include.split("/")) == len(f"{protocol}{bucket_name}/{folder}".split("/")):
-        #    return [f"{protocol}{bucket_name}/{folder}"]
-
         iterator = list_folders(
             bucket_name=bucket_name,
             prefix=folder,

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -1131,15 +1131,12 @@ class S3Source(StatefulIngestionSourceBase):
                     bucket = s3.Bucket(bucket_name)
 
                     # Create the full S3 path for this table
-                    table_s3_path = self.create_s3_path(bucket_name, table_folder)
-                    logger.info(
-                        f"Processing table folder: {table_folder} -> {table_s3_path}"
-                    )
+                    logger.info(f"Processing table path: {folder.path}")
 
                     # Extract table name using the ORIGINAL path spec pattern matching (not the modified one)
                     # This uses the compiled regex pattern to extract the table name from the full path
                     table_name, _ = self.extract_table_name_and_path(
-                        path_spec, table_s3_path
+                        path_spec, folder.path
                     )
 
                     # Apply table name filtering if configured

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -1149,15 +1149,9 @@ class S3Source(StatefulIngestionSourceBase):
 
                     if path_spec.traversal_method == FolderTraversalMethod.ALL:
                         # Process ALL partitions (original behavior)
-                        dirs_to_process = list(
-                            list_folders(
-                                bucket_name,
-                                table_folder,
-                                self.source_config.aws_config,
-                            )
-                        )
-                        logger.info(
-                            f"Found ALL {len(dirs_to_process)} partition folders under table {table_name}"
+                        dirs_to_process = [get_bucket_relative_path(folder.path)]
+                        logger.debug(
+                            f"Processing ALL partition folders under: {folder.path}"
                         )
 
                     else:

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -10,7 +10,6 @@ from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple
 
 import smart_open.compression as so_compression
-from more_itertools import peekable
 from pyspark.conf import SparkConf
 from pyspark.sql import SparkSession
 from pyspark.sql.dataframe import DataFrame
@@ -883,31 +882,28 @@ class S3Source(StatefulIngestionSourceBase):
             prefix=folder,
             aws_config=self.source_config.aws_config,
         )
-        iterator = peekable(iterator)
-        if iterator:
-            sorted_dirs = sorted(
-                iterator,
-                key=functools.cmp_to_key(partitioned_folder_comparator),
-                reverse=not min,
-            )
-            folders = []
-            for dir in sorted_dirs:
-                if path_spec.dir_allowed(f"{protocol}{bucket_name}/{dir}/"):
-                    folders_list = self.get_dir_to_process(
-                        bucket_name=bucket_name,
-                        folder=dir + "/",
-                        path_spec=path_spec,
-                        protocol=protocol,
-                        min=min,
-                    )
-                    folders.extend(folders_list)
-                    if path_spec.traversal_method != FolderTraversalMethod.ALL:
-                        return folders
-            if folders:
-                return folders
-            else:
-                return [f"{protocol}{bucket_name}/{folder}"]
-        return [f"{protocol}{bucket_name}/{folder}"]
+        sorted_dirs = sorted(
+            iterator,
+            key=functools.cmp_to_key(partitioned_folder_comparator),
+            reverse=not min,
+        )
+        folders = []
+        for dir in sorted_dirs:
+            if path_spec.dir_allowed(f"{protocol}{bucket_name}/{dir}/"):
+                folders_list = self.get_dir_to_process(
+                    bucket_name=bucket_name,
+                    folder=dir + "/",
+                    path_spec=path_spec,
+                    protocol=protocol,
+                    min=min,
+                )
+                folders.extend(folders_list)
+                if path_spec.traversal_method != FolderTraversalMethod.ALL:
+                    return folders
+        if folders:
+            return folders
+        else:
+            return [f"{protocol}{bucket_name}/{folder}"]
 
     def get_folder_info(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -1148,25 +1148,20 @@ class S3Source(StatefulIngestionSourceBase):
                         continue
 
                     # STEP 5: Handle partition traversal based on configuration
-                    # Get all partition folders first
-                    all_partition_folders = list(
-                        list_folders(
-                            bucket_name, table_folder, self.source_config.aws_config
-                        )
-                    )
-                    logger.info(
-                        f"Found {len(all_partition_folders)} partition folders under table {table_name} using method {path_spec.traversal_method}"
-                    )
-
-                    if all_partition_folders:
-                        # Apply the same traversal logic as the original code
+                    if True:
                         dirs_to_process = []
 
                         if path_spec.traversal_method == FolderTraversalMethod.ALL:
                             # Process ALL partitions (original behavior)
-                            dirs_to_process = all_partition_folders
-                            logger.debug(
-                                f"Processing ALL {len(all_partition_folders)} partitions"
+                            dirs_to_process = list(
+                                list_folders(
+                                    bucket_name,
+                                    table_folder,
+                                    self.source_config.aws_config,
+                                )
+                            )
+                            logger.info(
+                                f"Found ALL {len(dirs_to_process)} partition folders under table {table_name}"
                             )
 
                         else:

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -872,6 +872,12 @@ class S3Source(StatefulIngestionSourceBase):
     ) -> List[str]:
         if not uri.endswith("/"):
             uri += "/"
+        path_slash = uri.count("/")
+        glob_slash = path_spec.glob_include.count("/")
+        if path_slash == glob_slash and not path_spec.glob_include.endswith("**"):
+            # no need to list sub-folders, we're at the end of the include path
+            return [uri]
+
         iterator = list_folders_path(
             s3_uri=uri,
             aws_config=self.source_config.aws_config,

--- a/metadata-ingestion/tests/integration/s3/golden-files/gcs/golden_mces_allow_table.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/gcs/golden_mces_allow_table.json
@@ -8,13 +8,13 @@
         "json": {
             "customProperties": {
                 "schema_inferred_from": "gs://my-test-bucket/folder_a/folder_aa/folder_aaa/folder_aaaa/pokemon_abilities_yearwise_2021/month=march/part2.json",
-                "number_of_partitions": "6"
+                "number_of_partitions": "1"
             },
             "externalUrl": "https://console.cloud.google.com/storage/browser/my-test-bucket/folder_a/folder_aa/folder_aaa/folder_aaaa",
             "name": "folder_aaaa",
             "description": "",
             "created": {
-                "time": 1586847680000
+                "time": 1586847780000
             },
             "lastModified": {
                 "time": 1586847790000
@@ -628,9 +628,9 @@
     "aspect": {
         "json": {
             "minPartition": {
-                "partition": "partition_0=pokemon_abilities_yearwise_2019/partition_1=month=feb",
-                "createdTime": 1586847680000,
-                "lastModifiedTime": 1586847690000
+                "partition": "partition_0=pokemon_abilities_yearwise_2021/partition_1=month=march",
+                "createdTime": 1586847780000,
+                "lastModifiedTime": 1586847790000
             },
             "maxPartition": {
                 "partition": "partition_0=pokemon_abilities_yearwise_2021/partition_1=month=march",

--- a/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_allow_table.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_allow_table.json
@@ -8,13 +8,13 @@
         "json": {
             "customProperties": {
                 "schema_inferred_from": "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/folder_aaaa/pokemon_abilities_yearwise_2021/month=march/part2.json",
-                "number_of_partitions": "6"
+                "number_of_partitions": "1"
             },
             "externalUrl": "https://us-east-1.console.aws.amazon.com/s3/buckets/my-test-bucket?prefix=folder_a/folder_aa/folder_aaa/folder_aaaa",
             "name": "folder_aaaa",
             "description": "",
             "created": {
-                "time": 1586847680000
+                "time": 1586847780000
             },
             "lastModified": {
                 "time": 1586847790000
@@ -628,9 +628,9 @@
     "aspect": {
         "json": {
             "minPartition": {
-                "partition": "partition_0=pokemon_abilities_yearwise_2019/partition_1=month=feb",
-                "createdTime": 1586847680000,
-                "lastModifiedTime": 1586847690000
+                "partition": "partition_0=pokemon_abilities_yearwise_2021/partition_1=month=march",
+                "createdTime": 1586847780000,
+                "lastModifiedTime": 1586847790000
             },
             "maxPartition": {
                 "partition": "partition_0=pokemon_abilities_yearwise_2021/partition_1=month=march",

--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -14,7 +14,6 @@ from datahub.ingestion.run.pipeline import Pipeline, PipelineContext
 from datahub.ingestion.source.aws.aws_common import AwsConnectionConfig
 from datahub.ingestion.source.aws.s3_boto_utils import (
     list_folders_path,
-    list_objects_recursive,
     list_objects_recursive_path,
 )
 from datahub.ingestion.source.s3.source import S3Source
@@ -397,9 +396,8 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
-                call.list_objects_recursive(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                call.list_objects_recursive_path(
+                    "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
             ],
         ),
@@ -422,9 +420,8 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
-                call.list_objects_recursive(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                call.list_objects_recursive_path(
+                    "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
             ],
         ),
@@ -447,9 +444,8 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
-                call.list_objects_recursive(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                call.list_objects_recursive_path(
+                    "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/"
                 ),
             ],
         ),
@@ -464,9 +460,8 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
-                call.list_objects_recursive(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json",
+                call.list_objects_recursive_path(
+                    "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
                 ),
             ],
         ),
@@ -481,9 +476,8 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
-                call.list_objects_recursive(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json",
+                call.list_objects_recursive_path(
+                    "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
                 ),
             ],
         ),
@@ -506,16 +500,11 @@ def test_data_lake_s3_calls(s3_populate, calls_test_tuple):
 
     m = Mock()
     m.list_folders_path.side_effect = list_folders_path
-    m.list_objects_recursive.side_effect = list_objects_recursive
     m.list_objects_recursive_path.side_effect = list_objects_recursive_path
 
     with (
         patch(
             "datahub.ingestion.source.s3.source.list_folders_path", m.list_folders_path
-        ),
-        patch(
-            "datahub.ingestion.source.s3.source.list_objects_recursive",
-            m.list_objects_recursive,
         ),
         patch(
             "datahub.ingestion.source.s3.source.list_objects_recursive_path",

--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -412,11 +412,7 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
                 call.list_folders_path(
-                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
-                    startswith="year=2022",
-                ),
-                call.list_folders_path(
-                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022",
                     startswith="month=",
                 ),
                 call.list_objects_recursive_path(

--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -390,10 +390,6 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
                 call.list_folders(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json",
-                ),
-                call.list_folders(
                     bucket_name="my-test-bucket",
                     prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
                 ),
@@ -422,10 +418,6 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
                 call.list_folders(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json",
-                ),
-                call.list_folders(
                     bucket_name="my-test-bucket",
                     prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
                 ),
@@ -452,10 +444,6 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
             [
                 call.list_folders_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
-                ),
-                call.list_folders(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json",
                 ),
                 call.list_folders(
                     bucket_name="my-test-bucket",

--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -395,6 +395,7 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 ),
                 call.list_objects_recursive_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                    startswith="part",
                 ),
             ],
         ),
@@ -416,6 +417,7 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 ),
                 call.list_objects_recursive_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                    startswith="",
                 ),
             ],
         ),
@@ -439,7 +441,8 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
                 call.list_objects_recursive_path(
-                    "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/"
+                    "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                    startswith="",
                 ),
             ],
         ),
@@ -456,6 +459,7 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 ),
                 call.list_objects_recursive_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
+                    startswith="year=",
                 ),
             ],
         ),
@@ -471,7 +475,8 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
                 call.list_objects_recursive_path(
-                    "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
+                    "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022",
+                    startswith="month=",
                 ),
             ],
         ),

--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -393,9 +393,6 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
                 ),
-                call.list_folders_path(
-                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
-                ),
                 call.list_objects_recursive_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
@@ -416,9 +413,6 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 ),
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
-                ),
-                call.list_folders_path(
-                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
                 call.list_objects_recursive_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",

--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -389,9 +389,11 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 ),
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
+                    startswith="year=",
                 ),
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
+                    startswith="month=",
                 ),
                 call.list_objects_recursive_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
@@ -411,9 +413,11 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 ),
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
+                    startswith="year=2022",
                 ),
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
+                    startswith="month=",
                 ),
                 call.list_objects_recursive_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
@@ -432,13 +436,16 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
                 call.list_folders_path(
-                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/"
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
+                    startswith="",
                 ),
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
+                    startswith="",
                 ),
                 call.list_folders_path(
                     s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                    startswith="",
                 ),
                 call.list_objects_recursive_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",

--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -13,7 +13,6 @@ from pydantic import ValidationError
 from datahub.ingestion.run.pipeline import Pipeline, PipelineContext
 from datahub.ingestion.source.aws.aws_common import AwsConnectionConfig
 from datahub.ingestion.source.aws.s3_boto_utils import (
-    list_folders,
     list_folders_path,
     list_objects_recursive,
     list_objects_recursive_path,
@@ -389,21 +388,18 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
-                call.list_folders(
-                    bucket_name="my-test-bucket",
-                    prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
+                call.list_folders_path(
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
                 ),
-                call.list_folders(
-                    bucket_name="my-test-bucket",
-                    prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
+                call.list_folders_path(
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
                 ),
-                call.list_folders(
-                    bucket_name="my-test-bucket",
-                    prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                call.list_folders_path(
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
                 call.list_objects_recursive(
                     "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan",
+                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
             ],
         ),
@@ -417,21 +413,18 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
-                call.list_folders(
-                    bucket_name="my-test-bucket",
-                    prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
+                call.list_folders_path(
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
                 ),
-                call.list_folders(
-                    bucket_name="my-test-bucket",
-                    prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
+                call.list_folders_path(
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
                 ),
-                call.list_folders(
-                    bucket_name="my-test-bucket",
-                    prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                call.list_folders_path(
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
                 call.list_objects_recursive(
                     "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan",
+                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
             ],
         ),
@@ -445,21 +438,18 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
-                call.list_folders(
-                    bucket_name="my-test-bucket",
-                    prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/",
+                call.list_folders_path(
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/"
                 ),
-                call.list_folders(
-                    bucket_name="my-test-bucket",
-                    prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
+                call.list_folders_path(
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/",
                 ),
-                call.list_folders(
-                    bucket_name="my-test-bucket",
-                    prefix="folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
+                call.list_folders_path(
+                    s3_uri="s3://my-test-bucket/folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
                 call.list_objects_recursive(
                     "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan",
+                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json/year=2022/month=jan/",
                 ),
             ],
         ),
@@ -515,13 +505,11 @@ def test_data_lake_s3_calls(s3_populate, calls_test_tuple):
     source = S3Source.create(config, ctx)
 
     m = Mock()
-    m.list_folders.side_effect = list_folders
     m.list_folders_path.side_effect = list_folders_path
     m.list_objects_recursive.side_effect = list_objects_recursive
     m.list_objects_recursive_path.side_effect = list_objects_recursive_path
 
     with (
-        patch("datahub.ingestion.source.s3.source.list_folders", m.list_folders),
         patch(
             "datahub.ingestion.source.s3.source.list_folders_path", m.list_folders_path
         ),

--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -474,10 +474,6 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
                 call.list_folders_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
                 ),
-                call.list_folders(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json",
-                ),
                 call.list_objects_recursive(
                     "my-test-bucket",
                     "folder_a/folder_aa/folder_aaa/pokemon_abilities_json",
@@ -494,10 +490,6 @@ def test_data_lake_incorrect_config_raises_error(tmp_path, mock_time):
             [
                 call.list_folders_path(
                     "s3://my-test-bucket/folder_a/folder_aa/folder_aaa/"
-                ),
-                call.list_folders(
-                    "my-test-bucket",
-                    "folder_a/folder_aa/folder_aaa/pokemon_abilities_json",
                 ),
                 call.list_objects_recursive(
                     "my-test-bucket",

--- a/metadata-ingestion/tests/unit/data_lake/test_path_spec.py
+++ b/metadata-ingestion/tests/unit/data_lake/test_path_spec.py
@@ -331,6 +331,25 @@ def test_dir_allowed_with_debug_logging() -> None:
     assert result is True
 
 
+@pytest.mark.parametrize(
+    "include, allowed",
+    [
+        ("s3://bucket/{table}/1/*.json", "s3://bucket/table/1/"),
+        ("s3://bucket/{table}/1/*/*.json", "s3://bucket/table/1/"),
+        ("s3://bucket/{table}/1/*/*.json", "s3://bucket/table/1/2/"),
+    ],
+)
+def test_dir_allowed_with_table_filter_pattern(include: str, allowed: str) -> None:
+    """Test dir_allowed method with table filter patterns."""
+    path_spec = PathSpec(
+        include=include,
+        tables_filter_pattern=AllowDenyPattern(
+            allow=["^table$"],
+        ),
+    )
+    assert path_spec.dir_allowed(allowed) is True
+
+
 # Tests for get_parsable_include classmethod
 @pytest.mark.parametrize(
     "include, expected",

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -314,7 +314,8 @@ def test_get_folder_info_returns_latest_file_in_each_folder(s3_resource):
 
     # act
     res = _get_s3_source(path_spec).get_folder_info(
-        path_spec, bucket, prefix="my-folder"
+        path_spec,
+        "s3://my-bucket/my-folder",
     )
     res = list(res)
 
@@ -343,7 +344,7 @@ def test_get_folder_info_ignores_disallowed_path(s3_resource, caplog):
     s3_source = _get_s3_source(path_spec)
 
     # act
-    res = s3_source.get_folder_info(path_spec, bucket, prefix="my-folder")
+    res = s3_source.get_folder_info(path_spec, "s3://my-bucket/my-folder")
     res = list(res)
 
     # assert
@@ -377,7 +378,8 @@ def test_get_folder_info_returns_expected_folder(s3_resource):
 
     # act
     res = _get_s3_source(path_spec).get_folder_info(
-        path_spec, bucket, prefix="my-folder"
+        path_spec,
+        "s3://my-bucket/my-folder",
     )
     res = list(res)
 

--- a/metadata-ingestion/tests/unit/s3/test_s3_source.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_source.py
@@ -333,6 +333,7 @@ def test_get_folder_info_ignores_disallowed_path(s3_resource, caplog):
     path_spec = Mock(
         spec=PathSpec,
         include="s3://my-bucket/{table}/{partition0}/*.csv",
+        glob_include="s3://my-bucket/*/*/*.csv",
         table_name="{table}",
     )
     path_spec.allowed = Mock(return_value=False)


### PR DESCRIPTION
- fix: make `dir_allowed` work with `tables_filter_pattern`
- don't list all partitions when `traversal method != ALL`
- don't list all partitions when `traversal method == ALL`
- `get_dir_to_process`: don't recurse if already at correct depth
- `get_dir_to_process`: apply s3 prefix filter when listing folders
- `get_folder_info`: apply s3 prefix filter when listing objects
- `get_dir_process`: skip S3 listing for fully-specified components