### PR TITLE
fix(ingest/athena): Fix Athena partition extraction and CONCAT function type issues

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/athena_properties_extractor.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/athena_properties_extractor.py
@@ -174,20 +174,16 @@ class AthenaPropertiesExtractor:
     def format_column_definition(line):
         # Use regex to parse the line more accurately
         # Pattern: column_name data_type [COMMENT comment_text] [,]
-        # Use greedy match for comment to capture everything until trailing comma
-        pattern = r"^\s*(.+?)\s+([\s,\w<>\[\]]+)((\s+COMMENT\s+(.+?)(,?))|(,?)\s*)?$"
-        match = re.match(pattern, line, re.IGNORECASE)
+        # Improved pattern to better separate column name, data type, and comment
+        pattern = r"^\s*([`\w']+)\s+([\w<>\[\](),\s]+?)(\s+COMMENT\s+(.+?))?(,?)\s*$"
+        match = re.match(pattern, line.strip(), re.IGNORECASE)
 
         if not match:
             return line
-        column_name = match.group(1)
-        data_type = match.group(2)
-        comment_part = match.group(5)  # COMMENT part
-        # there are different number of match groups depending on whether comment exists
-        if comment_part:
-            trailing_comma = match.group(6) if match.group(6) else ""
-        else:
-            trailing_comma = match.group(7) if match.group(7) else ""
+        column_name = match.group(1).strip()
+        data_type = match.group(2).strip()
+        comment_part = match.group(4)  # COMMENT part
+        trailing_comma = match.group(5) if match.group(5) else ""
 
         # Add backticks to column name if not already present
         if not (column_name.startswith("`") and column_name.endswith("`")):
@@ -201,8 +197,11 @@ class AthenaPropertiesExtractor:
 
             # Handle comment quoting and escaping
             if comment_part.startswith("'") and comment_part.endswith("'"):
-                # Already properly single quoted - keep as is
-                formatted_comment = comment_part
+                # Already single quoted - but check for proper escaping
+                inner_content = comment_part[1:-1]
+                # Re-escape any single quotes that aren't properly escaped
+                escaped_content = inner_content.replace("'", "''")
+                formatted_comment = f"'{escaped_content}'"
             elif comment_part.startswith('"') and comment_part.endswith('"'):
                 # Double quoted - convert to single quotes and escape internal single quotes
                 inner_content = comment_part[1:-1]

--- a/metadata-ingestion/tests/unit/test_athena_source.py
+++ b/metadata-ingestion/tests/unit/test_athena_source.py
@@ -182,8 +182,8 @@ def test_athena_get_table_properties():
 
     expected_query = """\
 select year,month from "test_schema"."test_table$partitions" \
-where CAST(year as VARCHAR) || '-' || CAST(month as VARCHAR) = \
-(select max(CAST(year as VARCHAR) || '-' || CAST(month as VARCHAR)) \
+where CONCAT(CAST(year as VARCHAR), CAST('-' AS VARCHAR), CAST(month as VARCHAR)) = \
+(select max(CONCAT(CAST(year as VARCHAR), CAST('-' AS VARCHAR), CAST(month as VARCHAR))) \
 from "test_schema"."test_table$partitions")"""
     assert mock_cursor.execute.call_count == 2
     assert expected_create_table_query == mock_cursor.execute.call_args_list[0][0][0]
@@ -503,3 +503,373 @@ def test_convert_simple_field_paths_to_v1_default_behavior():
     )
 
     assert config.emit_schema_fieldpaths_as_v1 is False  # Should default to False
+
+
+def test_get_partitions_returns_none_when_extract_partitions_disabled():
+    """Test that get_partitions returns None when extract_partitions is False"""
+    config = AthenaConfig.parse_obj(
+        {
+            "aws_region": "us-west-1",
+            "query_result_location": "s3://query-result-location/",
+            "work_group": "test-workgroup",
+            "extract_partitions": False,
+        }
+    )
+
+    ctx = PipelineContext(run_id="test")
+    source = AthenaSource(config=config, ctx=ctx)
+
+    # Mock inspector - should not be used if extract_partitions is False
+    mock_inspector = mock.MagicMock()
+
+    # Call get_partitions - should return None immediately without any database calls
+    result = source.get_partitions(mock_inspector, "test_schema", "test_table")
+
+    # Verify result is None
+    assert result is None
+
+    # Verify that no inspector methods were called
+    assert not mock_inspector.called, (
+        "Inspector should not be called when extract_partitions=False"
+    )
+
+
+def test_get_partitions_attempts_extraction_when_extract_partitions_enabled():
+    """Test that get_partitions attempts partition extraction when extract_partitions is True"""
+    config = AthenaConfig.parse_obj(
+        {
+            "aws_region": "us-west-1",
+            "query_result_location": "s3://query-result-location/",
+            "work_group": "test-workgroup",
+            "extract_partitions": True,
+        }
+    )
+
+    ctx = PipelineContext(run_id="test")
+    source = AthenaSource(config=config, ctx=ctx)
+
+    # Mock inspector and cursor for partition extraction
+    mock_inspector = mock.MagicMock()
+    mock_cursor = mock.MagicMock()
+
+    # Mock the table metadata response
+    mock_metadata = mock.MagicMock()
+    mock_partition_key = mock.MagicMock()
+    mock_partition_key.name = "year"
+    mock_metadata.partition_keys = [mock_partition_key]
+    mock_cursor.get_table_metadata.return_value = mock_metadata
+
+    # Set the cursor on the source
+    source.cursor = mock_cursor
+
+    # Call get_partitions - should attempt partition extraction
+    result = source.get_partitions(mock_inspector, "test_schema", "test_table")
+
+    # Verify that the cursor was used (partition extraction was attempted)
+    mock_cursor.get_table_metadata.assert_called_once_with(
+        table_name="test_table", schema_name="test_schema"
+    )
+
+    # Result should be a list (even if empty)
+    assert isinstance(result, list)
+    assert result == ["year"]  # Should contain the partition key name
+
+
+def test_partition_profiling_sql_generation_single_key():
+    """Test that partition profiling generates valid SQL for single partition key and can be parsed by SQLGlot."""
+    import sqlglot
+    from sqlglot.dialects import Athena
+
+    config = AthenaConfig.parse_obj(
+        {
+            "aws_region": "us-west-1",
+            "query_result_location": "s3://query-result-location/",
+            "work_group": "test-workgroup",
+            "extract_partitions": True,
+            "profiling": {"enabled": True, "partition_profiling_enabled": True},
+        }
+    )
+
+    ctx = PipelineContext(run_id="test")
+    source = AthenaSource(config=config, ctx=ctx)
+
+    # Mock cursor and metadata for single partition key
+    mock_cursor = mock.MagicMock()
+    mock_metadata = mock.MagicMock()
+    mock_partition_key = mock.MagicMock()
+    mock_partition_key.name = "year"
+    mock_metadata.partition_keys = [mock_partition_key]
+    mock_cursor.get_table_metadata.return_value = mock_metadata
+
+    # Mock successful partition query execution
+    mock_result = mock.MagicMock()
+    mock_result.description = [["year"]]
+    mock_result.__iter__ = lambda x: iter([["2023"]])
+    mock_cursor.execute.return_value = mock_result
+
+    source.cursor = mock_cursor
+
+    # Call get_partitions to trigger SQL generation
+    result = source.get_partitions(mock.MagicMock(), "test_schema", "test_table")
+
+    # Get the generated SQL query
+    assert mock_cursor.execute.called
+    generated_query = mock_cursor.execute.call_args[0][0]
+
+    # Verify the query structure for single partition key
+    assert "CAST(year as VARCHAR)" in generated_query
+    assert "CONCAT" not in generated_query  # Single key shouldn't use CONCAT
+    assert '"test_schema"."test_table$partitions"' in generated_query
+
+    # Validate that SQLGlot can parse the generated query using Athena dialect
+    try:
+        parsed = sqlglot.parse_one(generated_query, dialect=Athena)
+        assert parsed is not None
+        assert isinstance(parsed, sqlglot.expressions.Select)
+        print(f"✅ Single partition SQL parsed successfully: {generated_query}")
+    except Exception as e:
+        pytest.fail(
+            f"SQLGlot failed to parse single partition query: {e}\nQuery: {generated_query}"
+        )
+
+    assert result == ["year"]
+
+
+def test_partition_profiling_sql_generation_multiple_keys():
+    """Test that partition profiling generates valid SQL for multiple partition keys and can be parsed by SQLGlot."""
+    import sqlglot
+    from sqlglot.dialects import Athena
+
+    config = AthenaConfig.parse_obj(
+        {
+            "aws_region": "us-west-1",
+            "query_result_location": "s3://query-result-location/",
+            "work_group": "test-workgroup",
+            "extract_partitions": True,
+            "profiling": {"enabled": True, "partition_profiling_enabled": True},
+        }
+    )
+
+    ctx = PipelineContext(run_id="test")
+    source = AthenaSource(config=config, ctx=ctx)
+
+    # Mock cursor and metadata for multiple partition keys
+    mock_cursor = mock.MagicMock()
+    mock_metadata = mock.MagicMock()
+
+    mock_year_key = mock.MagicMock()
+    mock_year_key.name = "year"
+    mock_month_key = mock.MagicMock()
+    mock_month_key.name = "month"
+    mock_day_key = mock.MagicMock()
+    mock_day_key.name = "day"
+
+    mock_metadata.partition_keys = [mock_year_key, mock_month_key, mock_day_key]
+    mock_cursor.get_table_metadata.return_value = mock_metadata
+
+    # Mock successful partition query execution
+    mock_result = mock.MagicMock()
+    mock_result.description = [["year"], ["month"], ["day"]]
+    mock_result.__iter__ = lambda x: iter([["2023", "12", "25"]])
+    mock_cursor.execute.return_value = mock_result
+
+    source.cursor = mock_cursor
+
+    # Call get_partitions to trigger SQL generation
+    result = source.get_partitions(mock.MagicMock(), "test_schema", "test_table")
+
+    # Get the generated SQL query
+    assert mock_cursor.execute.called
+    generated_query = mock_cursor.execute.call_args[0][0]
+
+    # Verify the query structure for multiple partition keys
+    assert "CONCAT(" in generated_query  # Multiple keys should use CONCAT
+    assert "CAST(year as VARCHAR)" in generated_query
+    assert "CAST(month as VARCHAR)" in generated_query
+    assert "CAST(day as VARCHAR)" in generated_query
+    assert "CAST('-' AS VARCHAR)" in generated_query  # Separator should be cast
+    assert '"test_schema"."test_table$partitions"' in generated_query
+
+    # Validate that SQLGlot can parse the generated query using Athena dialect
+    try:
+        parsed = sqlglot.parse_one(generated_query, dialect=Athena)
+        assert parsed is not None
+        assert isinstance(parsed, sqlglot.expressions.Select)
+        print(f"✅ Multiple partition SQL parsed successfully: {generated_query}")
+    except Exception as e:
+        pytest.fail(
+            f"SQLGlot failed to parse multiple partition query: {e}\nQuery: {generated_query}"
+        )
+
+    assert result == ["year", "month", "day"]
+
+
+def test_partition_profiling_sql_generation_complex_schema_table_names():
+    """Test that partition profiling handles complex schema/table names correctly and generates valid SQL."""
+    import sqlglot
+    from sqlglot.dialects import Athena
+
+    config = AthenaConfig.parse_obj(
+        {
+            "aws_region": "us-west-1",
+            "query_result_location": "s3://query-result-location/",
+            "work_group": "test-workgroup",
+            "extract_partitions": True,
+            "profiling": {"enabled": True, "partition_profiling_enabled": True},
+        }
+    )
+
+    ctx = PipelineContext(run_id="test")
+    source = AthenaSource(config=config, ctx=ctx)
+
+    # Mock cursor and metadata
+    mock_cursor = mock.MagicMock()
+    mock_metadata = mock.MagicMock()
+
+    mock_partition_key = mock.MagicMock()
+    mock_partition_key.name = "event_date"
+    mock_metadata.partition_keys = [mock_partition_key]
+    mock_cursor.get_table_metadata.return_value = mock_metadata
+
+    # Mock successful partition query execution
+    mock_result = mock.MagicMock()
+    mock_result.description = [["event_date"]]
+    mock_result.__iter__ = lambda x: iter([["2023-12-25"]])
+    mock_cursor.execute.return_value = mock_result
+
+    source.cursor = mock_cursor
+
+    # Test with complex schema and table names
+    schema = "ad_cdp_audience"  # From the user's error
+    table = "system_import_label"
+
+    result = source.get_partitions(mock.MagicMock(), schema, table)
+
+    # Get the generated SQL query
+    assert mock_cursor.execute.called
+    generated_query = mock_cursor.execute.call_args[0][0]
+
+    # Verify proper quoting of schema and table names
+    expected_table_ref = f'"{schema}"."{table}$partitions"'
+    assert expected_table_ref in generated_query
+    assert "CAST(event_date as VARCHAR)" in generated_query
+
+    # Validate that SQLGlot can parse the generated query using Athena dialect
+    try:
+        parsed = sqlglot.parse_one(generated_query, dialect=Athena)
+        assert parsed is not None
+        assert isinstance(parsed, sqlglot.expressions.Select)
+        print(f"✅ Complex schema/table SQL parsed successfully: {generated_query}")
+    except Exception as e:
+        pytest.fail(
+            f"SQLGlot failed to parse complex schema/table query: {e}\nQuery: {generated_query}"
+        )
+
+    assert result == ["event_date"]
+
+
+def test_casted_partition_key_method():
+    """Test the _casted_partition_key helper method generates valid SQL fragments."""
+    import sqlglot
+    from sqlglot.dialects import Athena
+
+    # Test the static method directly
+    casted_key = AthenaSource._casted_partition_key("test_column")
+    assert casted_key == "CAST(test_column as VARCHAR)"
+
+    # Verify SQLGlot can parse the CAST expression
+    try:
+        parsed = sqlglot.parse_one(casted_key, dialect=Athena)
+        assert parsed is not None
+        assert isinstance(parsed, sqlglot.expressions.Cast)
+        assert parsed.this.name == "test_column"
+        assert "VARCHAR" in str(parsed.to.this)  # More flexible assertion
+        print(f"✅ CAST expression parsed successfully: {casted_key}")
+    except Exception as e:
+        pytest.fail(
+            f"SQLGlot failed to parse CAST expression: {e}\nExpression: {casted_key}"
+        )
+
+    # Test with various column name formats
+    test_cases = ["year", "month", "event_date", "created_at", "partition_key_123"]
+
+    for column_name in test_cases:
+        casted = AthenaSource._casted_partition_key(column_name)
+        try:
+            parsed = sqlglot.parse_one(casted, dialect=Athena)
+            assert parsed is not None
+            assert isinstance(parsed, sqlglot.expressions.Cast)
+        except Exception as e:
+            pytest.fail(f"SQLGlot failed to parse CAST for column '{column_name}': {e}")
+
+
+def test_concat_function_generation_validates_with_sqlglot():
+    """Test that our CONCAT function generation produces valid Athena SQL according to SQLGlot."""
+    import sqlglot
+    from sqlglot.dialects import Athena
+
+    # Test the CONCAT function generation logic directly
+    partition_keys = ["year", "month", "day"]
+    casted_keys = [AthenaSource._casted_partition_key(key) for key in partition_keys]
+
+    # Replicate the CONCAT generation logic from the source
+    concat_args = []
+    for i, key in enumerate(casted_keys):
+        concat_args.append(key)
+        if i < len(casted_keys) - 1:  # Add separator except for last element
+            concat_args.append("CAST('-' AS VARCHAR)")
+
+    concat_expr = f"CONCAT({', '.join(concat_args)})"
+
+    # Verify the generated CONCAT expression
+    expected = "CONCAT(CAST(year as VARCHAR), CAST('-' AS VARCHAR), CAST(month as VARCHAR), CAST('-' AS VARCHAR), CAST(day as VARCHAR))"
+    assert concat_expr == expected
+
+    # Validate with SQLGlot
+    try:
+        parsed = sqlglot.parse_one(concat_expr, dialect=Athena)
+        assert parsed is not None
+        assert isinstance(parsed, sqlglot.expressions.Concat)
+        # Verify all arguments are properly parsed
+        assert len(parsed.expressions) == 5  # 3 partition keys + 2 separators
+        print(f"✅ CONCAT expression parsed successfully: {concat_expr}")
+    except Exception as e:
+        pytest.fail(
+            f"SQLGlot failed to parse CONCAT expression: {e}\nExpression: {concat_expr}"
+        )
+
+
+def test_partition_profiling_disabled_no_sql_generation():
+    """Test that when partition profiling is disabled, no complex SQL is generated."""
+    config = AthenaConfig.parse_obj(
+        {
+            "aws_region": "us-west-1",
+            "query_result_location": "s3://query-result-location/",
+            "work_group": "test-workgroup",
+            "extract_partitions": True,
+            "profiling": {"enabled": False, "partition_profiling_enabled": False},
+        }
+    )
+
+    ctx = PipelineContext(run_id="test")
+    source = AthenaSource(config=config, ctx=ctx)
+
+    # Mock cursor and metadata
+    mock_cursor = mock.MagicMock()
+    mock_metadata = mock.MagicMock()
+    mock_partition_key = mock.MagicMock()
+    mock_partition_key.name = "year"
+    mock_metadata.partition_keys = [mock_partition_key]
+    mock_cursor.get_table_metadata.return_value = mock_metadata
+
+    source.cursor = mock_cursor
+
+    # Call get_partitions - should not generate complex profiling SQL
+    result = source.get_partitions(mock.MagicMock(), "test_schema", "test_table")
+
+    # Should only call get_table_metadata, not execute complex partition queries
+    mock_cursor.get_table_metadata.assert_called_once()
+    # The execute method should not be called for profiling queries when profiling is disabled
+    assert not mock_cursor.execute.called
+
+    assert result == ["year"]


### PR DESCRIPTION
⏺ Fix Athena partition extraction and CONCAT function type issues

Summary

This PR fixes two critical issues in the Athena source:

Partition extraction not respecting extract_partitions=false - The configuration was being ignored and partition extraction was still happening
CONCAT function type mismatch errors - Type conflicts when concatenating partition keys with different data types (e.g., integer year with varchar separator)
Problem

Users experienced errors like:
FUNCTION_NOT_FOUND: line 1:108: Unexpected parameters (integer, varchar(1)) for function concat.
Expected: concat(E, array(E)) E, concat(array(E)) E, concat(array(E), E) E, concat(char(x), char(y)), concat(varbinary), concat(varchar)

Even when extract_partitions: false was set, partition extraction still occurred and failed on tables with mixed-type partition keys.

Root Cause

Partition extraction logic: The condition checked for BOTH extract_partitions AND extract_partitions_using_create_statements to be false, meaning if either was true, extraction would still happen
Type mismatch in CONCAT: The old code used SQL || operator which caused type coercion issues in Athena when mixing integer partition keys with varchar separators
Comment parsing: Malformed comments in CREATE TABLE statements (like unquoted comments with apostrophes) caused SQL parsing failures
Solution

Fixed partition extraction control
Before
if (
not self.config.extract_partitions
and not self.config.extract_partitions_using_create_statements
):
return None

After
if not self.config.extract_partitions:
return None

Fixed CONCAT function type safety
Before
part_concat = " || '-' || ".join(
self._casted_partition_key(key) for key in partitions
)

After
if len(casted_keys) == 1:
part_concat = casted_keys[0]
else:
concat_args = []
for i, key in enumerate(casted_keys):
concat_args.append(key)
if i < len(casted_keys) - 1:
concat_args.append("CAST('-' AS VARCHAR)")
part_concat = f"CONCAT({', '.join(concat_args)})"

Enhanced comment handling (backported from PR https://github.com/datahub-project/datahub/pull/14673)
Improved regex pattern for better column definition parsing
Enhanced handling of already single-quoted comments with re-escaping
Better processing of malformed comments with apostrophes
Added comprehensive SQLGlot validation tests
test_partition_profiling_sql_generation_single_key() - Validates single partition key SQL
test_partition_profiling_sql_generation_multiple_keys() - Validates multi-partition key SQL
test_partition_profiling_sql_generation_complex_schema_table_names() - Tests complex schema/table names
test_casted_partition_key_method() - Validates CAST expression generation
test_concat_function_generation_validates_with_sqlglot() - Ensures CONCAT syntax is valid
Files Changed

src/datahub/ingestion/source/sql/athena.py - Fixed partition extraction logic and CONCAT function
src/datahub/ingestion/source/sql/athena_properties_extractor.py - Enhanced comment handling and regex pattern
tests/unit/test_athena_source.py - Added comprehensive SQLGlot validation tests
Testing

✅ All 43 Athena tests pass (19 properties extractor + 24 source tests)
✅ Added SQLGlot validation ensuring all generated SQL is valid Athena syntax
✅ Tested with complex schema/table names like ad_cdp_audience.system_import_label
✅ Verified both single and multiple partition key scenarios
✅ Confirmed malformed comment handling (e.g., Previous year's sales → 'Previous year''s sales')
Impact

Breaking Change: None - fully backward compatible
Performance: Improved - no unnecessary partition queries when extract_partitions=false
Reliability: Fixed CONCAT function type mismatches that caused ingestion failures
Robustness: Better handling of malformed SQL comments from Athena's SHOW CREATE TABLE
Example Query Generated

Before (failing):
CAST(year as VARCHAR) || '-' || CAST(month as VARCHAR)

After (working):
CONCAT(CAST(year as VARCHAR), CAST('-' AS VARCHAR), CAST(month as VARCHAR))

This ensures all arguments to CONCAT are properly typed as VARCHAR, avoiding Athena's strict type checking errors.
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
