### PR TITLE
feat(ingest): add time taken by compute stats overall

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -204,6 +204,7 @@ class ExamplesReport(Report, Closeable):
     samples: Dict[str, Dict[str, List[str]]] = field(
         default_factory=lambda: defaultdict(lambda: defaultdict(list))
     )
+    compute_stats_time_seconds: float = 0.0
     _file_based_dict: Optional[FileBackedDict[SourceReportSubtypes]] = None
 
     # We are adding this to make querying easier for fine-grained lineage
@@ -405,6 +406,7 @@ class ExamplesReport(Report, Closeable):
             self._update_file_based_dict(urn, entityType, aspectName, mcp)
 
     def compute_stats(self) -> None:
+        start_time = datetime.now()
         if self._file_based_dict is None:
             return
 
@@ -466,6 +468,8 @@ class ExamplesReport(Report, Closeable):
             list(self._lineage_aspects_seen), "lineage"
         )
         self._collect_samples_with_all_conditions("all_3")
+        end_time = datetime.now()
+        self.compute_stats_time_seconds += (end_time - start_time).total_seconds()
 
 
 class EntityFilterReport(ReportAttribute):


### PR DESCRIPTION
There are some reports that between https://github.com/acryldata/datahub/compare/v1.1.0.4...v1.1.0.5 there has been slowness. Adding this to validate whether it is compute stats which is adding this latency or not.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
