### PR TITLE
fix(ingest): only add to samples where platform match

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -441,6 +441,7 @@ class Pipeline:
         return False
 
     def run(self) -> None:
+        self.source.get_report().set_platform(self.source.__class__.get_platform_id())
         self._warn_old_cli_version()
         with self.exit_stack, self.inner_exit_stack:
             if self.config.flags.generate_memory_profiles:

--- a/metadata-ingestion/src/datahub/utilities/urns/urn.py
+++ b/metadata-ingestion/src/datahub/utilities/urns/urn.py
@@ -1,8 +1,23 @@
-from datahub.metadata.urns import Urn
+from typing import Optional
 
-__all__ = ["Urn", "guess_entity_type"]
+from datahub.metadata.urns import (
+    Urn,
+)
+
+__all__ = ["Urn", "guess_entity_type", "get_platform_v1"]
 
 
 def guess_entity_type(urn: str) -> str:
     assert urn.startswith("urn:li:"), "urns must start with urn:li:"
     return urn.split(":")[2]
+
+
+def get_platform_v1(urn: str) -> Optional[str]:
+    """Extract platform from URN using a mapping dictionary."""
+    urn_obj = Urn.from_string(urn)
+
+    try:
+        return urn_obj.platform
+    except Exception:
+        # Not every platform has a platform attribute
+        return None


### PR DESCRIPTION
Some ingestions emit platforms that are not the same as ingestion. e.g. `dbt` might ingest `snowflake` lineage but we don't want to start showing snowflake in dbt ingestions.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
