### PR TITLE
chore(setup): Limit mixpanel dependency <=4.10.1

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -22,7 +22,7 @@ base_requirements = {
     # See https://github.com/samuelcolvin/pydantic/pull/3175#issuecomment-995382910.
     # pydantic 1.10.3 is incompatible with typing-extensions 4.1.1 - https://github.com/pydantic/pydantic/issues/4885
     "pydantic>=1.10.0,!=1.10.3",
-    "mixpanel>=4.9.0",
+    "mixpanel>=4.9.0,<=4.10.1",
     # Airflow depends on fairly old versions of sentry-sdk, which is why we need to be loose with our constraints.
     "sentry-sdk>=1.33.1",
 }


### PR DESCRIPTION
This avoids problems due to LICENSE file being moved to a separate directory in version `4.11.0`, pending discussion with mixpanel maintainers.
