### PR TITLE
feat(externalUrl): Store baseExternalUrl for chrome extension url matching

### DIFF
--- a/datahub-web-react/src/app/embed/lookup/useGetEntityByUrl.ts
+++ b/datahub-web-react/src/app/embed/lookup/useGetEntityByUrl.ts
@@ -7,7 +7,7 @@ import { PageRoutes } from '@conf/Global';
 import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
 import { FilterOperator } from '@types';
 
-const URL_FIELDS = ['externalUrl', 'chartUrl', 'dashboardUrl'] as const;
+const URL_FIELDS = ['externalUrl', 'chartUrl', 'dashboardUrl', 'baseExternalUrl'] as const;
 
 const useGetEntityByUrl = (externalUrl: string) => {
     const registry = useEntityRegistry();

--- a/metadata-ingestion/src/datahub/ingestion/transformer/replace_external_url.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/replace_external_url.py
@@ -53,27 +53,21 @@ class ReplaceExternalUrlDataset(DatasetPropertiesTransformer, ReplaceUrl):
     def transform_aspect(
         self, entity_urn: str, aspect_name: str, aspect: Optional[Aspect]
     ) -> Optional[Aspect]:
-        in_dataset_properties_aspect: DatasetPropertiesClass = cast(
-            DatasetPropertiesClass, aspect
-        )
+        input_aspect: DatasetPropertiesClass = cast(DatasetPropertiesClass, aspect)
 
-        if (
-            not hasattr(in_dataset_properties_aspect, "externalUrl")
-            or not in_dataset_properties_aspect.externalUrl
-        ):
-            return cast(Aspect, in_dataset_properties_aspect)
+        if not hasattr(input_aspect, "externalUrl") or not input_aspect.externalUrl:
+            return cast(Aspect, input_aspect)
         else:
-            out_dataset_properties_aspect: DatasetPropertiesClass = copy.deepcopy(
-                in_dataset_properties_aspect
-            )
+            output_aspect: DatasetPropertiesClass = copy.deepcopy(input_aspect)
 
-            out_dataset_properties_aspect.externalUrl = self.replace_url(
+            output_aspect.baseExternalUrl = input_aspect.externalUrl
+            output_aspect.externalUrl = self.replace_url(
                 self.config.input_pattern,
                 self.config.replacement,
-                in_dataset_properties_aspect.externalUrl,
+                input_aspect.externalUrl,
             )
 
-            return cast(Aspect, out_dataset_properties_aspect)
+            return cast(Aspect, output_aspect)
 
 
 class ReplaceExternalUrlContainer(ContainerPropertiesTransformer, ReplaceUrl):
@@ -103,23 +97,17 @@ class ReplaceExternalUrlContainer(ContainerPropertiesTransformer, ReplaceUrl):
     def transform_aspect(
         self, entity_urn: str, aspect_name: str, aspect: Optional[Aspect]
     ) -> Optional[Aspect]:
-        in_container_properties_aspect: ContainerPropertiesClass = cast(
-            ContainerPropertiesClass, aspect
-        )
-        if (
-            not hasattr(in_container_properties_aspect, "externalUrl")
-            or not in_container_properties_aspect.externalUrl
-        ):
-            return cast(Aspect, in_container_properties_aspect)
+        input_aspect: ContainerPropertiesClass = cast(ContainerPropertiesClass, aspect)
+        if not hasattr(input_aspect, "externalUrl") or not input_aspect.externalUrl:
+            return cast(Aspect, input_aspect)
         else:
-            out_container_properties_aspect: ContainerPropertiesClass = copy.deepcopy(
-                in_container_properties_aspect
-            )
+            output_aspect: ContainerPropertiesClass = copy.deepcopy(input_aspect)
 
-            out_container_properties_aspect.externalUrl = self.replace_url(
+            output_aspect.baseExternalUrl = input_aspect.externalUrl
+            output_aspect.externalUrl = self.replace_url(
                 self.config.input_pattern,
                 self.config.replacement,
-                in_container_properties_aspect.externalUrl,
+                input_aspect.externalUrl,
             )
 
-            return cast(Aspect, out_container_properties_aspect)
+            return cast(Aspect, output_aspect)

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -4294,6 +4294,10 @@ def test_replace_external_url_word_replace(
         output[0].record.aspect.externalUrl
         == "https://github.com/starhub/looker-demo/blob/master/foo.view.lkml"
     )
+    assert (
+        output[0].record.aspect.baseExternalUrl
+        == "https://github.com/datahub/looker-demo/blob/master/foo.view.lkml"
+    )
 
 
 def test_replace_external_regex_replace_1(
@@ -4321,6 +4325,10 @@ def test_replace_external_regex_replace_1(
         output[0].record.aspect.externalUrl
         == "https://github.com/starhub/test/foo.view.lkml"
     )
+    assert (
+        output[0].record.aspect.baseExternalUrl
+        == "https://github.com/datahub/looker-demo/blob/master/foo.view.lkml"
+    )
 
 
 def test_replace_external_regex_replace_2(
@@ -4347,6 +4355,10 @@ def test_replace_external_regex_replace_2(
     assert (
         output[0].record.aspect.externalUrl
         == "https://test.com/test/looker-demo/blob/master/foo.view.lkml"
+    )
+    assert (
+        output[0].record.aspect.baseExternalUrl
+        == "https://github.com/datahub/looker-demo/blob/master/foo.view.lkml"
     )
 
 
@@ -4942,6 +4954,10 @@ def test_replace_external_url_container_word_replace(
         output[0].record.aspect.externalUrl
         == "https://github.com/starhub/looker-demo/blob/master/foo.view.lkml"
     )
+    assert (
+        output[0].record.aspect.baseExternalUrl
+        == "https://github.com/datahub/looker-demo/blob/master/foo.view.lkml"
+    )
 
 
 def test_replace_external_regex_container_replace_1(
@@ -4970,6 +4986,10 @@ def test_replace_external_regex_container_replace_1(
         output[0].record.aspect.externalUrl
         == "https://github.com/starhub/test/foo.view.lkml"
     )
+    assert (
+        output[0].record.aspect.baseExternalUrl
+        == "https://github.com/datahub/looker-demo/blob/master/foo.view.lkml"
+    )
 
 
 def test_replace_external_regex_container_replace_2(
@@ -4997,4 +5017,8 @@ def test_replace_external_regex_container_replace_2(
     assert (
         output[0].record.aspect.externalUrl
         == "https://test.com/test/looker-demo/blob/master/foo.view.lkml"
+    )
+    assert (
+        output[0].record.aspect.baseExternalUrl
+        == "https://github.com/datahub/looker-demo/blob/master/foo.view.lkml"
     )

--- a/metadata-models/src/main/pegasus/com/linkedin/common/ExternalReference.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/ExternalReference.pdl
@@ -5,10 +5,21 @@ namespace com.linkedin.common
  */
 record ExternalReference {
   /**
-   * URL where the reference exist
+   * URL to which users can view the entity in the source platform.
+   * May be changed from the true source platform url to improve user experience,
+   * e.g. by routing through a proxy.
    */
   @Searchable = {
     "fieldType": "KEYWORD"
   }
   externalUrl: optional Url
+
+  /**
+   * The true source platform url of the entity, to the best of our knowledge.
+   * In practice, only set when `externalUrl` is different than the true source platform url.
+   */
+  @Searchable = {
+    "fieldType": "KEYWORD"
+  }
+  baseExternalUrl: optional Url
 }


### PR DESCRIPTION
When users use the external url transformer, this breaks the chrome extension for platforms that match by external url. This adds `baseExternalUrl` which will also be checked by the chrome extension, and sets it during the transformer.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
