### PR TITLE
chore(ingestion/iceberg): Safe-guard pyiceberg version before pydantic 1->2 transition

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -292,7 +292,11 @@ microsoft_common = {
 iceberg_common = {
     # Iceberg Python SDK
     # Kept at 0.4.0 due to higher versions requiring pydantic>2, as soon as we are fine with it, bump this dependency
-    "pyiceberg>=0.4.0",
+    # The limitation <=0.6.1 is set temporarily, as >0.4 allows for using pydantic 2, but versions >0.6.1 use different
+    # parameters for configuring credentials, i.e. for Glue catalogs, for details, see:
+    # https://github.com/apache/iceberg-python/compare/pyiceberg-0.6.1...pyiceberg-0.7.0#diff-497e037708cc64870c6ba9372f6064a69ca1e74d65d6195dcee5a44851e8b47dR283
+    # this would cause existing recipes to start failing in some cases
+    "pyiceberg>=0.4.0,<=0.6.1",
     *cachetools_lib,
 }
 


### PR DESCRIPTION
This is in preparation to merge https://github.com/datahub-project/datahub/pull/14014
See example change between `pycieberg` 0.6.1 and 0.7.0:
https://github.com/apache/iceberg-python/compare/pyiceberg-0.6.1...pyiceberg-0.7.0#diff-497e037708cc64870c6ba9372f6064a69ca1e74d65d6195dcee5a44851e8b47dR283-R289
