### PR TITLE
chore(ingestion/iceberg): Include explicit extras in dependencies

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -298,7 +298,7 @@ iceberg_common = {
     # this would cause existing recipes to start failing in some cases
     # the list of extras is quite arbitrary, it has been extended since 0.4.0, we can add more of them, once we bump
     # the lower version limit
-    "pyiceberg[glue,hive,dynamodb,snappy,hive,s3fs,adlfs,gcsfs,pyarrow,zstandard,sql-postgres]>=0.4.0,<=0.6.1",
+    "pyiceberg[glue,hive,dynamodb,snappy,hive,s3fs,adlfs,pyarrow,zstandard]>=0.4.0,<=0.6.1",
     *cachetools_lib,
 }
 

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -296,7 +296,9 @@ iceberg_common = {
     # parameters for configuring credentials, i.e. for Glue catalogs, for details, see:
     # https://github.com/apache/iceberg-python/compare/pyiceberg-0.6.1...pyiceberg-0.7.0#diff-497e037708cc64870c6ba9372f6064a69ca1e74d65d6195dcee5a44851e8b47dR283
     # this would cause existing recipes to start failing in some cases
-    "pyiceberg>=0.4.0,<=0.6.1",
+    # the list of extras is quite arbitrary, it has been extended since 0.4.0, we can add more of them, once we bump
+    # the lower version limit
+    "pyiceberg[glue,hive,dynamodb,snappy,hive,s3fs,adlfs,gcsfs,pyarrow,zstandard,sql-postgres]>=0.4.0,<=0.6.1",
     *cachetools_lib,
 }
 


### PR DESCRIPTION
This prevents errors like:
```
<class 'pyiceberg.exceptions.NotInstalledError'>: AWS glue support not installed: pip install 'pyiceberg[glue]'
```
