### PR TITLE
Revert "chore(ingestion/iceberg): Safe-guard pyiceberg version before pydantic 1->2 transition (#14736)"

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -292,11 +292,7 @@ microsoft_common = {
 iceberg_common = {
     # Iceberg Python SDK
     # Kept at 0.4.0 due to higher versions requiring pydantic>2, as soon as we are fine with it, bump this dependency
-    # The limitation <=0.6.1 is set temporarily, as >0.4 allows for using pydantic 2, but versions >0.6.1 use different
-    # parameters for configuring credentials, i.e. for Glue catalogs, for details, see:
-    # https://github.com/apache/iceberg-python/compare/pyiceberg-0.6.1...pyiceberg-0.7.0#diff-497e037708cc64870c6ba9372f6064a69ca1e74d65d6195dcee5a44851e8b47dR283
-    # this would cause existing recipes to start failing in some cases
-    "pyiceberg>=0.4.0,<=0.6.1",
+    "pyiceberg>=0.4.0",
     *cachetools_lib,
 }
 


### PR DESCRIPTION
This reverts commit 3af386b626da363df1efc7a21fe383b5485cf0cd.
Reverts PR: https://github.com/datahub-project/datahub/pull/14736

Rationale:
Currently Managed UI ingestion installs only `acryl-datahub[iceberg]` which actually pulls the newest (0.10.0) version. This safeguard would help for users who use `acryl-datahub[all]` (i.e. use datahub ingestion image directly), but potentially would break compatibility for users who are ingesting via the UI.
I propose we lift this safeguard and add a release note informing about difference in config, after we merge changes allowing to install pydantic version 2, when installing `all`.