### PR TITLE
fix(ui) Add collection of minor fixes for summary pages and home page

### DIFF
--- a/datahub-web-react/src/app/entity/application/ApplicationEntity.tsx
+++ b/datahub-web-react/src/app/entity/application/ApplicationEntity.tsx
@@ -211,6 +211,7 @@ export class ApplicationEntity implements Entity<Application> {
                 degree={(result as any).degree}
                 paths={(result as any).paths}
                 headerDropdownItems={headerDropdownItems}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entity/application/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/application/preview/Preview.tsx
@@ -22,7 +22,7 @@ interface Props {
     degree?: number;
     paths?: EntityPath[];
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
     actions?: EntityMenuActions;
 }
 

--- a/datahub-web-react/src/app/entity/chart/preview/ChartPreview.tsx
+++ b/datahub-web-react/src/app/entity/chart/preview/ChartPreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IconStyleType } from '@app/entity/Entity';
+import { IconStyleType, PreviewType } from '@app/entity/Entity';
 import { ChartStatsSummary as ChartStatsSummaryView } from '@app/entity/chart/shared/ChartStatsSummary';
 import DefaultPreviewCard from '@app/preview/DefaultPreviewCard';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
@@ -49,6 +49,7 @@ export const ChartPreview = ({
     paths,
     subType,
     health,
+    previewType,
 }: {
     urn: string;
     platform?: string;
@@ -75,6 +76,7 @@ export const ChartPreview = ({
     paths?: EntityPath[];
     subType?: string | null;
     health?: Health[] | null;
+    previewType?: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
 
@@ -112,6 +114,7 @@ export const ChartPreview = ({
             degree={degree}
             paths={paths}
             health={health || undefined}
+            previewType={previewType}
         />
     );
 };

--- a/datahub-web-react/src/app/entity/dashboard/preview/DashboardPreview.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/preview/DashboardPreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IconStyleType } from '@app/entity/Entity';
+import { IconStyleType, PreviewType } from '@app/entity/Entity';
 import { DashboardStatsSummary as DashboardStatsSummaryView } from '@app/entity/dashboard/shared/DashboardStatsSummary';
 import DefaultPreviewCard from '@app/preview/DefaultPreviewCard';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
@@ -50,6 +50,7 @@ export const DashboardPreview = ({
     degree,
     paths,
     health,
+    previewType,
 }: {
     urn: string;
     platform?: string;
@@ -77,6 +78,7 @@ export const DashboardPreview = ({
     degree?: number;
     paths?: EntityPath[];
     health?: Health[] | null;
+    previewType?: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
 
@@ -116,6 +118,7 @@ export const DashboardPreview = ({
             degree={degree}
             paths={paths}
             health={health || undefined}
+            previewType={previewType}
         />
     );
 };

--- a/datahub-web-react/src/app/entity/mlFeature/MLFeatureEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlFeature/MLFeatureEntity.tsx
@@ -139,7 +139,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
         },
     ];
 
-    renderPreview = (_: PreviewType, data: MlFeature) => {
+    renderPreview = (previewType: PreviewType, data: MlFeature) => {
         const genericProperties = this.getGenericEntityProperties(data);
         // eslint-disable-next-line
         const platform = data?.['featureTables']?.relationships?.[0]?.entity?.platform;
@@ -152,6 +152,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
                 owners={data.ownership?.owners}
                 platform={platform}
                 dataProduct={getDataProduct(genericProperties?.dataProduct)}
+                previewType={previewType}
             />
         );
     };
@@ -173,6 +174,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
                 platformInstanceId={data.dataPlatformInstance?.instanceId}
                 degree={(result as any).degree}
                 paths={(result as any).paths}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entity/mlFeature/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/mlFeature/preview/Preview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { IconStyleType } from '@app/entity/Entity';
+import { IconStyleType, PreviewType } from '@app/entity/Entity';
 import DefaultPreviewCard from '@app/preview/DefaultPreviewCard';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import { useEntityRegistry } from '@app/useEntityRegistry';
@@ -18,6 +18,7 @@ export const Preview = ({
     platform,
     degree,
     paths,
+    previewType,
 }: {
     urn: string;
     name: string;
@@ -29,6 +30,7 @@ export const Preview = ({
     platform?: DataPlatform | null | undefined;
     degree?: number;
     paths?: EntityPath[];
+    previewType: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     return (
@@ -48,6 +50,7 @@ export const Preview = ({
             dataProduct={dataProduct}
             degree={degree}
             paths={paths}
+            previewType={previewType}
         />
     );
 };

--- a/datahub-web-react/src/app/entity/tag/Tag.tsx
+++ b/datahub-web-react/src/app/entity/tag/Tag.tsx
@@ -60,7 +60,7 @@ export class TagEntity implements Entity<Tag> {
 
     renderProfile: (urn: string) => JSX.Element = (_) => <TagProfile />;
 
-    renderPreview = (_: PreviewType, data: Tag) => (
+    renderPreview = (previewType: PreviewType, data: Tag) => (
         <DefaultPreviewCard
             description={data.description || ''}
             name={this.displayName(data)}
@@ -69,6 +69,7 @@ export class TagEntity implements Entity<Tag> {
             logoComponent={<PreviewTagIcon />}
             type="Tag"
             typeIcon={this.icon(14, IconStyleType.ACCENT)}
+            previewType={previewType}
         />
     );
 

--- a/datahub-web-react/src/app/entityV2/application/ApplicationEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/application/ApplicationEntity.tsx
@@ -200,6 +200,7 @@ export class ApplicationEntity implements Entity<Application> {
                 degree={(result as any).degree}
                 paths={(result as any).paths}
                 headerDropdownItems={headerDropdownItems}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/application/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/application/preview/Preview.tsx
@@ -22,7 +22,7 @@ interface Props {
     degree?: number;
     paths?: EntityPath[];
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
     actions?: EntityMenuActions;
 }
 

--- a/datahub-web-react/src/app/entityV2/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/chart/ChartEntity.tsx
@@ -278,7 +278,7 @@ export class ChartEntity implements Entity<Chart> {
         };
     };
 
-    renderPreview = (_: PreviewType, data: Chart) => {
+    renderPreview = (previewType: PreviewType, data: Chart) => {
         const genericProperties = this.getGenericEntityProperties(data);
 
         return (
@@ -300,6 +300,7 @@ export class ChartEntity implements Entity<Chart> {
                 headerDropdownItems={headerDropdownItems}
                 browsePaths={data.browsePathV2 || undefined}
                 externalUrl={data.properties?.externalUrl}
+                previewType={previewType}
             />
         );
     };
@@ -339,6 +340,7 @@ export class ChartEntity implements Entity<Chart> {
                 isOutputPort={isOutputPort(result)}
                 headerDropdownItems={headerDropdownItems}
                 browsePaths={data.browsePathV2 || undefined}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/chart/preview/ChartPreview.tsx
+++ b/datahub-web-react/src/app/entityV2/chart/preview/ChartPreview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { GenericEntityProperties } from '@app/entity/shared/types';
-import { IconStyleType } from '@app/entityV2/Entity';
+import { IconStyleType, PreviewType } from '@app/entityV2/Entity';
 import { ChartStatsSummary as ChartStatsSummaryView } from '@app/entityV2/chart/shared/ChartStatsSummary';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { PopularityTier } from '@app/entityV2/shared/containers/profile/sidebar/shared/utils';
@@ -56,6 +56,7 @@ export const ChartPreview = ({
     tier,
     headerDropdownItems,
     browsePaths,
+    previewType,
 }: {
     urn: string;
     data: GenericEntityProperties | null;
@@ -86,6 +87,7 @@ export const ChartPreview = ({
     tier?: PopularityTier;
     headerDropdownItems?: Set<EntityMenuItems>;
     browsePaths?: BrowsePathV2 | undefined;
+    previewType: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     const hasStats = summaryHasStats(statsSummary);
@@ -134,6 +136,7 @@ export const ChartPreview = ({
             headerDropdownItems={headerDropdownItems}
             statsSummary={statsSummary}
             browsePaths={browsePaths}
+            previewType={previewType}
         />
     );
 };

--- a/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
@@ -187,7 +187,7 @@ export class ContainerEntity implements Entity<Container> {
         },
     ];
 
-    renderPreview = (_: PreviewType, data: Container) => {
+    renderPreview = (previewType: PreviewType, data: Container) => {
         const genericProperties = this.getGenericEntityProperties(data);
         return (
             <Preview
@@ -207,6 +207,7 @@ export class ContainerEntity implements Entity<Container> {
                 entityCount={data.entities?.total}
                 headerDropdownItems={headerDropdownItems}
                 browsePaths={data.browsePathV2 || undefined}
+                previewType={previewType}
             />
         );
     };
@@ -239,6 +240,7 @@ export class ContainerEntity implements Entity<Container> {
                 isOutputPort={isOutputPort(result)}
                 headerDropdownItems={headerDropdownItems}
                 browsePaths={data.browsePathV2 || undefined}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/container/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/container/preview/Preview.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { GenericEntityProperties } from '@app/entity/shared/types';
+import { PreviewType } from '@app/entityV2/Entity';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import EntityCount from '@app/entityV2/shared/containers/profile/header/EntityCount';
 import ContainerIcon from '@app/entityV2/shared/containers/profile/header/PlatformContent/ContainerIcon';
@@ -50,6 +51,7 @@ export const Preview = ({
     isOutputPort,
     headerDropdownItems,
     browsePaths,
+    previewType,
 }: {
     urn: string;
     data: GenericEntityProperties | null;
@@ -76,6 +78,7 @@ export const Preview = ({
     isOutputPort?: boolean;
     headerDropdownItems?: Set<EntityMenuItems>;
     browsePaths?: BrowsePathV2;
+    previewType: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     return (
@@ -108,6 +111,7 @@ export const Preview = ({
             isOutputPort={isOutputPort}
             headerDropdownItems={headerDropdownItems}
             browsePaths={browsePaths}
+            previewType={previewType}
         />
     );
 };

--- a/datahub-web-react/src/app/entityV2/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dashboard/DashboardEntity.tsx
@@ -339,6 +339,7 @@ export class DashboardEntity implements Entity<Dashboard> {
                 isOutputPort={isOutputPort(result)}
                 headerDropdownItems={headerDropdownItems}
                 browsePaths={data.browsePathV2 || undefined}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/dashboard/preview/DashboardPreview.tsx
+++ b/datahub-web-react/src/app/entityV2/dashboard/preview/DashboardPreview.tsx
@@ -88,7 +88,7 @@ export const DashboardPreview = ({
     isOutputPort?: boolean;
     tier?: PopularityTier;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
     browsePaths?: BrowsePathV2;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();

--- a/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
@@ -235,6 +235,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
                 headerDropdownItems={headerDropdownItems}
                 parentContainers={data.parentContainers}
                 subTypes={genericProperties?.subTypes}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/dataFlow/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/preview/Preview.tsx
@@ -72,7 +72,7 @@ export const Preview = ({
     paths?: EntityPath[];
     isOutputPort?: boolean;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
     parentContainers?: ParentContainersResult | null;
     subTypes?: SubTypes | null;
 }): JSX.Element => {

--- a/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
@@ -251,6 +251,7 @@ export class DataJobEntity implements Entity<DataJob> {
                 headerDropdownItems={headerDropdownItems}
                 browsePaths={data?.browsePathV2 || undefined}
                 parentContainers={data.parentContainers}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/dataJob/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/dataJob/preview/Preview.tsx
@@ -75,7 +75,7 @@ export const Preview = ({
     paths?: EntityPath[];
     isOutputPort?: boolean;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
     browsePaths?: BrowsePathV2;
     parentContainers?: ParentContainersResult | null;
 }): JSX.Element => {

--- a/datahub-web-react/src/app/entityV2/dataProcessInstance/DataProcessInstanceEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataProcessInstance/DataProcessInstanceEntity.tsx
@@ -134,7 +134,7 @@ export class DataProcessInstanceEntity implements Entity<DataProcessInstance> {
         };
     };
 
-    renderPreview = (_: PreviewType, data: DataProcessInstance) => {
+    renderPreview = (previewType: PreviewType, data: DataProcessInstance) => {
         const genericProperties = this.getGenericEntityProperties(data);
         const parentEntities = getParentEntities(data);
         return (
@@ -152,6 +152,7 @@ export class DataProcessInstanceEntity implements Entity<DataProcessInstance> {
                 externalUrl={data.properties?.externalUrl}
                 parentEntities={parentEntities}
                 container={data.container || undefined}
+                previewType={previewType}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/dataProcessInstance/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/dataProcessInstance/preview/Preview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { GenericEntityProperties } from '@app/entity/shared/types';
-import { IconStyleType } from '@app/entityV2/Entity';
+import { IconStyleType, PreviewType } from '@app/entityV2/Entity';
 import DefaultPreviewCard from '@app/previewV2/DefaultPreviewCard';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
@@ -41,6 +41,7 @@ export default function Preview({
     paths,
     health,
     parentEntities,
+    previewType,
 }: {
     urn: string;
     name: string;
@@ -63,6 +64,7 @@ export default function Preview({
     paths?: EntityPath[];
     health?: Health[] | null;
     parentEntities?: Array<GeneratedEntity> | null;
+    previewType: PreviewType;
 }): JSX.Element {
     const entityRegistry = useEntityRegistry();
     return (
@@ -92,6 +94,7 @@ export default function Preview({
             paths={paths}
             health={health || undefined}
             parentEntities={parentEntities}
+            previewType={previewType}
         />
     );
 }

--- a/datahub-web-react/src/app/entityV2/dataProduct/DataProductEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataProduct/DataProductEntity.tsx
@@ -236,6 +236,7 @@ export class DataProductEntity implements Entity<DataProduct> {
                 degree={(result as any).degree}
                 paths={(result as any).paths}
                 headerDropdownItems={headerDropdownItems}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/dataProduct/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/dataProduct/preview/Preview.tsx
@@ -22,7 +22,7 @@ interface Props {
     degree?: number;
     paths?: EntityPath[];
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
     actions?: EntityMenuActions;
 }
 

--- a/datahub-web-react/src/app/entityV2/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataset/DatasetEntity.tsx
@@ -462,6 +462,7 @@ export class DatasetEntity implements Entity<Dataset> {
                 isOutputPort={isOutputPort(result)}
                 headerDropdownItems={headerDropdownItems}
                 browsePaths={data.browsePathV2 || undefined}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/dataset/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/dataset/preview/Preview.tsx
@@ -97,7 +97,7 @@ export const Preview = ({
     isOutputPort?: boolean;
     tier?: PopularityTier;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: Maybe<PreviewType>;
+    previewType: PreviewType;
     browsePaths?: BrowsePathV2;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();

--- a/datahub-web-react/src/app/entityV2/domain/DomainEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/domain/DomainEntity.tsx
@@ -212,6 +212,7 @@ export class DomainEntity implements Entity<Domain> {
                 logoComponent={this.icon(12, IconStyleType.ACCENT)}
                 entityCount={data.entities?.total}
                 headerDropdownItems={headerDropdownItems}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/domain/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/domain/preview/Preview.tsx
@@ -35,7 +35,7 @@ export const Preview = ({
     logoComponent?: JSX.Element;
     entityCount?: number;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     return (

--- a/datahub-web-react/src/app/entityV2/glossaryNode/ChildrenTabWrapper.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryNode/ChildrenTabWrapper.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import ChildrenTab from '@app/entityV2/glossaryNode/ChildrenTab';
+
+export default function ChildrenTabWrapper() {
+    const { urn } = useEntityData();
+
+    return <ChildrenTab key={urn} />;
+}

--- a/datahub-web-react/src/app/entityV2/glossaryNode/GlossaryNodeEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryNode/GlossaryNodeEntity.tsx
@@ -3,7 +3,7 @@ import { BookmarksSimple } from '@phosphor-icons/react';
 import React from 'react';
 
 import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from '@app/entityV2/Entity';
-import ChildrenTab from '@app/entityV2/glossaryNode/ChildrenTab';
+import ChildrenTabWrapper from '@app/entityV2/glossaryNode/ChildrenTabWrapper';
 import { Preview } from '@app/entityV2/glossaryNode/preview/Preview';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
@@ -140,7 +140,7 @@ class GlossaryNodeEntity implements Entity<GlossaryNode> {
                 : []),
             {
                 name: 'Contents',
-                component: ChildrenTab,
+                component: ChildrenTabWrapper,
                 icon: AppstoreOutlined,
             },
             ...(!showSummaryTab

--- a/datahub-web-react/src/app/entityV2/glossaryNode/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryNode/preview/Preview.tsx
@@ -26,7 +26,7 @@ export const Preview = ({
     owners?: Array<Owner> | null;
     parentNodes?: ParentNodesResult | null;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     return (

--- a/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
@@ -230,6 +230,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
                 isOutputPort={isOutputPort(result)}
                 headerDropdownItems={headerDropdownItems}
                 browsePaths={data.browsePathV2 || undefined}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/mlFeature/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeature/preview/Preview.tsx
@@ -39,7 +39,7 @@ export const Preview = ({
     paths?: EntityPath[];
     isOutputPort?: boolean;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
     browsePaths?: BrowsePathV2 | undefined;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();

--- a/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
@@ -199,6 +199,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
                 paths={(result as any).paths}
                 isOutputPort={isOutputPort(result)}
                 headerDropdownItems={headerDropdownItems}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/mlFeatureTable/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeatureTable/preview/Preview.tsx
@@ -37,7 +37,7 @@ export const Preview = ({
     paths?: EntityPath[];
     isOutputPort?: boolean;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     return (

--- a/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
@@ -218,6 +218,7 @@ export class MLModelEntity implements Entity<MlModel> {
                 paths={(result as any).paths}
                 isOutputPort={isOutputPort(result)}
                 headerDropdownItems={headerDropdownItems}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/mlModel/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/preview/Preview.tsx
@@ -25,7 +25,7 @@ export const Preview = ({
     paths?: EntityPath[];
     isOutputPort?: boolean;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     const genericProperties = entityRegistry.getGenericEntityProperties(EntityType.Mlmodel, model);

--- a/datahub-web-react/src/app/entityV2/mlModelGroup/MLModelGroupEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModelGroup/MLModelGroupEntity.tsx
@@ -195,6 +195,7 @@ export class MLModelGroupEntity implements Entity<MlModelGroup> {
                 paths={(result as any).paths}
                 isOutputPort={isOutputPort(result)}
                 headerDropdownItems={headerDropdownItems}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/mlModelGroup/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModelGroup/preview/Preview.tsx
@@ -25,7 +25,7 @@ export const Preview = ({
     paths?: EntityPath[];
     isOutputPort?: boolean;
     headerDropdownItems?: Set<EntityMenuItems>;
-    previewType?: PreviewType;
+    previewType: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     const genericProperties = entityRegistry.getGenericEntityProperties(EntityType.MlmodelGroup, group);

--- a/datahub-web-react/src/app/entityV2/mlPrimaryKey/MLPrimaryKeyEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlPrimaryKey/MLPrimaryKeyEntity.tsx
@@ -192,6 +192,7 @@ export class MLPrimaryKeyEntity implements Entity<MlPrimaryKey> {
                 degree={(result as any).degree}
                 paths={(result as any).paths}
                 isOutputPort={isOutputPort(result)}
+                previewType={PreviewType.SEARCH}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/mlPrimaryKey/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/mlPrimaryKey/preview/Preview.tsx
@@ -35,7 +35,7 @@ export const Preview = ({
     degree?: number;
     paths?: EntityPath[];
     isOutputPort?: boolean;
-    previewType?: PreviewType;
+    previewType: PreviewType;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     return (

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/header/EntityName.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/header/EntityName.tsx
@@ -123,6 +123,7 @@ function EntityName(props: Props) {
             ellipsis={{
                 tooltip: { showArrow: false, color: 'white', overlayInnerStyle: { color: colors.gray[1700] } },
             }}
+            key={updatedName}
         >
             {updatedName}
         </EntityTitle>

--- a/datahub-web-react/src/app/entityV2/summary/documentation/EditDescriptionModal.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/documentation/EditDescriptionModal.tsx
@@ -2,6 +2,8 @@ import { Editor, Modal } from '@components';
 import React from 'react';
 import styled from 'styled-components';
 
+import { useDocumentationPermission } from '@app/entityV2/summary/documentation/useDocumentationPermission';
+
 const StyledEditor = styled(Editor)`
     border: none;
     &&& {
@@ -37,6 +39,7 @@ export default function EditDescriptionModal({
     emptyDescriptionText,
     closeModal,
 }: Props) {
+    const canEditDescription = useDocumentationPermission();
     return (
         <Modal
             title="Edit Description"
@@ -55,6 +58,7 @@ export default function EditDescriptionModal({
                         handleDescriptionUpdate();
                         closeModal();
                     },
+                    disabled: !canEditDescription,
                 },
             ]}
         >

--- a/datahub-web-react/src/app/entityV2/summary/modules/childHierarchy/ChildHierarchyModule.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/modules/childHierarchy/ChildHierarchyModule.tsx
@@ -20,8 +20,8 @@ export default function ChildHierarchyModule(props: ModuleProps) {
             <LargeModule {...props} module={module} dataTestId="hierarchy-module">
                 <EmptyContent
                     icon="Stack"
-                    title="No Child Domains"
-                    description="This domain has no child domains. Add children to see them in this module."
+                    title="No Domains"
+                    description="This domain has no children domains. Add domains to see them in this module."
                 />
             </LargeModule>
         );

--- a/datahub-web-react/src/app/homeV3/moduleModals/common/BaseModuleModal.tsx
+++ b/datahub-web-react/src/app/homeV3/moduleModals/common/BaseModuleModal.tsx
@@ -8,7 +8,7 @@ import { ANT_NOTIFICATION_Z_INDEX } from '@app/shared/constants';
 
 const modalBodyStyles = {
     overflow: 'auto',
-    maxHeight: '70vh',
+    maxHeight: '75vh',
 };
 
 interface Props {

--- a/datahub-web-react/src/app/homeV3/modules/assetCollection/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/homeV3/modules/assetCollection/__tests__/utils.test.ts
@@ -1,0 +1,340 @@
+import { sortByUrnOrder } from '@app/homeV3/modules/assetCollection/utils';
+
+// Mock entity interface with urn property
+interface MockEntity {
+    urn: string;
+    name?: string;
+    id?: number;
+}
+
+describe('sortByUrnOrder', () => {
+    describe('normal sorting behavior', () => {
+        it('should sort objects according to the provided urn order', () => {
+            const entities: MockEntity[] = [
+                { urn: 'urn:li:dataset:3', name: 'Third Dataset' },
+                { urn: 'urn:li:dataset:1', name: 'First Dataset' },
+                { urn: 'urn:li:dataset:2', name: 'Second Dataset' },
+            ];
+
+            const orderedUrns = ['urn:li:dataset:1', 'urn:li:dataset:2', 'urn:li:dataset:3'];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            expect(result).toEqual([
+                { urn: 'urn:li:dataset:1', name: 'First Dataset' },
+                { urn: 'urn:li:dataset:2', name: 'Second Dataset' },
+                { urn: 'urn:li:dataset:3', name: 'Third Dataset' },
+            ]);
+        });
+
+        it('should maintain original array order for objects with same urn order index', () => {
+            const entities: MockEntity[] = [
+                { urn: 'urn:li:dataset:1', name: 'Dataset A', id: 1 },
+                { urn: 'urn:li:dataset:1', name: 'Dataset B', id: 2 },
+            ];
+
+            const orderedUrns = ['urn:li:dataset:1'];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            // Should maintain original order for same URN
+            expect(result[0].id).toBe(1);
+            expect(result[1].id).toBe(2);
+        });
+
+        it('should work with different entity types', () => {
+            interface DataProduct {
+                urn: string;
+                displayName: string;
+                type: string;
+            }
+
+            const dataProducts: DataProduct[] = [
+                { urn: 'urn:li:dataProduct:analytics', displayName: 'Analytics', type: 'dataProduct' },
+                { urn: 'urn:li:dataProduct:customer', displayName: 'Customer', type: 'dataProduct' },
+                { urn: 'urn:li:dataProduct:billing', displayName: 'Billing', type: 'dataProduct' },
+            ];
+
+            const orderedUrns = [
+                'urn:li:dataProduct:customer',
+                'urn:li:dataProduct:billing',
+                'urn:li:dataProduct:analytics',
+            ];
+
+            const result = sortByUrnOrder(dataProducts, orderedUrns);
+
+            expect(result.map((dp) => dp.displayName)).toEqual(['Customer', 'Billing', 'Analytics']);
+        });
+    });
+
+    describe('edge cases with missing URNs', () => {
+        it('should place objects with URNs not in ordered list at the end', () => {
+            const entities: MockEntity[] = [
+                { urn: 'urn:li:dataset:unknown', name: 'Unknown Dataset' },
+                { urn: 'urn:li:dataset:1', name: 'First Dataset' },
+                { urn: 'urn:li:dataset:also-unknown', name: 'Also Unknown' },
+                { urn: 'urn:li:dataset:2', name: 'Second Dataset' },
+            ];
+
+            const orderedUrns = ['urn:li:dataset:1', 'urn:li:dataset:2'];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            // First two should be ordered according to orderedUrns
+            expect(result[0]).toEqual({ urn: 'urn:li:dataset:1', name: 'First Dataset' });
+            expect(result[1]).toEqual({ urn: 'urn:li:dataset:2', name: 'Second Dataset' });
+
+            // Last two should be the unknown ones (maintaining their relative order)
+            expect(result[2]).toEqual({ urn: 'urn:li:dataset:unknown', name: 'Unknown Dataset' });
+            expect(result[3]).toEqual({ urn: 'urn:li:dataset:also-unknown', name: 'Also Unknown' });
+        });
+
+        it('should handle case where no URNs match the ordered list', () => {
+            const entities: MockEntity[] = [
+                { urn: 'urn:li:dataset:x', name: 'X' },
+                { urn: 'urn:li:dataset:y', name: 'Y' },
+                { urn: 'urn:li:dataset:z', name: 'Z' },
+            ];
+
+            const orderedUrns = ['urn:li:dataset:1', 'urn:li:dataset:2'];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            // Should maintain original order since no URNs match
+            expect(result).toEqual(entities);
+        });
+
+        it('should handle case where ordered URNs list contains URNs not in objects', () => {
+            const entities: MockEntity[] = [
+                { urn: 'urn:li:dataset:2', name: 'Second' },
+                { urn: 'urn:li:dataset:1', name: 'First' },
+            ];
+
+            const orderedUrns = [
+                'urn:li:dataset:1',
+                'urn:li:dataset:2',
+                'urn:li:dataset:3', // This URN doesn't exist in entities
+                'urn:li:dataset:4', // This URN doesn't exist in entities
+            ];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            expect(result).toEqual([
+                { urn: 'urn:li:dataset:1', name: 'First' },
+                { urn: 'urn:li:dataset:2', name: 'Second' },
+            ]);
+        });
+    });
+
+    describe('empty arrays and edge cases', () => {
+        it('should handle empty objects array', () => {
+            const entities: MockEntity[] = [];
+            const orderedUrns = ['urn:li:dataset:1', 'urn:li:dataset:2'];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            expect(result).toEqual([]);
+        });
+
+        it('should handle empty ordered URNs array', () => {
+            const entities: MockEntity[] = [
+                { urn: 'urn:li:dataset:2', name: 'Second' },
+                { urn: 'urn:li:dataset:1', name: 'First' },
+            ];
+            const orderedUrns: string[] = [];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            // Should maintain original order when no ordering is provided
+            expect(result).toEqual(entities);
+        });
+
+        it('should handle both arrays being empty', () => {
+            const entities: MockEntity[] = [];
+            const orderedUrns: string[] = [];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            expect(result).toEqual([]);
+        });
+
+        it('should handle single object', () => {
+            const entities: MockEntity[] = [{ urn: 'urn:li:dataset:1', name: 'Only Dataset' }];
+            const orderedUrns = ['urn:li:dataset:1'];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            expect(result).toEqual(entities);
+        });
+    });
+
+    describe('mixed scenarios', () => {
+        it('should handle partial matches with complex sorting', () => {
+            const entities: MockEntity[] = [
+                { urn: 'urn:li:dataset:unknown1', name: 'Unknown 1' },
+                { urn: 'urn:li:dataset:c', name: 'C' },
+                { urn: 'urn:li:dataset:unknown2', name: 'Unknown 2' },
+                { urn: 'urn:li:dataset:a', name: 'A' },
+                { urn: 'urn:li:dataset:b', name: 'B' },
+                { urn: 'urn:li:dataset:unknown3', name: 'Unknown 3' },
+            ];
+
+            const orderedUrns = ['urn:li:dataset:a', 'urn:li:dataset:b', 'urn:li:dataset:c'];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            // First three should be ordered a, b, c
+            expect(result[0].name).toBe('A');
+            expect(result[1].name).toBe('B');
+            expect(result[2].name).toBe('C');
+
+            // Rest should be unknowns in original order
+            expect(result[3].name).toBe('Unknown 1');
+            expect(result[4].name).toBe('Unknown 2');
+            expect(result[5].name).toBe('Unknown 3');
+        });
+
+        it('should not mutate the original arrays', () => {
+            const originalEntities: MockEntity[] = [
+                { urn: 'urn:li:dataset:3', name: 'Third' },
+                { urn: 'urn:li:dataset:1', name: 'First' },
+                { urn: 'urn:li:dataset:2', name: 'Second' },
+            ];
+
+            const originalOrderedUrns = ['urn:li:dataset:1', 'urn:li:dataset:2', 'urn:li:dataset:3'];
+
+            // Create copies to compare against
+            const entitiesCopy = [...originalEntities];
+            const urnsCopy = [...originalOrderedUrns];
+
+            const result = sortByUrnOrder(originalEntities, originalOrderedUrns);
+
+            // Original arrays should remain unchanged
+            expect(originalEntities).toEqual(entitiesCopy);
+            expect(originalOrderedUrns).toEqual(urnsCopy);
+
+            // Result should be different from original order
+            expect(result).not.toEqual(originalEntities);
+            expect(result[0].name).toBe('First');
+        });
+
+        it('should work correctly with duplicate URNs in ordered list', () => {
+            const entities: MockEntity[] = [
+                { urn: 'urn:li:dataset:1', name: 'First', id: 1 },
+                { urn: 'urn:li:dataset:2', name: 'Second', id: 2 },
+            ];
+
+            // Ordered URNs with duplicate
+            const orderedUrns = ['urn:li:dataset:2', 'urn:li:dataset:1', 'urn:li:dataset:2'];
+
+            const result = sortByUrnOrder(entities, orderedUrns);
+
+            // Should use the first occurrence index (index 0 for dataset:2, index 1 for dataset:1)
+            expect(result[0].name).toBe('Second');
+            expect(result[1].name).toBe('First');
+        });
+    });
+
+    describe('performance and data integrity', () => {
+        it('should handle large datasets efficiently', () => {
+            // Create a large dataset
+            const largeEntityList: MockEntity[] = Array.from({ length: 1000 }, (_, i) => ({
+                urn: `urn:li:dataset:${i}`,
+                name: `Dataset ${i}`,
+            }));
+
+            // Create ordered URNs in reverse order
+            const orderedUrns = Array.from({ length: 1000 }, (_, i) => `urn:li:dataset:${999 - i}`);
+
+            const startTime = performance.now();
+            const result = sortByUrnOrder(largeEntityList, orderedUrns);
+            const endTime = performance.now();
+
+            // Should complete in reasonable time (less than 100ms)
+            expect(endTime - startTime).toBeLessThan(100);
+
+            // Verify correct sorting
+            expect(result[0].name).toBe('Dataset 999');
+            expect(result[999].name).toBe('Dataset 0');
+            expect(result).toHaveLength(1000);
+        });
+
+        it('should preserve all object properties during sorting', () => {
+            interface ComplexEntity {
+                urn: string;
+                name: string;
+                metadata: {
+                    created: Date;
+                    tags: string[];
+                };
+                nestedObject: {
+                    deep: {
+                        value: number;
+                    };
+                };
+            }
+
+            const complexEntities: ComplexEntity[] = [
+                {
+                    urn: 'urn:li:dataset:2',
+                    name: 'Second',
+                    metadata: {
+                        created: new Date('2023-01-02'),
+                        tags: ['tag1', 'tag2'],
+                    },
+                    nestedObject: {
+                        deep: {
+                            value: 42,
+                        },
+                    },
+                },
+                {
+                    urn: 'urn:li:dataset:1',
+                    name: 'First',
+                    metadata: {
+                        created: new Date('2023-01-01'),
+                        tags: ['tag3'],
+                    },
+                    nestedObject: {
+                        deep: {
+                            value: 24,
+                        },
+                    },
+                },
+            ];
+
+            const orderedUrns = ['urn:li:dataset:1', 'urn:li:dataset:2'];
+
+            const result = sortByUrnOrder(complexEntities, orderedUrns);
+
+            // Verify all properties are preserved
+            expect(result[0]).toEqual({
+                urn: 'urn:li:dataset:1',
+                name: 'First',
+                metadata: {
+                    created: new Date('2023-01-01'),
+                    tags: ['tag3'],
+                },
+                nestedObject: {
+                    deep: {
+                        value: 24,
+                    },
+                },
+            });
+
+            expect(result[1]).toEqual({
+                urn: 'urn:li:dataset:2',
+                name: 'Second',
+                metadata: {
+                    created: new Date('2023-01-02'),
+                    tags: ['tag1', 'tag2'],
+                },
+                nestedObject: {
+                    deep: {
+                        value: 42,
+                    },
+                },
+            });
+        });
+    });
+});

--- a/datahub-web-react/src/app/homeV3/modules/assetCollection/utils.ts
+++ b/datahub-web-react/src/app/homeV3/modules/assetCollection/utils.ts
@@ -1,0 +1,22 @@
+export function sortByUrnOrder<T extends { urn: string }>(objects: T[], orderedUrns: string[]): T[] {
+    // Create a map of urn to index for O(1) lookup
+    const urnToIndex = new Map<string, number>();
+    orderedUrns.forEach((urn, index) => {
+        if (!urnToIndex.has(urn)) {
+            urnToIndex.set(urn, index);
+        }
+    });
+
+    // Sort objects based on the index of their ID in the ordered list
+    return [...objects].sort((a, b) => {
+        const indexA = urnToIndex.get(a.urn);
+        const indexB = urnToIndex.get(b.urn);
+
+        // Handle cases where ID might not be in the ordered list
+        if (indexA === undefined && indexB === undefined) return 0;
+        if (indexA === undefined) return 1; // a goes to end
+        if (indexB === undefined) return -1; // b goes to end
+
+        return indexA - indexB;
+    });
+}

--- a/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/form/sections/relatedEntities/RelatedEntitiesSection.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/form/sections/relatedEntities/RelatedEntitiesSection.tsx
@@ -52,15 +52,15 @@ export default function RelatedEntitiesSection() {
                 <ShowRelatedEntitiesSwitch isChecked={isChecked} onChange={toggleShowRelatedEntitiesSwitch} />
             </FormItem>
 
-            <FormItem name={FORM_FIELD_RELATED_ENTITIES_FILTER}>
-                {isChecked && (
+            {isChecked && (
+                <FormItem name={FORM_FIELD_RELATED_ENTITIES_FILTER}>
                     <LogicalFiltersBuilder
                         filters={relatedEntitiesFilter ?? defaultRelatedEntitiesFilter ?? EMPTY_FILTER}
                         onChangeFilters={updateFilters}
                         properties={properties}
                     />
-                )}
-            </FormItem>
+                </FormItem>
+            )}
         </>
     );
 }

--- a/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/form/sections/relatedEntities/components/ShowRelatedEntitiesToggler.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/form/sections/relatedEntities/components/ShowRelatedEntitiesToggler.tsx
@@ -21,7 +21,7 @@ export default function ShowRelatedEntitiesSwitch({ isChecked, onChange }: Props
     return (
         <Wrapper>
             <LabelContainer>
-                <Text weight="bold" color="gray" lineHeight="sm">
+                <Text weight="bold" color="gray" colorLevel={600} lineHeight="sm">
                     Show Related Entities
                 </Text>
                 <Text color="gray" lineHeight="sm">

--- a/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/form/sections/selectAssets/SelectAssetsSection.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/hierarchyViewModule/components/form/sections/selectAssets/SelectAssetsSection.tsx
@@ -13,6 +13,11 @@ import FormItem from '@app/homeV3/modules/shared/Form/FormItem';
 
 const Wrapper = styled.div``;
 
+const ScrollWrapper = styled.div`
+    max-height: 40vh;
+    overflow: auto;
+`;
+
 export default function SelectAssetsSection() {
     const form = Form.useFormInstance();
 
@@ -35,7 +40,9 @@ export default function SelectAssetsSection() {
             label: 'Domains',
             content: (
                 <FormItem name="domainAssets">
-                    <DomainsSelectableTreeView />
+                    <ScrollWrapper>
+                        <DomainsSelectableTreeView />
+                    </ScrollWrapper>
                 </FormItem>
             ),
         },
@@ -44,7 +51,9 @@ export default function SelectAssetsSection() {
             label: 'Glossary',
             content: (
                 <FormItem name="glossaryAssets">
-                    <GlossarySelectableTreeView />
+                    <ScrollWrapper>
+                        <GlossarySelectableTreeView />
+                    </ScrollWrapper>
                 </FormItem>
             ),
         },
@@ -52,7 +61,7 @@ export default function SelectAssetsSection() {
 
     return (
         <Wrapper>
-            <Text color="gray" weight="bold">
+            <Text color="gray" colorLevel={600} weight="bold">
                 Search and Select Assets
             </Text>
             <FormItem name={FORM_FIELD_ASSET_TYPE}>

--- a/datahub-web-react/src/app/homeV3/template/Template.tsx
+++ b/datahub-web-react/src/app/homeV3/template/Template.tsx
@@ -2,6 +2,7 @@ import { spacing } from '@components';
 import React, { memo, useMemo } from 'react';
 import styled from 'styled-components';
 
+import { useEntityData } from '@app/entity/shared/EntityContext';
 import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
 import ModuleModalMapper from '@app/homeV3/moduleModals/ModuleModalMapper';
 import AddModuleButton from '@app/homeV3/template/components/AddModuleButton';
@@ -27,6 +28,7 @@ interface Props {
 }
 
 function Template({ className }: Props) {
+    const { urn } = useEntityData();
     const { template, isTemplateEditable, moduleContext } = usePageTemplateContext();
     const rows = useMemo(
         () => (template?.properties?.rows ?? []) as DataHubPageTemplateRow[],
@@ -37,7 +39,11 @@ function Template({ className }: Props) {
 
     return (
         // set data-testid once module context resolves to reduce cypress flakiness
-        <Wrapper className={className} data-testid={moduleContext.globalTemplate ? 'home-template-wrapper' : undefined}>
+        <Wrapper
+            className={className}
+            key={urn}
+            data-testid={moduleContext.globalTemplate ? 'home-template-wrapper' : undefined}
+        >
             <DragAndDropProvider>
                 <TemplateGrid wrappedRows={wrappedRows} />
             </DragAndDropProvider>

--- a/datahub-web-react/src/app/onboarding/WelcomeToDataHubModal.tsx
+++ b/datahub-web-react/src/app/onboarding/WelcomeToDataHubModal.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import analytics, { EventType } from '@app/analytics';
 import { useOnboardingTour } from '@app/onboarding/OnboardingTourContext.hooks';
+import { ANT_NOTIFICATION_Z_INDEX } from '@app/shared/constants';
 import {
     LoadingContainer,
     SlideContainer,
@@ -190,6 +191,7 @@ export const WelcomeToDataHubModal = () => {
             width={MODAL_WIDTH}
             onCancel={() => closeTour('close_button')}
             buttons={[]}
+            zIndex={ANT_NOTIFICATION_Z_INDEX + 2} // 2 higher because home settings button is 1 higher
         >
             <Carousel
                 ref={carouselRef}

--- a/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
@@ -170,7 +170,7 @@ interface Props {
     // how the listed node is connected to the source node
     degree?: number;
     parentEntities?: Entity[] | null;
-    previewType?: Maybe<PreviewType>;
+    previewType: PreviewType;
     paths?: EntityPath[];
     health?: Health[];
     lastUpdatedMs?: DatasetLastUpdatedMs | DashboardLastUpdatedMs;

--- a/datahub-web-react/src/app/searchV2/autoCompleteV2/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/searchV2/autoCompleteV2/__tests__/utils.test.ts
@@ -1,0 +1,482 @@
+import { getEntityDisplayType } from '@app/searchV2/autoCompleteV2/utils';
+import EntityRegistry from '@src/app/entityV2/EntityRegistry';
+import { capitalizeFirstLetterOnly } from '@src/app/shared/textUtil';
+import { EntityType } from '@src/types.generated';
+
+// Mock the dependencies
+vi.mock('@src/app/shared/textUtil', () => ({
+    capitalizeFirstLetterOnly: vi.fn(),
+}));
+
+// Mock Entity type
+interface MockEntity {
+    type: EntityType;
+    urn: string;
+    [key: string]: any;
+}
+
+describe('getEntityDisplayType', () => {
+    let mockRegistry: EntityRegistry;
+    let mockCapitalizeFirstLetterOnly: any;
+
+    beforeEach(() => {
+        // Reset all mocks
+        vi.clearAllMocks();
+
+        // Create a mock registry
+        mockRegistry = {
+            getGenericEntityProperties: vi.fn(),
+            getFirstSubType: vi.fn(),
+            getEntityName: vi.fn(),
+        } as any;
+
+        // Setup the mock function
+        mockCapitalizeFirstLetterOnly = vi.mocked(capitalizeFirstLetterOnly);
+    });
+
+    describe('when entity has a subtype', () => {
+        it('should return capitalized subtype when subtype exists', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Dataset,
+                urn: 'urn:li:dataset:test',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: ['view', 'table'],
+                },
+            };
+
+            // Setup mock responses
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('view');
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Dataset');
+            mockCapitalizeFirstLetterOnly.mockReturnValue('View');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(mockRegistry.getGenericEntityProperties).toHaveBeenCalledWith(EntityType.Dataset, mockEntity);
+            expect(mockRegistry.getFirstSubType).toHaveBeenCalledWith(mockProperties);
+            expect(capitalizeFirstLetterOnly).toHaveBeenCalledWith('view');
+            expect(mockRegistry.getEntityName).toHaveBeenCalledWith(EntityType.Dataset);
+            expect(result).toBe('View');
+        });
+
+        it('should handle complex subtype names correctly', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Dashboard,
+                urn: 'urn:li:dashboard:test',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: ['operational_dashboard'],
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('operational_dashboard');
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Dashboard');
+            mockCapitalizeFirstLetterOnly.mockReturnValue('Operational_dashboard');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(capitalizeFirstLetterOnly).toHaveBeenCalledWith('operational_dashboard');
+            expect(result).toBe('Operational_dashboard');
+        });
+
+        it('should handle empty string subtype', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Container,
+                urn: 'urn:li:container:test',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: [''],
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('');
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Container');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            // Empty string is falsy, so ternary should return entityName directly
+            expect(capitalizeFirstLetterOnly).not.toHaveBeenCalled();
+            expect(result).toBe('Container');
+        });
+    });
+
+    describe('when entity has no subtype', () => {
+        it('should return entity name when subtype is undefined', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.DataJob,
+                urn: 'urn:li:dataJob:test',
+            };
+
+            const mockProperties = {
+                name: 'Test Data Job',
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue(undefined);
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Data Job');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(mockRegistry.getFirstSubType).toHaveBeenCalledWith(mockProperties);
+            expect(capitalizeFirstLetterOnly).not.toHaveBeenCalled();
+            expect(mockRegistry.getEntityName).toHaveBeenCalledWith(EntityType.DataJob);
+            expect(result).toBe('Data Job');
+        });
+
+        it('should return entity name when subtype is null', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.GlossaryTerm,
+                urn: 'urn:li:glossaryTerm:test',
+            };
+
+            const mockProperties = {
+                subTypes: null,
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue(null);
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Glossary Term');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(result).toBe('Glossary Term');
+        });
+
+        it('should return entity name when typeNames array is empty', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Domain,
+                urn: 'urn:li:domain:test',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: [],
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue(undefined);
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Domain');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(result).toBe('Domain');
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should handle null properties from registry', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Chart,
+                urn: 'urn:li:chart:test',
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(null);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue(undefined);
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Chart');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(mockRegistry.getFirstSubType).toHaveBeenCalledWith(null);
+            expect(result).toBe('Chart');
+        });
+
+        it('should handle undefined properties from registry', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.CorpUser,
+                urn: 'urn:li:corpuser:test',
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(undefined);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue(undefined);
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('User');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(mockRegistry.getFirstSubType).toHaveBeenCalledWith(undefined);
+            expect(result).toBe('User');
+        });
+
+        it('should handle entity with unknown type', () => {
+            const mockEntity: MockEntity = {
+                type: 'UNKNOWN_TYPE' as EntityType,
+                urn: 'urn:li:unknown:test',
+            };
+
+            const mockProperties = {};
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue(undefined);
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Unknown');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(result).toBe('Unknown');
+        });
+
+        it('should handle capitalizeFirstLetterOnly returning undefined', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Dataset,
+                urn: 'urn:li:dataset:test',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: ['view'],
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('view');
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Dataset');
+            mockCapitalizeFirstLetterOnly.mockReturnValue(undefined);
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            // Function returns the result of capitalizeFirstLetterOnly directly when subtype exists
+            expect(result).toBe(undefined);
+        });
+
+        it('should handle capitalizeFirstLetterOnly returning null', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Dataset,
+                urn: 'urn:li:dataset:test',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: ['view'],
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('view');
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Dataset');
+            mockCapitalizeFirstLetterOnly.mockReturnValue(null);
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            // Function returns the result of capitalizeFirstLetterOnly directly when subtype exists
+            expect(result).toBe(null);
+        });
+    });
+
+    describe('registry method calls', () => {
+        it('should call registry methods in correct order', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Mlmodel,
+                urn: 'urn:li:mlModel:test',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: ['classification'],
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('classification');
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('ML Model');
+            mockCapitalizeFirstLetterOnly.mockReturnValue('Classification');
+
+            getEntityDisplayType(mockEntity, mockRegistry);
+
+            // Verify the order of calls
+            expect(mockRegistry.getGenericEntityProperties).toHaveBeenCalledBefore(mockRegistry.getFirstSubType as any);
+            expect(mockRegistry.getFirstSubType).toHaveBeenCalledBefore(mockRegistry.getEntityName as any);
+        });
+
+        it('should pass correct arguments to registry methods', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.DataFlow,
+                urn: 'urn:li:dataFlow:test',
+                additionalProperty: 'test-value',
+            };
+
+            const mockProperties = { name: 'Test Flow' };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue(undefined);
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Data Flow');
+
+            getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(mockRegistry.getGenericEntityProperties).toHaveBeenCalledWith(EntityType.DataFlow, mockEntity);
+            expect(mockRegistry.getFirstSubType).toHaveBeenCalledWith(mockProperties);
+            expect(mockRegistry.getEntityName).toHaveBeenCalledWith(EntityType.DataFlow);
+        });
+    });
+
+    describe('real-world scenarios', () => {
+        it('should handle dataset with table subtype', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Dataset,
+                urn: 'urn:li:dataset:(urn:li:dataPlatform:hive,default.users,PROD)',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: ['table'],
+                },
+                platform: {
+                    name: 'hive',
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('table');
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Dataset');
+            mockCapitalizeFirstLetterOnly.mockReturnValue('Table');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(result).toBe('Table');
+        });
+
+        it('should handle dashboard without subtype', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Dashboard,
+                urn: 'urn:li:dashboard:(looker,dashboard.1)',
+            };
+
+            const mockProperties = {
+                platform: {
+                    name: 'looker',
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue(undefined);
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Dashboard');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(result).toBe('Dashboard');
+        });
+
+        it('should handle ML model with custom subtype', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Mlmodel,
+                urn: 'urn:li:mlModel:(urn:li:dataPlatform:sagemaker,my-model,PROD)',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: ['tensorflow_serving'],
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('tensorflow_serving');
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('ML Model');
+            mockCapitalizeFirstLetterOnly.mockReturnValue('Tensorflow_serving');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(result).toBe('Tensorflow_serving');
+        });
+
+        it('should handle container with multiple subtypes (uses first one)', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.Container,
+                urn: 'urn:li:container:12345',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: ['database', 'schema', 'table'],
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('database'); // Only returns first one
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Container');
+            mockCapitalizeFirstLetterOnly.mockReturnValue('Database');
+
+            const result = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(mockRegistry.getFirstSubType).toHaveBeenCalledWith(mockProperties);
+            expect(capitalizeFirstLetterOnly).toHaveBeenCalledWith('database');
+            expect(result).toBe('Database');
+        });
+    });
+
+    describe('function behavior consistency', () => {
+        it('should return appropriate types based on conditions', () => {
+            const testCases = [
+                {
+                    entity: { type: EntityType.Dataset, urn: 'test1' },
+                    subtype: 'view',
+                    entityName: 'Dataset',
+                    capitalizedResult: 'View',
+                    expectedResult: 'View',
+                },
+                {
+                    entity: { type: EntityType.Chart, urn: 'test2' },
+                    subtype: undefined,
+                    entityName: 'Chart',
+                    capitalizedResult: undefined,
+                    expectedResult: 'Chart',
+                },
+                {
+                    entity: { type: EntityType.CorpUser, urn: 'test3' },
+                    subtype: null,
+                    entityName: 'User',
+                    capitalizedResult: null,
+                    expectedResult: 'User',
+                },
+                {
+                    entity: { type: EntityType.Dataset, urn: 'test4' },
+                    subtype: 'view',
+                    entityName: 'Dataset',
+                    capitalizedResult: undefined, // capitalizeFirstLetterOnly returns undefined
+                    expectedResult: undefined,
+                },
+            ];
+
+            testCases.forEach(({ entity, subtype, entityName, capitalizedResult, expectedResult }) => {
+                mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue({});
+                mockRegistry.getFirstSubType = vi.fn().mockReturnValue(subtype);
+                mockRegistry.getEntityName = vi.fn().mockReturnValue(entityName);
+                mockCapitalizeFirstLetterOnly.mockReturnValue(capitalizedResult);
+
+                const result = getEntityDisplayType(entity as MockEntity, mockRegistry);
+
+                expect(result).toBe(expectedResult);
+            });
+        });
+
+        it('should be deterministic with same inputs', () => {
+            const mockEntity: MockEntity = {
+                type: EntityType.GlossaryTerm,
+                urn: 'urn:li:glossaryTerm:test',
+            };
+
+            const mockProperties = {
+                subTypes: {
+                    typeNames: ['concept'],
+                },
+            };
+
+            mockRegistry.getGenericEntityProperties = vi.fn().mockReturnValue(mockProperties);
+            mockRegistry.getFirstSubType = vi.fn().mockReturnValue('concept');
+            mockRegistry.getEntityName = vi.fn().mockReturnValue('Glossary Term');
+            mockCapitalizeFirstLetterOnly.mockReturnValue('Concept');
+
+            const result1 = getEntityDisplayType(mockEntity, mockRegistry);
+            const result2 = getEntityDisplayType(mockEntity, mockRegistry);
+
+            expect(result1).toBe(result2);
+            expect(result1).toBe('Concept');
+        });
+    });
+});

--- a/datahub-web-react/src/app/searchV2/autoCompleteV2/utils.ts
+++ b/datahub-web-react/src/app/searchV2/autoCompleteV2/utils.ts
@@ -7,6 +7,6 @@ export function getEntityDisplayType(entity: Entity, registry: EntityRegistry) {
 
     const subtype = registry.getFirstSubType(properties);
     const entityName = registry.getEntityName(entity.type);
-    const displayType = capitalizeFirstLetterOnly((subtype ?? entityName)?.toLocaleLowerCase());
-    return displayType;
+
+    return subtype ? capitalizeFirstLetterOnly(subtype) : entityName;
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -136,6 +136,9 @@ public enum DataHubUsageEventType {
   HOME_PAGE_TEMPLATE_MODULE_LINK_CLICK_EVENT("HomePageTemplateModuleLinkClick"),
   HOME_PAGE_TEMPLATE_MODULE_ANNOUNCEMENT_DISMISS_EVENT("HomePageTemplateModuleAnnouncementDismiss"),
   SET_DEPRECATION("SetDeprecation"),
+  ASSET_PAGE_ADD_SUMMARY_ELEMENT("AssetPageAddSummaryElement"),
+  ASSET_PAGE_REMOVE_SUMMARY_ELEMENT("AssetPageRemoveSummaryElement"),
+  ASSET_PAGE_REPLACE_SUMMARY_ELEMENT("AssetPageReplaceSummaryElement"),
   // Not replicated in frontend, represents generic event from backend
   CREATE_USER_EVENT("CreateUserEvent"),
   UPDATE_USER_EVENT("UpdateUserEvent"),


### PR DESCRIPTION
This PR adds a collection of small fixes for both the new summary tabs and the new home page experience. It involves design nits that came out of design review and minor UX fixes from those reviews as well.

Additionally the second commit in this PR fixes a bug where we were not properly showing descriptions on search cards when the flag was flipped because we weren't properly passing in the preview type to the default preview card in all situations.

The vast majority of the diff here are tests for the functionality or old functionality missing tests.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
