### PR TITLE
fix(exception): surface exceptions to API response

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/exception/DataHubDataFetcherExceptionHandler.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/exception/DataHubDataFetcherExceptionHandler.java
@@ -50,7 +50,18 @@ public class DataHubDataFetcherExceptionHandler implements DataFetcherExceptionH
       message = validationException.getMessage();
     }
 
-    if (illException == null && graphQLException == null && validationException == null) {
+    RuntimeException runtimeException =
+        findFirstThrowableCauseOfClass(exception, RuntimeException.class);
+    if (message.equals(DEFAULT_ERROR_MESSAGE) && runtimeException != null) {
+      log.error("Failed to execute", runtimeException);
+      errorCode = DataHubGraphQLErrorCode.SERVER_ERROR;
+      message = runtimeException.getMessage();
+    }
+
+    if (illException == null
+        && graphQLException == null
+        && validationException == null
+        && runtimeException == null) {
       log.error("Failed to execute", exception);
     }
     DataHubGraphQLError error = new DataHubGraphQLError(message, path, sourceLocation, errorCode);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/exception/DataHubDataFetcherExceptionHandlerTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/exception/DataHubDataFetcherExceptionHandlerTest.java
@@ -1,0 +1,232 @@
+package com.linkedin.datahub.graphql.exception;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.metadata.entity.validation.ValidationException;
+import graphql.execution.DataFetcherExceptionHandlerParameters;
+import graphql.execution.DataFetcherExceptionHandlerResult;
+import graphql.execution.ResultPath;
+import graphql.language.SourceLocation;
+import java.util.concurrent.ExecutionException;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DataHubDataFetcherExceptionHandlerTest {
+
+  private DataHubDataFetcherExceptionHandler handler;
+  private DataFetcherExceptionHandlerParameters mockParameters;
+  private SourceLocation mockSourceLocation;
+  private ResultPath mockPath;
+
+  @BeforeMethod
+  public void setup() {
+    handler = new DataHubDataFetcherExceptionHandler();
+    mockParameters = Mockito.mock(DataFetcherExceptionHandlerParameters.class);
+    mockSourceLocation = Mockito.mock(SourceLocation.class);
+    mockPath = Mockito.mock(ResultPath.class);
+
+    Mockito.when(mockParameters.getSourceLocation()).thenReturn(mockSourceLocation);
+    Mockito.when(mockParameters.getPath()).thenReturn(mockPath);
+  }
+
+  @Test
+  public void testHandleIllegalArgumentException() throws ExecutionException, InterruptedException {
+    IllegalArgumentException exception = new IllegalArgumentException("Invalid argument");
+    Mockito.when(mockParameters.getException()).thenReturn(exception);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertEquals(error.getMessage(), "Invalid argument");
+    assertEquals(error.getErrorCode(), 400);
+  }
+
+  @Test
+  public void testHandleDataHubGraphQLException() throws ExecutionException, InterruptedException {
+    DataHubGraphQLException exception =
+        new DataHubGraphQLException("GraphQL error", DataHubGraphQLErrorCode.NOT_FOUND);
+    Mockito.when(mockParameters.getException()).thenReturn(exception);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertEquals(error.getMessage(), "GraphQL error");
+    assertEquals(error.getErrorCode(), 404);
+  }
+
+  @Test
+  public void testHandleValidationException() throws ExecutionException, InterruptedException {
+    ValidationException exception = new ValidationException("Validation failed");
+    Mockito.when(mockParameters.getException()).thenReturn(exception);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertEquals(error.getMessage(), "Validation failed");
+    assertEquals(error.getErrorCode(), 400);
+  }
+
+  @Test
+  public void testHandleRuntimeException() throws ExecutionException, InterruptedException {
+    RuntimeException exception = new RuntimeException("Runtime error");
+    Mockito.when(mockParameters.getException()).thenReturn(exception);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertEquals(error.getMessage(), "Runtime error");
+    assertEquals(error.getErrorCode(), 500);
+  }
+
+  @Test
+  public void testHandleNestedIllegalArgumentException()
+      throws ExecutionException, InterruptedException {
+    IllegalArgumentException cause = new IllegalArgumentException("Nested invalid argument");
+    RuntimeException wrapper = new RuntimeException("Wrapper exception", cause);
+    Mockito.when(mockParameters.getException()).thenReturn(wrapper);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertEquals(error.getMessage(), "Nested invalid argument");
+    assertEquals(error.getErrorCode(), 400);
+  }
+
+  @Test
+  public void testHandleNestedDataHubGraphQLException()
+      throws ExecutionException, InterruptedException {
+    DataHubGraphQLException cause =
+        new DataHubGraphQLException("Nested GraphQL error", DataHubGraphQLErrorCode.UNAUTHORIZED);
+    RuntimeException wrapper = new RuntimeException("Wrapper exception", cause);
+    Mockito.when(mockParameters.getException()).thenReturn(wrapper);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertEquals(error.getMessage(), "Nested GraphQL error");
+    assertEquals(error.getErrorCode(), 403);
+  }
+
+  @Test
+  public void testHandleNestedValidationException()
+      throws ExecutionException, InterruptedException {
+    ValidationException cause = new ValidationException("Nested validation failed");
+    RuntimeException wrapper = new RuntimeException("Wrapper exception", cause);
+    Mockito.when(mockParameters.getException()).thenReturn(wrapper);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertEquals(error.getMessage(), "Nested validation failed");
+    assertEquals(error.getErrorCode(), 400);
+  }
+
+  @Test
+  public void testHandleUnknownException() throws ExecutionException, InterruptedException {
+    Exception exception = new Exception("Unknown error");
+    Mockito.when(mockParameters.getException()).thenReturn(exception);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertEquals(error.getMessage(), "An unknown error occurred.");
+    assertEquals(error.getErrorCode(), 500);
+  }
+
+  @Test
+  public void testHandleRuntimeExceptionWithNullMessage()
+      throws ExecutionException, InterruptedException {
+    RuntimeException exception = new RuntimeException((String) null);
+    Mockito.when(mockParameters.getException()).thenReturn(exception);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertNull(error.getMessage());
+    assertEquals(error.getErrorCode(), 500);
+  }
+
+  @Test
+  public void testPriorityOrderOfExceptionHandling()
+      throws ExecutionException, InterruptedException {
+    DataHubGraphQLException dataHubException =
+        new DataHubGraphQLException("DataHub error", DataHubGraphQLErrorCode.CONFLICT);
+    IllegalArgumentException illegalArgException =
+        new IllegalArgumentException("Illegal arg", dataHubException);
+    Mockito.when(mockParameters.getException()).thenReturn(illegalArgException);
+
+    DataFetcherExceptionHandlerResult result = handler.handleException(mockParameters).get();
+
+    assertNotNull(result);
+    assertEquals(result.getErrors().size(), 1);
+    DataHubGraphQLError error = (DataHubGraphQLError) result.getErrors().get(0);
+    assertEquals(error.getMessage(), "DataHub error");
+    assertEquals(error.getErrorCode(), 409);
+  }
+
+  @Test
+  public void testFindFirstThrowableCauseOfClass() {
+    IllegalArgumentException rootCause = new IllegalArgumentException("Root cause");
+    RuntimeException middleCause = new RuntimeException("Middle cause", rootCause);
+    Exception topException = new Exception("Top exception", middleCause);
+
+    IllegalArgumentException found =
+        handler.findFirstThrowableCauseOfClass(topException, IllegalArgumentException.class);
+    assertNotNull(found);
+    assertEquals(found.getMessage(), "Root cause");
+
+    ValidationException notFound =
+        handler.findFirstThrowableCauseOfClass(topException, ValidationException.class);
+    assertNull(notFound);
+
+    RuntimeException runtimeFound =
+        handler.findFirstThrowableCauseOfClass(topException, RuntimeException.class);
+    assertNotNull(runtimeFound);
+    assertEquals(runtimeFound.getMessage(), "Middle cause");
+  }
+
+  @Test
+  public void testFindFirstThrowableCauseOfClassWithNullThrowable() {
+    IllegalArgumentException result =
+        handler.findFirstThrowableCauseOfClass(null, IllegalArgumentException.class);
+    assertNull(result);
+  }
+
+  @Test
+  public void testFindFirstThrowableCauseOfClassWithSameClass() {
+    IllegalArgumentException exception = new IllegalArgumentException("Direct match");
+
+    IllegalArgumentException result =
+        handler.findFirstThrowableCauseOfClass(exception, IllegalArgumentException.class);
+    assertNotNull(result);
+    assertEquals(result.getMessage(), "Direct match");
+  }
+
+  @Test
+  public void testFindFirstThrowableCauseOfClassWithNoCause() {
+    RuntimeException exception = new RuntimeException("No cause");
+
+    IllegalArgumentException result =
+        handler.findFirstThrowableCauseOfClass(exception, IllegalArgumentException.class);
+    assertNull(result);
+  }
+}


### PR DESCRIPTION
By default we throw `RuntimeException` in our code but in this exception handler we were not handling that leading to `An unknown error occurred` being the default response which caused API responses to not be useful in case an error happened.

On a local endpoint that I was working on
Before
```
❌ Test FAILED with error: GraphQL errors: [{'message': 'An unknown error occurred.', 'locations': [{'line': 3, 'column': 9}], 'path': ['startS3StreamingUpload'], 'extensions': {'code': 500, 'type': 'SERVER_ERROR', 'classification': 'DataFetchingException'}}]
Traceback (most recent call last):
  File "/Users/aseembansal/code/recipes/./scripts/test_s3_streaming_upload.py", line 267, in main
    upload_result = start_streaming_upload(
                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aseembansal/code/recipes/./scripts/test_s3_streaming_upload.py", line 119, in start_streaming_upload
    return graphql_request(query, variables)["startS3StreamingUpload"]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aseembansal/code/recipes/./scripts/test_s3_streaming_upload.py", line 90, in graphql_request
    raise Exception(f"GraphQL errors: {result['errors']}")
Exception: GraphQL errors: [{'message': 'An unknown error occurred.', 'locations': [{'line': 3, 'column': 9}], 'path': ['startS3StreamingUpload'], 'extensions': {'code': 500, 'type': 'SERVER_ERROR', 'classification': 'DataFetchingException'}}]
```

After
```
❌ Test FAILED with error: GraphQL errors: [{'message': 'java.lang.RuntimeException: Failed to start S3 multipart upload: User: arn:aws:sts::795586375822:assumed-role/f7700a3ff0-dev07-datahub-gms-sa-91a8f/aws-sdk-java-1758107902818 is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::MASKED_MANULLY3/ingestion_assets/sample-file.txt" because no identity-based policy allows the s3:PutObject action (Service: S3, Status Code: 403, Request ID: MASKED_MANUALLY, Extended Request ID: MASKED_MANUALLY2) (SDK Attempt Count: 1)', 'locations': [{'line': 3, 'column': 9}], 'path': ['startS3StreamingUpload'], 'extensions': {'code': 500, 'type': 'SERVER_ERROR', 'classification': 'DataFetchingException'}}]
Traceback (most recent call last):
  File "/Users/aseembansal/code/recipes/./scripts/test_s3_streaming_upload.py", line 267, in main
    upload_result = start_streaming_upload(
                    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aseembansal/code/recipes/./scripts/test_s3_streaming_upload.py", line 119, in start_streaming_upload
    return graphql_request(query, variables)["startS3StreamingUpload"]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aseembansal/code/recipes/./scripts/test_s3_streaming_upload.py", line 90, in graphql_request
    raise Exception(f"GraphQL errors: {result['errors']}")
Exception: GraphQL errors: [{'message': 'java.lang.RuntimeException: Failed to start S3 multipart upload: User: arn:aws:sts::795586375822:assumed-role/f7700a3ff0-dev07-datahub-gms-sa-91a8f/aws-sdk-java-1758107902818 is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::MASKED_MANULLY3/ingestion_assets/sample-file.txt" because no identity-based policy allows the s3:PutObject action (Service: S3, Status Code: 403, Request ID: MASKED_MANUALLY, Extended Request ID: MASKED_MANUALLY2) (SDK Attempt Count: 1)', 'locations': [{'line': 3, 'column': 9}], 'path': ['startS3StreamingUpload'], 'extensions': {'code': 500, 'type': 'SERVER_ERROR', 'classification': 'DataFetchingException'}}]
```

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
