### PR TITLE
fix(ui/summary-tab): fix view more button when switching tabs

### DIFF
--- a/datahub-web-react/src/app/entityV2/summary/documentation/DescriptionViewer.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/documentation/DescriptionViewer.tsx
@@ -1,6 +1,8 @@
 import { Button } from '@components';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+
+import { useVisibilityObserver } from '@app/entityV2/summary/documentation/useVisibilityObserver';
 
 const MAX_VIEW_HEIGHT = 286;
 
@@ -32,20 +34,13 @@ interface Props {
 }
 
 export default function DescriptionViewer({ children }: Props) {
-    const contentRef = useRef<HTMLDivElement | null>(null);
     const [isExpanded, setIsExpanded] = useState(false);
-    const [hasMore, setHasMore] = useState(false);
 
-    useEffect(() => {
-        const element = contentRef.current;
-        if (element) {
-            setHasMore(element.scrollHeight > MAX_VIEW_HEIGHT);
-        }
-    }, [children]);
+    const { elementRef, hasMore } = useVisibilityObserver(MAX_VIEW_HEIGHT, [children]);
 
     return (
         <Wrapper expanded={isExpanded}>
-            <ContentContainer ref={contentRef} $expanded={isExpanded} $hasMore={hasMore}>
+            <ContentContainer ref={elementRef} $expanded={isExpanded} $hasMore={hasMore}>
                 {children}
             </ContentContainer>
             {hasMore && (

--- a/datahub-web-react/src/app/entityV2/summary/documentation/__tests__/useVisibilityObserver.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/documentation/__tests__/useVisibilityObserver.test.ts
@@ -1,0 +1,177 @@
+import { act, waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useVisibilityObserver } from '@app/entityV2/summary/documentation/useVisibilityObserver';
+
+// Mock IntersectionObserver
+class MockIntersectionObserver {
+    cb: IntersectionObserverCallback;
+
+    elements: Element[] = [];
+
+    constructor(cb: IntersectionObserverCallback) {
+        this.cb = cb;
+    }
+
+    observe = (el: Element) => {
+        this.elements.push(el);
+    };
+
+    disconnect = vi.fn();
+
+    unobserve = vi.fn();
+
+    triggerIntersect = (isIntersecting: boolean) => {
+        const entries = this.elements.map((el) => ({
+            isIntersecting,
+            target: el,
+            boundingClientRect: {} as DOMRect,
+            intersectionRatio: isIntersecting ? 1 : 0,
+            intersectionRect: {} as DOMRect,
+            rootBounds: {} as DOMRect,
+            time: Date.now(),
+        }));
+        this.cb(entries, this as unknown as IntersectionObserver);
+    };
+}
+
+// @ts-expect-error override global (will be replaced per test in beforeEach)
+global.IntersectionObserver = MockIntersectionObserver;
+
+// helper to mock scrollHeight
+const setScrollHeight = (el: HTMLElement, value: number) => {
+    Object.defineProperty(el, 'scrollHeight', { value, configurable: true });
+};
+
+describe('useVisibilityObserver', () => {
+    let element: HTMLDivElement;
+    let mockObserver: MockIntersectionObserver;
+
+    beforeEach(() => {
+        element = document.createElement('div');
+        document.body.appendChild(element);
+
+        mockObserver = new MockIntersectionObserver(() => {});
+        // @ts-expect-error override with vi.fn factory
+        global.IntersectionObserver = vi.fn((cb) => {
+            mockObserver = new MockIntersectionObserver(cb);
+            return mockObserver;
+        });
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = '';
+        vi.restoreAllMocks();
+    });
+
+    it('should return default values when no element is attached', () => {
+        const { result } = renderHook(() => useVisibilityObserver(100));
+        expect(result.current.hasMore).toBe(false);
+        expect(result.current.elementRef.current).toBe(null);
+    });
+
+    it('should detect when element is taller than maxViewHeight', async () => {
+        const { result, rerender } = renderHook(({ maxHeight }) => useVisibilityObserver(maxHeight), {
+            initialProps: { maxHeight: 0 },
+        });
+
+        act(() => {
+            result.current.elementRef.current = element;
+            setScrollHeight(element, 200);
+        });
+
+        rerender({ maxHeight: 100 });
+
+        await waitFor(() => {
+            expect(result.current.hasMore).toBe(true);
+        });
+    });
+
+    it('should detect when element is shorter than maxViewHeight', async () => {
+        const { result, rerender } = renderHook(({ maxHeight }) => useVisibilityObserver(maxHeight), {
+            initialProps: { maxHeight: 0 },
+        });
+
+        act(() => {
+            result.current.elementRef.current = element;
+            setScrollHeight(element, 100);
+        });
+
+        rerender({ maxHeight: 300 });
+
+        await waitFor(() => {
+            expect(result.current.hasMore).toBe(false);
+        });
+    });
+
+    it('should update hasMore when intersection occurs', async () => {
+        const { result, rerender } = renderHook(({ maxHeight }) => useVisibilityObserver(maxHeight), {
+            initialProps: { maxHeight: 0 },
+        });
+
+        act(() => {
+            result.current.elementRef.current = element;
+            setScrollHeight(element, 200);
+        });
+
+        rerender({ maxHeight: 150 });
+
+        await waitFor(() => {
+            expect(result.current.hasMore).toBe(true);
+        });
+
+        act(() => {
+            setScrollHeight(element, 100);
+            mockObserver.triggerIntersect(true);
+        });
+
+        await waitFor(() => {
+            expect(result.current.hasMore).toBe(false);
+        });
+    });
+
+    it('should respond to dependency changes and recreate observer', async () => {
+        let depValue = 0;
+        const { result, rerender } = renderHook(({ dep }) => useVisibilityObserver(120, [dep]), {
+            initialProps: { dep: depValue },
+        });
+
+        act(() => {
+            result.current.elementRef.current = element;
+            setScrollHeight(element, 200);
+        });
+
+        depValue = 1;
+        rerender({ dep: depValue });
+
+        await waitFor(() => {
+            expect(result.current.hasMore).toBe(true);
+        });
+
+        depValue = 2;
+        rerender({ dep: depValue });
+
+        expect((global.IntersectionObserver as any).mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('should clean up observer on unmount', async () => {
+        const { result, unmount, rerender } = renderHook(({ maxHeight }) => useVisibilityObserver(maxHeight), {
+            initialProps: { maxHeight: 0 },
+        });
+
+        act(() => {
+            result.current.elementRef.current = element;
+            setScrollHeight(element, 200);
+        });
+
+        rerender({ maxHeight: 100 });
+
+        await waitFor(() => {
+            expect(mockObserver.elements.length).toBeGreaterThan(0);
+        });
+
+        unmount();
+        expect(mockObserver.disconnect).toHaveBeenCalled();
+    });
+});

--- a/datahub-web-react/src/app/entityV2/summary/documentation/useVisibilityObserver.ts
+++ b/datahub-web-react/src/app/entityV2/summary/documentation/useVisibilityObserver.ts
@@ -1,0 +1,34 @@
+import { DependencyList, useEffect, useRef, useState } from 'react';
+
+export function useVisibilityObserver(
+    maxViewHeight: number,
+    dependencies: DependencyList = [], // Additional dependencies to watch
+) {
+    const elementRef = useRef<HTMLDivElement | null>(null);
+    const [hasMore, setHasMore] = useState(false);
+
+    useEffect(() => {
+        const element = elementRef.current;
+        if (!element) return undefined;
+
+        setHasMore(element.scrollHeight > maxViewHeight);
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        setHasMore(element.scrollHeight > maxViewHeight);
+                    }
+                });
+            },
+            { threshold: 0.01 },
+        );
+
+        observer.observe(element);
+        return () => observer.disconnect();
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [maxViewHeight, ...dependencies]);
+
+    return { elementRef, hasMore };
+}


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-785/bug-view-more-disappears-when-switching-between-asset-tabs


**Video:**

https://github.com/user-attachments/assets/0ae15aa9-d15c-42b3-9ccc-c3b71623b87c



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
