### PR TITLE
improvement(ui/summary-tab): use editor from component library in CompactMarkdownViewer for consistent styles

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/CompactMarkdownViewer.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/CompactMarkdownViewer.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
-import { Editor } from '@app/entityV2/shared/tabs/Documentation/components/editor/Editor';
-import { Button, Tooltip } from '@src/alchemy-components';
+import { Button, Editor, Tooltip } from '@src/alchemy-components';
 
 const LINE_HEIGHT = 1.5;
 
@@ -41,6 +40,8 @@ const MarkdownViewContainer = styled.div<{ scrollableY: boolean }>`
 `;
 
 const CompactEditor = styled(Editor)<{ limit: number | null; customStyle?: React.CSSProperties }>`
+    border: none;
+
     .remirror-theme {
         max-width: 100%;
     }


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-769/documentation-on-the-sidebar-has-different-formatting-styles

**Description:**

Changes the `Editor` used in `CompactMarkdownViewer` to use the one from our component library. This allows the styles lije font size, underline etc. to consistently take effect.

**Screenshot:**

<img width="1512" height="858" alt="image" src="https://github.com/user-attachments/assets/09729717-cdf9-4339-b6cf-c5b738fbed33" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
