### PR TITLE
fix(ui): handle edit documentation button on sidebar with new summary page and update permissions

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/constants.ts
+++ b/datahub-web-react/src/app/entityV2/shared/constants.ts
@@ -240,3 +240,10 @@ export const TITLE_CASE_EXCEPTION_WORDS = ['of', 'the', 'in', 'on', 'and', 'a', 
 export const RECOMMENDATION_MODULE_ID_RECENTLY_VIEWED_ENTITIES = 'RecentlyViewedEntities';
 export const RECOMMENDATION_MODULE_ID_RECENTLY_EDITED_ENTITIES = 'RecentlyEditedEntities';
 export const RECOMMENDATION_MODULE_ID_RECENT_SEARCHES = 'RecentSearches';
+
+export const ENTITY_TYPES_WITH_NEW_SUMMARY_TAB = [
+    EntityType.GlossaryNode,
+    EntityType.GlossaryTerm,
+    EntityType.DataProduct,
+    EntityType.Domain,
+];

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection.tsx
@@ -3,7 +3,7 @@ import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import React from 'react';
 
 import { useEntityData, useMutationUrn, useRouteToTab } from '@app/entity/shared/EntityContext';
-import { EMPTY_MESSAGES } from '@app/entityV2/shared/constants';
+import { EMPTY_MESSAGES, ENTITY_TYPES_WITH_NEW_SUMMARY_TAB } from '@app/entityV2/shared/constants';
 import DescriptionSection from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/DescriptionSection';
 import LinksSection from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/LinksSection';
 import SourceRefSection from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SourceRefSection';
@@ -11,6 +11,8 @@ import EmptySectionText from '@app/entityV2/shared/containers/profile/sidebar/Em
 import SectionActionButton from '@app/entityV2/shared/containers/profile/sidebar/SectionActionButton';
 import { SidebarSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarSection';
 import { getEntityPath } from '@app/entityV2/shared/containers/profile/utils';
+import { useDocumentationPermission } from '@app/entityV2/summary/documentation/useDocumentationPermission';
+import { useShowAssetSummaryPage } from '@app/entityV2/summary/useShowAssetSummaryPage';
 import { useIsSeparateSiblingsMode } from '@src/app/entity/shared/siblingUtils';
 import { getAssetDescriptionDetails } from '@src/app/entityV2/shared/tabs/Documentation/utils';
 import useIsLineageMode from '@src/app/lineage/utils/useIsLineageMode';
@@ -47,7 +49,9 @@ export const SidebarAboutSection = ({ properties, readOnly }: Props) => {
 
     const hasContent = !!displayedDescription || links.length > 0;
 
-    const canEditDescription = !!entityData?.privileges?.canEditDescription;
+    const canEditDescription = useDocumentationPermission();
+
+    const showNewSummaryTab = useShowAssetSummaryPage();
 
     return (
         <>
@@ -74,7 +78,17 @@ export const SidebarAboutSection = ({ properties, readOnly }: Props) => {
                                 dataTestId="editDocumentation"
                                 onClick={(event) => {
                                     if (!isEmbeddedProfile) {
-                                        routeToTab({ tabName: 'Documentation', tabParams: { editing: true } });
+                                        if (
+                                            ENTITY_TYPES_WITH_NEW_SUMMARY_TAB.includes(entityType) &&
+                                            showNewSummaryTab
+                                        ) {
+                                            routeToTab({
+                                                tabName: 'Summary',
+                                                tabParams: { editingDescription: true },
+                                            });
+                                        } else {
+                                            routeToTab({ tabName: 'Documentation', tabParams: { editing: true } });
+                                        }
                                     } else {
                                         const url = getEntityPath(
                                             entityType,

--- a/datahub-web-react/src/app/entityV2/summary/SummaryTab.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/SummaryTab.tsx
@@ -23,6 +23,7 @@ interface Props {
 
 export default function SummaryTab({ properties }: { properties?: Props }) {
     const { urn } = useEntityData();
+
     return (
         <PageTemplateProvider templateType={PageTemplateSurfaceType.AssetSummary}>
             <SummaryWrapper>


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-714/handle-edit-button-for-docs-on-entity-sidebar-with-new-summary-page
https://linear.app/acryl-data/issue/CH-754/use-the-correct-permissions-to-edit-description-from-the-sidebar

**Description:**

Brings [PR](https://github.com/acryldata/datahub-fork/pull/6604) back to OSS

This PR handles the edit documentation button on the sidebar when flag for assetSummaryPageV1 is on for the required entities. It redirects to the Summary tab in edit mode with the edit documentation modal open.
It also syncs the permission used for editing documentation on the sidebar with the one that we're using in the summary tab.

**Video:**

https://github.com/user-attachments/assets/0db025d5-c9b0-490f-8787-4734eb2930b0

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
