### PR TITLE
fix(ui): fetch data product info for entity preview

### DIFF
--- a/datahub-web-react/src/graphql/preview.graphql
+++ b/datahub-web-react/src/graphql/preview.graphql
@@ -357,4 +357,7 @@ fragment entityPreview on Entity {
             ...versionProperties
         }
     }
+    ... on DataProduct {
+        ...dataProductFields
+    }
 }


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-753/bug-not-fetching-data-product-info-in-your-subscriptions-module

Brings [PR](https://github.com/acryldata/datahub-fork/pull/6605) back to OSS

**Screenshots:**

Before:
<img width="1512" height="854" alt="image" src="https://github.com/user-attachments/assets/7460ffa0-be76-4191-80f1-6c59eb693296" />


After:
<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/c3e71302-c40e-47e2-9213-cff1a577ab78" />

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/3b1b76ad-d0c2-4322-bf18-3544f2da7afc" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
