### PR TITLE
docs(invite-users) updates to Add Users and JAAS guides

### DIFF
--- a/docs/authentication/guides/add-users.md
+++ b/docs/authentication/guides/add-users.md
@@ -1,18 +1,154 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
 # Onboarding Users to DataHub
 
-New user accounts can be provisioned on DataHub in 3 ways:
+DataHub provides multiple approaches for adding users to your organization, with different methods available depending on whether you're using **DataHub Core** (self-hosted) or **DataHub Cloud**.
 
-1. Shared Invite Links
-2. Single Sign-On using [OpenID Connect](https://www.google.com/search?q=openid+connect&oq=openid+connect&aqs=chrome.0.0i131i433i512j0i512l4j69i60l2j69i61.1468j0j7&sourceid=chrome&ie=UTF-8)
-3. Static Credential Configuration File (Self-Hosted Only)
+## DataHub Cloud
 
-The first option is the easiest to get started with. The second is recommended for deploying DataHub in production. The third should
-be reserved for special circumstances where access must be closely monitored and controlled, and is only relevant for Self-Hosted instances.
+DataHub Cloud offers streamlined user management with intelligent recommendations and email-based invitations:
 
-# Shared Invite Links
+1. **Email Invitations** - Send personalized invitations directly to users with assigned roles
+2. **Smart User Recommendations** - Discover and invite power users from your data platforms
+3. **Single Sign-On (SSO)** - Enterprise authentication via OpenID Connect
+4. **Shared Invite Links** - Generate shareable links for bulk onboarding
+   ]
+
+## DataHub Core (Self-Hosted)
+
+DataHub Core provides foundational user management capabilities:
+
+1. **Shared Invite Links** - Generate shareable links for user onboarding
+2. **Single Sign-On (SSO)** - Configure OpenID Connect for enterprise authentication
+3. **Static Credential Configuration** - File-based user management for controlled environments
+
+---
+
+## Email Invitations (DataHub Cloud)
+
+<FeatureAvailability SaaS/>
+
+DataHub Cloud's email invitation system allows administrators to directly invite users via email with pre-assigned roles, streamlining the onboarding process for your organization.
+
+### How Email Invitations Work
+
+When you invite users via email, DataHub automatically:
+
+- Sends personalized invitation emails with your organization's branding
+- Assigns the specified role (Reader, Editor, Admin) to users upon signup
+- Handles both SSO and non-SSO authentication scenarios
+- Tracks invitation status and provides resend/revoke capabilities
+
+### Inviting Users via Email
+
+To invite users via email, you need the `Manage User Credentials` [Platform Privilege](../../authorization/access-policies-guide.md).
+
+1. Navigate to **Settings** > **Users & Groups**
+2. Click the **Invite Users** button to open the invitation modal
+3. Switch to the **Invite via Email** tab
+
+<p align="center">
+  <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/master/imgs/cloud/invite-users-email-modal.png"/>
+</p>
+
+4. Enter one or more email address
+5. Select the appropriate role for the invited users
+6. Click **Invite**
+
+<p align="center">
+  <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/master/imgs/cloud/invite-users-email-form.png"/>
+</p>
+
+### Email Invitation Features
+
+- **Bulk Invitations**: Add multiple email addresses at once using various separators
+- **Input Validation**: Real-time validation prevents sending to invalid email addresses
+- **Role Assignment**: Assign Reader, Editor, or Admin roles to invited users
+- **SSO Integration**: Automatic handling when Single Sign-On is configured
+- **Invitation Management**: Resend or revoke invitations from the Users table
+
+#### Managing Pending Invitations
+
+Invited users appear in your Users & Groups table with a "Invited" status. You can:
+
+<p align="center">
+  <img width="100%" src="https://raw.githubusercontent.com/datahub-project/static-assets/master/imgs/cloud/pending-invitations-table.png"/>
+</p>
+
+- **Resend Invitation**: Send the invitation email again
+- **Delete Invitation**: Cancel the invitation and remove access for that email address
+- **View Details**: See invitation status and assigned role
+
+---
+
+## User Invite Recommendations (DataHub Cloud)
+
+<FeatureAvailability/>
+
+DataHub Cloud analyzes usage data from your ingested platforms to automatically identify and recommend power users for invitation, making it easy to onboard your organization's most active data practitioners.
+
+## How User Invite Recommendations Work
+
+DataHub's recommendation engine:
+
+- Analyzes usage patterns from your connected data platforms like Snowflake, BigQuery, Redshift, and more
+- Identifies users with high query volumes and frequent data access
+- Calculates usage percentiles to surface top performers
+- Filters out users already invited or existing in your DataHub instance
+
+For more details on how usage data is collected and analyzed, see the [Dataset Usage & Query History](../features/dataset-usage-and-query-history.md) guide.
+
+### Viewing User Invite Recommendations
+
+User recommendations appear in two locations:
+
+### 1. Top Recommendations in Invite Users Modal
+
+<p align="center">
+  <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/master/imgs/cloud/invite-users-recommendations-tab.png"/>
+</p>
+
+Access top recommendations when inviting users:
+
+1. Navigate to **Settings** > **Users & Groups**
+2. Click **Invite Users**
+3. Switch to the **Recommendations** tab
+4. View the recommended users with highest query volume and invite with 1 click
+
+### 2. All Recommended Users
+
+<p align="center">
+  <img width="100%" src="https://raw.githubusercontent.com/datahub-project/static-assets/master/imgs/cloud/user-recommendations-full-view.png"/>
+</p>
+
+View all recommendations in the Users page:
+
+1. Navigate to **Settings** > **Users & Groups**
+2. In the Users page, there's a "Recommended" section that lists all recent suggestions
+
+### Recommendation Features
+
+- **Platform-Specific Insights**: See which data platform each user is most active on
+- **Usage Metrics**: View query counts, data access frequency, and usage percentiles
+- **Smart Filtering**: Automatically excludes already invited or existing users
+- **Fresh Data**: Recommendations update based on the latest usage analytics
+
+### Inviting Recommended Users
+
+You can:
+
+- **Invite Individual Users**: Click the invite button next to any recommended user
+- **Customize Roles**: Assign different roles based on user expertise and needs
+
+<p align="center">
+  <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/master/imgs/cloud/invite-recommended-user.png"/>
+</p>
+
+---
+
+## Shared Invite Links
 
 ### Generating an Invite Link
 
@@ -49,7 +185,7 @@ To reset the password, simply share the password reset link with the user who ne
   <img width="70%" src="https://raw.githubusercontent.com/datahub-project/static-assets/master/imgs/reset-user-password-popup.png"/>
 </p>
 
-# Configuring Single Sign-On with OpenID Connect
+## Configuring Single Sign-On with OpenID Connect
 
 Setting up Single Sign-On via OpenID Connect enables your organization's users to login to DataHub via a central Identity Provider such as
 

--- a/docs/authentication/guides/jaas.md
+++ b/docs/authentication/guides/jaas.md
@@ -68,3 +68,69 @@ datahub-frontend-react:
 ```
 
 And then run `docker-compose up` against your compose file.
+
+## Adding New Users via user.props File
+
+:::note Important
+Adding users via the `user.props` will require disabling existence checks on GMS using the `METADATA_SERVICE_AUTH_ENFORCE_EXISTENCE_ENABLED=false` environment variable or using the API to enable the user prior to login.
+The directions below demonstrate using the API to enable the user.
+:::
+
+To define a set of username / password combinations that should be allowed to log in to DataHub (in addition to the root 'datahub' user),
+create a new file called `user.props` at the file path `${HOME}/.datahub/plugins/frontend/auth/user.props` within the `datahub-frontend-react` container
+or pod.
+
+This file should contain username:password specifications, with one on each line. For example, to create 2 new users,
+with usernames "janesmith" and "johndoe", we would define the following file:
+
+```
+// custom user.props
+janesmith:janespassword
+johndoe:johnspassword
+```
+
+### Enabling Users via API
+
+In order to enable the user access with the credential defined in `user.props`, set the `status` aspect on the user with an Admin user. This can be done using an API call or via the [OpenAPI UI interface](/docs/api/openapi/openapi-usage-guide.md).
+
+Example enabling login for the `janesmith` user from the example above. Make sure to update the example with your access token.
+
+```shell
+curl -X 'POST' \
+  'http://localhost:9002/openapi/v3/entity/corpuser/urn%3Ali%3Acorpuser%3Ajanesmith/status?async=false&systemMetadata=false&createIfEntityNotExists=false&createIfNotExists=true' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <access token>' \
+  -d '{
+  "value": {
+    "removed": false
+  }
+}'
+```
+
+Once you've saved the file, simply start the DataHub containers & navigate to `http://localhost:9002/login`
+to verify that your new credentials work.
+
+To change or remove existing login credentials, edit and save the `user.props` file. Then restart DataHub containers.
+
+### User Details and Search
+
+If you add a new username / password to the `user.props` file, no other information about the user will exist
+about the user in DataHub (full name, email, bio, etc). This means that you will not be able to search to find the user.
+
+In order for the user to become searchable, simply navigate to the new user's profile page (top-right corner) and click
+**Edit Profile**. Add some details like a display name, an email, and more. Then click **Save**. Now you should be able
+to find the user via search.
+
+> You can also use our Python Emitter SDK to produce custom information about the new user via the CorpUser metadata entity.
+
+### User URNs
+
+User URNs are unique identifiers for users of DataHub. The usernames defined in the `user.props` file will be used to generate the DataHub user "urn", which uniquely identifies
+the user on DataHub. The urn is computed as `urn:li:corpuser:{username}`, where "username" is defined inside your user.props file.
+
+## Advanced Configuration
+
+### Custom user.props File Location
+
+If you want to customize the location of the `user.props` file, or if you're deploying DataHub via Helm, you'll need to mount the custom file to the container.


### PR DESCRIPTION
Simplifying the `Adding Users to DataHub` guide & updating to include DataHub Cloud support for email-based invites & recommended users. 