### PR TITLE
improvement(ui/summary-tab): handle deleted structured properties in properties header of asset summary

### DIFF
--- a/datahub-web-react/src/app/homeV3/context/hooks/useTemplateOperations.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useTemplateOperations.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import { useEntityContext } from '@app/entity/shared/EntityContext';
 import { insertModuleIntoRows } from '@app/homeV3/context/hooks/utils/moduleOperationsUtils';
+import { filterNonExistentStructuredProperties } from '@app/homeV3/context/hooks/utils/utils';
 import { DEFAULT_TEMPLATE_URN } from '@app/homeV3/modules/constants';
 import { ModulePositionInput } from '@app/homeV3/template/types';
 import useShowToast from '@app/homeV3/toast/useShowToast';
@@ -211,7 +212,9 @@ export function useTemplateOperations(
                     templateToUpsert.properties.assetSummary?.summaryElements !== undefined
                         ? {
                               summaryElements:
-                                  templateToUpsert.properties.assetSummary?.summaryElements?.map((el) => ({
+                                  filterNonExistentStructuredProperties(
+                                      templateToUpsert.properties.assetSummary?.summaryElements || [],
+                                  ).map((el) => ({
                                       elementType: el.elementType,
                                       structuredPropertyUrn: el.structuredProperty?.urn,
                                   })) || [],

--- a/datahub-web-react/src/app/homeV3/context/hooks/useTemplateState.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useTemplateState.ts
@@ -5,7 +5,10 @@ import { useUserContext } from '@app/context/useUserContext';
 import { useEntityContext } from '@app/entity/shared/EntityContext';
 import { mapSummaryElement } from '@app/entityV2/summary/properties/utils';
 import { filterOutNonExistentModulesFromTemplate } from '@app/homeV3/context/hooks/utils/moduleOperationsUtils';
-import { getDefaultSummaryPageTemplate } from '@app/homeV3/context/hooks/utils/utils';
+import {
+    filterNonExistentStructuredProperties,
+    getDefaultSummaryPageTemplate,
+} from '@app/homeV3/context/hooks/utils/utils';
 import { DEFAULT_TEMPLATE } from '@app/homeV3/modules/constants';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 
@@ -73,7 +76,10 @@ export function useTemplateState(templateType: PageTemplateSurfaceType) {
     };
 
     const summaryElements = useMemo(
-        () => template?.properties.assetSummary?.summaryElements?.map((el) => mapSummaryElement(el, entityRegistry)),
+        () =>
+            filterNonExistentStructuredProperties(template?.properties.assetSummary?.summaryElements || []).map((el) =>
+                mapSummaryElement(el, entityRegistry),
+            ),
         [template, entityRegistry],
     );
 

--- a/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.test.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.test.ts
@@ -1,4 +1,7 @@
-import { getDefaultSummaryPageTemplate } from '@app/homeV3/context/hooks/utils/utils';
+import {
+    filterNonExistentStructuredProperties,
+    getDefaultSummaryPageTemplate,
+} from '@app/homeV3/context/hooks/utils/utils';
 import {
     ASSETS_MODULE,
     CHILD_HIERARCHY_MODULE,
@@ -188,5 +191,179 @@ describe('getDefaultSummaryPageTemplate', () => {
         expect(domainResult?.properties?.assetSummary?.summaryElements).not.toEqual(
             glossaryTermResult?.properties?.assetSummary?.summaryElements,
         );
+    });
+});
+
+describe('filterNonExistentStructuredProperties', () => {
+    it('should return empty array for empty input', () => {
+        expect(filterNonExistentStructuredProperties([])).toEqual([]);
+    });
+
+    it('should keep all non-StructuredProperty elements', () => {
+        const input = [{ elementType: SummaryElementType.Created }, { elementType: SummaryElementType.Domain }];
+        expect(filterNonExistentStructuredProperties(input)).toEqual(input);
+    });
+
+    it('should keep StructuredProperty elements with exists=true', () => {
+        const input = [
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:1',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:2',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+        ];
+        expect(filterNonExistentStructuredProperties(input)).toEqual(input);
+    });
+
+    it('should remove StructuredProperty elements with exists=false', () => {
+        const input = [
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:1',
+                    exists: false,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:2',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+        ];
+        const expected = [
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:2',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+        ];
+        expect(filterNonExistentStructuredProperties(input)).toEqual(expected);
+    });
+
+    it('should remove StructuredProperty if structuredProperty is missing', () => {
+        const input = [
+            { elementType: SummaryElementType.StructuredProperty }, // no structuredProperty
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:2',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+        ];
+        const expected = [
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:2',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+        ];
+        expect(filterNonExistentStructuredProperties(input)).toEqual(expected);
+    });
+
+    it('should handle mixed elements keeping valid StructuredProperty and non-StructuredProperty', () => {
+        const input = [
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:1',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+            { elementType: SummaryElementType.Created },
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:2',
+                    exists: false,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+            { elementType: SummaryElementType.Domain },
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:3',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+        ];
+        const expected = [
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:1',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+            { elementType: SummaryElementType.Created },
+            { elementType: SummaryElementType.Domain },
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:3',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+        ];
+        expect(filterNonExistentStructuredProperties(input)).toEqual(expected);
+    });
+
+    it('should remove StructuredProperty when structuredProperty.exists is undefined', () => {
+        const input = [
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:1',
+                    exists: undefined as any,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:2',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+        ];
+        const expected = [
+            {
+                elementType: SummaryElementType.StructuredProperty,
+                structuredProperty: {
+                    urn: 'urn:2',
+                    exists: true,
+                    type: EntityType.StructuredProperty,
+                },
+            },
+        ];
+        expect(filterNonExistentStructuredProperties(input)).toEqual(expected);
     });
 });

--- a/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/utils/utils.ts
@@ -54,3 +54,9 @@ export function getDefaultSummaryPageTemplate(entityType: EntityType): PageTempl
         },
     };
 }
+
+export function filterNonExistentStructuredProperties(summaryElements) {
+    return summaryElements.filter((element) =>
+        element.elementType === SummaryElementType.StructuredProperty ? element.structuredProperty?.exists : true,
+    );
+}


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-721/handle-property-header-situation-where-structured-property-is-deleted

**Description:**

This handles the situation where deleted structured properties were shown in the properties header on asset summary pages with a blank value. We hide the properties which don't exist now, and remove them on the next update to the template.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
