### PR TITLE
fix(ui): fix link in entity header flashing infinitely

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/header/DefaultEntityHeader.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/header/DefaultEntityHeader.tsx
@@ -66,13 +66,11 @@ export const Row = styled.div`
 `;
 
 export const LeftColumn = styled.div`
-    flex: 1;
     min-width: 0;
 
     display: flex;
-    flex-direction: column;
     justify-content: center;
-    align-items: start;
+    align-items: center;
 `;
 
 export const RightColumn = styled.div`
@@ -145,8 +143,8 @@ export const DefaultEntityHeader = ({
                         displayProperties={displayProperties}
                     />
                 )}
-                <EntityBackButton />
                 <LeftColumn>
+                    <EntityBackButton />
                     {(loading && <EntityTitleLoadingSection />) || (
                         <>
                             <TitleWrapper>

--- a/datahub-web-react/src/app/sharedV2/OverflowList.tsx
+++ b/datahub-web-react/src/app/sharedV2/OverflowList.tsx
@@ -17,9 +17,7 @@ const HiddenContainer = styled.div`
     pointer-events: none;
 `;
 
-const FitContainer = styled.div`
-    width: fit-content;
-`;
+const FitContainer = styled.div``;
 
 export interface OverflowListItem {
     key: string;
@@ -89,7 +87,7 @@ export default function OverflowList<Item extends OverflowListItem>({
             const newVisibleItems: Item[] = [firstItem];
             const newHiddenItems: Item[] = [];
 
-            // compute available width considering that the first item and container with hidden items shlould be rendered to
+            // compute available width considering that the first item and container with hidden items should be rendered too
             const availableWidth =
                 containerWidth - firstItemWidth - finalGap - (renderedHiddenItemsWidth ?? 0) - finalGap;
 


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-784/adding-link-to-header-infinite-flashing

**Description:**

This fixes the links of certain widths flashing infinitely in the entity header.
This also handles the entity name getting truncated even when there's space available.

**Screenshots:**

Before:
<img width="1029" height="92" alt="image" src="https://github.com/user-attachments/assets/fb548614-0e77-40c1-9d80-9e4bb7b6e720" />

After:
<img width="1035" height="92" alt="image" src="https://github.com/user-attachments/assets/e5552863-c8fc-4cc4-8172-007de8989dfc" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
