### PR TITLE
fix(ingest/redshift): Fix for missing schema containers during ingestion

### DIFF
--- a/metadata-ingestion/docs/sources/redshift/redshift_pre.md
+++ b/metadata-ingestion/docs/sources/redshift/redshift_pre.md
@@ -15,45 +15,46 @@ DataHub requires three categories of permissions:
 Execute the following commands as a database superuser or user with sufficient privileges to grant these permissions:
 
 ```sql
--- Enable access to system log tables (STL_*, SVL_*, SYS_*)
--- Required for lineage extraction and usage statistics
-ALTER USER datahub_user WITH SYSLOG ACCESS UNRESTRICTED;
+-- Core system access (required for lineage and usage statistics)
+ALTER USER datahub WITH SYSLOG ACCESS UNRESTRICTED;
 
--- Database and schema metadata
-GRANT SELECT ON pg_catalog.svv_redshift_databases TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_redshift_schemas TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_external_schemas TO datahub_user;
-
--- Table and column metadata
-GRANT SELECT ON pg_catalog.svv_redshift_tables TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_redshift_columns TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_table_info TO datahub_user;
-
--- External table support (Amazon Redshift Spectrum)
-GRANT SELECT ON pg_catalog.svv_external_tables TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_external_columns TO datahub_user;
-
--- User information for usage statistics
-GRANT SELECT ON pg_catalog.svv_user_info TO datahub_user;      -- Serverless workgroups
-GRANT SELECT ON pg_catalog.svl_user_info TO datahub_user;      -- Provisioned clusters
-
--- Materialized view information
-GRANT SELECT ON pg_catalog.stv_mv_info TO datahub_user;        -- Provisioned clusters
-GRANT SELECT ON pg_catalog.svv_mv_info TO datahub_user;        -- Serverless workgroups
-
--- Datashares (cross-cluster lineage)
-GRANT SELECT ON pg_catalog.svv_datashares TO datahub_user;
-
--- Table creation timestamps (provisioned clusters)
-GRANT SELECT ON pg_catalog.pg_class_info TO datahub_user;
+-- Core metadata extraction (always required)
+GRANT SELECT ON pg_catalog.svv_redshift_databases TO datahub;    -- Database information and properties
+GRANT SELECT ON pg_catalog.svv_redshift_schemas TO datahub;      -- Schema information within databases
+GRANT SELECT ON pg_catalog.svv_external_schemas TO datahub;      -- External schemas (Spectrum, federated)
+GRANT SELECT ON pg_catalog.svv_table_info TO datahub;           -- Table metadata, statistics, and properties
+GRANT SELECT ON pg_catalog.svv_external_tables TO datahub;       -- External table definitions (Spectrum)
+GRANT SELECT ON pg_catalog.svv_external_columns TO datahub;      -- External table column information
+GRANT SELECT ON pg_catalog.pg_class_info TO datahub;            -- Table creation timestamps and basic info
 
 -- Essential pg_catalog tables for table discovery
-GRANT SELECT ON pg_catalog.pg_class TO datahub_user;
-GRANT SELECT ON pg_catalog.pg_namespace TO datahub_user;
-GRANT SELECT ON pg_catalog.pg_description TO datahub_user;
-GRANT SELECT ON pg_catalog.pg_database TO datahub_user;
-GRANT SELECT ON pg_catalog.pg_attribute TO datahub_user;
-GRANT SELECT ON pg_catalog.pg_attrdef TO datahub_user;
+GRANT SELECT ON pg_catalog.pg_class TO datahub;                 -- Table and view definitions
+GRANT SELECT ON pg_catalog.pg_namespace TO datahub;             -- Schema namespace information
+GRANT SELECT ON pg_catalog.pg_description TO datahub;           -- Table and column descriptions/comments
+GRANT SELECT ON pg_catalog.pg_database TO datahub;              -- Database catalog information
+GRANT SELECT ON pg_catalog.pg_attribute TO datahub;             -- Column definitions and properties
+GRANT SELECT ON pg_catalog.pg_attrdef TO datahub;               -- Column default values
+GRANT SELECT ON pg_catalog.svl_user_info TO datahub;            -- User information for ownership
+
+-- Datashare lineage (enabled by default)
+GRANT SELECT ON pg_catalog.svv_datashares TO datahub;           -- Cross-cluster datashare information
+
+-- Choose ONE based on your Redshift type:
+-- For Provisioned Clusters:
+GRANT SELECT ON pg_catalog.stv_mv_info TO datahub;              -- Materialized view information (provisioned)
+
+-- For Serverless Workgroups:
+-- GRANT SELECT ON pg_catalog.svv_user_info TO datahub;          -- User information (serverless alternative)
+-- GRANT SELECT ON pg_catalog.svv_mv_info TO datahub;           -- Materialized view information (serverless)
+
+-- Schema access (required to read tables in each schema)
+GRANT USAGE ON SCHEMA <schema_to_ingest> TO datahub;             -- Replace with actual schema names
+```
+
+**Important**: Make sure to grant USAGE on any schema you want to ingest from:
+
+```sql
+GRANT USAGE ON SCHEMA <schema_to_ingest> TO datahub;
 ```
 
 ## Detailed Permission Breakdown
@@ -66,21 +67,21 @@ These system views are accessed in all DataHub configurations:
 
 ```sql
 -- Schema discovery
-GRANT SELECT ON pg_catalog.svv_redshift_schemas TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_external_schemas TO datahub_user;
+GRANT SELECT ON pg_catalog.svv_redshift_schemas TO datahub;      -- Schema information within databases
+GRANT SELECT ON pg_catalog.svv_external_schemas TO datahub;      -- External schemas (Spectrum, federated)
 
 -- Database information
-GRANT SELECT ON pg_catalog.svv_redshift_databases TO datahub_user;
+GRANT SELECT ON pg_catalog.svv_redshift_databases TO datahub;    -- Database information and properties
 
 -- Table metadata and statistics
-GRANT SELECT ON pg_catalog.svv_table_info TO datahub_user;
+GRANT SELECT ON pg_catalog.svv_table_info TO datahub;           -- Table metadata, statistics, and properties
 
 -- External table support
-GRANT SELECT ON pg_catalog.svv_external_tables TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_external_columns TO datahub_user;
+GRANT SELECT ON pg_catalog.svv_external_tables TO datahub;       -- External table definitions (Spectrum)
+GRANT SELECT ON pg_catalog.svv_external_columns TO datahub;      -- External table column information
 
 -- Table creation timestamps
-GRANT SELECT ON pg_catalog.pg_class_info TO datahub_user;
+GRANT SELECT ON pg_catalog.pg_class_info TO datahub;            -- Table creation timestamps and basic info
 ```
 
 ### Conditional System Tables (Feature Dependent)
@@ -89,31 +90,31 @@ GRANT SELECT ON pg_catalog.pg_class_info TO datahub_user;
 
 ```sql
 -- Required when is_shared_database = True
-GRANT SELECT ON pg_catalog.svv_redshift_tables TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_redshift_columns TO datahub_user;
+GRANT SELECT ON pg_catalog.svv_redshift_tables TO datahub;       -- Table information in shared databases
+GRANT SELECT ON pg_catalog.svv_redshift_columns TO datahub;      -- Column information in shared databases
 ```
 
 #### Redshift Serverless Workgroups
 
 ```sql
 -- Required for serverless workgroups
-GRANT SELECT ON pg_catalog.svv_user_info TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_mv_info TO datahub_user;
+GRANT SELECT ON pg_catalog.svv_user_info TO datahub;            -- User information (serverless alternative)
+GRANT SELECT ON pg_catalog.svv_mv_info TO datahub;             -- Materialized view information (serverless)
 ```
 
 #### Redshift Provisioned Clusters
 
 ```sql
 -- Required for provisioned clusters
-GRANT SELECT ON pg_catalog.svl_user_info TO datahub_user;    -- Covered by SYSLOG ACCESS
-GRANT SELECT ON pg_catalog.stv_mv_info TO datahub_user;
+GRANT SELECT ON pg_catalog.svl_user_info TO datahub;            -- User information for ownership (superuser table)
+GRANT SELECT ON pg_catalog.stv_mv_info TO datahub;              -- Materialized view information (provisioned)
 ```
 
 #### Datashares Lineage
 
 ```sql
 -- Required when include_share_lineage: true (default)
-GRANT SELECT ON pg_catalog.svv_datashares TO datahub_user;
+GRANT SELECT ON pg_catalog.svv_datashares TO datahub;           -- Cross-cluster datashare information
 ```
 
 ### Recommended Permission Set
@@ -122,22 +123,34 @@ For a typical provisioned cluster with default settings:
 
 ```sql
 -- Core system access
-ALTER USER datahub_user WITH SYSLOG ACCESS UNRESTRICTED;
+ALTER USER datahub WITH SYSLOG ACCESS UNRESTRICTED;
 
--- Always required (7 grants)
-GRANT SELECT ON pg_catalog.svv_redshift_databases TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_redshift_schemas TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_external_schemas TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_table_info TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_external_tables TO datahub_user;
-GRANT SELECT ON pg_catalog.svv_external_columns TO datahub_user;
-GRANT SELECT ON pg_catalog.pg_class_info TO datahub_user;
+-- Always required
+GRANT SELECT ON pg_catalog.svv_redshift_databases TO datahub;    -- Database information and properties
+GRANT SELECT ON pg_catalog.svv_redshift_schemas TO datahub;      -- Schema information within databases
+GRANT SELECT ON pg_catalog.svv_external_schemas TO datahub;      -- External schemas (Spectrum, federated)
+GRANT SELECT ON pg_catalog.svv_table_info TO datahub;           -- Table metadata, statistics, and properties
+GRANT SELECT ON pg_catalog.svv_external_tables TO datahub;       -- External table definitions (Spectrum)
+GRANT SELECT ON pg_catalog.svv_external_columns TO datahub;      -- External table column information
+GRANT SELECT ON pg_catalog.pg_class_info TO datahub;            -- Table creation timestamps and basic info
+
+-- Essential pg_catalog tables for table discovery
+GRANT SELECT ON pg_catalog.pg_class TO datahub;                 -- Table and view definitions
+GRANT SELECT ON pg_catalog.pg_namespace TO datahub;             -- Schema namespace information
+GRANT SELECT ON pg_catalog.pg_description TO datahub;           -- Table and column descriptions/comments
+GRANT SELECT ON pg_catalog.pg_database TO datahub;              -- Database catalog information
+GRANT SELECT ON pg_catalog.pg_attribute TO datahub;             -- Column definitions and properties
+GRANT SELECT ON pg_catalog.pg_attrdef TO datahub;               -- Column default values
+GRANT SELECT ON pg_catalog.svl_user_info TO datahub;            -- User information for ownership (superuser table)
 
 -- Datashares (since include_share_lineage defaults to true)
-GRANT SELECT ON pg_catalog.svv_datashares TO datahub_user;
+GRANT SELECT ON pg_catalog.svv_datashares TO datahub;           -- Cross-cluster datashare information
 
 -- Provisioned cluster materialized views
-GRANT SELECT ON pg_catalog.stv_mv_info TO datahub_user;
+GRANT SELECT ON pg_catalog.stv_mv_info TO datahub;              -- Materialized view information (provisioned)
+
+-- Schema access (required to read tables in each schema)
+GRANT USAGE ON SCHEMA <schema_to_ingest> TO datahub;             -- Replace with actual schema names
 ```
 
 #### Data Access Privileges (Required for Data Profiling and Classification)
@@ -146,30 +159,30 @@ GRANT SELECT ON pg_catalog.stv_mv_info TO datahub_user;
 
 ```sql
 -- Grant USAGE privilege on schemas (required to access schema objects)
-GRANT USAGE ON SCHEMA public TO datahub_user;
-GRANT USAGE ON SCHEMA your_schema_name TO datahub_user;
+GRANT USAGE ON SCHEMA public TO datahub;
+GRANT USAGE ON SCHEMA your_schema_name TO datahub;
 
 -- Grant SELECT privilege on existing tables for data access
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO datahub_user;
-GRANT SELECT ON ALL TABLES IN SCHEMA your_schema_name TO datahub_user;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO datahub;
+GRANT SELECT ON ALL TABLES IN SCHEMA your_schema_name TO datahub;
 
 -- Grant privileges on future objects (recommended for production)
 -- IMPORTANT: These must be run by each user who will create tables/views
 -- OR by a superuser with FOR ROLE clause
 
 -- Option 1: If you (as admin) will create all future tables/views:
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO datahub_user;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON VIEWS TO datahub_user;
-ALTER DEFAULT PRIVILEGES IN SCHEMA your_schema_name GRANT SELECT ON TABLES TO datahub_user;
-ALTER DEFAULT PRIVILEGES IN SCHEMA your_schema_name GRANT SELECT ON VIEWS TO datahub_user;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO datahub;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON VIEWS TO datahub;
+ALTER DEFAULT PRIVILEGES IN SCHEMA your_schema_name GRANT SELECT ON TABLES TO datahub;
+ALTER DEFAULT PRIVILEGES IN SCHEMA your_schema_name GRANT SELECT ON VIEWS TO datahub;
 
 -- Option 2: If other users will create tables/views, run this for each user:
--- ALTER DEFAULT PRIVILEGES FOR ROLE other_user_name IN SCHEMA public GRANT SELECT ON TABLES TO datahub_user;
--- ALTER DEFAULT PRIVILEGES FOR ROLE other_user_name IN SCHEMA public GRANT SELECT ON VIEWS TO datahub_user;
+-- ALTER DEFAULT PRIVILEGES FOR ROLE other_user_name IN SCHEMA public GRANT SELECT ON TABLES TO datahub;
+-- ALTER DEFAULT PRIVILEGES FOR ROLE other_user_name IN SCHEMA public GRANT SELECT ON VIEWS TO datahub;
 
 -- Option 3: For all future users (requires superuser):
--- ALTER DEFAULT PRIVILEGES FOR ALL ROLES IN SCHEMA public GRANT SELECT ON TABLES TO datahub_user;
--- ALTER DEFAULT PRIVILEGES FOR ALL ROLES IN SCHEMA public GRANT SELECT ON VIEWS TO datahub_user;
+-- ALTER DEFAULT PRIVILEGES FOR ALL ROLES IN SCHEMA public GRANT SELECT ON TABLES TO datahub;
+-- ALTER DEFAULT PRIVILEGES FOR ALL ROLES IN SCHEMA public GRANT SELECT ON VIEWS TO datahub;
 ```
 
 :::caution Data Access vs Metadata Access
@@ -191,7 +204,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA your_schema_name GRANT SELECT ON VIEWS TO dat
 
 ```sql
 -- Run this periodically to catch new tables
-GRANT SELECT ON ALL TABLES IN SCHEMA your_schema_name TO datahub_user;
+GRANT SELECT ON ALL TABLES IN SCHEMA your_schema_name TO datahub;
 ```
 
 :::
@@ -202,7 +215,7 @@ To enable cross-cluster lineage through datashares, grant the following privileg
 
 ```sql
 -- Grant SHARE privilege on datashares (replace with actual datashare names)
-GRANT SHARE ON your_datashare_name TO datahub_user;
+GRANT SHARE ON your_datashare_name TO datahub;
 ```
 
 ## Ingestion of multiple redshift databases, namespaces
@@ -299,6 +312,6 @@ profiling:
 
 :::note
 
-**Datashare lineage**: For cross-cluster lineage through datashares, the DataHub user requires `SHARE` privileges on datashares in both producer and consumer namespaces. See the [Amazon Redshift datashare documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_DATASHARES.html) for more information.
+**Datashare lineage**: For cross-cluster lineage through datashares, the `datahub` user requires `SHARE` privileges on datashares in both producer and consumer namespaces. See the [Amazon Redshift datashare documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_DATASHARES.html) for more information.
 
 :::


### PR DESCRIPTION
Because of a lack of permission, we could not extract tables from a schema that was not visible in our schema query.
I added a join to make sure the two queries are consistent.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
