### PR TITLE
tests(snaplogic): fix tests

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -675,7 +675,8 @@ base_dev_requirements = {
     "pytest-cov>=2.8.1",
     "pytest-random-order~=1.1.0",
     "requests-mock",
-    "freezegun",
+    "freezegun",  # TODO: fully remove and use time-machine
+    "time-machine",  # better Pydantic v2 compatibility
     "jsonpickle",
     "build",
     "twine",

--- a/metadata-ingestion/tests/integration/snaplogic/test_snaplogic.py
+++ b/metadata-ingestion/tests/integration/snaplogic/test_snaplogic.py
@@ -3,7 +3,7 @@ import pathlib
 from typing import Any
 from unittest.mock import patch
 
-from freezegun import freeze_time
+import time_machine
 
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.testing import mce_helpers
@@ -114,7 +114,7 @@ def run_ingest(
         return pipeline
 
 
-@freeze_time(FROZEN_TIME)
+@time_machine.travel(FROZEN_TIME, tick=False)
 def test_snaplogic_source_default_configs(
     pytestconfig, mock_datahub_graph, tmp_path, requests_mock
 ):
@@ -136,7 +136,7 @@ def test_snaplogic_source_default_configs(
     )
 
 
-@freeze_time(FROZEN_TIME)
+@time_machine.travel(FROZEN_TIME, tick=False)
 def test_snaplogic_source_create_non_snaplogic_datasets(
     pytestconfig, mock_datahub_graph, tmp_path, requests_mock
 ):


### PR DESCRIPTION
`freezegun` does not properly support pydantic v2 https://github.com/spulec/freezegun/issues/480, and this results into errors depending on the order of the imports

Snaplogic just hit this issue

Eventually, we should just move from `freezegun` to `time-machine`