### PR TITLE
fix(ingestion): Fix for module level variable caching in sqllite check

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -33,13 +33,12 @@ from datahub.utilities.sentinels import Unset, unset
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-OVERRIDE_SQLITE_VERSION_REQUIREMENT_STR = (
-    os.environ.get("OVERRIDE_SQLITE_VERSION_REQ") or ""
-)
-OVERRIDE_SQLITE_VERSION_REQUIREMENT = (
-    OVERRIDE_SQLITE_VERSION_REQUIREMENT_STR
-    and OVERRIDE_SQLITE_VERSION_REQUIREMENT_STR.lower() != "false"
-)
+
+def _get_sqlite_version_override() -> bool:
+    """Check if SQLite version requirement should be overridden at runtime."""
+    override_str = os.environ.get("OVERRIDE_SQLITE_VERSION_REQ") or ""
+    return bool(override_str and override_str.lower() != "false")
+
 
 _DEFAULT_FILE_NAME = "sqlite.db"
 _DEFAULT_TABLE_NAME = "data"
@@ -231,7 +230,7 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
             # We use the ON CONFLICT clause to implement UPSERTs with sqlite.
             # This was added in 3.24.0 from 2018-06-04.
             # See https://www.sqlite.org/lang_conflict.html
-            if OVERRIDE_SQLITE_VERSION_REQUIREMENT:
+            if _get_sqlite_version_override():
                 self._use_sqlite_on_conflict = False
             else:
                 raise RuntimeError("SQLite version 3.24.0 or later is required")

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -1,5 +1,6 @@
 import dataclasses
 import json
+import os
 import pathlib
 import random
 import sqlite3
@@ -35,10 +36,7 @@ def test_set_use_sqlite_on_conflict():
 
     with (
         patch("sqlite3.sqlite_version_info", (3, 23, 1)),
-        patch(
-            "datahub.utilities.file_backed_collections.OVERRIDE_SQLITE_VERSION_REQUIREMENT",
-            True,
-        ),
+        patch.dict(os.environ, {"OVERRIDE_SQLITE_VERSION_REQ": "true"}),
     ):
         cache = FileBackedDict[int](
             tablename="cache",


### PR DESCRIPTION
This fixes the issue on MWAA, where it seems like the import level variable setting didn't work.

My idea is this is what happened:
  1. Module import happens first (when Python starts up, before your DAG runs)
  2. At import time, OVERRIDE_SQLITE_VERSION_REQ is not yet set
  3. So the module-level variables get cached as:
  OVERRIDE_SQLITE_VERSION_REQUIREMENT_STR = ""
  OVERRIDE_SQLITE_VERSION_REQUIREMENT = False
  4. Later, your DAG code sets OVERRIDE_SQLITE_VERSION_REQ=true
  5. The log shows the environment variable is now set correctly
  6. But the module-level cached variables are still False from the original import
  7. When FileBackedDict.__post_init__ runs, it uses the cached OVERRIDE_SQLITE_VERSION_REQUIREMENT = False
  8. So it raises the SQLite version error



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
