### PR TITLE
feat(ui/select): add support of auto update to select component

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
@@ -68,6 +68,7 @@ export const BasicSelect = <OptionType extends SelectOption = SelectOption>({
     emptyState,
     descriptionMaxWidth,
     dataTestId,
+    autoUpdate = false,
     ...props
 }: SelectProps<OptionType>) => {
     const [searchQuery, setSearchQuery] = useState('');
@@ -83,6 +84,23 @@ export const BasicSelect = <OptionType extends SelectOption = SelectOption>({
     const [selectedValues, setSelectedValues] = useState<string[]>(initialValues || values || []);
     const [tempValues, setTempValues] = useState<string[]>(values || []);
     const [areAllSelected, setAreAllSelected] = useState(false);
+
+    const prevIsOpen = useRef(isOpen);
+
+    const handleUpdateClick = useCallback(() => {
+        setSelectedValues(tempValues);
+        closeDropdown();
+        if (onUpdate) {
+            onUpdate(tempValues);
+        }
+    }, [closeDropdown, tempValues, onUpdate]);
+
+    useEffect(() => {
+        if (prevIsOpen.current && !isOpen && autoUpdate) {
+            handleUpdateClick();
+        }
+        prevIsOpen.current = isOpen;
+    }, [isOpen, autoUpdate, handleUpdateClick]);
 
     useEffect(() => {
         if (values !== undefined && !isEqual(selectedValues, values)) {
@@ -127,14 +145,6 @@ export const BasicSelect = <OptionType extends SelectOption = SelectOption>({
         },
         [selectedValues, onUpdate],
     );
-
-    const handleUpdateClick = useCallback(() => {
-        setSelectedValues(tempValues);
-        closeDropdown();
-        if (onUpdate) {
-            onUpdate(tempValues);
-        }
-    }, [closeDropdown, tempValues, onUpdate]);
 
     const handleCancelClick = useCallback(() => {
         closeDropdown();
@@ -263,11 +273,13 @@ export const BasicSelect = <OptionType extends SelectOption = SelectOption>({
                                     </OptionLabel>
                                 ))}
                             </OptionList>
-                            <DropdownFooterActions
-                                onCancel={handleCancelClick}
-                                onUpdate={handleUpdateClick}
-                                size={getFooterButtonSize(size)}
-                            />
+                            {!autoUpdate && (
+                                <DropdownFooterActions
+                                    onCancel={handleCancelClick}
+                                    onUpdate={handleUpdateClick}
+                                    size={getFooterButtonSize(size)}
+                                />
+                            )}
                         </DropdownContainer>
                     )}
                 >

--- a/datahub-web-react/src/alchemy-components/components/Select/Select.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/Select.stories.tsx
@@ -193,6 +193,16 @@ const meta: Meta = {
                 defaultValue: { summary: 'undefined' },
             },
         },
+        autoUpdate: {
+            description: 'Set to `true` to update value on option click',
+            type: 'boolean',
+            table: {
+                defaultValue: { summary: 'undefined' },
+            },
+            control: {
+                type: 'boolean',
+            },
+        },
     },
 
     // Define defaults
@@ -369,6 +379,33 @@ export const simpleSelectWithIcon = () => (
     />
 );
 
+export const withMultiSelectAndAutoUpdate = () => (
+    <Select
+        options={[
+            { label: 'Option 1', value: '1' },
+            { label: 'Option 2', value: '2' },
+            { label: 'Option 3', value: '3' },
+        ]}
+        label="Select with multi-select and auto update"
+        values={['2', '3']}
+        isMultiSelect
+        autoUpdate
+    />
+);
+
+export const withAutoUpdate = () => (
+    <Select
+        options={[
+            { label: 'Option 1', value: '1' },
+            { label: 'Option 2', value: '2' },
+            { label: 'Option 3', value: '3' },
+        ]}
+        label="Select with auto update"
+        values={['2']}
+        autoUpdate
+    />
+);
+
 // Basic story is what is displayed 1st in storybook & is used as the code sandbox
 // Pass props to this so that it can be customized via the UI props panel
 export const BasicSelectSandbox: Story = {
@@ -390,6 +427,7 @@ export const BasicSelectSandbox: Story = {
             isMultiSelect={props.isMultiSelect}
             placeholder={props.placeholder}
             icon={props.icon}
+            autoUpdate={props.autoUpdate}
         />
     ),
 };

--- a/datahub-web-react/src/alchemy-components/components/Select/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/types.ts
@@ -59,6 +59,7 @@ export interface SelectProps<OptionType extends SelectOption = SelectOption> {
     emptyState?: React.ReactElement;
     descriptionMaxWidth?: number;
     dataTestId?: string;
+    autoUpdate?: boolean;
 }
 
 export interface SelectStyleProps {


### PR DESCRIPTION
This PR adds support to enable auto updating our Select component on hiding of dropdown instead of showing Update/Cancel buttons

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
