### PR TITLE
feat(identity): only suggest users that are active or have displayName

### DIFF
--- a/datahub-web-react/src/app/entity/group/AddGroupMembersModal.tsx
+++ b/datahub-web-react/src/app/entity/group/AddGroupMembersModal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { OwnerLabel } from '@app/shared/OwnerLabel';
 import { useGetRecommendations } from '@app/shared/recommendation';
+import { addUserFiltersToSearchInput } from '@app/shared/userSearchUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { useAddGroupMembersMutation } from '@graphql/group.generated';
@@ -42,14 +43,19 @@ export const AddGroupMembersModal = ({ urn, open, onCloseModal, onSubmit }: Prop
     const inputEl = useRef(null);
 
     const handleUserSearch = (text: string) => {
+        const input = addUserFiltersToSearchInput(
+            {
+                type: EntityType.CorpUser,
+                query: text,
+                start: 0,
+                count: 5,
+            },
+            EntityType.CorpUser,
+        );
+
         userSearch({
             variables: {
-                input: {
-                    type: EntityType.CorpUser,
-                    query: text,
-                    start: 0,
-                    count: 5,
-                },
+                input,
             },
         });
     };

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/EditOwnersModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/EditOwnersModal.tsx
@@ -6,6 +6,7 @@ import analytics, { EntityActionType, EventType } from '@app/analytics';
 import { handleBatchError } from '@app/entity/shared/utils';
 import { OwnerLabel } from '@app/shared/OwnerLabel';
 import { useGetRecommendations } from '@app/shared/recommendation';
+import { addUserFiltersToSearchInput } from '@app/shared/userSearchUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { getModalDomContainer } from '@utils/focus';
 
@@ -150,14 +151,19 @@ export const EditOwnersModal = ({
 
     // Invokes the search API as the owner types
     const handleSearch = (type: EntityType, text: string, searchQuery: any) => {
+        const input = addUserFiltersToSearchInput(
+            {
+                type,
+                query: text,
+                start: 0,
+                count: 5,
+            },
+            type,
+        );
+
         searchQuery({
             variables: {
-                input: {
-                    type,
-                    query: text,
-                    start: 0,
-                    count: 5,
-                },
+                input,
             },
         });
     };

--- a/datahub-web-react/src/app/entityV2/group/AddGroupMembersModal.tsx
+++ b/datahub-web-react/src/app/entityV2/group/AddGroupMembersModal.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { ANTD_GRAY } from '@app/entityV2/shared/constants';
 import { OwnerLabel } from '@app/shared/OwnerLabel';
 import { useGetRecommendations } from '@app/shared/recommendation';
+import { addUserFiltersToSearchInput } from '@app/shared/userSearchUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { getModalDomContainer } from '@src/utils/focus';
 
@@ -54,14 +55,19 @@ export const AddGroupMembersModal = ({ urn, visible, onCloseModal, onSubmit }: P
     const inputEl = useRef(null);
 
     const handleUserSearch = (text: string) => {
+        const input = addUserFiltersToSearchInput(
+            {
+                type: EntityType.CorpUser,
+                query: text,
+                start: 0,
+                count: 5,
+            },
+            EntityType.CorpUser,
+        );
+
         userSearch({
             variables: {
-                input: {
-                    type: EntityType.CorpUser,
-                    query: text,
-                    start: 0,
-                    count: 5,
-                },
+                input,
             },
         });
     };

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Ownership/EditOwnersModal.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Ownership/EditOwnersModal.tsx
@@ -10,6 +10,7 @@ import { handleBatchError } from '@app/entityV2/shared/utils';
 import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
 import { OwnerLabel } from '@app/shared/OwnerLabel';
 import { useGetRecommendations } from '@app/shared/recommendation';
+import { addUserFiltersToAutoCompleteInput } from '@app/shared/userSearchUtils';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { Button } from '@src/alchemy-components';
 import { ANTD_GRAY } from '@src/app/entityV2/shared/constants';
@@ -152,13 +153,18 @@ export const EditOwnersModal = ({
     // Invokes the search API as the owner types
     const handleSearch = (type: EntityType, text: string, searchQuery: any) => {
         if (text) {
+            const input = addUserFiltersToAutoCompleteInput(
+                {
+                    type,
+                    query: text,
+                    limit: 10,
+                },
+                type,
+            );
+
             searchQuery({
                 variables: {
-                    input: {
-                        type,
-                        query: text,
-                        limit: 10,
-                    },
+                    input,
                 },
             });
         }

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Incident/AcrylComponents/IncidentAssigneeSelector.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Incident/AcrylComponents/IncidentAssigneeSelector.tsx
@@ -8,6 +8,7 @@ import { getAssigneeWithURN } from '@app/entityV2/shared/tabs/Incident/utils';
 import { Avatar, SimpleSelect } from '@src/alchemy-components';
 import { NestedSelectOption } from '@src/alchemy-components/components/Select/Nested/types';
 import { useGetRecommendations } from '@src/app/shared/recommendation';
+import { addUserFiltersToAutoCompleteInput } from '@src/app/shared/userSearchUtils';
 import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
 import { useGetEntitiesLazyQuery } from '@src/graphql/entity.generated';
 import { useGetAutoCompleteResultsLazyQuery } from '@src/graphql/search.generated';
@@ -117,9 +118,11 @@ export const IncidentAssigneeSelector = ({ data, form, setCachedAssignees }: Ass
 
     const handleSearch = (type: EntityType, text: string) => {
         if (text) {
+            const input = addUserFiltersToAutoCompleteInput({ type, query: text, limit: 10 }, type);
+
             userSearch({
                 variables: {
-                    input: { type, query: text, limit: 10 },
+                    input,
                 },
             });
             setUseSearch(true);

--- a/datahub-web-react/src/app/shared/recommendation.tsx
+++ b/datahub-web-react/src/app/shared/recommendation.tsx
@@ -1,15 +1,22 @@
+import { addUserFiltersToMultiEntitySearchInput } from '@app/shared/userSearchUtils';
+
 import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
 import { Entity, EntityType } from '@types';
 
 export const useGetRecommendations = (types: Array<EntityType>) => {
+    const input = addUserFiltersToMultiEntitySearchInput(
+        {
+            types,
+            query: '*',
+            start: 0,
+            count: 10,
+        },
+        types,
+    );
+
     const { data, loading } = useGetSearchResultsForMultipleQuery({
         variables: {
-            input: {
-                types,
-                query: '*',
-                start: 0,
-                count: 10,
-            },
+            input,
         },
     });
 


### PR DESCRIPTION
### Summary
* typeaheads for adding users will now suggest only users that are either active or have a displayName
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
