### PR TITLE
feat(structuredProperties): add new property to hide properties with emty value

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolver.java
@@ -115,6 +115,13 @@ public class CreateStructuredPropertyResolver
     if (settingsInput.getShowInAssetSummary() != null) {
       settings.setShowInAssetSummary(settingsInput.getShowInAssetSummary());
     }
+    if (settingsInput.getShowInAssetSummary() != null && !settingsInput.getShowInAssetSummary()) {
+      // FYI: when `showInAssetSummary` is false, `hideInAssetSummaryWhenEmpty` should be false too
+      // as it is dependent property
+      settings.setHideInAssetSummaryWhenEmpty(false);
+    } else if (settingsInput.getHideInAssetSummaryWhenEmpty() != null) {
+      settings.setHideInAssetSummaryWhenEmpty(settingsInput.getHideInAssetSummaryWhenEmpty());
+    }
     if (settingsInput.getShowAsAssetBadge() != null) {
       settings.setShowAsAssetBadge(settingsInput.getShowAsAssetBadge());
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
@@ -114,6 +114,12 @@ public class UpdateStructuredPropertyResolver
         && !existingSettings.isShowInAssetSummary().equals(settingsInput.getShowInAssetSummary())) {
       return true;
     }
+    if (settingsInput.getHideInAssetSummaryWhenEmpty() != null
+        && !existingSettings
+            .isHideInAssetSummaryWhenEmpty()
+            .equals(settingsInput.getHideInAssetSummaryWhenEmpty())) {
+      return true;
+    }
     if (settingsInput.getShowAsAssetBadge() != null
         && !existingSettings.isShowAsAssetBadge().equals(settingsInput.getShowAsAssetBadge())) {
       return true;
@@ -147,6 +153,14 @@ public class UpdateStructuredPropertyResolver
     }
     if (settingsInput.getShowInAssetSummary() != null) {
       existingSettings.setShowInAssetSummary(settingsInput.getShowInAssetSummary());
+    }
+    if (settingsInput.getShowInAssetSummary() != null && !settingsInput.getShowInAssetSummary()) {
+      // FYI: when `showInAssetSummary` is false, `hideInAssetSummaryWhenEmpty` should be false too
+      // as it is dependent property
+      existingSettings.setHideInAssetSummaryWhenEmpty(false);
+    } else if (settingsInput.getHideInAssetSummaryWhenEmpty() != null) {
+      existingSettings.setHideInAssetSummaryWhenEmpty(
+          settingsInput.getHideInAssetSummaryWhenEmpty());
     }
     if (settingsInput.getShowAsAssetBadge() != null) {
       existingSettings.setShowAsAssetBadge(settingsInput.getShowAsAssetBadge());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapper.java
@@ -127,6 +127,7 @@ public class StructuredPropertyMapper
     settings.setIsHidden(gmsSettings.isIsHidden());
     settings.setShowInSearchFilters(gmsSettings.isShowInSearchFilters());
     settings.setShowInAssetSummary(gmsSettings.isShowInAssetSummary());
+    settings.setHideInAssetSummaryWhenEmpty(gmsSettings.isHideInAssetSummaryWhenEmpty());
     settings.setShowAsAssetBadge(gmsSettings.isShowAsAssetBadge());
     settings.setShowInColumnsTable(gmsSettings.isShowInColumnsTable());
 

--- a/datahub-graphql-core/src/main/resources/properties.graphql
+++ b/datahub-graphql-core/src/main/resources/properties.graphql
@@ -150,6 +150,12 @@ type StructuredPropertySettings {
   showInAssetSummary: Boolean!
 
   """
+  Whether or not this asset should be hidden in the asset sidebar (showInAssetSummary should be enabled)
+  when its value is empty
+  """
+  hideInAssetSummaryWhenEmpty: Boolean!
+
+  """
   Whether or not this asset should be displayed as an asset badge on other asset's headers
   """
   showAsAssetBadge: Boolean!
@@ -560,6 +566,12 @@ input StructuredPropertySettingsInput {
   Whether or not this asset should be displayed in the asset sidebar
   """
   showInAssetSummary: Boolean
+
+  """
+  Whether or not this asset should be hidden in the asset sidebar (showInAssetSummary should be enabled)
+  when its value is empty
+  """
+  hideInAssetSummaryWhenEmpty: Boolean
 
   """
   Whether or not this asset should be displayed as an asset badge on other asset's headers

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolverTest.java
@@ -3,8 +3,8 @@ package com.linkedin.datahub.graphql.resolvers.structuredproperties;
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContext;
 import static org.mockito.ArgumentMatchers.any;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.*;
+import static org.testng.Assert.assertFalse;
 
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -15,10 +15,15 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.structured.StructuredPropertySettings;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletionException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -205,6 +210,107 @@ public class CreateStructuredPropertyResolverTest {
     // Validate that we called ingest
     Mockito.verify(mockEntityClient, Mockito.times(1))
         .batchIngestProposals(any(), Mockito.anyList(), Mockito.eq(false));
+  }
+
+  @Test
+  public void testShouldCorrectlySetHideInAssetSummaryWhenEmpty() throws Exception {
+    EntityClient mockEntityClient = initMockEntityClient(true);
+    CreateStructuredPropertyResolver resolver =
+        new CreateStructuredPropertyResolver(mockEntityClient);
+
+    StructuredPropertySettingsInput settingsInput = new StructuredPropertySettingsInput();
+    settingsInput.setShowInAssetSummary(true);
+    settingsInput.setHideInAssetSummaryWhenEmpty(true);
+
+    final CreateStructuredPropertyInput testInput =
+        new CreateStructuredPropertyInput(
+            null,
+            "io.acryl.test",
+            "Display Name",
+            "description",
+            true,
+            null,
+            null,
+            null,
+            null,
+            new ArrayList<>(),
+            settingsInput);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    StructuredPropertyEntity prop = resolver.get(mockEnv).get();
+
+    assertEquals(prop.getUrn(), TEST_STRUCTURED_PROPERTY_URN);
+
+    // Validate that we called ingest
+    ArgumentCaptor<List<MetadataChangeProposal>> mcpCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(mockEntityClient, Mockito.times(1))
+        .batchIngestProposals(any(), mcpCaptor.capture(), Mockito.eq(false));
+
+    // Validate final values in mcp
+    MetadataChangeProposal proposal = mcpCaptor.getValue().get(1);
+    StructuredPropertySettings settings =
+        GenericRecordUtils.deserializeAspect(
+            proposal.getAspect().getValue(),
+            proposal.getAspect().getContentType(),
+            StructuredPropertySettings.class);
+    assertTrue(settings.isShowInAssetSummary());
+    assertTrue(settings.isHideInAssetSummaryWhenEmpty());
+  }
+
+  @Test
+  public void testShouldCorrectlySetHideInAssetSummaryWhenEmptyIfShowInAssetSummaryIsFalse()
+      throws Exception {
+    EntityClient mockEntityClient = initMockEntityClient(true);
+    CreateStructuredPropertyResolver resolver =
+        new CreateStructuredPropertyResolver(mockEntityClient);
+
+    StructuredPropertySettingsInput settingsInput = new StructuredPropertySettingsInput();
+    settingsInput.setShowInAssetSummary(false);
+    settingsInput.setHideInAssetSummaryWhenEmpty(true);
+
+    final CreateStructuredPropertyInput testInput =
+        new CreateStructuredPropertyInput(
+            null,
+            "io.acryl.test",
+            "Display Name",
+            "description",
+            true,
+            null,
+            null,
+            null,
+            null,
+            new ArrayList<>(),
+            settingsInput);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    StructuredPropertyEntity prop = resolver.get(mockEnv).get();
+
+    assertEquals(prop.getUrn(), TEST_STRUCTURED_PROPERTY_URN);
+
+    // Validate that we called ingest
+    ArgumentCaptor<List<MetadataChangeProposal>> mcpCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(mockEntityClient, Mockito.times(1))
+        .batchIngestProposals(any(), mcpCaptor.capture(), Mockito.eq(false));
+
+    // Validate final values in mcp
+    MetadataChangeProposal proposal = mcpCaptor.getValue().get(1);
+    StructuredPropertySettings settings =
+        GenericRecordUtils.deserializeAspect(
+            proposal.getAspect().getValue(),
+            proposal.getAspect().getContentType(),
+            StructuredPropertySettings.class);
+    assertFalse(settings.isShowInAssetSummary());
+    assertFalse(settings.isHideInAssetSummaryWhenEmpty());
   }
 
   private EntityClient initMockEntityClient(boolean shouldSucceed) throws Exception {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolverTest.java
@@ -4,8 +4,7 @@ import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContext;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME;
 import static org.mockito.ArgumentMatchers.any;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.*;
 
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.UrnUtils;
@@ -19,10 +18,15 @@ import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.structured.StructuredPropertyDefinition;
+import com.linkedin.structured.StructuredPropertySettings;
 import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
 import java.util.concurrent.CompletionException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -171,6 +175,104 @@ public class UpdateStructuredPropertyResolverTest {
     // Validate that we called ingest
     Mockito.verify(mockEntityClient, Mockito.times(1))
         .batchIngestProposals(any(), Mockito.anyList(), Mockito.eq(false));
+  }
+
+  @Test
+  public void testShouldCorrectlySetHideInAssetSummaryWhenEmpty() throws Exception {
+    EntityClient mockEntityClient = initMockEntityClient(true);
+    UpdateStructuredPropertyResolver resolver =
+        new UpdateStructuredPropertyResolver(mockEntityClient);
+
+    // if isHidden is true, other fields should not be true
+    StructuredPropertySettingsInput settingsInput = new StructuredPropertySettingsInput();
+    settingsInput.setShowInAssetSummary(true);
+    settingsInput.setHideInAssetSummaryWhenEmpty(true);
+
+    final UpdateStructuredPropertyInput testInput =
+        new UpdateStructuredPropertyInput(
+            TEST_STRUCTURED_PROPERTY_URN,
+            "New Display Name",
+            "new description",
+            true,
+            null,
+            null,
+            null,
+            null,
+            settingsInput);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    StructuredPropertyEntity prop = resolver.get(mockEnv).get();
+
+    assertEquals(prop.getUrn(), TEST_STRUCTURED_PROPERTY_URN);
+
+    // Validate that we called ingest
+    ArgumentCaptor<List<MetadataChangeProposal>> mcpCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(mockEntityClient, Mockito.times(1))
+        .batchIngestProposals(any(), mcpCaptor.capture(), Mockito.eq(false));
+
+    // Validate final values in mcp
+    MetadataChangeProposal proposal = mcpCaptor.getValue().get(1);
+    StructuredPropertySettings settings =
+        GenericRecordUtils.deserializeAspect(
+            proposal.getAspect().getValue(),
+            proposal.getAspect().getContentType(),
+            StructuredPropertySettings.class);
+    assertTrue(settings.isShowInAssetSummary());
+    assertTrue(settings.isHideInAssetSummaryWhenEmpty());
+  }
+
+  @Test
+  public void testShouldCorrectlySetHideInAssetSummaryWhenEmptyIfShowInAssetSummaryIsFalse()
+      throws Exception {
+    EntityClient mockEntityClient = initMockEntityClient(true);
+    UpdateStructuredPropertyResolver resolver =
+        new UpdateStructuredPropertyResolver(mockEntityClient);
+
+    StructuredPropertySettingsInput settingsInput = new StructuredPropertySettingsInput();
+    settingsInput.setShowInAssetSummary(false);
+    settingsInput.setHideInAssetSummaryWhenEmpty(true);
+
+    final UpdateStructuredPropertyInput testInput =
+        new UpdateStructuredPropertyInput(
+            TEST_STRUCTURED_PROPERTY_URN,
+            "New Display Name",
+            "new description",
+            true,
+            null,
+            null,
+            null,
+            null,
+            settingsInput);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    StructuredPropertyEntity prop = resolver.get(mockEnv).get();
+
+    assertEquals(prop.getUrn(), TEST_STRUCTURED_PROPERTY_URN);
+
+    // Validate that we called ingest
+    ArgumentCaptor<List<MetadataChangeProposal>> mcpCaptor = ArgumentCaptor.forClass(List.class);
+    Mockito.verify(mockEntityClient, Mockito.times(1))
+        .batchIngestProposals(any(), mcpCaptor.capture(), Mockito.eq(false));
+
+    // Validate final values in mcp
+    MetadataChangeProposal proposal = mcpCaptor.getValue().get(1);
+    StructuredPropertySettings settings =
+        GenericRecordUtils.deserializeAspect(
+            proposal.getAspect().getValue(),
+            proposal.getAspect().getContentType(),
+            StructuredPropertySettings.class);
+    assertFalse(settings.isShowInAssetSummary());
+    assertFalse(settings.isHideInAssetSummaryWhenEmpty());
   }
 
   private EntityClient initMockEntityClient(boolean shouldSucceed) throws Exception {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapperTest.java
@@ -1,0 +1,127 @@
+package com.linkedin.datahub.graphql.types.structuredproperty;
+
+import static com.linkedin.metadata.Constants.*;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.data.template.StringArrayMap;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.PropertyCardinality;
+import com.linkedin.datahub.graphql.generated.StructuredPropertyEntity;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.structured.PrimitivePropertyValue;
+import com.linkedin.structured.PropertyValue;
+import com.linkedin.structured.PropertyValueArray;
+import org.testng.annotations.Test;
+
+public class StructuredPropertyMapperTest {
+
+  private static final Urn TEST_URN = UrnUtils.getUrn("urn:li:structuredProperty:test");
+  private static final Urn TEST_DATA_TYPE_URN = UrnUtils.getUrn("urn:li:dataType:datahub.string");
+  private static final Urn TEST_ENTITY_TYPE_URN =
+      UrnUtils.getUrn("urn:li:entityType:datahub.dataset");
+
+  @Test
+  public void testMapFull() throws Exception {
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(TEST_URN);
+    EnvelopedAspectMap aspectMap = new EnvelopedAspectMap();
+    aspectMap.put(
+        STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(createFullDefinition().data())));
+    aspectMap.put(
+        STRUCTURED_PROPERTY_SETTINGS_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(createFullSettings().data())));
+    entityResponse.setAspects(aspectMap);
+
+    StructuredPropertyEntity mapped = StructuredPropertyMapper.map(null, entityResponse);
+
+    assertEquals(mapped.getUrn(), TEST_URN.toString());
+    assertEquals(mapped.getType(), EntityType.STRUCTURED_PROPERTY);
+    assertEquals(mapped.getDefinition().getQualifiedName(), "test");
+    assertEquals(mapped.getDefinition().getCardinality(), PropertyCardinality.SINGLE);
+    assertEquals(mapped.getDefinition().getImmutable(), (Boolean) true);
+    assertEquals(mapped.getDefinition().getValueType().getUrn(), TEST_DATA_TYPE_URN.toString());
+    assertEquals(mapped.getDefinition().getDisplayName(), "Test");
+    assertEquals(mapped.getDefinition().getDescription(), "Test description");
+    assertEquals(mapped.getDefinition().getAllowedValues().size(), 1);
+    assertEquals(
+        ((com.linkedin.datahub.graphql.generated.StringValue)
+                mapped.getDefinition().getAllowedValues().get(0).getValue())
+            .getStringValue(),
+        "test");
+    assertEquals(mapped.getDefinition().getTypeQualifier().getAllowedTypes().size(), 1);
+    assertEquals(
+        mapped.getDefinition().getTypeQualifier().getAllowedTypes().get(0).getUrn(),
+        TEST_ENTITY_TYPE_URN.toString());
+    assertEquals(mapped.getSettings().getIsHidden(), (Boolean) true);
+  }
+
+  @Test
+  public void testMapDefault() {
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(TEST_URN);
+    entityResponse.setAspects(new EnvelopedAspectMap());
+
+    StructuredPropertyEntity mapped = StructuredPropertyMapper.map(null, entityResponse);
+
+    assertEquals(mapped.getUrn(), TEST_URN.toString());
+    assertEquals(mapped.getType(), EntityType.STRUCTURED_PROPERTY);
+    assertEquals(mapped.getDefinition().getQualifiedName(), "");
+    assertEquals(mapped.getDefinition().getCardinality(), PropertyCardinality.SINGLE);
+    assertEquals(mapped.getDefinition().getImmutable(), (Boolean) true);
+    assertEquals(mapped.getDefinition().getValueType().getUrn(), "urn:li:dataType:datahub.string");
+    assertEquals(mapped.getDefinition().getEntityTypes().size(), 1);
+    assertEquals(
+        mapped.getDefinition().getEntityTypes().get(0).getUrn(),
+        "urn:li:entityType:datahub.dataset");
+  }
+
+  private com.linkedin.structured.StructuredPropertyDefinition createFullDefinition()
+      throws Exception {
+    com.linkedin.structured.StructuredPropertyDefinition definition =
+        new com.linkedin.structured.StructuredPropertyDefinition();
+    definition.setQualifiedName("test");
+    definition.setCardinality(com.linkedin.structured.PropertyCardinality.SINGLE);
+    definition.setImmutable(true);
+    definition.setValueType(TEST_DATA_TYPE_URN);
+    definition.setDisplayName("Test");
+    definition.setDescription("Test description");
+    PropertyValueArray allowedValues = new PropertyValueArray();
+    PropertyValue propertyValue = new PropertyValue();
+    PrimitivePropertyValue primitivePropertyValue = new PrimitivePropertyValue();
+    primitivePropertyValue.setString("test");
+    propertyValue.setValue(primitivePropertyValue);
+    allowedValues.add(propertyValue);
+    definition.setAllowedValues(allowedValues);
+    StringArrayMap typeQualifier = new StringArrayMap();
+    StringArray allowedTypes = new StringArray();
+    allowedTypes.add(TEST_ENTITY_TYPE_URN.toString());
+    typeQualifier.put("allowedTypes", allowedTypes);
+    definition.setTypeQualifier(typeQualifier);
+    definition.setCreated(
+        new AuditStamp().setActor(Urn.createFromString("urn:li:corpuser:test")).setTime(0L));
+    definition.setLastModified(
+        new AuditStamp().setActor(Urn.createFromString("urn:li:corpuser:test")).setTime(0L));
+    definition.setEntityTypes(new com.linkedin.common.UrnArray());
+    return definition;
+  }
+
+  private com.linkedin.structured.StructuredPropertySettings createFullSettings() {
+    com.linkedin.structured.StructuredPropertySettings settings =
+        new com.linkedin.structured.StructuredPropertySettings();
+    settings.setIsHidden(true);
+    settings.setShowInSearchFilters(false);
+    settings.setShowInAssetSummary(false);
+    settings.setHideInAssetSummaryWhenEmpty(false);
+    settings.setShowAsAssetBadge(false);
+    settings.setShowInColumnsTable(false);
+    return settings;
+  }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/structured/StructuredPropertySettings.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/structured/StructuredPropertySettings.pdl
@@ -34,6 +34,15 @@ record StructuredPropertySettings {
   showInAssetSummary: boolean = false
 
   /**
+  * Whether or not this asset should be hidden in the asset sidebar (showInAssetSummary should be enabled)
+  * when its value is empty
+  */
+  @Searchable = {
+    "fieldType": "BOOLEAN"
+  }
+  hideInAssetSummaryWhenEmpty: boolean = false
+
+  /**
    * Whether or not this asset should be displayed as an asset badge on other
    * asset's headers
    */


### PR DESCRIPTION
This PR adds new property to settings of Structured Property to hide properties in asset sidebar when their value is empty

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
