### PR TITLE
fix(ui) Limit the number of entities per page in search (#5198)

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
@@ -286,7 +286,7 @@ export const EmbeddedListSearchResults = ({
                     onChange={onChangePage}
                     showSizeChanger={totalResults > SearchCfg.RESULTS_PER_PAGE}
                     onShowSizeChange={(_currNum, newNum) => setNumResultsPerPage(newNum)}
-                    pageSizeOptions={['10', '20', '50', '100']}
+                    pageSizeOptions={['10', '20', '30']}
                 />
                 {applyView ? <MatchingViewsLabel /> : <span />}
             </PaginationInfoContainer>

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/EmbeddedListSearchResults.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/EmbeddedListSearchResults.tsx
@@ -291,7 +291,7 @@ export const EmbeddedListSearchResults = ({
                         onChange={onChangePage}
                         showSizeChanger={totalResults > SearchCfg.RESULTS_PER_PAGE}
                         onShowSizeChange={(_currNum, newNum) => setNumResultsPerPage(newNum)}
-                        pageSizeOptions={['10', '20', '50', '100']}
+                        pageSizeOptions={['10', '20', '30']}
                     />
                     {applyView ? (
                         <MatchingViewsLabel

--- a/datahub-web-react/src/app/search/SearchResults.tsx
+++ b/datahub-web-react/src/app/search/SearchResults.tsx
@@ -278,7 +278,7 @@ export const SearchResults = ({
                                                 onChange={onChangePage}
                                                 showSizeChanger={totalResults > SearchCfg.RESULTS_PER_PAGE}
                                                 onShowSizeChange={(_currNum, newNum) => setNumResultsPerPage(newNum)}
-                                                pageSizeOptions={['10', '20', '50', '100']}
+                                                pageSizeOptions={['10', '20', '30']}
                                             />
                                         </PaginationControlContainer>
                                     )}


### PR DESCRIPTION
In order to prevent people from getting into a bad situation with fetching too many results and breaking their experience, we are currently limiting the page size to max 30.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
