### PR TITLE
feat(structuredProperties): add option to hide properties with empty values

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Checkbox/Checkbox.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Checkbox/Checkbox.stories.tsx
@@ -97,6 +97,34 @@ const meta = {
                 type: 'boolean',
             },
         },
+        labelTooltip: {
+            description: 'Tooltip for the Checkbox label.',
+            control: {
+                type: 'text',
+            },
+        },
+        shouldHandleLabelClicks: {
+            description: 'Whether the label should handle clicks.',
+            control: {
+                type: 'boolean',
+            },
+        },
+        justifyContent: {
+            description: 'Justify content for the Checkbox container.',
+            table: {
+                defaultValue: { summary: 'center' },
+            },
+            control: {
+                type: 'select',
+                options: ['flex-start', 'center'],
+            },
+        },
+        gap: {
+            description: 'Additional gap between the label and the checkbox.',
+            control: {
+                type: 'text',
+            },
+        },
     },
     args: {
         label: checkboxDefaults.label,
@@ -163,5 +191,27 @@ export const checkboxGroups = () => (
             <Heading>Vertical Checkbox Group</Heading>
             <CheckboxGroup isVertical checkboxes={MOCK_CHECKBOXES} />
         </div>
+    </GridList>
+);
+
+export const withTooltip = () => (
+    <GridList>
+        <Checkbox label="With Tooltip" labelTooltip="This is a tooltip" />
+        <Checkbox label="With Tooltip and Checked" isChecked labelTooltip="This is a tooltip" />
+    </GridList>
+);
+
+export const withJustifyContent = () => (
+    <GridList isVertical>
+        <Checkbox label="Flex Start" justifyContent="flex-start" />
+        <Checkbox label="Center" justifyContent="center" />
+    </GridList>
+);
+
+export const withGap = () => (
+    <GridList isVertical>
+        <Checkbox label="Default Gap" />
+        <Checkbox label="20px Gap" gap="20px" />
+        <Checkbox label="50px Gap" gap="50px" />
     </GridList>
 );

--- a/datahub-web-react/src/alchemy-components/components/Checkbox/Checkbox.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import {
     CheckboxBase,
@@ -10,6 +10,7 @@ import {
     StyledCheckbox,
 } from '@components/components/Checkbox/components';
 import { CheckboxGroupProps, CheckboxProps } from '@components/components/Checkbox/types';
+import { Tooltip } from '@components/components/Tooltip';
 
 export const checkboxDefaults: CheckboxProps = {
     error: '',
@@ -19,10 +20,12 @@ export const checkboxDefaults: CheckboxProps = {
     isRequired: false,
     setIsChecked: () => {},
     size: 'md',
+    justifyContent: 'center',
 };
 
 export const Checkbox = ({
     label = checkboxDefaults.label,
+    labelTooltip,
     error = checkboxDefaults.error,
     isChecked = checkboxDefaults.isChecked,
     isDisabled = checkboxDefaults.isDisabled,
@@ -32,6 +35,9 @@ export const Checkbox = ({
     size = checkboxDefaults.size,
     onCheckboxChange,
     dataTestId,
+    justifyContent = checkboxDefaults.justifyContent,
+    gap,
+    shouldHandleLabelClicks,
     ...props
 }: CheckboxProps) => {
     const [checked, setChecked] = useState(isChecked || false);
@@ -42,25 +48,33 @@ export const Checkbox = ({
 
     const id = props.id || `checkbox-${label}`;
 
+    const onClick = useCallback(
+        (e: React.MouseEvent) => {
+            e.stopPropagation();
+            e.preventDefault();
+            if (!isDisabled) {
+                setChecked(!checked);
+                setIsChecked?.(!checked);
+                onCheckboxChange?.(!checked);
+            }
+        },
+        [setIsChecked, onCheckboxChange, checked, isDisabled],
+    );
+
     return (
-        <CheckboxContainer>
+        <CheckboxContainer justifyContent={justifyContent} gap={gap}>
             {label ? (
-                <Label aria-label={label}>
-                    {label} {isRequired && <Required>*</Required>}
-                </Label>
+                <Tooltip title={labelTooltip}>
+                    <Label
+                        aria-label={label}
+                        clickable={shouldHandleLabelClicks}
+                        onClick={shouldHandleLabelClicks ? onClick : undefined}
+                    >
+                        {label} {isRequired && <Required>*</Required>}
+                    </Label>
+                </Tooltip>
             ) : null}
-            <CheckboxBase
-                onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    if (!isDisabled) {
-                        setChecked(!checked);
-                        setIsChecked?.(!checked);
-                        onCheckboxChange?.();
-                    }
-                }}
-                data-testid={dataTestId}
-            >
+            <CheckboxBase onClick={onClick} data-testid={dataTestId}>
                 <StyledCheckbox
                     type="checkbox"
                     id="checked-input"

--- a/datahub-web-react/src/alchemy-components/components/Checkbox/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Checkbox/components.ts
@@ -11,15 +11,19 @@ import { borders, colors, radius, spacing, transform, zIndices } from '@componen
 
 import { SizeOptions } from '@src/alchemy-components/theme/config';
 
-export const CheckboxContainer = styled.div({
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-});
+export const CheckboxContainer = styled.div<{ justifyContent?: 'center' | 'flex-start' | undefined; gap?: string }>(
+    ({ justifyContent, gap }) => ({
+        display: 'flex',
+        justifyContent: justifyContent ?? 'center',
+        alignItems: 'center',
+        gap,
+    }),
+);
 
-export const Label = styled.div({
+export const Label = styled.div<{ clickable?: boolean }>(({ clickable }) => ({
     ...formLabelTextStyles,
-});
+    ...(clickable ? { cursor: 'pointer' } : {}),
+}));
 
 export const Required = styled.span({
     color: colors.red[500],
@@ -77,7 +81,7 @@ export const Checkmark = styled.div<{
         left: !intermediate ? '30%' : '45%',
         width: !intermediate ? '35%' : '0px',
         height: !intermediate ? '60%' : '50%',
-        border: 'solid white',
+        border: disabled ? `solid ${colors.gray[300]}` : 'solid white',
         borderWidth: '0 2px 2px 0',
         transform: !intermediate ? 'rotate(45deg)' : transform.rotate[90],
     },

--- a/datahub-web-react/src/alchemy-components/components/Checkbox/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Checkbox/types.ts
@@ -4,15 +4,19 @@ import { SizeOptions } from '@src/alchemy-components/theme/config';
 
 export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
     label?: string;
+    labelTooltip?: string;
     error?: string;
     isChecked?: boolean;
     setIsChecked?: React.Dispatch<React.SetStateAction<boolean>>;
     isDisabled?: boolean;
     isIntermediate?: boolean;
     isRequired?: boolean;
-    onCheckboxChange?: () => void;
+    onCheckboxChange?: (isChecked: boolean) => void;
     size?: SizeOptions;
     dataTestId?: string;
+    justifyContent?: 'center' | 'flex-start';
+    gap?: string;
+    shouldHandleLabelClicks?: boolean;
 }
 
 export interface CheckboxGroupProps {

--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -893,6 +893,7 @@ interface StructuredPropertyEvent extends BaseEvent {
     showInSearchFilters: boolean;
     showAsAssetBadge: boolean;
     showInAssetSummary: boolean;
+    hideInAssetSummaryWhenEmpty: boolean;
     showInColumnsTable: boolean;
 }
 

--- a/datahub-web-react/src/app/entityV2/shared/sidebarSection/SidebarStructuredProperties.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/sidebarSection/SidebarStructuredProperties.tsx
@@ -111,7 +111,7 @@ const SidebarStructuredProperties = ({ properties }: Props) => {
                 const propertyName = getDisplayName(structuredProperty);
                 const shouldHideIfPropertyIsEmpty = structuredProperty.settings?.hideInAssetSummaryWhenEmpty;
 
-                if (shouldHideIfPropertyIsEmpty && !values) {
+                if (!isSchemaSidebar && shouldHideIfPropertyIsEmpty && !values) {
                     return null;
                 }
 

--- a/datahub-web-react/src/app/entityV2/shared/sidebarSection/SidebarStructuredProperties.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/sidebarSection/SidebarStructuredProperties.tsx
@@ -43,6 +43,8 @@ interface Props {
     properties?: FieldProperties;
 }
 
+const MAX_STRUCTURED_PROPERTIES_TO_FETCH = 100;
+
 const SidebarStructuredProperties = ({ properties }: Props) => {
     const { entityData, entityType } = useEntityData();
     const entityRegistry = useEntityRegistryV2();
@@ -55,7 +57,7 @@ const SidebarStructuredProperties = ({ properties }: Props) => {
         types: [EntityType.StructuredProperty],
         query: '',
         start: 0,
-        count: 50,
+        count: MAX_STRUCTURED_PROPERTIES_TO_FETCH,
         searchFlags: { skipCache: true },
         orFilters: [
             {

--- a/datahub-web-react/src/app/entityV2/shared/sidebarSection/SidebarStructuredProperties.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/sidebarSection/SidebarStructuredProperties.tsx
@@ -102,10 +102,16 @@ const SidebarStructuredProperties = ({ properties }: Props) => {
     return (
         <>
             {entityTypeProperties?.map((property) => {
+                const structuredProperty = property.entity as StructuredPropertyEntity;
                 const propertyRow: PropertyRow | undefined = getPropertyRowFromSearchResult(property, allProperties);
                 const isRichText = propertyRow?.dataType?.info?.type === StdDataType.RichText;
                 const values = propertyRow?.values;
-                const propertyName = getDisplayName(property.entity as StructuredPropertyEntity);
+                const propertyName = getDisplayName(structuredProperty);
+                const shouldHideIfPropertyIsEmpty = structuredProperty.settings?.hideInAssetSummaryWhenEmpty;
+
+                if (shouldHideIfPropertyIsEmpty && !values) {
+                    return null;
+                }
 
                 return (
                     <>

--- a/datahub-web-react/src/app/govern/structuredProperties/DisplayPreferences.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/DisplayPreferences.tsx
@@ -2,13 +2,16 @@ import { Collapse } from 'antd';
 import React, { useState } from 'react';
 
 import {
+    CheckboxContainer,
     CollapseHeader,
+    CompoundedItemWrapper,
     StyledCollapse,
     StyledFormItem,
+    StyledFormSubItem,
     TogglesContainer,
 } from '@app/govern/structuredProperties/styledComponents';
 import { StructuredProp, canBeAssetBadge, getDisplayName } from '@app/govern/structuredProperties/utils';
-import { Icon, Pill, Switch, Text } from '@src/alchemy-components';
+import { Checkbox, Icon, Pill, Switch, Text } from '@src/alchemy-components';
 import { ConfirmationModal } from '@src/app/sharedV2/modals/ConfirmationModal';
 import { useUpdateStructuredPropertyMutation } from '@src/graphql/structuredProperties.generated';
 import { AllowedValue, StructuredPropertyEntity } from '@src/types.generated';
@@ -93,16 +96,36 @@ const DisplayPreferences = ({
                                 labelHoverText="If enabled, this property will appear in search filters"
                             />
                         </StyledFormItem>
-                        <StyledFormItem name={['settings', 'showInAssetSummary']}>
-                            <Switch
-                                label="Show in Asset Sidebar"
-                                size="sm"
-                                checked={formValues?.settings?.showInAssetSummary}
-                                onChange={(e) => handleDisplaySettingChange('showInAssetSummary', e.target.checked)}
-                                isDisabled={formValues?.settings?.isHidden}
-                                labelHoverText="If enabled, this property will appear in asset sidebar"
-                            />
-                        </StyledFormItem>
+                        <CompoundedItemWrapper>
+                            <StyledFormItem name={['settings', 'showInAssetSummary']}>
+                                <Switch
+                                    label="Show in Asset Sidebar"
+                                    size="sm"
+                                    checked={formValues?.settings?.showInAssetSummary}
+                                    onChange={(e) => handleDisplaySettingChange('showInAssetSummary', e.target.checked)}
+                                    isDisabled={formValues?.settings?.isHidden}
+                                    labelHoverText="If enabled, this property will appear in asset sidebar"
+                                />
+                            </StyledFormItem>
+                            {formValues?.settings?.showInAssetSummary && (
+                                <StyledFormSubItem name={['settings', 'hideInAssetSummaryWhenEmpty']}>
+                                    <CheckboxContainer>
+                                        <Checkbox
+                                            label="Hide when Empty"
+                                            isChecked={formValues?.settings?.hideInAssetSummaryWhenEmpty}
+                                            labelTooltip="If enabled, this property will only show in the asset sidebar if it's assigned to the asset"
+                                            size="sm"
+                                            gap="2px"
+                                            onCheckboxChange={(isChecked) =>
+                                                handleDisplaySettingChange('hideInAssetSummaryWhenEmpty', isChecked)
+                                            }
+                                            justifyContent="flex-start"
+                                            shouldHandleLabelClicks
+                                        />
+                                    </CheckboxContainer>
+                                </StyledFormSubItem>
+                            )}
+                        </CompoundedItemWrapper>
                         <StyledFormItem name={['settings', 'showAsAssetBadge']}>
                             <Switch
                                 label="Show as Asset Badge"

--- a/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsDrawer.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsDrawer.tsx
@@ -150,6 +150,7 @@ const StructuredPropsDrawer = ({
                         showInSearchFilters: updateValues.settings?.showInSearchFilters ?? false,
                         showAsAssetBadge: updateValues.settings?.showAsAssetBadge ?? false,
                         showInAssetSummary: updateValues.settings?.showInAssetSummary ?? false,
+                        hideInAssetSummaryWhenEmpty: updateValues.settings?.hideInAssetSummaryWhenEmpty ?? false,
                         showInColumnsTable: updateValues.settings?.showInColumnsTable ?? false,
                     },
                 };
@@ -176,6 +177,8 @@ const StructuredPropsDrawer = ({
                             showInSearchFilters: form.getFieldValue(['settings', 'showInSearchFilters']) ?? false,
                             showAsAssetBadge: form.getFieldValue(['settings', 'showAsAssetBadge']) ?? false,
                             showInAssetSummary: form.getFieldValue(['settings', 'showInAssetSummary']) ?? false,
+                            hideInAssetSummaryWhenEmpty:
+                                form.getFieldValue(['settings', 'hideInAssetSummaryWhenEmpty']) ?? false,
                             showInColumnsTable: form.getFieldValue(['settings', 'showInColumnsTable']) ?? false,
                         });
                         refetch();
@@ -205,6 +208,8 @@ const StructuredPropsDrawer = ({
                         showInSearchFilters: form.getFieldValue(['settings', 'showInSearchFilters']) ?? false,
                         showAsAssetBadge: form.getFieldValue(['settings', 'showAsAssetBadge']) ?? false,
                         showInAssetSummary: form.getFieldValue(['settings', 'showInAssetSummary']) ?? false,
+                        hideInAssetSummaryWhenEmpty:
+                            form.getFieldValue(['settings', 'hideInAssetSummaryWhenEmpty']) ?? false,
                         showInColumnsTable: form.getFieldValue(['settings', 'showInColumnsTable']) ?? false,
                     },
                 };
@@ -230,6 +235,8 @@ const StructuredPropsDrawer = ({
                             showInSearchFilters: form.getFieldValue(['settings', 'showInSearchFilters']) ?? false,
                             showAsAssetBadge: form.getFieldValue(['settings', 'showAsAssetBadge']) ?? false,
                             showInAssetSummary: form.getFieldValue(['settings', 'showInAssetSummary']) ?? false,
+                            hideInAssetSummaryWhenEmpty:
+                                form.getFieldValue(['settings', 'hideInAssetSummaryWhenEmpty']) ?? false,
                             showInColumnsTable: form.getFieldValue(['settings', 'showInColumnsTable']) ?? false,
                         });
 

--- a/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsTable.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsTable.tsx
@@ -105,6 +105,7 @@ const StructuredPropsTable = ({
                     showInSearchFilters: deleteEntity.settings?.showInSearchFilters ?? false,
                     showAsAssetBadge: deleteEntity.settings?.showAsAssetBadge ?? false,
                     showInAssetSummary: deleteEntity.settings?.showInAssetSummary ?? false,
+                    hideInAssetSummaryWhenEmpty: deleteEntity.settings?.hideInAssetSummaryWhenEmpty ?? false,
                     showInColumnsTable: deleteEntity.settings?.showInColumnsTable ?? false,
                 });
                 showToastMessage(ToastType.SUCCESS, 'Structured property deleted successfully!', 3);

--- a/datahub-web-react/src/app/govern/structuredProperties/ViewDisplayPreferences.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/ViewDisplayPreferences.tsx
@@ -2,12 +2,15 @@ import { Collapse } from 'antd';
 import React from 'react';
 
 import {
+    CheckboxContainer,
     CollapseHeader,
+    CompoundedItemWrapper,
     StyledCollapse,
     StyledFormItem,
+    StyledFormSubItem,
     TogglesContainer,
 } from '@app/govern/structuredProperties/styledComponents';
-import { Icon, Switch, Text, colors } from '@src/alchemy-components';
+import { Checkbox, Icon, Switch, Text, colors } from '@src/alchemy-components';
 import { StructuredPropertyEntity } from '@src/types.generated';
 
 interface Props {
@@ -55,15 +58,34 @@ const ViewDisplayPreferences = ({ propEntity }: Props) => {
                                 isDisabled
                             />
                         </StyledFormItem>
-                        <StyledFormItem name={['settings', 'showInAssetSummary']}>
-                            <Switch
-                                label="Show in Asset Sidebar"
-                                size="sm"
-                                checked={propEntity?.settings?.showInAssetSummary}
-                                labelStyle={{ fontSize: 12, color: colors.gray[1700], fontWeight: 700 }}
-                                isDisabled
-                            />
-                        </StyledFormItem>
+                        <CompoundedItemWrapper>
+                            <StyledFormItem name={['settings', 'showInAssetSummary']}>
+                                <Switch
+                                    label="Show in Asset Sidebar"
+                                    size="sm"
+                                    checked={propEntity?.settings?.showInAssetSummary}
+                                    labelStyle={{ fontSize: 12, color: colors.gray[1700], fontWeight: 700 }}
+                                    isDisabled
+                                />
+                            </StyledFormItem>
+
+                            {propEntity?.settings?.showInAssetSummary && (
+                                <StyledFormSubItem name={['settings', 'hideInAssetSummaryWhenEmpty']}>
+                                    <CheckboxContainer>
+                                        <Checkbox
+                                            label="Hide when Empty"
+                                            isChecked={propEntity?.settings?.hideInAssetSummaryWhenEmpty}
+                                            labelTooltip="If enabled, this property will only show in the asset sidebar if it's assigned to the asset"
+                                            size="sm"
+                                            gap="2px"
+                                            justifyContent="flex-start"
+                                            shouldHandleLabelClicks
+                                            isDisabled
+                                        />
+                                    </CheckboxContainer>
+                                </StyledFormSubItem>
+                            )}
+                        </CompoundedItemWrapper>
                         <StyledFormItem name={['settings', 'showAsAssetBadge']}>
                             <Switch
                                 label="Show as Asset Badge"

--- a/datahub-web-react/src/app/govern/structuredProperties/__tests__/cacheUtils.test.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/__tests__/cacheUtils.test.ts
@@ -1,0 +1,134 @@
+import { vi } from 'vitest';
+
+import { removeFromPropertiesList, updatePropertiesList } from '@app/govern/structuredProperties/cacheUtils';
+
+describe('cacheUtils', () => {
+    const mockClient = {
+        readQuery: vi.fn(),
+        writeQuery: vi.fn(),
+    };
+
+    const mockInputs = {
+        types: ['STRUCTURED_PROPERTY'],
+        query: '*',
+        start: 0,
+        count: 10,
+    };
+
+    const mockSearchAcrossEntities = {
+        start: 0,
+        count: 1,
+        total: 1,
+        searchResults: [],
+        facets: [],
+    };
+
+    const mockProperty = {
+        urn: 'urn:li:structuredProperty:my-property',
+        type: 'STRUCTURED_PROPERTY',
+        definition: {
+            displayName: 'My Property',
+            qualifiedName: 'my-property',
+            description: 'This is my property.',
+            cardinality: 'SINGLE',
+            immutable: false,
+            valueType: 'STRING',
+            entityTypes: [],
+            typeQualifier: null,
+            allowedValues: [],
+            created: {
+                time: 1622547800000,
+                actor: 'urn:li:corpuser:datahub',
+            },
+            lastModified: {
+                time: 1622547800000,
+                actor: 'urn:li:corpuser:datahub',
+            },
+        },
+        settings: {
+            isHidden: false,
+            showInSearchFilters: true,
+            showAsAssetBadge: true,
+            showInAssetSummary: true,
+            hideInAssetSummaryWhenEmpty: false,
+            showInColumnsTable: true,
+        },
+        exists: true,
+    };
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('updatePropertiesList', () => {
+        it('should add a new property to the cache', () => {
+            mockClient.readQuery.mockReturnValue({
+                searchAcrossEntities: {
+                    searchResults: [],
+                },
+            });
+
+            updatePropertiesList(mockClient, mockInputs, mockProperty, mockSearchAcrossEntities);
+
+            expect(mockClient.writeQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        searchAcrossEntities: expect.objectContaining({
+                            searchResults: expect.arrayContaining([
+                                expect.objectContaining({
+                                    entity: expect.objectContaining({
+                                        urn: mockProperty.urn,
+                                    }),
+                                }),
+                            ]),
+                        }),
+                    }),
+                }),
+            );
+        });
+
+        it('should not write to the cache if it is empty', () => {
+            mockClient.readQuery.mockReturnValue(null);
+
+            updatePropertiesList(mockClient, mockInputs, mockProperty, mockSearchAcrossEntities);
+
+            expect(mockClient.writeQuery).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('removeFromPropertiesList', () => {
+        it('should remove a property from the cache', () => {
+            mockClient.readQuery.mockReturnValue({
+                searchAcrossEntities: {
+                    searchResults: [
+                        {
+                            entity: {
+                                urn: mockProperty.urn,
+                            },
+                        },
+                    ],
+                },
+            });
+
+            removeFromPropertiesList(mockClient, mockInputs, mockProperty.urn, mockSearchAcrossEntities);
+
+            expect(mockClient.writeQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        searchAcrossEntities: expect.objectContaining({
+                            searchResults: [],
+                        }),
+                    }),
+                }),
+            );
+        });
+
+        it('should not write to the cache if it is empty', () => {
+            mockClient.readQuery.mockReturnValue(null);
+
+            removeFromPropertiesList(mockClient, mockInputs, mockProperty.urn, mockSearchAcrossEntities);
+
+            expect(mockClient.writeQuery).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/datahub-web-react/src/app/govern/structuredProperties/__tests__/useStructuredProp.test.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/__tests__/useStructuredProp.test.ts
@@ -1,0 +1,122 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { Mock, vi } from 'vitest';
+
+import useStructuredProp from '@app/govern/structuredProperties/useStructuredProp';
+import { useEntityRegistry } from '@src/app/useEntityRegistry';
+
+vi.mock('@app/govern/structuredProperties/utils', () => ({
+    getEntityTypeUrn: vi.fn(),
+    valueTypes: [],
+}));
+
+vi.mock('@src/app/useEntityRegistry');
+
+describe('useStructuredProp', () => {
+    beforeEach(() => {
+        (useEntityRegistry as Mock).mockReturnValue({
+            getEntityName: vi.fn(),
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should return correct initial values', () => {
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: {} as any,
+                setFormValues: vi.fn(),
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        expect(result.current.disabledEntityTypeValues).toEqual(undefined);
+        expect(result.current.disabledTypeQualifierValues).toEqual(undefined);
+    });
+
+    it('should return a list of entities', () => {
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: {} as any,
+                setFormValues: vi.fn(),
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        const entities = result.current.getEntitiesListOptions(['DATASET' as any]);
+        expect(entities.length).toEqual(1);
+    });
+
+    it('should update form values on select change', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleSelectChange('field', 'value');
+        expect(setFormValues).toHaveBeenCalled();
+    });
+
+    it('should update form values on select update change', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+                selectedProperty: {
+                    entity: {
+                        definition: {
+                            entityTypes: [],
+                            typeQualifier: {
+                                allowedTypes: [],
+                            },
+                        },
+                    },
+                } as any,
+            }),
+        );
+
+        result.current.handleSelectUpdateChange('field', []);
+        expect(setFormValues).toHaveBeenCalled();
+    });
+
+    it('should update form values on type update', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleTypeUpdate('type');
+        expect(setFormValues).toHaveBeenCalled();
+    });
+
+    it('should update form values on display setting change', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('field', true);
+        expect(setFormValues).toHaveBeenCalled();
+    });
+});

--- a/datahub-web-react/src/app/govern/structuredProperties/__tests__/useStructuredProp.test.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/__tests__/useStructuredProp.test.ts
@@ -6,7 +6,10 @@ import { useEntityRegistry } from '@src/app/useEntityRegistry';
 
 vi.mock('@app/govern/structuredProperties/utils', () => ({
     getEntityTypeUrn: vi.fn(),
-    valueTypes: [],
+    valueTypes: [
+        { value: 'typeSingle', label: 'Single', cardinality: 'SINGLE' },
+        { value: 'typeMultiple', label: 'Multiple', cardinality: 'MULTIPLE' },
+    ],
 }));
 
 vi.mock('@src/app/useEntityRegistry');
@@ -118,5 +121,412 @@ describe('useStructuredProp', () => {
 
         result.current.handleDisplaySettingChange('field', true);
         expect(setFormValues).toHaveBeenCalled();
+    });
+
+    it('should reset all settings when isHidden is true', () => {
+        const setFormValues = vi.fn();
+        const setFieldValue = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('isHidden', true);
+        expect(setFormValues).toHaveBeenCalledWith(expect.any(Function));
+        expect(setFieldValue).toHaveBeenCalledTimes(7);
+    });
+
+    it('should disable hideInAssetSummaryWhenEmpty when showInAssetSummary is false', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('showInAssetSummary', false);
+        expect(setFormValues).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should return disabled entity type values', () => {
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: {} as any,
+                setFormValues: vi.fn(),
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+                selectedProperty: {
+                    entity: {
+                        definition: {
+                            entityTypes: [{ urn: 'urn:li:entityType:DATASET' }],
+                        },
+                    },
+                } as any,
+            }),
+        );
+
+        expect(result.current.disabledEntityTypeValues).toEqual(['urn:li:entityType:DATASET']);
+    });
+
+    it('should return disabled type qualifier values', () => {
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: {} as any,
+                setFormValues: vi.fn(),
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+                selectedProperty: {
+                    entity: {
+                        definition: {
+                            typeQualifier: {
+                                allowedTypes: [{ urn: 'urn:li:entityType:DATASET' }],
+                            },
+                        },
+                    },
+                } as any,
+            }),
+        );
+
+        expect(result.current.disabledTypeQualifierValues).toEqual(['urn:li:entityType:DATASET']);
+    });
+
+    it('should set cardinality to Multiple when type has multiple cardinality', () => {
+        const setCardinality = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues: vi.fn(),
+                setCardinality,
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleTypeUpdate('typeMultiple');
+        expect(setCardinality).toHaveBeenCalledWith('MULTIPLE');
+    });
+
+    it('should set cardinality to Single when type has single cardinality', () => {
+        const setCardinality = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues: vi.fn(),
+                setCardinality,
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleTypeUpdate('typeSingle');
+        expect(setCardinality).toHaveBeenCalledWith('SINGLE');
+    });
+
+    it('should handle typeQualifier in handleSelectChange', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleSelectChange('typeQualifier', ['value']);
+        expect(setFormValues).toHaveBeenCalled();
+    });
+
+    it('should handle entityTypes in handleSelectUpdateChange', () => {
+        const setFieldValue = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue } as any,
+                setFormValues: vi.fn(),
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+                selectedProperty: {
+                    entity: {
+                        definition: {
+                            entityTypes: [{ urn: 'urn1' }],
+                        },
+                    },
+                } as any,
+            }),
+        );
+
+        result.current.handleSelectUpdateChange('entityTypes', ['urn2']);
+        expect(setFieldValue).toHaveBeenCalledWith('entityTypes', ['urn1', 'urn2']);
+    });
+
+    it('should handle typeQualifier in handleSelectUpdateChange', () => {
+        const setFieldValue = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue } as any,
+                setFormValues: vi.fn(),
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+                selectedProperty: {
+                    entity: {
+                        definition: {
+                            typeQualifier: {
+                                allowedTypes: [{ urn: 'urn1' }],
+                            },
+                        },
+                    },
+                } as any,
+            }),
+        );
+
+        result.current.handleSelectUpdateChange('typeQualifier', ['urn2']);
+        expect(setFieldValue).toHaveBeenCalledWith('typeQualifier', ['urn1', 'urn2']);
+    });
+
+    it('should not reset settings when isHidden is false', () => {
+        const setFormValues = vi.fn();
+        const setFieldValue = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('isHidden', false);
+        expect(setFormValues).toHaveBeenCalledWith(expect.any(Function));
+        expect(setFieldValue).toHaveBeenCalledWith(['settings', 'isHidden'], false);
+        expect(setFieldValue).toHaveBeenCalledTimes(1);
+    });
+
+    it('should enable showInAssetSummary', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('showInAssetSummary', true);
+        expect(setFormValues).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should handle display setting change with previous settings', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        // Set an initial value
+        result.current.handleDisplaySettingChange('showInSearchFilters', true);
+
+        // Update another value
+        result.current.handleDisplaySettingChange('showAsAssetBadge', true);
+
+        expect(setFormValues).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle null entity name in getEntitiesListOptions', () => {
+        (useEntityRegistry as Mock).mockReturnValue({
+            getEntityName: vi.fn().mockReturnValue(null),
+        });
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: {} as any,
+                setFormValues: vi.fn(),
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        const entities = result.current.getEntitiesListOptions(['DATASET' as any]);
+        expect(entities[0].label).toEqual('');
+    });
+
+    it('should correctly update form values using previous state', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleSelectChange('field', 'value');
+
+        const updaterFn = setFormValues.mock.calls[0][0];
+        const newState = updaterFn({ existing: 'data' });
+        expect(newState).toEqual({ existing: 'data', field: 'value' });
+    });
+
+    it('should handle missing typeQualifier in handleSelectUpdateChange', () => {
+        const setFieldValue = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue } as any,
+                setFormValues: vi.fn(),
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+                selectedProperty: {
+                    entity: {
+                        definition: {
+                            entityTypes: [],
+                        },
+                    },
+                } as any,
+            }),
+        );
+
+        result.current.handleSelectUpdateChange('typeQualifier', ['urn2']);
+        expect(setFieldValue).toHaveBeenCalledWith('typeQualifier', ['urn2']);
+    });
+
+    it('should default to single cardinality if type not found in handleTypeUpdate', () => {
+        const setCardinality = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues: vi.fn(),
+                setCardinality,
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleTypeUpdate('nonexistentType');
+        expect(setCardinality).toHaveBeenCalledWith('SINGLE');
+    });
+
+    it('should handle display setting change when previous settings are undefined', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('showInSearchFilters', true);
+
+        const updaterFn = setFormValues.mock.calls[0][0];
+        let newState = updaterFn(undefined);
+        expect(newState.settings.showInSearchFilters).toBe(true);
+
+        newState = updaterFn({ some: 'value' });
+        expect(newState.settings.showInSearchFilters).toBe(true);
+    });
+
+    it('should handle showInAssetSummary change when previous settings are undefined', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('showInAssetSummary', false);
+
+        const updaterFn = setFormValues.mock.calls[0][0];
+        const newState = updaterFn(undefined);
+        expect(newState.settings.showInAssetSummary).toBe(false);
+        expect(newState.settings.hideInAssetSummaryWhenEmpty).toBe(false);
+    });
+
+    it('should correctly update settings when isHidden is true', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('isHidden', true);
+
+        const updaterFn = setFormValues.mock.calls[0][0];
+        const newState = updaterFn({ existing: 'data' });
+        expect(newState).toEqual({
+            existing: 'data',
+            settings: {
+                isHidden: true,
+                showInSearchFilters: false,
+                showAsAssetBadge: false,
+                showInAssetSummary: false,
+                hideInAssetSummaryWhenEmpty: false,
+                showInColumnsTable: false,
+            },
+        });
+    });
+
+    it('should correctly update settings when showInAssetSummary is false', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('showInAssetSummary', false);
+
+        const updaterFn = setFormValues.mock.calls[0][0];
+        const prevState = { settings: { showInAssetSummary: true, hideInAssetSummaryWhenEmpty: true, other: 'value' } };
+        const newState = updaterFn(prevState);
+        expect(newState).toEqual({
+            settings: {
+                showInAssetSummary: false,
+                hideInAssetSummaryWhenEmpty: false,
+                other: 'value',
+            },
+        });
+    });
+
+    it('should correctly update settings for other fields', () => {
+        const setFormValues = vi.fn();
+        const { result } = renderHook(() =>
+            useStructuredProp({
+                form: { setFieldValue: vi.fn() } as any,
+                setFormValues,
+                setCardinality: vi.fn(),
+                setSelectedValueType: vi.fn(),
+            }),
+        );
+
+        result.current.handleDisplaySettingChange('showAsAssetBadge', true);
+
+        const updaterFn = setFormValues.mock.calls[0][0];
+        const prevState = { settings: { showInSearchFilters: true } };
+        const newState = updaterFn(prevState);
+        expect(newState).toEqual({
+            settings: {
+                showInSearchFilters: true,
+                showAsAssetBadge: true,
+            },
+        });
     });
 });

--- a/datahub-web-react/src/app/govern/structuredProperties/cacheUtils.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/cacheUtils.ts
@@ -23,6 +23,7 @@ const addToCache = (existingProperties, newProperty) => {
                 showInSearchFilters: newProperty.settings.showInSearchFilters,
                 showAsAssetBadge: newProperty.settings.showAsAssetBadge,
                 showInAssetSummary: newProperty.settings.showInAssetSummary,
+                hideInAssetSummaryWhenEmpty: newProperty.settings.hideInAssetSummaryWhenEmpty,
                 showInColumnsTable: newProperty.settings.showInColumnsTable,
             },
             exists: newProperty.exists,

--- a/datahub-web-react/src/app/govern/structuredProperties/styledComponents.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/styledComponents.ts
@@ -154,7 +154,7 @@ export const StyledCheckbox = styled(Checkbox)`
     .ant-checkbox-checked .ant-checkbox-inner {
         background-color: ${(props) => props.theme.styles['primary-color']};
         border-color: ${(props) => props.theme.styles['primary-color']} !important;
-    },
+    }
 `;
 
 export const StyledText = styled.div`
@@ -165,6 +165,26 @@ export const StyledText = styled.div`
 export const StyledFormItem = styled(Form.Item)`
     margin: 0;
 `;
+
+export const SupItemsContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    padding-top: 32px;
+`;
+
+export const StyledFormSubItem = styled(StyledFormItem)`
+    padding-top: 32px;
+    padding-left: 24px;
+
+    .ant-form-item-control-input {
+        min-height: 0px !important;
+    }
+`;
+
+export const CheckboxContainer = styled.div``;
+
+export const CompoundedItemWrapper = styled.div``;
 
 export const GridFormItem = styled(Form.Item)`
     display: grid;

--- a/datahub-web-react/src/app/govern/structuredProperties/useStructuredProp.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/useStructuredProp.ts
@@ -89,6 +89,7 @@ export default function useStructuredProp({
         showInSearchFilters: false,
         showAsAssetBadge: false,
         showInAssetSummary: false,
+        hideInAssetSummaryWhenEmpty: false,
         showInColumnsTable: false,
     };
 
@@ -100,6 +101,16 @@ export default function useStructuredProp({
                 settings: {
                     ...settingsDefault,
                     [settingField]: value,
+                },
+            }));
+        } else if (settingField === 'showInAssetSummary' && !value) {
+            // Automatically disable `hideInAssetSummaryWhenEmpty` on disabling of `showInAssetSummary`
+            setFormValues((prev) => ({
+                ...prev,
+                settings: {
+                    ...(prev?.settings || settingsDefault),
+                    showInAssetSummary: false,
+                    hideInAssetSummaryWhenEmpty: false,
                 },
             }));
         } else {

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -1652,6 +1652,7 @@ fragment structuredPropertyFields on StructuredPropertyEntity {
         showInSearchFilters
         showAsAssetBadge
         showInAssetSummary
+        hideInAssetSummaryWhenEmpty
         showInColumnsTable
     }
 }


### PR DESCRIPTION
This PR adds to UI option in settings of structured properties to hide them in assets sidebar
<img width="408" height="275" alt="image" src="https://github.com/user-attachments/assets/89eacb68-9de0-4b00-8337-c018f7152f0a" />


Additionally adjusted color of check mark in Checkbox component when it's disabled

<img width="759" height="240" alt="image" src="https://github.com/user-attachments/assets/f1c6341b-0be8-46be-9190-f45f157aaf19" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
