### PR TITLE
tests(structuredProperties): add cypress tests

### DIFF
--- a/datahub-web-react/src/app/govern/structuredProperties/DisplayPreferences.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/DisplayPreferences.tsx
@@ -105,6 +105,7 @@ const DisplayPreferences = ({
                                     onChange={(e) => handleDisplaySettingChange('showInAssetSummary', e.target.checked)}
                                     isDisabled={formValues?.settings?.isHidden}
                                     labelHoverText="If enabled, this property will appear in asset sidebar"
+                                    data-testid="structured-props-show-in-asset-summary-switch"
                                 />
                             </StyledFormItem>
                             {formValues?.settings?.showInAssetSummary && (
@@ -120,6 +121,7 @@ const DisplayPreferences = ({
                                                 handleDisplaySettingChange('hideInAssetSummaryWhenEmpty', isChecked)
                                             }
                                             justifyContent="flex-start"
+                                            dataTestId="structured-props-hide-in-asset-summary-when-empty-checkbox"
                                             shouldHandleLabelClicks
                                         />
                                     </CheckboxContainer>

--- a/smoke-test/tests/cypress/cypress/e2e/structured_properties/structured_properties.js
+++ b/smoke-test/tests/cypress/cypress/e2e/structured_properties/structured_properties.js
@@ -85,6 +85,39 @@ const showStructuredPropertyInColumnsTable = (prop) => {
   cy.waitTextVisible(updateToastMessage);
 };
 
+const showStructuredPropertyInAssetSummaryTab = (prop) => {
+  cy.get('[data-testid="structured-props-table"]').contains(prop.name).click();
+  cy.get(
+    '[data-testid="structured-props-show-in-asset-summary-switch"]',
+  ).click();
+  cy.get('[data-testid="structured-props-create-update-button"]').click();
+  cy.waitTextVisible(updateToastMessage);
+};
+
+const hideStructuredPropertyInAssetSummaryTabWhenEmpty = (prop) => {
+  cy.getWithTestId("structured-props-table").contains(prop.name).click();
+  cy.getWithTestId(
+    "structured-props-hide-in-asset-summary-when-empty-checkbox",
+  ).click({ force: true });
+  cy.getWithTestId("structured-props-create-update-button").click();
+  cy.waitTextVisible(updateToastMessage);
+};
+
+const openEntityAssetSummaryTab = () => {
+  cy.get('[id="entity-sidebar-tabs-tab-Summary"]').then(($el) => {
+    const isSelected = $el.attr("aria-selected") === "true";
+    if (!isSelected) cy.wrap($el).click();
+  });
+};
+
+const ensureStructuredPropertyIsAvailableInAssetSummaryTab = (prop) => {
+  cy.get('[id="entity-profile-v2-sidebar"]').should("contain", prop.name);
+};
+
+const ensureStructuredPropertyIsNotAvailableInAssetSummaryTab = (prop) => {
+  cy.get('[id="entity-profile-v2-sidebar"]').should("not.contain", prop.name);
+};
+
 const addStructuredPropertyToField = (prop) => {
   cy.goToDataset(datasetUrn, datasetName);
   cy.contains(fieldName);
@@ -252,5 +285,59 @@ describe("Verify manage structured properties functionalities", () => {
       .should("not.exist");
     goToStructuredProperties();
     deleteStructuredProperty(fieldStructuredProperty);
+  });
+
+  it("Verify property is available in asset summary tab when empty", () => {
+    const property = {
+      ...structuredProperty,
+      name: "Property-showInSummaryTab",
+    };
+
+    createStructuredProperty(property);
+    showStructuredPropertyInAssetSummaryTab(property);
+    cy.goToDataset(datasetUrn, datasetName);
+
+    openEntityAssetSummaryTab();
+    ensureStructuredPropertyIsAvailableInAssetSummaryTab(property);
+
+    goToStructuredProperties();
+    deleteStructuredProperty(property);
+  });
+
+  it("Verify property is not available in asset summary tab when it's empty", () => {
+    const property = {
+      ...structuredProperty,
+      name: "Property-hideInSummaryTabWithoutValue",
+    };
+    createStructuredProperty(property);
+    showStructuredPropertyInAssetSummaryTab(property);
+    goToStructuredProperties();
+    hideStructuredPropertyInAssetSummaryTabWhenEmpty(property);
+    cy.goToDataset(datasetUrn, datasetName);
+
+    openEntityAssetSummaryTab();
+    ensureStructuredPropertyIsNotAvailableInAssetSummaryTab(property);
+
+    goToStructuredProperties();
+    deleteStructuredProperty(property);
+  });
+
+  it("Verify property is available in asset summary tab when it isn't empty", () => {
+    const property = {
+      ...structuredProperty,
+      name: "Property-hideInSummaryTabWhenEmptyWithValue",
+    };
+    createStructuredProperty(property);
+    showStructuredPropertyInAssetSummaryTab(property);
+    goToStructuredProperties();
+    hideStructuredPropertyInAssetSummaryTabWhenEmpty(property);
+    cy.goToDataset(datasetUrn, datasetName);
+    addStructuredPropertyToEntity(property);
+
+    openEntityAssetSummaryTab();
+    ensureStructuredPropertyIsAvailableInAssetSummaryTab(property);
+
+    goToStructuredProperties();
+    deleteStructuredProperty(property);
   });
 });


### PR DESCRIPTION
This PR adds cypress tests to cover flow with the new setting property `Hide when Empty` in structured properties

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
