### PR TITLE
feat(ingest): ensure payload size constraints for querySubjects and upstreamLineage aspects

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/auto_work_units/auto_ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/auto_work_units/auto_ensure_aspect_size.py
@@ -7,8 +7,10 @@ from datahub.emitter.serialization_helper import pre_json_transform
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
     DatasetProfileClass,
+    QuerySubjectsClass,
     SchemaFieldClass,
     SchemaMetadataClass,
+    UpstreamLineageClass,
 )
 
 if TYPE_CHECKING:
@@ -81,6 +83,149 @@ class EnsureAspectSizeProcessor:
 
         schema.fields = accepted_fields
 
+    def ensure_query_subjects_size(
+        self, entity_urn: str, query_subjects: QuerySubjectsClass
+    ) -> None:
+        """
+        Ensure query subjects aspect does not exceed allowed size by removing column-level lineage first,
+        then table lineage if necessary.
+        """
+        if not query_subjects.subjects:
+            return
+
+        total_subjects_size = 0
+        accepted_subjects = []
+        column_level_subjects_with_sizes = []
+        table_level_subjects_with_sizes = []
+
+        # Separate column-level and table-level subjects
+        for subject in query_subjects.subjects:
+            subject_size = len(json.dumps(pre_json_transform(subject.to_obj())))
+
+            if subject.entity.startswith("urn:li:schemaField:"):
+                column_level_subjects_with_sizes.append((subject, subject_size))
+            else:
+                table_level_subjects_with_sizes.append((subject, subject_size))
+
+        # First, try to include all table-level subjects
+        for subject, subject_size in table_level_subjects_with_sizes:
+            if total_subjects_size + subject_size < self.schema_size_constraint:
+                accepted_subjects.append(subject)
+                total_subjects_size += subject_size
+            else:
+                self.report.warning(
+                    title="Query subjects truncated due to size constraint",
+                    message="Query subjects contained too much data and would have caused ingestion to fail",
+                    context=f"Table-level lineage subject {subject.entity} was removed from query subjects for {entity_urn} due to aspect size constraints",
+                )
+
+        # Then, add column-level subjects if there's remaining space
+        for subject, subject_size in column_level_subjects_with_sizes:
+            if total_subjects_size + subject_size < self.schema_size_constraint:
+                accepted_subjects.append(subject)
+                total_subjects_size += subject_size
+            else:
+                self.report.warning(
+                    title="Query subjects truncated due to size constraint",
+                    message="Query subjects contained too much data and would have caused ingestion to fail",
+                    context=f"Column-level lineage subject {subject.entity} was removed from query subjects for {entity_urn} due to aspect size constraints",
+                )
+
+        query_subjects.subjects = accepted_subjects
+
+    def ensure_upstream_lineage_size(
+        self, entity_urn: str, upstream_lineage: UpstreamLineageClass
+    ) -> None:
+        """
+        Ensure upstream lineage aspect does not exceed allowed size by removing lineage in priority order:
+        first NONE fine-grained lineages (lowest priority), then FIELD_SET fine-grained lineages,
+        then DATASET fine-grained lineages, and finally upstreams (highest priority).
+        """
+        if not upstream_lineage.fineGrainedLineages and not upstream_lineage.upstreams:
+            return
+
+        total_lineage_size = 0
+        accepted_upstreams = []
+        accepted_fine_grained_lineages = []
+        upstream_items_with_sizes = []
+        dataset_fg_items_with_sizes = []
+        field_set_fg_items_with_sizes = []
+        none_fg_items_with_sizes = []
+
+        # Add upstreams (highest priority)
+        if upstream_lineage.upstreams:
+            for upstream in upstream_lineage.upstreams:
+                upstream_size = len(json.dumps(pre_json_transform(upstream.to_obj())))
+                upstream_items_with_sizes.append((upstream, upstream_size))
+
+        # Separate fine-grained lineage items by upstreamType: DATASET > FIELD_SET > NONE
+        if upstream_lineage.fineGrainedLineages:
+            for fg_lineage in upstream_lineage.fineGrainedLineages:
+                fg_lineage_size = len(
+                    json.dumps(pre_json_transform(fg_lineage.to_obj()))
+                )
+
+                upstream_type_str = str(fg_lineage.upstreamType)
+                if upstream_type_str == "DATASET":
+                    dataset_fg_items_with_sizes.append((fg_lineage, fg_lineage_size))
+                elif upstream_type_str == "FIELD_SET":
+                    field_set_fg_items_with_sizes.append((fg_lineage, fg_lineage_size))
+                elif upstream_type_str == "NONE":
+                    none_fg_items_with_sizes.append((fg_lineage, fg_lineage_size))
+
+        # First, include all upstreams
+        for item, item_size in upstream_items_with_sizes:
+            if total_lineage_size + item_size < self.schema_size_constraint:
+                accepted_upstreams.append(item)
+                total_lineage_size += item_size
+            else:
+                self.report.warning(
+                    title="Upstream lineage truncated due to size constraint",
+                    message="Upstream lineage contained too much data and would have caused ingestion to fail",
+                    context=f"Upstream dataset {item.dataset} was removed from upstream lineage for {entity_urn} due to aspect size constraints",
+                )
+
+        # Second, include DATASET fine-grained lineages
+        for item, item_size in dataset_fg_items_with_sizes:
+            if total_lineage_size + item_size < self.schema_size_constraint:
+                accepted_fine_grained_lineages.append(item)
+                total_lineage_size += item_size
+            else:
+                self.report.warning(
+                    title="Upstream lineage truncated due to size constraint",
+                    message="Upstream lineage contained too much data and would have caused ingestion to fail",
+                    context=f"Dataset-level fine-grained lineage was removed from upstream lineage for {entity_urn} due to aspect size constraints",
+                )
+
+        # Third, include FIELD_SET fine-grained lineages
+        for item, item_size in field_set_fg_items_with_sizes:
+            if total_lineage_size + item_size < self.schema_size_constraint:
+                accepted_fine_grained_lineages.append(item)
+                total_lineage_size += item_size
+            else:
+                self.report.warning(
+                    title="Upstream lineage truncated due to size constraint",
+                    message="Upstream lineage contained too much data and would have caused ingestion to fail",
+                    context=f"Field-level fine-grained lineage was removed from upstream lineage for {entity_urn} due to aspect size constraints",
+                )
+
+        # Finally, include NONE fine-grained lineages (lowest priority)
+        for item, item_size in none_fg_items_with_sizes:
+            if total_lineage_size + item_size < self.schema_size_constraint:
+                accepted_fine_grained_lineages.append(item)
+                total_lineage_size += item_size
+            else:
+                self.report.warning(
+                    title="Upstream lineage truncated due to size constraint",
+                    message="Upstream lineage contained too much data and would have caused ingestion to fail",
+                    context=f"No-upstream fine-grained lineage was removed from upstream lineage for {entity_urn} due to aspect size constraints",
+                )
+
+        upstream_lineage.upstreams = accepted_upstreams
+        upstream_lineage.fineGrainedLineages = (
+            accepted_fine_grained_lineages if accepted_fine_grained_lineages else None
+        )
+
     def ensure_aspect_size(
         self,
         stream: Iterable[MetadataWorkUnit],
@@ -96,4 +241,8 @@ class EnsureAspectSizeProcessor:
                 self.ensure_schema_metadata_size(wu.get_urn(), schema)
             elif profile := wu.get_aspect_of_type(DatasetProfileClass):
                 self.ensure_dataset_profile_size(wu.get_urn(), profile)
+            elif query_subjects := wu.get_aspect_of_type(QuerySubjectsClass):
+                self.ensure_query_subjects_size(wu.get_urn(), query_subjects)
+            elif upstream_lineage := wu.get_aspect_of_type(UpstreamLineageClass):
+                self.ensure_upstream_lineage_size(wu.get_urn(), upstream_lineage)
             yield wu

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_ensure_aspect_size.py
@@ -17,18 +17,26 @@ from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
 from datahub.metadata.schema_classes import (
     ChangeTypeClass,
     DatasetFieldProfileClass,
+    DatasetLineageTypeClass,
     DatasetProfileClass,
     DatasetSnapshotClass,
+    FineGrainedLineageClass,
+    FineGrainedLineageDownstreamTypeClass,
+    FineGrainedLineageUpstreamTypeClass,
     GenericAspectClass,
     MetadataChangeProposalClass,
     NumberTypeClass,
     OtherSchemaClass,
+    QuerySubjectClass,
+    QuerySubjectsClass,
     SchemaFieldClass,
     SchemaFieldDataTypeClass,
     SchemaMetadataClass,
     StatusClass,
     StringTypeClass,
     SubTypesClass,
+    UpstreamClass,
+    UpstreamLineageClass,
 )
 
 
@@ -109,6 +117,150 @@ def proper_schema_metadata() -> SchemaMetadataClass:
         hash="ABCDE1234567890",
         platformSchema=OtherSchemaClass(rawSchema="aaa"),
         fields=fields,
+    )
+
+
+def proper_query_subjects() -> QuerySubjectsClass:
+    subjects = [
+        QuerySubjectClass(
+            entity="urn:li:dataset:(urn:li:dataPlatform:hive,db1.table1,PROD)"
+        ),
+        QuerySubjectClass(
+            entity="urn:li:dataset:(urn:li:dataPlatform:hive,db1.table2,PROD)"
+        ),
+        QuerySubjectClass(
+            entity="urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,db1.table1,PROD),col1)"
+        ),
+        QuerySubjectClass(
+            entity="urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,db1.table2,PROD),col2)"
+        ),
+    ]
+    return QuerySubjectsClass(subjects=subjects)
+
+
+def too_big_query_subjects() -> QuerySubjectsClass:
+    subjects = []
+
+    # Add a few table-level subjects
+    for i in range(5):
+        subjects.append(
+            QuerySubjectClass(
+                entity=f"urn:li:dataset:(urn:li:dataPlatform:hive,db.table{i},PROD)"
+            )
+        )
+
+    # Add many column-level subjects with very large entity URNs to exceed the 15MB constraint
+    # Each URN will be about 40KB, so 500 subjects should create ~20MB of data
+    for i in range(500):
+        large_table_name = "a" * 20000  # Very large table name
+        large_column_name = "b" * 20000  # Very large column name
+        subjects.append(
+            QuerySubjectClass(
+                entity=f"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,{large_table_name}_{i},PROD),{large_column_name}_{i})"
+            )
+        )
+
+    return QuerySubjectsClass(subjects=subjects)
+
+
+def proper_upstream_lineage() -> UpstreamLineageClass:
+    upstreams = [
+        UpstreamClass(
+            dataset="urn:li:dataset:(urn:li:dataPlatform:hive,db1.table1,PROD)",
+            type=DatasetLineageTypeClass.TRANSFORMED,
+        ),
+        UpstreamClass(
+            dataset="urn:li:dataset:(urn:li:dataPlatform:hive,db1.table2,PROD)",
+            type=DatasetLineageTypeClass.TRANSFORMED,
+        ),
+    ]
+    fine_grained_lineages = [
+        FineGrainedLineageClass(
+            upstreamType=FineGrainedLineageUpstreamTypeClass.DATASET,
+            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+            upstreams=["urn:li:dataset:(urn:li:dataPlatform:hive,db1.table3,PROD)"],
+            downstreams=[
+                "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,db1.target,PROD),col1)"
+            ],
+        ),
+        FineGrainedLineageClass(
+            upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+            downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+            upstreams=[
+                "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,db1.table4,PROD),col2)"
+            ],
+            downstreams=[
+                "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,db1.target,PROD),col2)"
+            ],
+        ),
+    ]
+    return UpstreamLineageClass(
+        upstreams=upstreams, fineGrainedLineages=fine_grained_lineages
+    )
+
+
+def too_big_upstream_lineage() -> UpstreamLineageClass:
+    upstreams = []
+    fine_grained_lineages = []
+
+    # Add upstreams (highest priority)
+    for i in range(5):
+        upstreams.append(
+            UpstreamClass(
+                dataset=f"urn:li:dataset:(urn:li:dataPlatform:hive,upstream_table_{i},PROD)",
+                type=DatasetLineageTypeClass.TRANSFORMED,
+            )
+        )
+
+    # Add DATASET fine-grained lineages with large URNs
+    for i in range(200):
+        large_dataset_name = "a" * 20000
+        large_downstream_name = "b" * 20000
+        fine_grained_lineages.append(
+            FineGrainedLineageClass(
+                upstreamType=FineGrainedLineageUpstreamTypeClass.DATASET,
+                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                upstreams=[
+                    f"urn:li:dataset:(urn:li:dataPlatform:hive,{large_dataset_name}_{i},PROD)"
+                ],
+                downstreams=[
+                    f"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,target,PROD),{large_downstream_name}_{i})"
+                ],
+            )
+        )
+
+    # Add FIELD_SET fine-grained lineages with large URNs
+    for i in range(200):
+        large_upstream_name = "c" * 20000
+        large_downstream_name = "d" * 20000
+        fine_grained_lineages.append(
+            FineGrainedLineageClass(
+                upstreamType=FineGrainedLineageUpstreamTypeClass.FIELD_SET,
+                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                upstreams=[
+                    f"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,source,PROD),{large_upstream_name}_{i})"
+                ],
+                downstreams=[
+                    f"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,target,PROD),{large_downstream_name}_{i})"
+                ],
+            )
+        )
+
+    # Add NONE fine-grained lineages with large URNs (lowest priority)
+    for i in range(200):
+        large_downstream_name = "e" * 20000
+        fine_grained_lineages.append(
+            FineGrainedLineageClass(
+                upstreamType=FineGrainedLineageUpstreamTypeClass.NONE,
+                downstreamType=FineGrainedLineageDownstreamTypeClass.FIELD,
+                downstreams=[
+                    f"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,target,PROD),{large_downstream_name}_{i})"
+                ],
+            )
+        )
+
+    return UpstreamLineageClass(
+        upstreams=upstreams, fineGrainedLineages=fine_grained_lineages
     )
 
 
@@ -344,3 +496,180 @@ def test_wu_processor_not_triggered_by_unhandled_aspects(
     ]
     ensure_schema_metadata_size_mock.assert_not_called()
     ensure_dataset_profile_size_mock.assert_not_called()
+
+
+@freeze_time("2023-01-02 00:00:00")
+def test_ensure_size_of_proper_query_subjects(processor):
+    query_subjects = proper_query_subjects()
+    orig_repr = json.dumps(query_subjects.to_obj())
+    processor.ensure_query_subjects_size(
+        "urn:li:query:(urn:li:dataPlatform:hive, dummy_query, DEV)", query_subjects
+    )
+    assert orig_repr == json.dumps(query_subjects.to_obj()), (
+        "Aspect was modified in case where workunit processor should have been no-op"
+    )
+
+
+@freeze_time("2023-01-02 00:00:00")
+def test_ensure_size_of_too_big_query_subjects(processor):
+    query_subjects = too_big_query_subjects()
+    assert len(query_subjects.subjects) == 505  # 5 table + 500 column subjects
+
+    # Verify that the initial size exceeds the default payload constraint
+    initial_size = len(json.dumps(query_subjects.to_obj()))
+    expected_size = 20 * 1024 * 1024  # 20MB
+    assert initial_size == pytest.approx(expected_size, rel=0.05), (
+        f"Initial size {initial_size} should be around 20MB (±5%), got {initial_size / (1024 * 1024):.1f}MB"
+    )
+    assert initial_size > INGEST_MAX_PAYLOAD_BYTES, (
+        f"Initial size {initial_size} should exceed payload constraint {INGEST_MAX_PAYLOAD_BYTES}"
+    )
+
+    processor.ensure_query_subjects_size(
+        "urn:li:query:(urn:li:dataPlatform:hive, dummy_query, DEV)", query_subjects
+    )
+
+    # Should be significantly reduced due to size constraints
+    # With ~20MB of data needing to be reduced to ~15MB, we expect ~25% reduction (125 subjects)
+    # So final count should be around 380, using 400 as upper bound with buffer
+    assert len(query_subjects.subjects) < 400, (
+        "Query subjects has not been properly truncated"
+    )
+
+    # Check that table-level subjects are prioritized (should still be present)
+    table_subjects = [
+        s
+        for s in query_subjects.subjects
+        if not s.entity.startswith("urn:li:schemaField:")
+    ]
+    assert len(table_subjects) > 0, (
+        "Table-level subjects should be prioritized and present"
+    )
+
+    # The aspect should not exceed acceptable size
+    assert len(json.dumps(query_subjects.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
+        "Aspect exceeded acceptable size"
+    )
+
+
+@freeze_time("2023-01-02 00:00:00")
+@patch(
+    "datahub.ingestion.api.auto_work_units.auto_ensure_aspect_size.EnsureAspectSizeProcessor.ensure_query_subjects_size"
+)
+def test_wu_processor_triggered_by_query_subjects_aspect(
+    ensure_query_subjects_size_mock, processor
+):
+    ret = [  # noqa: F841
+        *processor.ensure_aspect_size(
+            [
+                MetadataChangeProposalWrapper(
+                    entityUrn="urn:li:query:(urn:li:dataPlatform:hive, dummy_query, DEV)",
+                    aspect=proper_query_subjects(),
+                ).as_workunit()
+            ]
+        )
+    ]
+    ensure_query_subjects_size_mock.assert_called_once()
+
+
+@freeze_time("2023-01-02 00:00:00")
+def test_ensure_size_of_proper_upstream_lineage(processor):
+    upstream_lineage = proper_upstream_lineage()
+    orig_repr = json.dumps(upstream_lineage.to_obj())
+    processor.ensure_upstream_lineage_size(
+        "urn:li:dataset:(urn:li:dataPlatform:hive, dummy_dataset, DEV)",
+        upstream_lineage,
+    )
+    assert orig_repr == json.dumps(upstream_lineage.to_obj()), (
+        "Aspect was modified in case where workunit processor should have been no-op"
+    )
+
+
+@freeze_time("2023-01-02 00:00:00")
+def test_ensure_size_of_too_big_upstream_lineage(processor):
+    upstream_lineage = too_big_upstream_lineage()
+    assert len(upstream_lineage.upstreams) == 5  # 5 upstreams
+    assert (
+        len(upstream_lineage.fineGrainedLineages) == 600
+    )  # 200 DATASET + 200 FIELD_SET + 200 NONE
+
+    # Verify that the initial size exceeds the default payload constraint
+    initial_size = len(json.dumps(upstream_lineage.to_obj()))
+    expected_size = 20 * 1024 * 1024  # 20MB
+    assert initial_size == pytest.approx(expected_size, rel=0.05), (
+        f"Initial size {initial_size} should be around 20MB (±5%), got {initial_size / (1024 * 1024):.1f}MB"
+    )
+    assert initial_size > INGEST_MAX_PAYLOAD_BYTES, (
+        f"Initial size {initial_size} should exceed payload constraint {INGEST_MAX_PAYLOAD_BYTES}"
+    )
+
+    processor.ensure_upstream_lineage_size(
+        "urn:li:dataset:(urn:li:dataPlatform:hive, dummy_dataset, DEV)",
+        upstream_lineage,
+    )
+
+    # Should be significantly reduced due to size constraints
+    # With ~20MB of data needing to be reduced to ~15MB, we expect ~25% reduction
+    # Total items: 5 upstreams + 600 fine-grained = 605, expect around ~450 after 25% reduction
+    total_items = len(upstream_lineage.upstreams) + (
+        len(upstream_lineage.fineGrainedLineages)
+        if upstream_lineage.fineGrainedLineages
+        else 0
+    )
+    assert total_items < 500, "Upstream lineage has not been properly truncated"
+
+    # Check that upstreams are prioritized (should still be present)
+    assert len(upstream_lineage.upstreams) > 0, (
+        "Upstreams should be prioritized and present"
+    )
+
+    # Check that DATASET fine-grained lineages are prioritized over FIELD_SET and NONE
+    if upstream_lineage.fineGrainedLineages:
+        dataset_count = sum(
+            1
+            for fg in upstream_lineage.fineGrainedLineages
+            if str(fg.upstreamType) == "DATASET"
+        )
+        field_set_count = sum(
+            1
+            for fg in upstream_lineage.fineGrainedLineages
+            if str(fg.upstreamType) == "FIELD_SET"
+        )
+        none_count = sum(
+            1
+            for fg in upstream_lineage.fineGrainedLineages
+            if str(fg.upstreamType) == "NONE"
+        )
+
+        # DATASET should be prioritized over FIELD_SET and NONE
+        assert dataset_count >= field_set_count, (
+            "DATASET fine-grained lineages should be prioritized"
+        )
+        assert dataset_count >= none_count, (
+            "DATASET fine-grained lineages should be prioritized over NONE"
+        )
+
+    # The aspect should not exceed acceptable size
+    assert len(json.dumps(upstream_lineage.to_obj())) < INGEST_MAX_PAYLOAD_BYTES, (
+        "Aspect exceeded acceptable size"
+    )
+
+
+@freeze_time("2023-01-02 00:00:00")
+@patch(
+    "datahub.ingestion.api.auto_work_units.auto_ensure_aspect_size.EnsureAspectSizeProcessor.ensure_upstream_lineage_size"
+)
+def test_wu_processor_triggered_by_upstream_lineage_aspect(
+    ensure_upstream_lineage_size_mock, processor
+):
+    ret = [  # noqa: F841
+        *processor.ensure_aspect_size(
+            [
+                MetadataChangeProposalWrapper(
+                    entityUrn="urn:li:dataset:(urn:li:dataPlatform:hive, dummy_dataset, DEV)",
+                    aspect=proper_upstream_lineage(),
+                ).as_workunit()
+            ]
+        )
+    ]
+    ensure_upstream_lineage_size_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- Add payload size constraints for `querySubjects` aspect with column-level lineage removal priority
- Add payload size constraints for `upstreamLineage` aspect with fine-grained lineage type priority (DATASET → FIELD_SET → NONE)
- Comprehensive test coverage for both aspects with realistic size validation

## Test plan
- [x] Unit tests for proper size handling of both aspects
- [x] Unit tests for oversized aspect trimming with priority preservation
- [x] Size validation using pytest.approx() for accurate constraint verification
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)