### PR TITLE
fix(ingest/grafana): add exception handling

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/models.py
@@ -91,10 +91,13 @@ class Dashboard(_GrafanaBaseModel):
     def parse_obj(cls, data: Dict[str, Any]) -> "Dashboard":
         """Custom parsing to handle nested panel extraction."""
         dashboard_data = data.get("dashboard", {})
+        _panel_data = dashboard_data.get("panels", [])
         try:
-            panels = cls.extract_panels(dashboard_data.get("panels", []))
+            panels = cls.extract_panels(_panel_data)
         except Exception as e:
-            logger.warning(f"Error parsing dashboard: {e}")
+            logger.warning(
+                f"Error extracting panels from dashboard for dashboard panels {_panel_data} : {e}"
+            )
 
         # Extract meta.folderId from nested structure
         meta = dashboard_data.get("meta", {})

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/models.py
@@ -8,12 +8,14 @@ References:
 - Dashboard JSON structure: https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/
 """
 
+import logging
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from datahub.emitter.mcp_builder import ContainerKey
 
+logger = logging.getLogger(__name__)
 # Grafana-specific type definitions for better type safety
 GrafanaQueryTarget = Dict[
     str, Any
@@ -89,7 +91,10 @@ class Dashboard(_GrafanaBaseModel):
     def parse_obj(cls, data: Dict[str, Any]) -> "Dashboard":
         """Custom parsing to handle nested panel extraction."""
         dashboard_data = data.get("dashboard", {})
-        panels = cls.extract_panels(dashboard_data.get("panels", []))
+        try:
+            panels = cls.extract_panels(dashboard_data.get("panels", []))
+        except Exception as e:
+            logger.warning(f"Error parsing dashboard: {e}")
 
         # Extract meta.folderId from nested structure
         meta = dashboard_data.get("meta", {})


### PR DESCRIPTION
In case title of panel is missing we started getting
```packages/datahub/ingestion/source/grafana/models.py", line 82, in extract_panels
Fri Oct  3 18:16:12 IST 2025	 panels.append(Panel.parse_obj(panel_data))
Fri Oct  3 18:16:12 IST 2025	 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Fri Oct  3 18:16:12 IST 2025	 File "pydantic/main.py", line 532, in pydantic.main.BaseModel.parse_obj
Fri Oct  3 18:16:12 IST 2025	 File "pydantic/main.py", line 347, in pydantic.main.BaseModel.__init__
Fri Oct  3 18:16:12 IST 2025	 pydantic.error_wrappers.ValidationError: 1 validation error for Panel
Fri Oct  3 18:16:12 IST 2025	 title
Fri Oct  3 18:16:12 IST 2025	 field required (type=value_error.missing)
```

which caused the whole ingestion to start failing.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
