### PR TITLE
fix(ui) Move template editable changes to their own files

### DIFF
--- a/datahub-web-react/src/app/homeV3/HomePageContent.tsx
+++ b/datahub-web-react/src/app/homeV3/HomePageContent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Announcements } from '@app/homeV3/announcements/Announcements';
 import EditDefaultTemplateBar from '@app/homeV3/settings/EditDefaultTemplateBar';
-// import EditHomePageSettingsButton from '@app/homeV3/settings/EditHomePageSettingsButton';
+import HomePageSettingsButtonWrapper from '@app/homeV3/settings/HomePageSettingsButtonWrapper';
 import { CenteredContainer, ContentContainer, ContentDiv } from '@app/homeV3/styledComponents';
 import Template from '@app/homeV3/template/Template';
 
@@ -11,7 +11,7 @@ const HomePageContent = () => {
         <ContentContainer>
             <CenteredContainer>
                 <ContentDiv>
-                    {/* <EditHomePageSettingsButton /> Editing templates is not enabled in OSS */}
+                    <HomePageSettingsButtonWrapper />
                     <Announcements />
                     <Template />
                     <EditDefaultTemplateBar />

--- a/datahub-web-react/src/app/homeV3/context/PageTemplateContext.tsx
+++ b/datahub-web-react/src/app/homeV3/context/PageTemplateContext.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, createContext, useContext, useMemo } from 'react';
 
 import { useAssetSummaryOperations } from '@app/homeV3/context/hooks/useAssetSummaryOperations';
+import useIsTemplateEditable from '@app/homeV3/context/hooks/useIsTemplateEditable';
 import { useModuleModalState } from '@app/homeV3/context/hooks/useModuleModalState';
 import { useModuleOperations } from '@app/homeV3/context/hooks/useModuleOperations';
 import { useTemplateOperations } from '@app/homeV3/context/hooks/useTemplateOperations';
@@ -17,7 +18,7 @@ interface Props {
 }
 
 export const PageTemplateProvider = ({ children, templateType }: Props) => {
-    const isTemplateEditable = false; // template is not editable in OSS
+    const isTemplateEditable = useIsTemplateEditable();
     // Template state management
     const {
         personalTemplate,

--- a/datahub-web-react/src/app/homeV3/context/hooks/useIsTemplateEditable.ts
+++ b/datahub-web-react/src/app/homeV3/context/hooks/useIsTemplateEditable.ts
@@ -1,0 +1,4 @@
+export default function useIsTemplateEditable() {
+    // Editing is disabled in OSS
+    return false;
+}

--- a/datahub-web-react/src/app/homeV3/settings/HomePageSettingsButtonWrapper.tsx
+++ b/datahub-web-react/src/app/homeV3/settings/HomePageSettingsButtonWrapper.tsx
@@ -1,0 +1,4 @@
+export default function HomePageSettingsButtonWrapper() {
+    // There is no settings button in OSS because editing is disabled in OSS.
+    return null;
+}


### PR DESCRIPTION
Moves the changes to determine if a template should be editable and the settings button to their own files to separate concerns.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
