### PR TITLE
fix(ui): Entity text overflow in 'owner of' section

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/sidebarSection/UserOwnershipSideBarSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/sidebarSection/UserOwnershipSideBarSection.tsx
@@ -1,5 +1,6 @@
 import { Col } from 'antd';
 import React, { useState } from 'react';
+import { CSSObject } from 'styled-components';
 
 import { OwnershipContainer, ShowMoreText } from '@app/entityV2/shared/SidebarStyledComponents';
 import { SidebarSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarSection';
@@ -10,7 +11,7 @@ import { SearchResults } from '@types';
 
 const DEFAULT_MAX_ENTITIES_TO_SHOW = 4;
 
-const entityLinkTextStyle = {
+const entityLinkTextStyle: CSSObject = {
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',


### PR DESCRIPTION
The 'Owner of' section lays out the Entities into two columns which are overflowing into each other for long texts. Fixes these overflows

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
