### PR TITLE
feat(analytics) Support google tag tracking only with ID supplied

### DIFF
--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -286,3 +286,6 @@ graphql.verbose.logging = false
 graphql.verbose.logging = ${?GRAPHQL_VERBOSE_LOGGING}
 graphql.verbose.slowQueryMillis = 2500
 graphql.verbose.slowQueryMillis = ${?GRAPHQL_VERBOSE_LONG_QUERY_MILLIS}
+
+# Analytics specific configs
+analytics.google.tracking.id=${?GOOGLE_TAG_TRACKING_ID}


### PR DESCRIPTION
This PR adds support for google tag manager tracking if you supply a `GOOGLE_TAG_TRACKING_ID` env var to `datahub-frontend`. 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
