### PR TITLE
fix(smoke-test):cleanup existing token and add wait

### DIFF
--- a/smoke-test/tests/tokens/revokable_access_token_test.py
+++ b/smoke-test/tests/tokens/revokable_access_token_test.py
@@ -113,15 +113,24 @@ def access_token_setup(auth_session, auth_exclude_filter):
     res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
     assert res_data
     assert res_data["data"]
+
+    if res_data["data"]["listAccessTokens"]["tokens"]:
+        for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
+            revokeAccessToken(admin_session, metadata["id"])
+        wait_for_writes_to_sync()
+
+    # Verify clean state after cleanup
+    res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
     assert res_data["data"]["listAccessTokens"]["total"] == 0
     assert not res_data["data"]["listAccessTokens"]["tokens"]
 
     yield
 
-    # Clean up
+    # Clean up after the test
     res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
     for metadata in res_data["data"]["listAccessTokens"]["tokens"]:
         revokeAccessToken(admin_session, metadata["id"])
+    wait_for_writes_to_sync()
 
 
 def test_admin_can_create_list_and_revoke_tokens(auth_exclude_filter):


### PR DESCRIPTION
This PR fixes following failing smoke test

tests/tokens/revokable_access_token_test.py::test_admin_can_create_and_revoke_tokens_for_other_user ERROR [ 83%]
tests/tokens/revokable_access_token_test.py::test_admin_can_create_list_and_revoke_tokens ERROR [ 84%]
tests/tokens/revokable_access_token_test.py::test_admin_can_manage_tokens_generated_by_other_user ERROR [ 85%]
tests/tokens/revokable_access_token_test.py::test_non_admin_can_create_list_revoke_tokens ERROR [ 86%]
tests/tokens/revokable_access_token_test.py::test_non_admin_can_not_generate_tokens_for_others ERROR [ 87%]

`___ ERROR at setup of test_admin_can_create_and_revoke_tokens_for_other_user ___

auth_session = <tests.utils.TestSessionWrapper object at 0x7f00c0fd7150>
auth_exclude_filter = {'condition': 'EQUAL', 'field': 'name', 'negated': True, 'values': ['Test Session Token']}

    @pytest.fixture(autouse=True)
    def access_token_setup(auth_session, auth_exclude_filter):
        """Fixture to execute asserts before and after a test is run"""
        admin_session = login_as(admin_user, admin_pass)
    
        res_data = listAccessTokens(admin_session, filters=[auth_exclude_filter])
        assert res_data
        assert res_data["data"]
        assert res_data["data"]["listAccessTokens"]["total"] == 0
        assert 1 == 0`
