### PR TITLE
fix(ingest): serialisation of structured report

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source_report/ingestion_stage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_report/ingestion_stage.py
@@ -78,8 +78,9 @@ class IngestionStageContext(AbstractContextManager):
                 f"Time spent in stage <{self._ingestion_stage}>: {elapsed} seconds",
                 stacklevel=2,
             )
-            # Cannot add a tuple here as that will cause serialization errors
-            self._report.ingestion_stage_durations[self._ingestion_stage] = elapsed
+            # Store tuple as string to avoid serialization errors
+            key = f"({self._high_stage.value}, {self._ingestion_stage})"
+            self._report.ingestion_stage_durations[key] = elapsed
         else:
             logger.info(
                 f"Time spent in stage <{self._high_stage.value}>: {elapsed} seconds",

--- a/metadata-ingestion/tests/unit/reporting/test_ingestion_stage.py
+++ b/metadata-ingestion/tests/unit/reporting/test_ingestion_stage.py
@@ -14,6 +14,7 @@ def test_ingestion_stage_context_records_duration():
         pass
     assert len(report.ingestion_stage_durations) == 1
     key = next(iter(report.ingestion_stage_durations.keys()))
+    assert "Ingestion" in key
     assert "Test Stage" in key
 
 
@@ -26,6 +27,7 @@ def test_ingestion_stage_context_handles_exceptions():
         pass
     assert len(report.ingestion_stage_durations) == 1
     key = next(iter(report.ingestion_stage_durations.keys()))
+    assert "Ingestion" in key
     assert "Test Stage" in key
 
 
@@ -95,5 +97,6 @@ def test_ingestion_stage_with_high_stage():
         time.sleep(0.1)
     assert len(report.ingestion_stage_durations) == 1
     key = next(iter(report.ingestion_stage_durations.keys()))
+    assert "Profiling" in key
     assert "Test Stage" in key
     assert report.ingestion_high_stage_seconds[IngestionHighStage.PROFILING] > 0


### PR DESCRIPTION
This was causing serialisation of structured report to DataHub to fail after ingestion. This was happening because Tuple are not serialisable.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
