### PR TITLE
fix(log): do not consider error if not strict

### DIFF
--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/UrnValidationUtil.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/UrnValidationUtil.java
@@ -74,7 +74,7 @@ public class UrnValidationUtil {
                   "Simple URN %s contains comma character which is not allowed in non-tuple URNs",
                   urn));
         } else {
-          log.error(
+          log.warn(
               "Simple URN {} contains comma character which is not allowed in non-tuple URNs", urn);
         }
       }
@@ -91,7 +91,7 @@ public class UrnValidationUtil {
       if (strict) {
         throw new IllegalArgumentException(message);
       } else {
-        log.error(message);
+        log.warn(message);
       }
     }
 


### PR DESCRIPTION
This log is not actionable until we can discuss and decide on making urn validation consistent on ingestion and platform side. Thus changing it to be a warning instead so it does not trip alerts.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
