### PR TITLE
fix(cli): remove pydantic warning

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -173,11 +173,11 @@ class ConnectionModel(BaseModel):
     """Represents the config associated with a connection"""
 
     class Config:
-        if PYDANTIC_VERSION_2:  # noqa: SIM108
+        if PYDANTIC_VERSION_2:
             extra = "allow"
         else:
             extra = Extra.allow
-        underscore_attrs_are_private = True
+            underscore_attrs_are_private = True
 
 
 class TransformerSemantics(ConfigEnum):


### PR DESCRIPTION
Currently this warning is showing up on 
```
datahub version
/Users/aseembansal/code/datahub-apps/venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:383: UserWarning: Valid config keys have changed in V2:
* 'underscore_attrs_are_private' has been removed
  warnings.warn(message, UserWarning)
```

This fixes this warning

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
