### PR TITLE
fix(build): add ability to specificy constraints for bundled-venvs

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -147,6 +147,7 @@ RUN mkdir -p $DATAHUB_BUNDLED_VENV_PATH && \
 # Copy the self-contained venv build scripts
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/build_bundled_venvs_unified.py /tmp/
 COPY --chown=datahub:datahub ./docker/snippets/ingestion/build_bundled_venvs_unified.sh /tmp/
+COPY --chown=datahub:datahub ./docker/snippets/ingestion/constraints.txt ${DATAHUB_BUNDLED_VENV_PATH}/
 
 # Make scripts executable
 RUN chmod +x /tmp/build_bundled_venvs_unified.sh && \

--- a/docker/snippets/ingestion/build_bundled_venvs_unified.py
+++ b/docker/snippets/ingestion/build_bundled_venvs_unified.py
@@ -43,7 +43,8 @@ def create_venv(plugin: str, venv_name: str, bundled_cli_version: str, venv_base
         # Install DataHub with the specific plugin
         print(f"  → Installing datahub with {plugin} plugin...")
         datahub_package = f'acryl-datahub[datahub-rest,datahub-kafka,file,{plugin}]=={bundled_cli_version}'
-        install_cmd = f'source {venv_path}/bin/activate && uv pip install "{datahub_package}"'
+        constraints_path = os.path.join(venv_base_path, "constraints.txt")
+        install_cmd = f'source {venv_path}/bin/activate && uv pip install "{datahub_package}"  --constraints {constraints_path}'
         subprocess.run(['bash', '-c', install_cmd], check=True, capture_output=True)
 
         print(f"  ✅ Successfully created {venv_name}")

--- a/docker/snippets/ingestion/constraints.txt
+++ b/docker/snippets/ingestion/constraints.txt
@@ -1,0 +1,1 @@
+pydantic_core!=2.41.3


### PR DESCRIPTION
pydantic v2.41.3 released on oct 7th seems to have uploaded a corrupt whl. https://github.com/pydantic/pydantic-core/issues/1841
Adding the ability to specify constraints to exclude this and in future, any other package that we may need to skip for bundled_venvs.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
