### PR TITLE
chore(docker): upgrade OpenSearch from 2.17.0 to 2.19.3

### DIFF
--- a/docker/profiles/docker-compose.prerequisites.yml
+++ b/docker/profiles/docker-compose.prerequisites.yml
@@ -397,7 +397,7 @@ services:
   opensearch:
     profiles: *opensearch-profiles
     hostname: search
-    image: ${DATAHUB_SEARCH_IMAGE:-opensearchproject/opensearch}:${DATAHUB_SEARCH_TAG:-2.17.0}
+    image: ${DATAHUB_SEARCH_IMAGE:-opensearchproject/opensearch}:${DATAHUB_SEARCH_TAG:-2.19.3}
     ports:
       - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
     env_file: elasticsearch/env/docker.env

--- a/docker/quickstart/docker-compose.quickstart-profile.yml
+++ b/docker/quickstart/docker-compose.quickstart-profile.yml
@@ -336,7 +336,7 @@ services:
       interval: 5s
       retries: 10
       start_period: 1m0s
-    image: opensearchproject/opensearch:2.17.0
+    image: opensearchproject/opensearch:2.19.3
     networks:
       default: null
     ports:

--- a/metadata-io/src/test/java/io/datahubproject/test/search/OpenSearchTestContainer.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/search/OpenSearchTestContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class OpenSearchTestContainer implements SearchTestContainer {
-  private static final String OPENSEARCH_VERSION = "2.17.0";
+  private static final String OPENSEARCH_VERSION = "2.19.3";
   private static final String OPENSEARCH_IMAGE_NAME = "opensearchproject/opensearch";
   private static final String ENV_OPENSEARCH_IMAGE_FULL_NAME =
       System.getenv("OPENSEARCH_IMAGE_FULL_NAME");

--- a/smoke-test/run-quickstart.sh
+++ b/smoke-test/run-quickstart.sh
@@ -15,7 +15,7 @@ echo "test_user:test_pass" >> ~/.datahub/plugins/frontend/auth/user.props
 
 echo "DATAHUB_VERSION = $DATAHUB_VERSION"
 DATAHUB_SEARCH_IMAGE="${DATAHUB_SEARCH_IMAGE:=opensearchproject/opensearch}"
-DATAHUB_SEARCH_TAG="${DATAHUB_SEARCH_TAG:=2.17.0}"
+DATAHUB_SEARCH_TAG="${DATAHUB_SEARCH_TAG:=2.19.3}"
 XPACK_SECURITY_ENABLED="${XPACK_SECURITY_ENABLED:=plugins.security.disabled=true}"
 ELASTICSEARCH_USE_SSL="${ELASTICSEARCH_USE_SSL:=false}"
 USE_AWS_ELASTICSEARCH="${USE_AWS_ELASTICSEARCH:=true}"


### PR DESCRIPTION
## Summary

Upgrade local quickstart OpenSearch version from 2.17.0 to 2.19.3 to align with production version 2.19.

## Changes

- **docker/profiles/docker-compose.prerequisites.yml**: Update default `DATAHUB_SEARCH_TAG` from 2.17.0 to 2.19.3
- **docker/quickstart/docker-compose.quickstart-profile.yml**: Update hardcoded image version from 2.17.0 to 2.19.3

## Motivation

The production OpenSearch instance is running version 2.19, while the local quickstart environment was using 2.17.0. This upgrade brings the local development environment in sync with production, ensuring:

- Consistent behavior between local development and production
- Access to latest OpenSearch 2.19.x features and improvements
- Better testing parity with production environment

## Test Plan

- [x] Pull fresh OpenSearch 2.19.3 image: `docker pull opensearchproject/opensearch:2.19.3`
- [x] Remove old OpenSearch volumes: `docker volume rm datahub_osdata`
- [x] Start quickstart: `./gradlew quickstartDebug` (or equivalent)
- [x] Verify OpenSearch starts successfully and indices are created
- [x] Run smoke tests to ensure DataHub functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)