### PR TITLE
fix(ui): Minor UX improvements for Query Tab

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/shared/TopUsersFacepile.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/shared/TopUsersFacepile.tsx
@@ -15,9 +15,10 @@ export type Props = {
 };
 
 export default function TopUsersFacepile({ users, max, checkExistence = true }: Props) {
+    const entityRegistry = useEntityRegistry();
     const displayedUsers = users.filter((user) => userExists(user));
     const usersList = checkExistence ? displayedUsers : users;
-    const entityRegistry = useEntityRegistry();
+    if (!usersList?.length) return <div>-</div>;
     return (
         <Avatar.Group maxCount={max}>
             {usersList?.map((user) => {

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/QueriesListSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/QueriesListSection.tsx
@@ -141,7 +141,7 @@ export default function QueriesListSection({
         createdByColumn,
         createdDateColumn,
         powersColumn,
-        usedByColumn,
+        topUsersColumn,
         columnsColumn,
         editColumn,
     } = useQueryTableColumns({
@@ -165,7 +165,7 @@ export default function QueriesListSection({
         editColumn,
     ];
 
-    const popularQueriesColumns = [queryTextColumn(), usedByColumn, columnsColumn];
+    const popularQueriesColumns = [queryTextColumn(), topUsersColumn, columnsColumn];
 
     const downstreamQueriesColumns = [queryTextColumn(550), powersColumn];
 

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/queryColumns.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/queryColumns.tsx
@@ -180,13 +180,9 @@ interface ColumnProps {
     query: Query;
 }
 
-const ColumnsWrapper = styled.div`
-    text-align: right;
-`;
-
 /*
  * Columns Column
  */
 export const ColumnsColumn = ({ query }: ColumnProps) => {
-    return <ColumnsWrapper>{query.columns?.length ?? 0}</ColumnsWrapper>;
+    return <div>{query.columns?.length ?? 0}</div>;
 };

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/useQueryTableColumns.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/useQueryTableColumns.tsx
@@ -145,8 +145,8 @@ export default function useQueryTableColumns({
         },
     };
 
-    const usedByColumn = {
-        title: 'Used By',
+    const topUsersColumn = {
+        title: 'Top Users',
         dataIndex: 'usedBy',
         key: 'usedBy',
         className: 'usedBy',
@@ -195,7 +195,7 @@ export default function useQueryTableColumns({
         createdByColumn,
         createdDateColumn,
         powersColumn,
-        usedByColumn,
+        topUsersColumn,
         columnsColumn,
         editColumn,
     };


### PR DESCRIPTION
The UsedBy column title doesn't convey that these are the top users for that query (in 30days: as we might change this window, didn't add this info in the title). So changed the title to 'Top Users' instead.
Also, added empty strings in the cells for when there's no usage data
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
