### PR TITLE
feat(uploadFiles): add anaytics events

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Editor/Editor.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Editor/Editor.tsx
@@ -53,6 +53,10 @@ export const Editor = forwardRef((props: EditorProps, ref) => {
         onKeyDown,
         hideBorder,
         uploadFile,
+        onFileUploadAttempt,
+        onFileUploadFailed,
+        onFileUploadSucceeded,
+        onFileDownloadView,
     } = props;
     const { manager, state, getContext } = useRemirror({
         extensions: () => [
@@ -67,7 +71,13 @@ export const Editor = forwardRef((props: EditorProps, ref) => {
             new HeadingExtension({}),
             new HistoryExtension({}),
             new HorizontalRuleExtension({}),
-            new FileDragDropExtension({ onFileUpload: uploadFile }),
+            new FileDragDropExtension({
+                onFileUpload: uploadFile,
+                onFileUploadAttempt,
+                onFileUploadFailed,
+                onFileUploadSucceeded,
+                onFileDownloadView,
+            }),
             new ImageExtension({ enableResizing: !readOnly }),
             new ItalicExtension(),
             new LinkExtension({ autoLink: true, defaultTarget: '_blank' }),

--- a/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/FileDragDropExtension.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/FileDragDropExtension.tsx
@@ -28,11 +28,22 @@ import {
     isFileUrl,
     validateFile,
 } from '@components/components/Editor/extensions/fileDragDrop/fileUtils';
+import { FileUploadFailureType, FileUploadSource } from '@components/components/Editor/types';
 import { notification } from '@components/components/Notification/notification';
 
 interface FileDragDropOptions {
     onFileUpload?: (file: File) => Promise<string>;
     supportedTypes?: string[];
+    onFileUploadAttempt?: (fileType: string, fileSize: number, source: FileUploadSource) => void;
+    onFileUploadFailed?: (
+        fileType: string,
+        fileSize: number,
+        source: FileUploadSource,
+        failureType: FileUploadFailureType,
+        comment?: string,
+    ) => void;
+    onFileUploadSucceeded?: (fileType: string, fileSize: number, source: FileUploadSource) => void;
+    onFileDownloadView?: (fileType: string, fileSize: number) => void;
 }
 
 /**
@@ -107,9 +118,17 @@ class FileDragDropExtension extends NodeExtension<FileDragDropOptions> {
         // Process each file
         const fileArray = Array.from(files);
         const processPromises = fileArray.map(async (file) => {
+            this.options.onFileUploadAttempt?.(file.type, file.size, 'drag-and-drop');
+
             const validation = validateFile(file, { allowedTypes: supportedTypes });
             if (!validation.isValid) {
                 console.error(validation.error);
+                this.options.onFileUploadFailed?.(
+                    file.type,
+                    file.size,
+                    'drag-and-drop',
+                    validation.failureType || FileUploadFailureType.UNKNOWN,
+                );
                 notification.error({
                     message: 'Upload Failed',
                     description: validation.displayError || validation.error,
@@ -143,8 +162,16 @@ class FileDragDropExtension extends NodeExtension<FileDragDropOptions> {
                 try {
                     const finalUrl = await this.options.onFileUpload(file);
                     this.updateNodeWithUrl(view, placeholderAttrs.id, finalUrl);
+                    this.options.onFileUploadSucceeded?.(file.type, file.size, 'drag-and-drop');
                 } catch (uploadError) {
                     console.error(uploadError);
+                    this.options.onFileUploadFailed?.(
+                        file.type,
+                        file.size,
+                        'drag-and-drop',
+                        FileUploadFailureType.UNKNOWN,
+                        `${uploadError}`,
+                    );
                     this.removeNode(view, placeholderAttrs.id);
                     notification.error({
                         message: 'Upload Failed',
@@ -154,6 +181,13 @@ class FileDragDropExtension extends NodeExtension<FileDragDropOptions> {
             }
         } catch (error) {
             console.error(error);
+            this.options.onFileUploadFailed?.(
+                file.type,
+                file.size,
+                'drag-and-drop',
+                FileUploadFailureType.UNKNOWN,
+                `${error}`,
+            );
             notification.error({
                 message: 'Upload Failed',
                 description: 'Something went wrong',
@@ -311,7 +345,12 @@ class FileDragDropExtension extends NodeExtension<FileDragDropOptions> {
     /**
      * Renders a React Component in place of the dom node spec
      */
-    ReactComponent: ComponentType<NodeViewComponentProps> = (props) => <FileNodeView {...props} />;
+    ReactComponent: ComponentType<NodeViewComponentProps> = (props) => (
+        <FileNodeView
+            {...props}
+            onFileDownloadView={(fileType, fileSize) => this.options.onFileDownloadView?.(fileType, fileSize)}
+        />
+    );
 
     createCommands() {
         return {
@@ -334,6 +373,10 @@ const decoratedExt = extension<FileDragDropOptions>({
     defaultOptions: {
         onFileUpload: async (_file: File) => '',
         supportedTypes: SUPPORTED_FILE_TYPES,
+        onFileUploadAttempt: () => {},
+        onFileUploadFailed: () => {},
+        onFileUploadSucceeded: () => {},
+        onFileDownloadView: () => {},
     },
 })(FileDragDropExtension);
 

--- a/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/FileNodeView.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/FileNodeView.tsx
@@ -37,9 +37,10 @@ interface FileNodeViewProps extends NodeViewComponentProps {
     node: {
         attrs: FileNodeAttributes;
     };
+    onFileDownloadView?: (fileType: string, fileSize: number) => void;
 }
 
-export const FileNodeView: React.FC<FileNodeViewProps> = ({ node }) => {
+export const FileNodeView: React.FC<FileNodeViewProps> = ({ node, onFileDownloadView }) => {
     const { url, name, type, size, id } = node.attrs;
 
     // Create props with data attributes for markdown conversion
@@ -70,6 +71,8 @@ export const FileNodeView: React.FC<FileNodeViewProps> = ({ node }) => {
             <FileDetails
                 onClick={(e) => {
                     e.stopPropagation();
+                    // Track file download/view event
+                    onFileDownloadView?.(type, size);
                     handleFileDownload(url, name);
                 }}
             >

--- a/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/__tests__/fileUtils.test.ts
+++ b/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/__tests__/fileUtils.test.ts
@@ -85,9 +85,10 @@ describe('fileUtils', () => {
 
             expect(result.isValid).toBe(true);
             expect(result.error).toBeUndefined();
+            expect(result.failureType).toBeUndefined();
         });
 
-        it('should reject files that exceed max size', () => {
+        it('should reject files that exceed max size and return FILE_SIZE failure type', () => {
             const mockFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
             Object.defineProperty(mockFile, 'size', { value: 3000000000 }); // 3GB
 
@@ -95,9 +96,10 @@ describe('fileUtils', () => {
 
             expect(result.isValid).toBe(false);
             expect(result.error).toContain('exceeds maximum allowed size');
+            expect(result.failureType).toBe('file_size');
         });
 
-        it('should reject files with unsupported types', () => {
+        it('should reject files with unsupported types and return FILE_TYPE failure type', () => {
             const mockFile = new File(['content'], 'test.exe', { type: 'application/x-executable' });
             Object.defineProperty(mockFile, 'size', { value: 1024 });
 
@@ -105,9 +107,10 @@ describe('fileUtils', () => {
 
             expect(result.isValid).toBe(false);
             expect(result.error).toContain('not allowed');
+            expect(result.failureType).toBe('file_type');
         });
 
-        it('should respect custom max size', () => {
+        it('should respect custom max size and return FILE_SIZE failure type', () => {
             const mockFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
             Object.defineProperty(mockFile, 'size', { value: 2048 });
 
@@ -115,9 +118,10 @@ describe('fileUtils', () => {
 
             expect(result.isValid).toBe(false);
             expect(result.error).toContain('exceeds maximum allowed size');
+            expect(result.failureType).toBe('file_size');
         });
 
-        it('should respect custom allowed types', () => {
+        it('should respect custom allowed types and return FILE_TYPE failure type', () => {
             const mockFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
             Object.defineProperty(mockFile, 'size', { value: 1024 });
 
@@ -125,6 +129,7 @@ describe('fileUtils', () => {
 
             expect(result.isValid).toBe(false);
             expect(result.error).toContain('not allowed');
+            expect(result.failureType).toBe('file_type');
         });
 
         it('should validate when custom options allow file', () => {
@@ -137,6 +142,7 @@ describe('fileUtils', () => {
             });
 
             expect(result.isValid).toBe(true);
+            expect(result.failureType).toBeUndefined();
         });
     });
 

--- a/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/fileUtils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/fileUtils.ts
@@ -1,6 +1,7 @@
 /**
  * Utility functions for file handling in the editor
  */
+import { FileUploadFailureType } from '@components/components/Editor/types';
 
 export const FILE_ATTRS = {
     url: 'data-file-url',
@@ -134,7 +135,7 @@ export const validateFile = (
         maxSize?: number; // in bytes
         allowedTypes?: string[];
     },
-): { isValid: boolean; error?: string; displayError?: string } => {
+): { isValid: boolean; error?: string; displayError?: string; failureType?: FileUploadFailureType } => {
     const { maxSize = MAX_FILE_SIZE_IN_BYTES, allowedTypes = SUPPORTED_FILE_TYPES } = options || {};
 
     // Check file size
@@ -143,6 +144,7 @@ export const validateFile = (
             isValid: false,
             error: `File size (${(file.size / 1000 / 1000).toFixed(2)}MB) exceeds maximum allowed size (${(maxSize / 1000 / 1000).toFixed(2)}MB)`,
             displayError: `Your file size (${(file.size / 1000 / 1000 / 1000).toFixed(2)}GB) exceeded the max ${parseFloat((maxSize / 1000 / 1000 / 1000).toFixed(2))}GB`,
+            failureType: FileUploadFailureType.FILE_SIZE,
         };
     }
 
@@ -153,6 +155,7 @@ export const validateFile = (
             isValid: false,
             error: `File type "${file.type}" is not allowed. Supported types: ${allowedTypes.join(', ')}`,
             displayError: `File type not supported${extension ? `: ${extension.toLocaleUpperCase()}` : ''}`,
+            failureType: FileUploadFailureType.FILE_TYPE,
         };
     }
 

--- a/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/index.ts
+++ b/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/index.ts
@@ -2,7 +2,7 @@ export { FileDragDropExtension } from './FileDragDropExtension';
 export { FileNodeView } from './FileNodeView';
 export {
     FILE_ATTRS,
-    FileNodeAttributes,
+    // FileNodeAttributes,
     SUPPORTED_FILE_TYPES,
     createFileNodeAttributes,
     handleFileDownload,

--- a/datahub-web-react/src/alchemy-components/components/Editor/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Editor/types.ts
@@ -1,3 +1,11 @@
+export type FileUploadSource = 'drag-and-drop' | 'button';
+
+export enum FileUploadFailureType {
+    FILE_SIZE = 'file_size',
+    FILE_TYPE = 'file_type',
+    UNKNOWN = 'unknown',
+}
+
 export type EditorProps = {
     readOnly?: boolean;
     content?: string;
@@ -11,4 +19,14 @@ export type EditorProps = {
     onKeyDown?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
     hideBorder?: boolean;
     uploadFile?: (file: File) => Promise<string>;
+    onFileUploadAttempt?: (fileType: string, fileSize: number, source: FileUploadSource) => void;
+    onFileUploadFailed?: (
+        fileType: string,
+        fileSize: number,
+        source: FileUploadSource,
+        failureType: FileUploadFailureType,
+        comment?: string,
+    ) => void;
+    onFileUploadSucceeded?: (fileType: string, fileSize: number, source: FileUploadSource) => void;
+    onFileDownloadView?: (fileType: string, fileSize: number) => void;
 };

--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -1,3 +1,5 @@
+import { FileUploadFailureType } from '@components/components/Editor/types';
+
 import { EmbedLookupNotFoundReason } from '@app/embed/lookup/constants';
 import { PersonaType } from '@app/homeV2/shared/types';
 import { Direction } from '@app/lineage/types';
@@ -17,6 +19,7 @@ import {
     ScenarioType,
     SearchBarApi,
     SummaryElementType,
+    UploadDownloadScenario,
 } from '@types';
 
 /**
@@ -160,6 +163,10 @@ export enum EventType {
     AssetPageAddSummaryElement,
     AssetPageRemoveSummaryElement,
     AssetPageReplaceSummaryElement,
+    FileUploadAttemptEvent,
+    FileUploadFailedEvent,
+    FileUploadSucceededEvent,
+    FileDownloadViewEvent,
 }
 
 /**
@@ -1171,6 +1178,48 @@ export interface AssetPageReplaceSummaryElementEvent extends BaseEvent {
     newElementType: SummaryElementType;
 }
 
+export interface FileUploadAttemptEvent extends BaseEvent {
+    type: EventType.FileUploadAttemptEvent;
+    fileType: string;
+    fileSize: number;
+    scenario: UploadDownloadScenario;
+    source: 'drag-and-drop' | 'button';
+    assetUrn?: string;
+    schemaFieldUrn?: string;
+}
+
+export interface FileUploadFailedEvent extends BaseEvent {
+    type: EventType.FileUploadFailedEvent;
+    fileType: string;
+    fileSize: number;
+    scenario: UploadDownloadScenario;
+    source: 'drag-and-drop' | 'button';
+    assetUrn?: string;
+    schemaFieldUrn?: string;
+    failureType: FileUploadFailureType;
+    comment?: string;
+}
+
+export interface FileUploadSucceededEvent extends BaseEvent {
+    type: EventType.FileUploadSucceededEvent;
+    fileType: string;
+    fileSize: number;
+    scenario: UploadDownloadScenario;
+    source: 'drag-and-drop' | 'button';
+    assetUrn?: string;
+    schemaFieldUrn?: string;
+}
+
+export interface FileDownloadViewEvent extends BaseEvent {
+    type: EventType.FileDownloadViewEvent;
+    // These fields aren't accessible while downloading
+    // fileType: string;
+    // fileSize: number;
+    scenario: UploadDownloadScenario;
+    assetUrn?: string;
+    schemaFieldUrn?: string;
+}
+
 /**
  * Event consisting of a union of specific event types.
  */
@@ -1311,4 +1360,8 @@ export type Event =
     | IngestionViewAllClickWarningEvent
     | AssetPageAddSummaryElementEvent
     | AssetPageRemoveSummaryElementEvent
-    | AssetPageReplaceSummaryElementEvent;
+    | AssetPageReplaceSummaryElementEvent
+    | FileUploadAttemptEvent
+    | FileUploadFailedEvent
+    | FileUploadSucceededEvent
+    | FileDownloadViewEvent;

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/AboutFieldTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/AboutFieldTab.tsx
@@ -13,6 +13,7 @@ import SampleValuesSection from '@app/entityV2/shared/tabs/Dataset/Schema/compon
 import StatsSection from '@app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/StatsSection';
 import { StyledDivider } from '@app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/components';
 import useFileUpload from '@app/shared/hooks/useFileUpload';
+import useFileUploadAnalyticsCallbacks from '@app/shared/hooks/useFileUploadAnalyticsCallbacks';
 import SidebarStructuredProperties from '@src/app/entityV2/shared/sidebarSection/SidebarStructuredProperties';
 
 import {
@@ -49,6 +50,12 @@ interface AboutFieldTabProps {
 export function AboutFieldTab({ properties }: AboutFieldTabProps) {
     const datasetUrn = useMutationUrn();
     const { refetch, refetchNotes } = properties;
+
+    const uploadFileAnalyticsCallbacks = useFileUploadAnalyticsCallbacks({
+        scenario: UploadDownloadScenario.AssetDocumentation,
+        assetUrn: properties.assetUrn,
+        schemaField: properties.fieldUrn,
+    });
 
     const { uploadFile } = useFileUpload({
         scenario: UploadDownloadScenario.AssetDocumentation,
@@ -96,7 +103,7 @@ export function AboutFieldTab({ properties }: AboutFieldTabProps) {
                         <FieldDescription
                             expandedField={expandedField}
                             editableFieldInfo={editableFieldInfo}
-                            editorProps={{ uploadFile }}
+                            editorProps={{ uploadFile, ...uploadFileAnalyticsCallbacks }}
                         />
                         <FieldTags
                             expandedField={expandedField}

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/DescriptionEditor.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/DescriptionEditor.tsx
@@ -11,6 +11,7 @@ import SourceDescription from '@app/entityV2/shared/tabs/Documentation/component
 import { getAssetDescriptionDetails } from '@app/entityV2/shared/tabs/Documentation/utils';
 import { EDITED_DESCRIPTIONS_CACHE_NAME } from '@app/entityV2/shared/utils';
 import useFileUpload from '@app/shared/hooks/useFileUpload';
+import useFileUploadAnalyticsCallbacks from '@app/shared/hooks/useFileUploadAnalyticsCallbacks';
 
 import { useUpdateDescriptionMutation } from '@graphql/mutations.generated';
 import { UploadDownloadScenario } from '@types';
@@ -34,6 +35,11 @@ export const DescriptionEditor = ({ onComplete }: DescriptionEditorProps) => {
     const mutationUrn = useMutationUrn();
     const { entityType, entityData, loading } = useEntityData();
     const refetch = useRefetch();
+
+    const uploadFileAnalyticsCallbacks = useFileUploadAnalyticsCallbacks({
+        scenario: UploadDownloadScenario.AssetDocumentation,
+        assetUrn: mutationUrn,
+    });
 
     const { uploadFile } = useFileUpload({
         scenario: UploadDownloadScenario.AssetDocumentation,
@@ -209,6 +215,7 @@ export const DescriptionEditor = ({ onComplete }: DescriptionEditorProps) => {
                         onChange={handleEditorChange}
                         placeholder="Describe this asset to make it more discoverable. Tag @user or reference @asset to make your docs come to life!"
                         uploadFile={uploadFile}
+                        {...uploadFileAnalyticsCallbacks}
                         hideBorder
                     />
                 </EditorContainer>

--- a/datahub-web-react/src/app/entityV2/summary/documentation/EditDescriptionModal.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/documentation/EditDescriptionModal.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { useEntityData } from '@app/entity/shared/EntityContext';
 import { useDocumentationPermission } from '@app/entityV2/summary/documentation/useDocumentationPermission';
 import useFileUpload from '@app/shared/hooks/useFileUpload';
+import useFileUploadAnalyticsCallbacks from '@app/shared/hooks/useFileUploadAnalyticsCallbacks';
 
 import { UploadDownloadScenario } from '@types';
 
@@ -46,6 +47,10 @@ export default function EditDescriptionModal({
 }: Props) {
     const canEditDescription = useDocumentationPermission();
     const { urn: assetUrn } = useEntityData();
+    const uploadFileAnalyticsCallbacks = useFileUploadAnalyticsCallbacks({
+        scenario: UploadDownloadScenario.AssetDocumentation,
+        assetUrn,
+    });
     const { uploadFile } = useFileUpload({ scenario: UploadDownloadScenario.AssetDocumentation, assetUrn });
     return (
         <Modal
@@ -85,6 +90,7 @@ export default function EditDescriptionModal({
                 toolbarStyles={toolbarStyles}
                 dataTestId="description-editor"
                 uploadFile={uploadFile}
+                {...uploadFileAnalyticsCallbacks}
             />
         </Modal>
     );

--- a/datahub-web-react/src/app/shared/hooks/__tests__/useFileUploadAnalyticsCallbacks.test.ts
+++ b/datahub-web-react/src/app/shared/hooks/__tests__/useFileUploadAnalyticsCallbacks.test.ts
@@ -1,0 +1,283 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FileUploadFailureType, FileUploadSource } from '@components/components/Editor/types';
+
+import analytics from '@app/analytics';
+import { EventType } from '@app/analytics/event';
+import useFileUploadAnalyticsCallbacks from '@app/shared/hooks/useFileUploadAnalyticsCallbacks';
+
+import { UploadDownloadScenario } from '@types';
+
+// Mock analytics module
+vi.mock('@app/analytics', async () => {
+    const actual = await vi.importActual('@app/analytics');
+    return {
+        default: {
+            event: vi.fn(),
+        },
+        EventType: actual.EventType,
+    };
+});
+
+describe('useFileUploadAnalyticsCallbacks', () => {
+    const mockScenario = UploadDownloadScenario.AssetDocumentation;
+    const mockAssetUrn = 'urn:li:dataset:(urn:li:dataPlatform:mysql,abc,PROD)';
+    const mockSchemaField = 'urn:li:schemaField:abc';
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('onFileUploadAttempt', () => {
+        it('should call analytics event with correct properties for upload attempt', () => {
+            const { result } = renderHook(() =>
+                useFileUploadAnalyticsCallbacks({
+                    scenario: mockScenario,
+                    assetUrn: mockAssetUrn,
+                    schemaField: mockSchemaField,
+                }),
+            );
+
+            const fileType = 'application/pdf';
+            const fileSize = 1024;
+            const source: FileUploadSource = 'drag-and-drop';
+
+            result.current.onFileUploadAttempt(fileType, fileSize, source);
+
+            expect(analytics.event).toHaveBeenCalledWith({
+                type: EventType.FileUploadAttemptEvent,
+                fileType,
+                fileSize,
+                scenario: mockScenario,
+                source,
+                assetUrn: mockAssetUrn,
+                schemaFieldUrn: mockSchemaField,
+            });
+        });
+
+        it('should call analytics event with button source', () => {
+            const { result } = renderHook(() =>
+                useFileUploadAnalyticsCallbacks({
+                    scenario: mockScenario,
+                    assetUrn: mockAssetUrn,
+                }),
+            );
+
+            const fileType = 'image/png';
+            const fileSize = 2048;
+            const source: FileUploadSource = 'button';
+
+            result.current.onFileUploadAttempt(fileType, fileSize, source);
+
+            expect(analytics.event).toHaveBeenCalledWith({
+                type: EventType.FileUploadAttemptEvent,
+                fileType,
+                fileSize,
+                scenario: mockScenario,
+                source,
+                assetUrn: mockAssetUrn,
+                schemaFieldUrn: undefined,
+            });
+        });
+    });
+
+    describe('onFileUploadFailed', () => {
+        it('should call analytics event with correct properties for upload failure', () => {
+            const { result } = renderHook(() =>
+                useFileUploadAnalyticsCallbacks({
+                    scenario: mockScenario,
+                    assetUrn: mockAssetUrn,
+                    schemaField: mockSchemaField,
+                }),
+            );
+
+            const fileType = 'application/pdf';
+            const fileSize = 1024;
+            const source: FileUploadSource = 'drag-and-drop';
+            const failureType = FileUploadFailureType.FILE_SIZE;
+            const comment = 'File too large';
+
+            result.current.onFileUploadFailed(fileType, fileSize, source, failureType, comment);
+
+            expect(analytics.event).toHaveBeenCalledWith({
+                type: EventType.FileUploadFailedEvent,
+                fileType,
+                fileSize,
+                scenario: mockScenario,
+                source,
+                assetUrn: mockAssetUrn,
+                schemaFieldUrn: mockSchemaField,
+                failureType,
+                comment,
+            });
+        });
+
+        it('should call analytics event without comment when not provided', () => {
+            const { result } = renderHook(() =>
+                useFileUploadAnalyticsCallbacks({
+                    scenario: mockScenario,
+                    assetUrn: mockAssetUrn,
+                }),
+            );
+
+            const fileType = 'application/pdf';
+            const fileSize = 1024;
+            const source: FileUploadSource = 'button';
+            const failureType = FileUploadFailureType.FILE_TYPE;
+
+            result.current.onFileUploadFailed(fileType, fileSize, source, failureType);
+
+            expect(analytics.event).toHaveBeenCalledWith({
+                type: EventType.FileUploadFailedEvent,
+                fileType,
+                fileSize,
+                scenario: mockScenario,
+                source,
+                assetUrn: mockAssetUrn,
+                schemaFieldUrn: undefined,
+                failureType,
+                comment: undefined,
+            });
+        });
+    });
+
+    describe('onFileUploadSucceeded', () => {
+        it('should call analytics event with correct properties for upload success', () => {
+            const { result } = renderHook(() =>
+                useFileUploadAnalyticsCallbacks({
+                    scenario: mockScenario,
+                    assetUrn: mockAssetUrn,
+                    schemaField: mockSchemaField,
+                }),
+            );
+
+            const fileType = 'application/pdf';
+            const fileSize = 1024;
+            const source: FileUploadSource = 'drag-and-drop';
+
+            result.current.onFileUploadSucceeded(fileType, fileSize, source);
+
+            expect(analytics.event).toHaveBeenCalledWith({
+                type: EventType.FileUploadSucceededEvent,
+                fileType,
+                fileSize,
+                scenario: mockScenario,
+                source,
+                assetUrn: mockAssetUrn,
+                schemaFieldUrn: mockSchemaField,
+            });
+        });
+
+        it('should call analytics event from button source', () => {
+            const { result } = renderHook(() =>
+                useFileUploadAnalyticsCallbacks({
+                    scenario: mockScenario,
+                }),
+            );
+
+            const fileType = 'image/png';
+            const fileSize = 2048;
+            const source: FileUploadSource = 'button';
+
+            result.current.onFileUploadSucceeded(fileType, fileSize, source);
+
+            expect(analytics.event).toHaveBeenCalledWith({
+                type: EventType.FileUploadSucceededEvent,
+                fileType,
+                fileSize,
+                scenario: mockScenario,
+                source,
+                assetUrn: undefined,
+                schemaFieldUrn: undefined,
+            });
+        });
+    });
+
+    describe('onFileDownloadView', () => {
+        it('should call analytics event with correct properties for file download/view', () => {
+            const { result } = renderHook(() =>
+                useFileUploadAnalyticsCallbacks({
+                    scenario: mockScenario,
+                    assetUrn: mockAssetUrn,
+                    schemaField: mockSchemaField,
+                }),
+            );
+
+            result.current.onFileDownloadView();
+
+            expect(analytics.event).toHaveBeenCalledWith({
+                type: EventType.FileDownloadViewEvent,
+                scenario: mockScenario,
+                assetUrn: mockAssetUrn,
+                schemaFieldUrn: mockSchemaField,
+            });
+        });
+
+        it('should call analytics event with minimal properties', () => {
+            const { result } = renderHook(() =>
+                useFileUploadAnalyticsCallbacks({
+                    scenario: mockScenario,
+                }),
+            );
+
+            result.current.onFileDownloadView();
+
+            expect(analytics.event).toHaveBeenCalledWith({
+                type: EventType.FileDownloadViewEvent,
+                scenario: mockScenario,
+                assetUrn: undefined,
+                schemaFieldUrn: undefined,
+            });
+        });
+    });
+
+    describe('memoization', () => {
+        it('should memoize the callback functions', () => {
+            const { result, rerender } = renderHook((props) => useFileUploadAnalyticsCallbacks(props), {
+                initialProps: {
+                    scenario: mockScenario,
+                    assetUrn: mockAssetUrn,
+                },
+            });
+
+            const initialCallbacks = result.current;
+
+            // Rerender with same props
+            rerender({
+                scenario: mockScenario,
+                assetUrn: mockAssetUrn,
+            });
+
+            // Functions should be the same reference (memoized)
+            expect(result.current.onFileUploadAttempt).toBe(initialCallbacks.onFileUploadAttempt);
+            expect(result.current.onFileUploadFailed).toBe(initialCallbacks.onFileUploadFailed);
+            expect(result.current.onFileUploadSucceeded).toBe(initialCallbacks.onFileUploadSucceeded);
+            expect(result.current.onFileDownloadView).toBe(initialCallbacks.onFileDownloadView);
+        });
+
+        it('should update callbacks when dependencies change', () => {
+            const { result, rerender } = renderHook((props) => useFileUploadAnalyticsCallbacks(props), {
+                initialProps: {
+                    scenario: mockScenario,
+                    assetUrn: mockAssetUrn,
+                },
+            });
+
+            const initialCallbacks = result.current;
+            const newAssetUrn = 'urn:li:dataset:(urn:li:dataPlatform:mysql,xyz,PROD)';
+
+            // Rerender with different props
+            rerender({
+                scenario: mockScenario,
+                assetUrn: newAssetUrn,
+            });
+
+            // Functions should be different references since dependencies changed
+            expect(result.current.onFileUploadAttempt).not.toBe(initialCallbacks.onFileUploadAttempt);
+            expect(result.current.onFileUploadFailed).not.toBe(initialCallbacks.onFileUploadFailed);
+            expect(result.current.onFileUploadSucceeded).not.toBe(initialCallbacks.onFileUploadSucceeded);
+            expect(result.current.onFileDownloadView).not.toBe(initialCallbacks.onFileDownloadView);
+        });
+    });
+});

--- a/datahub-web-react/src/app/shared/hooks/useFileUploadAnalyticsCallbacks.ts
+++ b/datahub-web-react/src/app/shared/hooks/useFileUploadAnalyticsCallbacks.ts
@@ -1,0 +1,82 @@
+import { useCallback } from 'react';
+
+import { FileUploadFailureType, FileUploadSource } from '@components/components/Editor/types';
+
+import analytics, { EventType } from '@app/analytics';
+
+import { UploadDownloadScenario } from '@types';
+
+interface Props {
+    scenario: UploadDownloadScenario;
+    assetUrn?: string;
+    schemaField?: string;
+}
+
+export default function useFileUploadAnalyticsCallbacks({ scenario, assetUrn, schemaField }: Props) {
+    const onFileUploadAttempt = useCallback(
+        (fileType: string, fileSize: number, source: FileUploadSource) => {
+            analytics.event({
+                type: EventType.FileUploadAttemptEvent,
+                fileType,
+                fileSize,
+                scenario,
+                source,
+                assetUrn,
+                schemaFieldUrn: schemaField,
+            });
+        },
+        [scenario, assetUrn, schemaField],
+    );
+
+    const onFileUploadFailed = useCallback(
+        (
+            fileType: string,
+            fileSize: number,
+            source: FileUploadSource,
+            failureType: FileUploadFailureType,
+            comment?: string,
+        ) => {
+            analytics.event({
+                type: EventType.FileUploadFailedEvent,
+                fileType,
+                fileSize,
+                scenario,
+                source,
+                assetUrn,
+                schemaFieldUrn: schemaField,
+                failureType,
+                comment,
+            });
+        },
+        [scenario, assetUrn, schemaField],
+    );
+
+    const onFileUploadSucceeded = useCallback(
+        (fileType: string, fileSize: number, source: FileUploadSource) => {
+            analytics.event({
+                type: EventType.FileUploadSucceededEvent,
+                fileType,
+                fileSize,
+                scenario,
+                source,
+                assetUrn,
+                schemaFieldUrn: schemaField,
+            });
+        },
+        [scenario, assetUrn, schemaField],
+    );
+
+    const onFileDownloadView = useCallback(() => {
+        analytics.event({
+            type: EventType.FileDownloadViewEvent,
+            // These fields aren't accessible while downloading
+            // fileType,
+            // fileSize,
+            scenario,
+            assetUrn,
+            schemaFieldUrn: schemaField,
+        });
+    }, [scenario, assetUrn, schemaField]);
+
+    return { onFileUploadAttempt, onFileUploadFailed, onFileUploadSucceeded, onFileDownloadView };
+}

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -139,6 +139,10 @@ public enum DataHubUsageEventType {
   ASSET_PAGE_ADD_SUMMARY_ELEMENT("AssetPageAddSummaryElement"),
   ASSET_PAGE_REMOVE_SUMMARY_ELEMENT("AssetPageRemoveSummaryElement"),
   ASSET_PAGE_REPLACE_SUMMARY_ELEMENT("AssetPageReplaceSummaryElement"),
+  FILE_UPLOAD_ATTEMPT_EVENT("FileUploadAttemptEvent"),
+  FILE_UPLOAD_FAILED_EVENT("FileUploadFailedEvent"),
+  FILE_UPLOAD_SUCCEEDED_EVENT("FileUploadSucceededEvent"),
+  FILE_DOWNLOAD_VIEW_EVENT("FileDownloadViewEvent"),
   // Not replicated in frontend, represents generic event from backend
   CREATE_USER_EVENT("CreateUserEvent"),
   UPDATE_USER_EVENT("UpdateUserEvent"),


### PR DESCRIPTION
This PR adds analytics events for uploading files feature

Also it includes:
- errors handling while uploading files by button in editor
- hiding of the uploading button if uploading is disabled

DEPENDS ON: https://github.com/datahub-project/datahub/pull/15055

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
