### PR TITLE
fix(druid): fixes docker setup for postgres in druid integration tests

### DIFF
--- a/metadata-ingestion/tests/integration/druid/docker/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/druid/docker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - metadata_data:/var/lib/postgresql/data
+      - metadata_data:/var/lib/postgresql
     environment:
       - POSTGRES_PASSWORD=FoolishPassword
       - POSTGRES_USER=druid


### PR DESCRIPTION
Postgres docker latest points now to recently new v18 and results to the version below

Either we pin <18 version or we fix mounted volume

This PR tries to fix mounted volume

```
Error: in 18+, these Docker images are configured to store database data in a
       format which is compatible with "pg_ctlcluster" (specifically, using
       major-version-specific directory names).  This better reflects how
       PostgreSQL itself works, and how upgrades are to be performed.

       See also https://github.com/docker-library/postgres/pull/1259

       Counter to that, there appears to be PostgreSQL data in:
         /var/lib/postgresql/data (unused mount/volume)

       This is usually the result of upgrading the Docker image without
       upgrading the underlying database using "pg_upgrade" (which requires both
       versions).

       The suggested container configuration for 18+ is to place a single mount
       at /var/lib/postgresql which will then place PostgreSQL data in a
       subdirectory, allowing usage of "pg_upgrade --link" without mount point
       boundary issues.

       See https://github.com/docker-library/postgres/issues/37 for a (long)
       discussion around this process, and suggestions for how to do so.
```