### PR TITLE
fix(smoke-tests): correct server config access in tracking test

### DIFF
--- a/smoke-test/tests/openapi/v1/test_tracking.py
+++ b/smoke-test/tests/openapi/v1/test_tracking.py
@@ -43,9 +43,7 @@ def test_tracking_api_mixpanel(auth_session, graph_client):
 
     # Check if Mixpanel is enabled in server configuration
     graph_client.test_connection()  # Hack: Needed to ensure that the server config is loaded
-    if not graph_client.server_config.get("telemetry", {}).get(
-        "enabledMixpanel", False
-    ):
+    if not graph_client.get_config().get("telemetry", {}).get("enabledMixpanel", False):
         pytest.skip("Mixpanel is disabled in server configuration, skipping test")
 
     # Test configuration


### PR DESCRIPTION
## Summary

Fixes an AttributeError in `test_tracking_api_mixpanel` smoke test.

The test was calling `.get()` directly on the `RestServiceConfig` object instead of accessing the underlying dictionary. This caused an AttributeError when `MIXPANEL_API_SECRET` was set, though the test was typically skipped in CI due to missing credentials.

## Changes

- Changed to use `graph_client.get_config()` which returns the raw config dictionary
- Matches the pattern used elsewhere in the codebase for accessing config values

## Test Plan

- Verified the test now correctly accesses the config dictionary
- No functional changes to test logic, only fixes the config access method