### PR TITLE
fix(datahub-web-react): Fix icons not rendering for domains on autocomplete search results

### DIFF
--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -223,6 +223,9 @@ fragment autoCompleteFields on Entity {
         parentDomains {
             ...parentDomainsFields
         }
+        displayProperties {
+            ...displayPropertiesFields
+        }
     }
     ... on DataProduct {
         properties {


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
Updated autocomplete query results to include icon for domains, so they're rendered in the results.

| Before (click image to zoom) | After (click image to zoom) |
|--------|--------|
| <img width="1218" height="367" alt="Screenshot 2025-10-23 at 2 43 01 PM" src="https://github.com/user-attachments/assets/1e1660f2-05f8-4fc1-bd48-fefcd5da2488" /> | <img width="1166" height="367" alt="Screenshot 2025-10-23 at 2 43 44 PM" src="https://github.com/user-attachments/assets/e04182a6-a58f-4875-92a8-40abda41ccdc" /> |
