### PR TITLE
feat(docs): add structured property for search field names in metadata model

### DIFF
--- a/.github/workflows/metadata-model.yml
+++ b/.github/workflows/metadata-model.yml
@@ -5,6 +5,8 @@ on:
       - master
     paths:
       - "metadata-models/**"
+      - "metadata-ingestion/scripts/modeldocgen.py"
+      - "metadata-ingestion/scripts/modeldocupload.sh"
   release:
     types: [published]
 


### PR DESCRIPTION
## Summary

When schema fields have different search index names (e.g., `instance` field indexed as `platformInstance`), users currently have to search through Git/PDL files to discover the actual search field name. This PR adds a structured property that captures and displays this information directly in the DataHub UI.

## Problem

Users browsing the metadata model at demo.datahub.com (e.g., Container entity) see fields marked as "Searchable" but cannot tell what name to use in search queries when the search index name differs from the schema field name. This leads to:
- Frustration trying to construct correct search queries
- Needing to dig through Git/PDL definitions
- Missed opportunity to use DataHub to document itself

## Solution

Created a new structured property `com.datahub.metadata.searchFieldName` that:
- Displays as a column in schema field tables
- Shows the actual search index name when it differs from the field name
- Is automatically populated for all 130+ fields with differing names
- Makes the metadata model self-documenting

## Changes

- **New structured property**: `com.datahub.metadata.searchFieldName`
  - Type: String (single value)
  - Applied to: Schema fields
  - Display: Shows in column tables and asset summary
- **Script updates**: Modified `modeldocgen.py` to:
  - Create the structured property definition
  - Detect fields with different search names
  - Emit property assignments as schema field entity MCPs
- **Workflow updates**: Added triggers for `modeldocgen.py` and `modeldocupload.sh` changes

## Testing

- ✅ Ran `./gradlew :metadata-ingestion:modelDocGen` successfully
- ✅ Generated 132 MCPs (2 for property + 130 schema field assignments)
- ✅ Uploaded to local DataHub instance successfully
- ✅ Verified structured property exists with correct settings
- ✅ Verified DataHubFile entity loaded with all metadata
- ✅ All linting checks passed

## Screenshots

Before: Users see "Searchable" tag but no indication of the search field name
After: Users see "Search Field Name" column showing `platformInstance` for the `instance` field

## Deployment

Once merged to master, the `metadata-model.yml` workflow will automatically:
1. Generate metadata with the new structured property
2. Upload to S3 for artifacts
3. Upload to demo.datahub.com

Users will then see the search field names displayed in the UI without needing to consult PDL files.