### PR TITLE
fix(ui): Fix routing issue in Manage Views

### DIFF
--- a/datahub-web-react/src/app/entityV2/view/ManageViews.tsx
+++ b/datahub-web-react/src/app/entityV2/view/ManageViews.tsx
@@ -1,5 +1,5 @@
 import { Button, PageTitle, Tabs, colors } from '@components';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
 import styled from 'styled-components';
 
@@ -98,8 +98,6 @@ export const ManageViews = () => {
         }
     }, [selectedTab, location.pathname]);
 
-    const getCurrentUrl = useCallback(() => location.pathname, [location.pathname]);
-
     return (
         <PageContainer>
             <PageHeaderContainer>
@@ -129,7 +127,6 @@ export const ManageViews = () => {
                     onChange={(tab) => setSelectedTab(tab as TabType)}
                     urlMap={tabUrlMap}
                     defaultTab={TabType.Personal}
-                    getCurrentUrl={getCurrentUrl}
                 />
             </ListContainer>
             {showViewBuilder && (


### PR DESCRIPTION
The Tabs component use window.history.replace method which doesn't update the react router's useLocation hook, thereby not changing the tab in ManageViews page.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
