### PR TITLE
feat(iam-setup): additional support for iam

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
@@ -35,14 +35,12 @@ public class MySqlDatabaseOperations implements DatabaseOperations {
 
   @Override
   public String createIamUserSql(String username, String iamRole) {
-    // MySQL - IAM authentication with configurable role
+    // The iamRole parameter is not used for MySQL (unlike PostgreSQL)
+    // The actual IAM permissions are managed by AWS IAM policies, not stored in MySQL
     String escapedUser = escapeMysqlStringLiteral(username);
-    String escapedRole = escapeMysqlStringLiteral(iamRole);
-    return "CREATE USER "
+    return "CREATE USER IF NOT EXISTS "
         + escapedUser
-        + "@'%' IDENTIFIED WITH AWSAuthenticationPlugin AS "
-        + escapedRole
-        + ";";
+        + "@'%' IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS';";
   }
 
   @Override
@@ -50,7 +48,11 @@ public class MySqlDatabaseOperations implements DatabaseOperations {
     // MySQL - traditional authentication
     String escapedUser = escapeMysqlStringLiteral(username);
     String escapedPassword = escapeMysqlStringLiteral(password);
-    return "CREATE USER " + escapedUser + "@'%' IDENTIFIED BY " + escapedPassword + ";";
+    return "CREATE USER IF NOT EXISTS "
+        + escapedUser
+        + "@'%' IDENTIFIED BY "
+        + escapedPassword
+        + ";";
   }
 
   @Override

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupArgs.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupArgs.java
@@ -17,9 +17,8 @@ public class SqlSetupArgs {
   String cdcUser;
   String cdcPassword;
   String createUserUsername;
-  String createUserPassword;
+  String createUserPassword; // If null, IAM authentication is used
   String host;
   int port;
   String databaseName;
-  String createUserIamRole; // IAM role for new user creation (required if IAM auth enabled)
 }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/BuildIndices.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/BuildIndices.java
@@ -8,6 +8,7 @@ import com.linkedin.datahub.upgrade.system.elasticsearch.steps.BuildIndicesPostS
 import com.linkedin.datahub.upgrade.system.elasticsearch.steps.BuildIndicesPreStep;
 import com.linkedin.datahub.upgrade.system.elasticsearch.steps.BuildIndicesStep;
 import com.linkedin.datahub.upgrade.system.elasticsearch.steps.CreateUsageEventIndicesStep;
+import com.linkedin.datahub.upgrade.system.elasticsearch.steps.CreateUserStep;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
 import com.linkedin.metadata.entity.AspectDao;
@@ -70,6 +71,8 @@ public class BuildIndices implements BlockingSystemUpgrade {
     }
 
     final List<UpgradeStep> steps = new ArrayList<>();
+    // Setup Elasticsearch users and roles (if enabled)
+    steps.add(new CreateUserStep(baseElasticSearchComponents, configurationProvider));
     // Setup usage event indices and policies
     steps.add(new CreateUsageEventIndicesStep(baseElasticSearchComponents, configurationProvider));
     // Disable ES write mode/change refresh rate and clone indices

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/CreateUserStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/CreateUserStep.java
@@ -1,0 +1,137 @@
+package com.linkedin.datahub.upgrade.system.elasticsearch.steps;
+
+import com.linkedin.datahub.upgrade.UpgradeContext;
+import com.linkedin.datahub.upgrade.UpgradeStep;
+import com.linkedin.datahub.upgrade.UpgradeStepResult;
+import com.linkedin.datahub.upgrade.impl.DefaultUpgradeStepResult;
+import com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexRoleUtils;
+import com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils;
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
+import com.linkedin.metadata.utils.EnvironmentUtils;
+import com.linkedin.upgrade.DataHubUpgradeState;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class CreateUserStep implements UpgradeStep {
+  private final BaseElasticSearchComponentsFactory.BaseElasticSearchComponents esComponents;
+  private final ConfigurationProvider configurationProvider;
+
+  @Override
+  public String id() {
+    return "CreateElasticsearchUserStep";
+  }
+
+  @Override
+  public int retryCount() {
+    return 3;
+  }
+
+  @Override
+  public boolean skip(UpgradeContext context) {
+    boolean createUser = EnvironmentUtils.getBoolean("CREATE_USER_ES", false);
+    if (!createUser) {
+      log.info("Elasticsearch user creation is disabled, skipping user setup");
+    }
+    return !createUser;
+  }
+
+  @Override
+  public Function<UpgradeContext, UpgradeStepResult> executable() {
+    return (context) -> {
+      try {
+        final String indexPrefix =
+            configurationProvider.getElasticSearch().getIndex().getFinalPrefix();
+
+        // Check for CREATE_USER_ES_USERNAME and CREATE_USER_ES_PASSWORD environment variables first
+        String username = EnvironmentUtils.getString("CREATE_USER_ES_USERNAME");
+        String password = EnvironmentUtils.getString("CREATE_USER_ES_PASSWORD");
+        String iamRoleArn = EnvironmentUtils.getString("CREATE_USER_ES_IAM_ROLE_ARN");
+
+        // Determine the authentication mode
+        boolean usingIam = iamRoleArn != null && !iamRoleArn.isEmpty();
+        boolean usingUserPassword =
+            username != null && !username.isEmpty() && password != null && !password.isEmpty();
+
+        // Validate that at least one authentication method is configured
+        if (!usingIam && !usingUserPassword) {
+          log.warn(
+              "Either CREATE_USER_ES_IAM_ROLE_ARN or CREATE_USER_ES_USERNAME/CREATE_USER_ES_PASSWORD must be configured");
+          return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
+        }
+
+        String roleName = indexPrefix + "access";
+
+        if (esComponents.getSearchClient().getEngineType().isOpenSearch()) {
+          setupOpenSearchUser(
+              indexPrefix,
+              roleName,
+              username,
+              password,
+              iamRoleArn,
+              usingIam,
+              usingUserPassword,
+              context.opContext());
+        } else {
+          // Elasticsearch Cloud doesn't support IAM authentication
+          if (usingIam) {
+            log.warn("IAM authentication is only supported for AWS OpenSearch Service");
+            return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
+          }
+          setupElasticsearchCloudUser(indexPrefix, roleName, username, password);
+        }
+
+        return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.SUCCEEDED);
+      } catch (Exception e) {
+        log.error("CreateElasticsearchUserStep failed.", e);
+        return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
+      }
+    };
+  }
+
+  private void setupElasticsearchCloudUser(
+      String prefix, String roleName, String username, String password) throws Exception {
+    log.info("Creating Elasticsearch Cloud user and role");
+    IndexRoleUtils.createElasticsearchCloudUser(esComponents, roleName, username, password, prefix);
+  }
+
+  private void setupOpenSearchUser(
+      String prefix,
+      String roleName,
+      String username,
+      String password,
+      String iamRoleArn,
+      boolean usingIam,
+      boolean usingUserPassword,
+      OperationContext operationContext)
+      throws Exception {
+    // Check if this is AWS OpenSearch Service
+    boolean isAwsOpenSearch = IndexUtils.isAwsOpenSearchService(esComponents);
+
+    if (isAwsOpenSearch) {
+      log.info("Detected AWS OpenSearch Service. Creating AWS-specific role.");
+
+      // Create the role first (required for both modes)
+      IndexRoleUtils.createAwsOpenSearchRole(esComponents, roleName, prefix);
+
+      if (usingIam) {
+        // IAM authentication: create role mapping to IAM role
+        log.info("IAM mode: Creating role mapping for IAM role: {}", iamRoleArn);
+        IndexRoleUtils.createAwsOpenSearchRoleMapping(esComponents, roleName, iamRoleArn);
+      }
+
+      if (usingUserPassword) {
+        // Internal user authentication: create internal user
+        log.info("Internal user mode: Creating internal user: {}", username);
+        IndexRoleUtils.createAwsOpenSearchUser(
+            esComponents, username, password, roleName, null, operationContext);
+      }
+    } else {
+      log.warn("Detected self-hosted OpenSearch. Creating user and role not supported.");
+    }
+  }
+}

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/IndexRoleUtils.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/IndexRoleUtils.java
@@ -1,0 +1,479 @@
+package com.linkedin.datahub.upgrade.system.elasticsearch.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
+import com.linkedin.metadata.utils.elasticsearch.responses.RawResponse;
+import io.datahubproject.metadata.context.OperationContext;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpEntity;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+/**
+ * Utility class for creating and managing Elasticsearch/OpenSearch users and roles for DataHub
+ * authentication. This class provides methods to set up security roles and users required for
+ * DataHub to access Elasticsearch/OpenSearch clusters.
+ *
+ * <p>The class handles both standard Elasticsearch and AWS OpenSearch scenarios, using appropriate
+ * APIs and configurations for each environment.
+ */
+@Slf4j
+public class IndexRoleUtils {
+
+  /** Extracts the response body from a Response or RawResponse for error logging. */
+  private static String extractResponseBody(Object response) {
+    try {
+      HttpEntity entity = null;
+      if (response instanceof Response) {
+        entity = ((Response) response).getEntity();
+      } else if (response instanceof RawResponse) {
+        entity = ((RawResponse) response).getEntity();
+      }
+
+      if (entity != null) {
+        return new String(entity.getContent().readAllBytes(), StandardCharsets.UTF_8);
+      }
+    } catch (Exception e) {
+      log.debug("Failed to read response body", e);
+    }
+    return "No response body";
+  }
+
+  /**
+   * Creates a user and role for Elasticsearch Cloud environments.
+   *
+   * <p>This method creates both a security role with appropriate permissions and a user associated
+   * with that role for Elasticsearch Cloud environments. The role is configured with cluster
+   * monitoring permissions and full access to indices matching the prefix pattern.
+   *
+   * @param esComponents the Elasticsearch components factory providing search client access
+   * @param roleName the name of the role to create (e.g., "prod_access")
+   * @param username the username to create (e.g., "datahub")
+   * @param password the password for the user
+   * @param prefix the index prefix to apply to role permissions (e.g., "prod_")
+   * @throws IOException if there's an error reading the role/user templates or making requests
+   */
+  public static void createElasticsearchCloudUser(
+      BaseElasticSearchComponentsFactory.BaseElasticSearchComponents esComponents,
+      String roleName,
+      String username,
+      String password,
+      String prefix)
+      throws IOException {
+
+    // Create role first
+    createElasticsearchCloudRole(esComponents, roleName, prefix);
+
+    // Then create user
+    createElasticsearchCloudUserInternal(esComponents, username, password, roleName);
+  }
+
+  /**
+   * Creates a security role for Elasticsearch Cloud environments.
+   *
+   * @param esComponents the Elasticsearch components factory providing search client access
+   * @param roleName the name of the role to create
+   * @param prefix the index prefix to apply to role permissions
+   * @throws IOException if there's an error creating the role
+   */
+  public static void createElasticsearchCloudRole(
+      BaseElasticSearchComponentsFactory.BaseElasticSearchComponents esComponents,
+      String roleName,
+      String prefix)
+      throws IOException {
+    try {
+      String roleJson =
+          IndexUtils.loadResourceAsString("/index/user/access_policy_data_es_cloud.json")
+              .replace("PREFIX", prefix);
+
+      String endpoint = "/_security/role/" + roleName;
+
+      // Use retry logic for role creation
+      boolean success =
+          IndexUtils.retryWithBackoff(
+              5,
+              2000,
+              () -> {
+                try {
+                  RawResponse response =
+                      IndexUtils.performPutRequest(esComponents, endpoint, roleJson);
+
+                  int statusCode = response.getStatusLine().getStatusCode();
+                  if (statusCode == 200 || statusCode == 201) {
+                    log.info("Successfully created Elasticsearch Cloud role: {}", roleName);
+                    return true;
+                  } else if (statusCode == 409) {
+                    log.info("Elasticsearch Cloud role {} already exists", roleName);
+                    return true; // Consider this a success since role exists
+                  } else {
+                    log.warn("Elasticsearch Cloud role creation returned status: {}", statusCode);
+                    throw new RuntimeException("Retryable error: " + statusCode);
+                  }
+                } catch (ResponseException e) {
+                  if (e.getResponse().getStatusLine().getStatusCode() == 409) {
+                    log.info("Elasticsearch Cloud role {} already exists", roleName);
+                    return true;
+                  } else {
+                    throw new RuntimeException(
+                        "Retryable error: " + e.getResponse().getStatusLine().getStatusCode());
+                  }
+                }
+              });
+
+      if (!success) {
+        throw new IOException(
+            "Failed to create Elasticsearch Cloud role after retries: " + roleName);
+      }
+
+    } catch (ResponseException e) {
+      if (e.getResponse().getStatusLine().getStatusCode() == 409) {
+        log.info("Elasticsearch Cloud role {} already exists", roleName);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Creates a user for Elasticsearch Cloud environments.
+   *
+   * @param esComponents the Elasticsearch components factory providing search client access
+   * @param username the username to create
+   * @param password the password for the user
+   * @param roleName the role to assign to the user
+   * @throws IOException if there's an error creating the user
+   */
+  private static void createElasticsearchCloudUserInternal(
+      BaseElasticSearchComponentsFactory.BaseElasticSearchComponents esComponents,
+      String username,
+      String password,
+      String roleName)
+      throws IOException {
+    try {
+      String userJson =
+          IndexUtils.loadResourceAsString("/index/user/user_data_es_cloud.json")
+              .replace("ELASTICSEARCH_PASSWORD", password)
+              .replace("PREFIX", roleName);
+
+      String endpoint = "/_security/user/" + username;
+
+      // Use retry logic for user creation
+      boolean success =
+          IndexUtils.retryWithBackoff(
+              5,
+              2000,
+              () -> {
+                try {
+                  Request request = new Request("PUT", endpoint);
+                  request.setJsonEntity(userJson);
+
+                  RawResponse response =
+                      esComponents.getSearchClient().performLowLevelRequest(request);
+
+                  int statusCode = response.getStatusLine().getStatusCode();
+                  if (statusCode == 200 || statusCode == 201) {
+                    log.info("Successfully created Elasticsearch Cloud user: {}", username);
+                    return true;
+                  } else if (statusCode == 409) {
+                    log.info("Elasticsearch Cloud user {} already exists", username);
+                    return true; // Consider this a success since user exists
+                  } else {
+                    log.warn("Elasticsearch Cloud user creation returned status: {}", statusCode);
+                    throw new RuntimeException("Retryable error: " + statusCode);
+                  }
+                } catch (ResponseException e) {
+                  if (e.getResponse().getStatusLine().getStatusCode() == 409) {
+                    log.info("Elasticsearch Cloud user {} already exists", username);
+                    return true;
+                  } else {
+                    throw new RuntimeException(
+                        "Retryable error: " + e.getResponse().getStatusLine().getStatusCode());
+                  }
+                }
+              });
+
+      if (!success) {
+        throw new IOException(
+            "Failed to create Elasticsearch Cloud user after retries: " + username);
+      }
+
+    } catch (ResponseException e) {
+      if (e.getResponse().getStatusLine().getStatusCode() == 409) {
+        log.info("Elasticsearch Cloud user {} already exists", username);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Creates a security role for AWS OpenSearch environments.
+   *
+   * @param esComponents the Elasticsearch components factory providing search client access
+   * @param roleName the name of the role to create
+   * @param prefix the index prefix to apply to role permissions
+   * @throws IOException if there's an error creating the role
+   */
+  public static void createAwsOpenSearchRole(
+      BaseElasticSearchComponentsFactory.BaseElasticSearchComponents esComponents,
+      String roleName,
+      String prefix)
+      throws IOException {
+    try {
+      String roleJson =
+          IndexUtils.loadResourceAsString("/index/user/aws_role.json").replace("PREFIX", prefix);
+
+      String endpoint = "/_opendistro/_security/api/roles/" + roleName;
+
+      // Use retry logic for role creation
+      boolean success =
+          IndexUtils.retryWithBackoff(
+              5,
+              2000,
+              () -> {
+                try {
+                  RawResponse response =
+                      IndexUtils.performPutRequest(esComponents, endpoint, roleJson);
+
+                  int statusCode = response.getStatusLine().getStatusCode();
+                  if (statusCode == 200 || statusCode == 201) {
+                    log.info("Successfully created AWS OpenSearch role: {}", roleName);
+                    return true;
+                  } else if (statusCode == 409) {
+                    log.info("AWS OpenSearch role {} already exists", roleName);
+                    return true; // Consider this a success since role exists
+                  } else {
+                    log.warn("AWS OpenSearch role creation returned status: {}", statusCode);
+                    throw new RuntimeException("Retryable error: " + statusCode);
+                  }
+                } catch (ResponseException e) {
+                  if (e.getResponse().getStatusLine().getStatusCode() == 409) {
+                    log.info("AWS OpenSearch role {} already exists", roleName);
+                    return true;
+                  } else {
+                    throw new RuntimeException(
+                        "Retryable error: " + e.getResponse().getStatusLine().getStatusCode());
+                  }
+                }
+              });
+
+      if (!success) {
+        throw new IOException("Failed to create AWS OpenSearch role after retries: " + roleName);
+      }
+
+    } catch (ResponseException e) {
+      if (e.getResponse().getStatusLine().getStatusCode() == 409) {
+        log.info("AWS OpenSearch role {} already exists", roleName);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Creates a user for AWS OpenSearch environments.
+   *
+   * @param esComponents the Elasticsearch components factory providing search client access
+   * @param username the username to create
+   * @param password the password for the user
+   * @param roleName the role to assign to the user
+   * @param operationContext the operation context for JSON parsing
+   * @throws IOException if there's an error creating the user
+   */
+  public static void createAwsOpenSearchUser(
+      BaseElasticSearchComponentsFactory.BaseElasticSearchComponents esComponents,
+      String username,
+      String password,
+      String roleName,
+      String iamRoleArn,
+      OperationContext operationContext)
+      throws IOException {
+    try {
+      ObjectMapper mapper = operationContext.getObjectMapper();
+
+      // Build the user JSON
+      ObjectNode userNode = mapper.createObjectNode();
+
+      // Add password or hash for IAM-only auth
+      if (password != null && !password.isEmpty()) {
+        userNode.put("password", password);
+      } else {
+        userNode.put("hash", "");
+        log.info("Using IAM-only authentication, setting empty hash");
+      }
+
+      // Add security role
+      ArrayNode securityRoles = mapper.createArrayNode();
+      securityRoles.add(roleName);
+      userNode.set("opendistro_security_roles", securityRoles);
+
+      // Add backend_roles for IAM if provided
+      if (iamRoleArn != null && !iamRoleArn.isEmpty()) {
+        log.info("Setting backend_roles to IAM role ARN: {}", iamRoleArn);
+        ArrayNode backendRoles = mapper.createArrayNode();
+        backendRoles.add(iamRoleArn);
+        userNode.set("backend_roles", backendRoles);
+      }
+
+      String userJson = mapper.writeValueAsString(userNode);
+
+      String endpoint = "/_opendistro/_security/api/internalusers/" + username;
+
+      // Use retry logic for user creation
+      boolean success =
+          IndexUtils.retryWithBackoff(
+              5,
+              2000,
+              () -> {
+                try {
+                  RawResponse response =
+                      IndexUtils.performPutRequest(esComponents, endpoint, userJson);
+
+                  int statusCode = response.getStatusLine().getStatusCode();
+                  if (statusCode == 200 || statusCode == 201) {
+                    log.info("Successfully created AWS OpenSearch user: {}", username);
+                    return true;
+                  } else if (statusCode == 409) {
+                    log.info("AWS OpenSearch user {} already exists", username);
+                    return true; // Consider this a success since user exists
+                  } else {
+                    // Log error response body
+                    String responseBody = extractResponseBody(response);
+                    log.error(
+                        "AWS OpenSearch user creation returned status: {}. Response: {}",
+                        statusCode,
+                        responseBody);
+                    throw new RuntimeException(
+                        "Retryable error: " + statusCode + " - " + responseBody);
+                  }
+                } catch (ResponseException e) {
+                  int exStatusCode = e.getResponse().getStatusLine().getStatusCode();
+                  if (exStatusCode == 409) {
+                    log.info("AWS OpenSearch user {} already exists", username);
+                    return true;
+                  } else {
+                    // Log error response body
+                    String responseBody = extractResponseBody(e.getResponse());
+                    log.error(
+                        "AWS OpenSearch user PUT exception. Status: {}. Response: {}",
+                        exStatusCode,
+                        responseBody);
+                    throw new RuntimeException(
+                        "Retryable error: " + exStatusCode + " - " + responseBody);
+                  }
+                } catch (Exception e) {
+                  log.error("Unexpected exception during PUT request", e);
+                  throw e;
+                }
+              });
+
+      if (!success) {
+        throw new IOException(
+            "Failed to create AWS OpenSearch user after retries: "
+                + username
+                + ". Check logs for error details from OpenSearch.");
+      }
+
+    } catch (ResponseException e) {
+      if (e.getResponse().getStatusLine().getStatusCode() == 409) {
+        log.info("AWS OpenSearch user {} already exists", username);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Creates a role mapping for AWS OpenSearch IAM authentication.
+   *
+   * <p>This method creates a role mapping that maps an IAM role ARN to an OpenSearch security role.
+   * This is used for IAM authentication where no internal user is needed.
+   *
+   * @param esComponents the Elasticsearch components factory providing search client access
+   * @param roleName the name of the role to map to (e.g., "prod_access")
+   * @param iamRoleArn the IAM role ARN to map (e.g., "arn:aws:iam::123456789012:role/datahub")
+   * @throws IOException if there's an error creating the role mapping
+   */
+  public static void createAwsOpenSearchRoleMapping(
+      BaseElasticSearchComponentsFactory.BaseElasticSearchComponents esComponents,
+      String roleName,
+      String iamRoleArn)
+      throws IOException {
+    try {
+      // Load the role mapping template
+      String mappingJson =
+          IndexUtils.loadResourceAsString("/index/user/aws_roles_mapping.json")
+              .replace("IAM_ROLE_ARN", iamRoleArn);
+
+      String endpoint = "/_plugins/_security/api/rolesmapping/" + roleName;
+
+      log.info(
+          "Creating role mapping from IAM role {} to OpenSearch role {}", iamRoleArn, roleName);
+
+      // Use retry logic for role mapping creation
+      boolean success =
+          IndexUtils.retryWithBackoff(
+              5,
+              2000,
+              () -> {
+                try {
+                  RawResponse response =
+                      IndexUtils.performPutRequest(esComponents, endpoint, mappingJson);
+
+                  int statusCode = response.getStatusLine().getStatusCode();
+                  if (statusCode == 200 || statusCode == 201) {
+                    log.info(
+                        "Successfully created AWS OpenSearch role mapping: {} -> {}",
+                        iamRoleArn,
+                        roleName);
+                    return true;
+                  } else if (statusCode == 409) {
+                    log.info("AWS OpenSearch role mapping {} already exists", roleName);
+                    return true; // Consider this a success since mapping exists
+                  } else {
+                    String responseBody = extractResponseBody(response);
+                    log.warn(
+                        "AWS OpenSearch role mapping creation returned status: {}. Response: {}",
+                        statusCode,
+                        responseBody);
+                    throw new RuntimeException(
+                        "Retryable error: " + statusCode + " - " + responseBody);
+                  }
+                } catch (ResponseException e) {
+                  int exStatusCode = e.getResponse().getStatusLine().getStatusCode();
+                  if (exStatusCode == 409) {
+                    log.info("AWS OpenSearch role mapping {} already exists", roleName);
+                    return true;
+                  } else {
+                    String responseBody = extractResponseBody(e.getResponse());
+                    log.error(
+                        "AWS OpenSearch role mapping PUT exception. Status: {}. Response: {}",
+                        exStatusCode,
+                        responseBody);
+                    throw new RuntimeException(
+                        "Retryable error: " + exStatusCode + " - " + responseBody);
+                  }
+                }
+              });
+
+      if (!success) {
+        throw new IOException(
+            "Failed to create AWS OpenSearch role mapping after retries: "
+                + roleName
+                + ". Check logs for error details from OpenSearch.");
+      }
+
+    } catch (ResponseException e) {
+      if (e.getResponse().getStatusLine().getStatusCode() == 409) {
+        log.info("AWS OpenSearch role mapping {} already exists", roleName);
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/IndexUtils.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/IndexUtils.java
@@ -206,7 +206,7 @@ public class IndexUtils {
             }
           });
     } catch (Exception e) {
-      log.error("All {} attempts failed", maxAttempts);
+      log.error("All {} attempts failed", maxAttempts, e);
       return false;
     }
   }

--- a/datahub-upgrade/src/main/resources/index/user/access_policy_data_es_cloud.json
+++ b/datahub-upgrade/src/main/resources/index/user/access_policy_data_es_cloud.json
@@ -1,0 +1,9 @@
+{
+    "cluster":[ "monitor" ],
+    "indices":[
+       {
+          "names":["PREFIX*"],
+          "privileges":["all"]
+       }
+    ]
+ }

--- a/datahub-upgrade/src/main/resources/index/user/aws_role.json
+++ b/datahub-upgrade/src/main/resources/index/user/aws_role.json
@@ -1,0 +1,16 @@
+{
+    "cluster_permissions": [
+        "indices:*",
+        "cluster:monitor/tasks/lists"
+    ],
+    "index_permissions": [
+        {
+            "index_patterns": [
+                "PREFIX*"
+            ],
+            "allowed_actions": [
+                "indices_all"
+            ]
+        }
+    ]
+}

--- a/datahub-upgrade/src/main/resources/index/user/aws_roles_mapping.json
+++ b/datahub-upgrade/src/main/resources/index/user/aws_roles_mapping.json
@@ -1,0 +1,10 @@
+{
+    "hosts": [],
+    "users": [],
+    "backend_roles": [
+        "IAM_ROLE_ARN"
+    ],
+    "and_backend_roles": [],
+    "description": "DataHub access via IAM authentication"
+}
+

--- a/datahub-upgrade/src/main/resources/index/user/aws_user.json
+++ b/datahub-upgrade/src/main/resources/index/user/aws_user.json
@@ -1,0 +1,9 @@
+{
+    "password": "ELASTICSEARCH_PASSWORD",
+    "opendistro_security_roles": [
+        "ROLE"
+    ],
+    "backend_roles": [
+        "BACKEND_ROLES"
+    ]
+}

--- a/datahub-upgrade/src/main/resources/index/user/user_data_es_cloud.json
+++ b/datahub-upgrade/src/main/resources/index/user/user_data_es_cloud.json
@@ -1,0 +1,4 @@
+{
+    "password": "ELASTICSEARCH_PASSWORD",
+ 	  "roles":["PREFIXaccess"]
+ }

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateCdcUserStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateCdcUserStepTest.java
@@ -52,8 +52,7 @@ public class CreateCdcUserStepTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "testdb", // databaseName
-            null // createUserIamRole
+            "testdb" // databaseName
             );
     createCdcUserStep = new CreateCdcUserStep(mockDatabase, defaultSetupArgs);
     when(mockUpgradeContext.report()).thenReturn(mockUpgradeReport);
@@ -115,8 +114,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     CreateCdcUserStep disabledCdcStep = new CreateCdcUserStep(mockDatabase, disabledCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = disabledCdcStep.executable();
@@ -149,8 +147,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     CreateCdcUserStep mysqlCdcStep = new CreateCdcUserStep(mockDatabase, mysqlCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = mysqlCdcStep.executable();
@@ -184,8 +181,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             5432,
-            "testdb",
-            null);
+            "testdb");
     CreateCdcUserStep postgresCdcStep = new CreateCdcUserStep(mockDatabase, postgresCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = postgresCdcStep.executable();
@@ -273,8 +269,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             5432,
-            "custom_db",
-            null);
+            "custom_db");
     CreateCdcUserStep customCdcStep = new CreateCdcUserStep(mockDatabase, customCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = customCdcStep.executable();
@@ -307,8 +302,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     CreateCdcUserStep defaultCdcStep = new CreateCdcUserStep(mockDatabase, defaultCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = defaultCdcStep.executable();
@@ -340,8 +334,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             5432,
-            "testdb",
-            null);
+            "testdb");
     CreateCdcUserStep postgresStep = new CreateCdcUserStep(mockDatabase, postgresArgs);
 
     // This test is now covered by DatabaseOperationsTest
@@ -367,8 +360,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     CreateCdcUserStep mysqlStep = new CreateCdcUserStep(mockDatabase, mysqlArgs);
 
     // This test is now covered by DatabaseOperationsTest
@@ -394,8 +386,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             5432,
-            "testdb",
-            null);
+            "testdb");
     CreateCdcUserStep postgresStep = new CreateCdcUserStep(mockDatabase, postgresArgs);
 
     // This test is now covered by DatabaseOperationsTest
@@ -421,8 +412,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     CreateCdcUserStep mysqlStep = new CreateCdcUserStep(mockDatabase, mysqlArgs);
 
     // This test is now covered by DatabaseOperationsTest
@@ -454,8 +444,7 @@ public class CreateCdcUserStepTest {
               null,
               "localhost",
               3306,
-              "testdb",
-              null);
+              "testdb");
       createCdcUserStep.createCdcUser(testArgs);
       assertTrue(false, "Expected RuntimeException to be thrown");
     } catch (Exception e) {
@@ -482,8 +471,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     SqlSetupResult result = createCdcUserStep.createCdcUser(testArgs);
 
     assertNotNull(result);
@@ -512,8 +500,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     SqlSetupResult result = createCdcUserStep.createCdcUser(testArgs);
 
     assertNotNull(result);
@@ -539,8 +526,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     SqlSetupResult result = createCdcUserStep.createCdcUser(testArgs);
 
     assertNotNull(result);
@@ -569,8 +555,7 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     SqlSetupResult result = createCdcUserStep.createCdcUser(testArgs);
 
     assertNotNull(result);

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStepTest.java
@@ -52,8 +52,7 @@ public class CreateTablesStepTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "testdb", // databaseName
-            null // createUserIamRole
+            "testdb" // databaseName
             );
     createTablesStep = new CreateTablesStep(mockDatabase, defaultSetupArgs);
     when(mockUpgradeContext.report()).thenReturn(mockUpgradeReport);
@@ -116,8 +115,7 @@ public class CreateTablesStepTest {
             null, // createUserPassword
             "localhost", // host
             5432, // port
-            "testdb", // databaseName
-            null // createUserIamRole
+            "testdb" // databaseName
             );
     CreateTablesStep postgresStep = new CreateTablesStep(mockDatabase, postgresSetupArgs);
     when(mockDatabase.dataSource()).thenReturn(mockDataSource);
@@ -315,8 +313,7 @@ public class CreateTablesStepTest {
             null,
             "localhost",
             5432,
-            "testdb",
-            null);
+            "testdb");
     CreateTablesStep postgresStep = new CreateTablesStep(mockDatabase, postgresArgs);
 
     // Mock that database exists (ResultSet.next() returns true)
@@ -364,8 +361,7 @@ public class CreateTablesStepTest {
             null,
             "localhost",
             5432,
-            "testdb",
-            null);
+            "testdb");
     CreateTablesStep postgresStep = new CreateTablesStep(mockDatabase, postgresArgs);
 
     // Mock database check failure - PreparedStatement throws exception

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateUsersStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateUsersStepTest.java
@@ -52,8 +52,7 @@ public class CreateUsersStepTest {
             "testpass", // createUserPassword
             "localhost", // host
             3306, // port
-            "testdb", // databaseName
-            null // createUserIamRole
+            "testdb" // databaseName
             );
     createUsersStep = new CreateUsersStep(mockDatabase, defaultSetupArgs);
     when(mockUpgradeContext.report()).thenReturn(mockUpgradeReport);
@@ -115,8 +114,7 @@ public class CreateUsersStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     CreateUsersStep disabledUserStep = new CreateUsersStep(mockDatabase, disabledUserArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = disabledUserStep.executable();
@@ -252,15 +250,15 @@ public class CreateUsersStepTest {
             null,
             "localhost",
             3306,
-            "testdb",
-            "arn:aws:iam::123456789012:role/datahub-role");
+            "testdb");
     createUsersStep.createIamUser(testArgs, result);
 
     assertEquals(result.getUsersCreated(), 1);
     // Verify PreparedStatement approach - should call dataSource() and prepareStatement()
+    // Three statements: CREATE USER, GRANT PRIVILEGES, FLUSH PRIVILEGES (for MySQL)
     verify(mockDatabase).dataSource();
-    verify(mockConnection, times(2)).prepareStatement(anyString());
-    verify(mockPreparedStatement, times(2)).executeUpdate();
+    verify(mockConnection, times(3)).prepareStatement(anyString());
+    verify(mockPreparedStatement, times(3)).executeUpdate();
   }
 
   @Test
@@ -281,15 +279,15 @@ public class CreateUsersStepTest {
             "testpass",
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     createUsersStep.createTraditionalUser(testArgs, result);
 
     assertEquals(result.getUsersCreated(), 1);
     // Verify PreparedStatement approach - should call dataSource() and prepareStatement()
+    // Three statements: CREATE USER, GRANT PRIVILEGES, FLUSH PRIVILEGES (for MySQL)
     verify(mockDatabase).dataSource();
-    verify(mockConnection, times(2)).prepareStatement(anyString());
-    verify(mockPreparedStatement, times(2)).executeUpdate();
+    verify(mockConnection, times(3)).prepareStatement(anyString());
+    verify(mockPreparedStatement, times(3)).executeUpdate();
   }
 
   @Test
@@ -368,8 +366,7 @@ public class CreateUsersStepTest {
             "testpass",
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     SqlSetupResult result = createUsersStep.createUsers(testArgs);
 
     assertNotNull(result);
@@ -394,8 +391,7 @@ public class CreateUsersStepTest {
             "testpass",
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     SqlSetupResult result = createUsersStep.createUsers(testArgs);
 
     assertNotNull(result);
@@ -420,8 +416,7 @@ public class CreateUsersStepTest {
             "testpass",
             "localhost",
             3306,
-            "testdb",
-            null);
+            "testdb");
     SqlSetupResult result = createUsersStep.createUsers(testArgs);
 
     assertNotNull(result);
@@ -451,8 +446,7 @@ public class CreateUsersStepTest {
               null,
               "localhost",
               3306,
-              "testdb",
-              "arn:aws:iam::123456789012:role/datahub-role");
+              "testdb");
       createUsersStep.createIamUser(testArgs, result);
       assertTrue(false, "Expected SQLException to be thrown");
     } catch (Exception e) {
@@ -482,8 +476,7 @@ public class CreateUsersStepTest {
               "testpass",
               "localhost",
               3306,
-              "testdb",
-              null);
+              "testdb");
       createUsersStep.createTraditionalUser(testArgs, result);
       assertTrue(false, "Expected SQLException to be thrown");
     } catch (Exception e) {

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupTest.java
@@ -40,8 +40,7 @@ public class SqlSetupTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub", // databaseName
-            null // createUserIamRole
+            "datahub" // databaseName
             );
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);
 
@@ -67,8 +66,7 @@ public class SqlSetupTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub", // databaseName
-            null // createUserIamRole
+            "datahub" // databaseName
             );
     sqlSetup = new SqlSetup(null, setupArgs);
 
@@ -114,8 +112,7 @@ public class SqlSetupTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub", // databaseName
-            null // createUserIamRole
+            "datahub" // databaseName
             );
 
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);
@@ -141,8 +138,7 @@ public class SqlSetupTest {
             "testpass", // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub", // databaseName
-            null // createUserIamRole
+            "datahub" // databaseName
             );
 
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);
@@ -169,8 +165,7 @@ public class SqlSetupTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub", // databaseName
-            null // createUserIamRole
+            "datahub" // databaseName
             );
 
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);
@@ -197,8 +192,7 @@ public class SqlSetupTest {
             "testpass", // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub", // databaseName
-            null // createUserIamRole
+            "datahub" // databaseName
             );
 
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/CreateUserStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/CreateUserStepTest.java
@@ -1,0 +1,503 @@
+package com.linkedin.datahub.upgrade.system.elasticsearch.steps;
+
+import com.linkedin.datahub.upgrade.UpgradeContext;
+import com.linkedin.datahub.upgrade.UpgradeStepResult;
+import com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexRoleUtils;
+import com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils;
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
+import com.linkedin.metadata.config.search.ElasticSearchConfiguration;
+import com.linkedin.metadata.config.search.IndexConfiguration;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
+import com.linkedin.upgrade.DataHubUpgradeState;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.function.Function;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CreateUserStepTest {
+
+  @Mock private BaseElasticSearchComponentsFactory.BaseElasticSearchComponents esComponents;
+  @Mock private ConfigurationProvider configurationProvider;
+  @Mock private SearchClientShim searchClient;
+  @Mock private SearchClientShim.SearchEngineType searchEngineType;
+  @Mock private UpgradeContext upgradeContext;
+  @Mock private ElasticSearchConfiguration elasticSearch;
+  @Mock private IndexConfiguration index;
+
+  private CreateUserStep step;
+  private OperationContext opContext = TestOperationContexts.systemContextNoValidate();
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    // Setup common mocks
+    Mockito.when(esComponents.getSearchClient()).thenReturn(searchClient);
+    Mockito.when(searchClient.getEngineType()).thenReturn(searchEngineType);
+    Mockito.when(configurationProvider.getElasticSearch()).thenReturn(elasticSearch);
+    Mockito.when(elasticSearch.getIndex()).thenReturn(index);
+
+    Mockito.when(upgradeContext.opContext()).thenReturn(opContext);
+
+    step = new CreateUserStep(esComponents, configurationProvider);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    // Clear environment variables after each test
+    System.clearProperty("CREATE_USER_ES");
+    System.clearProperty("CREATE_USER_ES_USERNAME");
+    System.clearProperty("CREATE_USER_ES_PASSWORD");
+    System.clearProperty("CREATE_USER_ES_IAM_ROLE_ARN");
+  }
+
+  @Test
+  public void testId() {
+    // Act
+    String id = step.id();
+
+    // Assert
+    Assert.assertEquals(id, "CreateElasticsearchUserStep");
+  }
+
+  @Test
+  public void testRetryCount() {
+    // Act
+    int retryCount = step.retryCount();
+
+    // Assert
+    Assert.assertEquals(retryCount, 3);
+  }
+
+  @Test
+  public void testSkip_WhenCreateUserEsIsFalse() {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "false");
+
+    // Act
+    boolean shouldSkip = step.skip(upgradeContext);
+
+    // Assert
+    Assert.assertTrue(shouldSkip);
+  }
+
+  @Test
+  public void testSkip_WhenCreateUserEsIsTrue() {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+
+    // Act
+    boolean shouldSkip = step.skip(upgradeContext);
+
+    // Assert
+    Assert.assertFalse(shouldSkip);
+  }
+
+  @Test
+  public void testSkip_WhenCreateUserEsIsNotSet() {
+    // Arrange - no environment variable set
+
+    // Act
+    boolean shouldSkip = step.skip(upgradeContext);
+
+    // Assert
+    Assert.assertTrue(shouldSkip); // Should skip by default
+  }
+
+  @Test
+  public void testExecutable_OpenSearchPath_Success() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    System.setProperty("CREATE_USER_ES_PASSWORD", "testpass");
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+    Mockito.when(searchEngineType.isOpenSearch()).thenReturn(true);
+
+    try (MockedStatic<IndexUtils> indexUtilsMock = Mockito.mockStatic(IndexUtils.class);
+        MockedStatic<IndexRoleUtils> indexRoleUtilsMock =
+            Mockito.mockStatic(IndexRoleUtils.class)) {
+
+      indexUtilsMock.when(() -> IndexUtils.isAwsOpenSearchService(esComponents)).thenReturn(true);
+      indexRoleUtilsMock
+          .when(
+              () ->
+                  IndexRoleUtils.createAwsOpenSearchRole(
+                      Mockito.any(), Mockito.anyString(), Mockito.anyString()))
+          .thenAnswer(invocation -> null);
+      indexRoleUtilsMock
+          .when(
+              () ->
+                  IndexRoleUtils.createAwsOpenSearchUser(
+                      Mockito.any(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.any()))
+          .thenAnswer(invocation -> null);
+
+      // Act
+      Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+      UpgradeStepResult result = executable.apply(upgradeContext);
+
+      // Assert
+      Assert.assertNotNull(result);
+      Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+      Assert.assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+
+      // Verify OpenSearch path was taken
+      Mockito.verify(searchEngineType).isOpenSearch();
+      Mockito.verify(index).getFinalPrefix();
+    }
+  }
+
+  @Test
+  public void testExecutable_ElasticsearchPath_Success() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    System.setProperty("CREATE_USER_ES_PASSWORD", "testpass");
+    Mockito.when(index.getFinalPrefix()).thenReturn("prod_");
+    Mockito.when(searchEngineType.isOpenSearch()).thenReturn(false);
+
+    try (MockedStatic<IndexRoleUtils> indexRoleUtilsMock =
+        Mockito.mockStatic(IndexRoleUtils.class)) {
+
+      indexRoleUtilsMock
+          .when(
+              () ->
+                  IndexRoleUtils.createElasticsearchCloudUser(
+                      Mockito.any(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString()))
+          .thenAnswer(invocation -> null);
+
+      // Act
+      Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+      UpgradeStepResult result = executable.apply(upgradeContext);
+
+      // Assert
+      Assert.assertNotNull(result);
+      Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+      Assert.assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+
+      // Verify Elasticsearch path was taken
+      Mockito.verify(searchEngineType).isOpenSearch();
+      Mockito.verify(index).getFinalPrefix();
+    }
+  }
+
+  @Test
+  public void testExecutable_MissingUsername() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_PASSWORD", "testpass");
+    // Username not set
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+
+    // Act
+    Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+    UpgradeStepResult result = executable.apply(upgradeContext);
+
+    // Assert
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+    Assert.assertEquals(result.result(), DataHubUpgradeState.FAILED);
+  }
+
+  @Test
+  public void testExecutable_MissingPassword() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    // Password not set
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+
+    // Act
+    Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+    UpgradeStepResult result = executable.apply(upgradeContext);
+
+    // Assert
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+    Assert.assertEquals(result.result(), DataHubUpgradeState.FAILED);
+  }
+
+  @Test
+  public void testExecutable_MissingBothCredentials() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    // Neither username nor password set
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+
+    // Act
+    Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+    UpgradeStepResult result = executable.apply(upgradeContext);
+
+    // Assert
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+    Assert.assertEquals(result.result(), DataHubUpgradeState.FAILED);
+  }
+
+  @Test
+  public void testExecutable_OpenSearchPath_Exception() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    System.setProperty("CREATE_USER_ES_PASSWORD", "testpass");
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+    Mockito.when(searchEngineType.isOpenSearch()).thenReturn(true);
+    Mockito.when(index.getFinalPrefix()).thenThrow(new RuntimeException("OpenSearch setup failed"));
+
+    // Act
+    Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+    UpgradeStepResult result = executable.apply(upgradeContext);
+
+    // Assert
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+    Assert.assertEquals(result.result(), DataHubUpgradeState.FAILED);
+  }
+
+  @Test
+  public void testExecutable_ElasticsearchPath_Exception() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    System.setProperty("CREATE_USER_ES_PASSWORD", "testpass");
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+    Mockito.when(searchEngineType.isOpenSearch()).thenReturn(false);
+    Mockito.when(index.getFinalPrefix())
+        .thenThrow(new RuntimeException("Elasticsearch setup failed"));
+
+    // Act
+    Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+    UpgradeStepResult result = executable.apply(upgradeContext);
+
+    // Assert
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+    Assert.assertEquals(result.result(), DataHubUpgradeState.FAILED);
+  }
+
+  @Test
+  public void testExecutable_WithEmptyPrefix() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    System.setProperty("CREATE_USER_ES_PASSWORD", "testpass");
+    Mockito.when(index.getFinalPrefix()).thenReturn(""); // Empty prefix
+    Mockito.when(searchEngineType.isOpenSearch()).thenReturn(false);
+
+    try (MockedStatic<IndexRoleUtils> indexRoleUtilsMock =
+        Mockito.mockStatic(IndexRoleUtils.class)) {
+
+      indexRoleUtilsMock
+          .when(
+              () ->
+                  IndexRoleUtils.createElasticsearchCloudUser(
+                      Mockito.any(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString()))
+          .thenAnswer(invocation -> null);
+
+      // Act
+      Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+      UpgradeStepResult result = executable.apply(upgradeContext);
+
+      // Assert
+      Assert.assertNotNull(result);
+      Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+      Assert.assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+
+      // Verify empty prefix was used
+      Mockito.verify(index).getFinalPrefix();
+    }
+  }
+
+  @Test
+  public void testExecutable_WithNullPrefix() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    System.setProperty("CREATE_USER_ES_PASSWORD", "testpass");
+    Mockito.when(index.getFinalPrefix()).thenReturn(null); // Null prefix
+    Mockito.when(searchEngineType.isOpenSearch()).thenReturn(false);
+
+    try (MockedStatic<IndexRoleUtils> indexRoleUtilsMock =
+        Mockito.mockStatic(IndexRoleUtils.class)) {
+
+      indexRoleUtilsMock
+          .when(
+              () ->
+                  IndexRoleUtils.createElasticsearchCloudUser(
+                      Mockito.any(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString()))
+          .thenAnswer(invocation -> null);
+
+      // Act
+      Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+      UpgradeStepResult result = executable.apply(upgradeContext);
+
+      // Assert
+      Assert.assertNotNull(result);
+      Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+      Assert.assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+
+      // Verify null prefix was handled
+      Mockito.verify(index).getFinalPrefix();
+    }
+  }
+
+  @Test
+  public void testExecutable_MultipleCalls() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    System.setProperty("CREATE_USER_ES_PASSWORD", "testpass");
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+    Mockito.when(searchEngineType.isOpenSearch()).thenReturn(false);
+
+    try (MockedStatic<IndexRoleUtils> indexRoleUtilsMock =
+        Mockito.mockStatic(IndexRoleUtils.class)) {
+
+      indexRoleUtilsMock
+          .when(
+              () ->
+                  IndexRoleUtils.createElasticsearchCloudUser(
+                      Mockito.any(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString(),
+                      Mockito.anyString()))
+          .thenAnswer(invocation -> null);
+
+      // Act
+      Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+      UpgradeStepResult result1 = executable.apply(upgradeContext);
+      UpgradeStepResult result2 = executable.apply(upgradeContext);
+
+      // Assert
+      Assert.assertNotNull(result1);
+      Assert.assertNotNull(result2);
+      Assert.assertEquals(result1.result(), DataHubUpgradeState.SUCCEEDED);
+      Assert.assertEquals(result2.result(), DataHubUpgradeState.SUCCEEDED);
+
+      // Verify that the executable function can be called multiple times
+      Mockito.verify(searchEngineType, Mockito.times(2)).isOpenSearch();
+      Mockito.verify(index, Mockito.times(2)).getFinalPrefix();
+    }
+  }
+
+  @Test
+  public void testExecutable_IamOnlyAuth_Success() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_IAM_ROLE_ARN", "arn:aws:iam::123456789012:role/test-role");
+    // No username/password - IAM-only authentication
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+    Mockito.when(searchEngineType.isOpenSearch()).thenReturn(true);
+
+    try (MockedStatic<IndexUtils> indexUtilsMock = Mockito.mockStatic(IndexUtils.class);
+        MockedStatic<IndexRoleUtils> indexRoleUtilsMock =
+            Mockito.mockStatic(IndexRoleUtils.class)) {
+
+      indexUtilsMock.when(() -> IndexUtils.isAwsOpenSearchService(esComponents)).thenReturn(true);
+      indexRoleUtilsMock
+          .when(
+              () ->
+                  IndexRoleUtils.createAwsOpenSearchRole(
+                      Mockito.any(), Mockito.anyString(), Mockito.anyString()))
+          .thenAnswer(invocation -> null);
+      indexRoleUtilsMock
+          .when(
+              () ->
+                  IndexRoleUtils.createAwsOpenSearchRoleMapping(
+                      Mockito.any(), Mockito.anyString(), Mockito.anyString()))
+          .thenAnswer(invocation -> null);
+
+      // Act
+      Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+      UpgradeStepResult result = executable.apply(upgradeContext);
+
+      // Assert
+      Assert.assertNotNull(result);
+      Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+      Assert.assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+
+      // Verify OpenSearch path was taken
+      Mockito.verify(searchEngineType).isOpenSearch();
+      Mockito.verify(index).getFinalPrefix();
+    }
+  }
+
+  @Test
+  public void testExecutable_MissingUsernameWithIamRole() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_IAM_ROLE_ARN", "arn:aws:iam::123456789012:role/test-role");
+    // Username not set - should fail
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+
+    // Act
+    Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+    UpgradeStepResult result = executable.apply(upgradeContext);
+
+    // Assert
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+    Assert.assertEquals(result.result(), DataHubUpgradeState.FAILED);
+  }
+
+  @Test
+  public void testExecutable_MissingPasswordAndIamRole() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    // Neither password nor IAM role set - should fail
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+
+    // Act
+    Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+    UpgradeStepResult result = executable.apply(upgradeContext);
+
+    // Assert
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+    Assert.assertEquals(result.result(), DataHubUpgradeState.FAILED);
+  }
+
+  @Test
+  public void testExecutable_IamOnlyAuth_EmptyIamRole() throws Exception {
+    // Arrange
+    System.setProperty("CREATE_USER_ES", "true");
+    System.setProperty("CREATE_USER_ES_USERNAME", "testuser");
+    System.setProperty("CREATE_USER_ES_IAM_ROLE_ARN", ""); // Empty IAM role ARN
+    Mockito.when(index.getFinalPrefix()).thenReturn("test_");
+
+    // Act
+    Function<UpgradeContext, UpgradeStepResult> executable = step.executable();
+    UpgradeStepResult result = executable.apply(upgradeContext);
+
+    // Assert
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.stepId(), "CreateElasticsearchUserStep");
+    Assert.assertEquals(result.result(), DataHubUpgradeState.FAILED);
+  }
+}

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/IndexRoleUtilsTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/IndexRoleUtilsTest.java
@@ -1,0 +1,945 @@
+package com.linkedin.datahub.upgrade.system.elasticsearch.util;
+
+import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
+import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
+import com.linkedin.metadata.utils.elasticsearch.responses.RawResponse;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.io.IOException;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.client.Request;
+import org.opensearch.client.ResponseException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for IndexRoleUtils class.
+ *
+ * <p>This test class covers all public methods in IndexRoleUtils, including:
+ *
+ * <ul>
+ *   <li>Elasticsearch Cloud role and user creation
+ *   <li>AWS OpenSearch role and user creation
+ *   <li>Retry logic for transient failures
+ *   <li>Proper handling of existing resources (409 conflicts)
+ *   <li>Error scenarios and exception handling
+ * </ul>
+ */
+public class IndexRoleUtilsTest {
+
+  @Mock private BaseElasticSearchComponentsFactory.BaseElasticSearchComponents esComponents;
+  @Mock private SearchClientShim searchClient;
+  @Mock private RawResponse rawResponse;
+  @Mock private ResponseException responseException;
+
+  private OperationContext operationContext = TestOperationContexts.systemContextNoValidate();
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    Mockito.when(esComponents.getSearchClient()).thenReturn(searchClient);
+  }
+
+  // ==================== Elasticsearch Cloud Role Tests ====================
+
+  @Test
+  public void testCreateElasticsearchCloudRole_Success() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+
+    // Assert
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testCreateElasticsearchCloudRole_AlreadyExists() throws IOException {
+    // Arrange
+    String roleName = "existing_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+
+    // Assert
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testCreateElasticsearchCloudRole_ResponseException409() throws IOException {
+    // Arrange
+    String roleName = "existing_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+
+    // Assert
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateElasticsearchCloudRole_ResponseException500() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(500, "Internal Server Error"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateElasticsearchCloudRole_RetryFailure() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    // Mock 5 consecutive failures to trigger retry exhaustion
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(400, "Bad Request"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+  }
+
+  // ==================== Elasticsearch Cloud User Tests ====================
+
+  @Test
+  public void testCreateElasticsearchCloudUser_Success() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+    String prefix = "test_";
+
+    // Mock successful role creation
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudUser(esComponents, roleName, username, password, prefix);
+
+    // Assert
+    // Should make 2 calls: one for role creation, one for user creation
+    Mockito.verify(searchClient, Mockito.times(2))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testCreateElasticsearchCloudUser_RoleAlreadyExists() throws IOException {
+    // Arrange
+    String roleName = "existing_role";
+    String username = "test_user";
+    String password = "test_password";
+    String prefix = "test_";
+
+    // Mock role already exists (409), then successful user creation
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse)
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine())
+        .thenReturn(createStatusLine(409, "Conflict"))
+        .thenReturn(createStatusLine(200, "OK"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudUser(esComponents, roleName, username, password, prefix);
+
+    // Assert
+    Mockito.verify(searchClient, Mockito.times(2))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateElasticsearchCloudUser_RoleCreationFails() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+    String prefix = "test_";
+
+    // Mock role creation failure
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(400, "Bad Request"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudUser(esComponents, roleName, username, password, prefix);
+  }
+
+  // ==================== AWS OpenSearch Role Tests ====================
+
+  @Test
+  public void testCreateAwsOpenSearchRole_Success() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRole(esComponents, roleName, prefix);
+
+    // Assert
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testCreateAwsOpenSearchRole_AlreadyExists() throws IOException {
+    // Arrange
+    String roleName = "existing_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRole(esComponents, roleName, prefix);
+
+    // Assert
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testCreateAwsOpenSearchRole_ResponseException409() throws IOException {
+    // Arrange
+    String roleName = "existing_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRole(esComponents, roleName, prefix);
+
+    // Assert
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchRole_ResponseException500() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(500, "Internal Server Error"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRole(esComponents, roleName, prefix);
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchRole_RetryFailure() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    // Mock 5 consecutive failures to trigger retry exhaustion
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(400, "Bad Request"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRole(esComponents, roleName, prefix);
+  }
+
+  // ==================== AWS OpenSearch User Tests ====================
+
+  @Test
+  public void testCreateAwsOpenSearchUser_Success() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+
+    // Mock successful user creation only (role should be created separately)
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK")); // PUT user
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, null, operationContext);
+
+    // Assert
+    // Should make calls for user creation
+    Mockito.verify(searchClient, Mockito.atLeast(1))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testCreateAwsOpenSearchUser_AlreadyExists() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+
+    // Mock user already exists (409)
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine())
+        .thenReturn(createStatusLine(409, "Conflict")); // PUT user - already exists
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, null, operationContext);
+
+    // Assert
+    // User creation attempted
+    Mockito.verify(searchClient, Mockito.atLeast(1))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  // ==================== AWS OpenSearch Role Mapping Tests ====================
+
+  @Test
+  public void testCreateAwsOpenSearchRoleMapping_Success() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String iamRoleArn = "arn:aws:iam::123456789012:role/test-role";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRoleMapping(esComponents, roleName, iamRoleArn);
+
+    // Assert
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testCreateAwsOpenSearchRoleMapping_AlreadyExists() throws IOException {
+    // Arrange
+    String roleName = "existing_role";
+    String iamRoleArn = "arn:aws:iam::123456789012:role/test-role";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRoleMapping(esComponents, roleName, iamRoleArn);
+
+    // Assert
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchRoleMapping_ResponseException500() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String iamRoleArn = "arn:aws:iam::123456789012:role/test-role";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(500, "Internal Server Error"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRoleMapping(esComponents, roleName, iamRoleArn);
+  }
+
+  // ==================== Retry Logic Tests ====================
+
+  @Test
+  public void testRetryLogic_TransientFailureThenSuccess() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    // Mock transient failure (400) followed by success (200)
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse)
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine())
+        .thenReturn(createStatusLine(400, "Bad Request"))
+        .thenReturn(createStatusLine(200, "OK"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+
+    // Assert
+    // Should retry once and succeed on second attempt
+    Mockito.verify(searchClient, Mockito.times(2))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testRetryLogic_TransientFailureThenConflict() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    // Mock transient failure (400) followed by conflict (409)
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse)
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine())
+        .thenReturn(createStatusLine(400, "Bad Request"))
+        .thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+
+    // Assert
+    // Should retry once and succeed on second attempt (409 is considered success)
+    Mockito.verify(searchClient, Mockito.times(2))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  // ==================== Endpoint Verification Tests ====================
+
+  @Test
+  public void testElasticsearchCloudRoleEndpoint() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+
+    // Assert
+    Mockito.verify(searchClient)
+        .performLowLevelRequest(
+            Mockito.argThat(
+                request ->
+                    request.getMethod().equals("PUT")
+                        && request.getEndpoint().equals("/_security/role/" + roleName)));
+  }
+
+  @Test
+  public void testAwsOpenSearchRoleEndpoint() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRole(esComponents, roleName, prefix);
+
+    // Assert
+    Mockito.verify(searchClient)
+        .performLowLevelRequest(
+            Mockito.argThat(
+                request ->
+                    request.getMethod().equals("PUT")
+                        && request
+                            .getEndpoint()
+                            .equals("/_opendistro/_security/api/roles/" + roleName)));
+  }
+
+  @Test
+  public void testCreateElasticsearchCloudRole_OuterResponseException409() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    // Mock ResponseException with 409 status in the outer catch block
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+
+    // Assert - Should handle 409 gracefully without throwing exception
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateElasticsearchCloudRole_OuterResponseException500() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    // Mock ResponseException with 500 status in the outer catch block
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(500, "Internal Server Error"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudRole(esComponents, roleName, prefix);
+  }
+
+  @Test
+  public void testCreateElasticsearchCloudUserInternal_OuterResponseException409()
+      throws IOException {
+    // Arrange
+    String username = "test_user";
+    String password = "test_password";
+    String roleName = "test_role";
+
+    // Mock ResponseException with 409 status in the outer catch block
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudUser(
+        esComponents, roleName, username, password, "test_");
+
+    // Assert - Should handle 409 gracefully without throwing exception
+    Mockito.verify(searchClient, Mockito.atLeast(1))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateElasticsearchCloudUserInternal_OuterResponseException500()
+      throws IOException {
+    // Arrange
+    String username = "test_user";
+    String password = "test_password";
+    String roleName = "test_role";
+
+    // Mock ResponseException with 500 status in the outer catch block
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(500, "Internal Server Error"));
+
+    // Act
+    IndexRoleUtils.createElasticsearchCloudUser(
+        esComponents, roleName, username, password, "test_");
+  }
+
+  @Test
+  public void testCreateAwsOpenSearchRole_OuterResponseException409() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    // Mock ResponseException with 409 status in the outer catch block
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRole(esComponents, roleName, prefix);
+
+    // Assert - Should handle 409 gracefully without throwing exception
+    Mockito.verify(searchClient).performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchRole_OuterResponseException500() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String prefix = "test_";
+
+    // Mock ResponseException with 500 status in the outer catch block
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(500, "Internal Server Error"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRole(esComponents, roleName, prefix);
+  }
+
+  @Test
+  public void testCreateAwsOpenSearchUserInternal_OuterResponseException409() throws IOException {
+    // Arrange
+    String username = "test_user";
+    String password = "test_password";
+    String roleName = "test_role";
+
+    // Mock ResponseException with 409 status in the outer catch block
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(409, "Conflict"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, null, operationContext);
+
+    // Assert - Should handle 409 gracefully without throwing exception
+    Mockito.verify(searchClient, Mockito.atLeast(1))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchUserInternal_OuterResponseException500() throws IOException {
+    // Arrange
+    String username = "test_user";
+    String password = "test_password";
+    String roleName = "test_role";
+
+    // Mock ResponseException with 500 status in the outer catch block
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse())
+        .thenReturn(Mockito.mock(org.opensearch.client.Response.class));
+    Mockito.when(responseException.getResponse().getStatusLine())
+        .thenReturn(createStatusLine(500, "Internal Server Error"));
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, null, operationContext);
+  }
+
+  // ==================== IAM-Only Authentication Tests ====================
+
+  @Test
+  public void testCreateAwsOpenSearchUser_IamOnlyAuth_Success() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = null; // IAM-only, no password
+    String iamRoleArn = "arn:aws:iam::123456789012:role/test-role";
+    String prefix = "test_";
+
+    // Mock successful user creation only (role should be created separately)
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK")); // PUT user
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, iamRoleArn, operationContext);
+
+    // Assert
+    // Should make calls for user creation
+    Mockito.verify(searchClient, Mockito.atLeast(1))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testCreateAwsOpenSearchUser_PasswordBasedAuth_Success() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+    String iamRoleArn = null; // No IAM role, password-based
+    String prefix = "test_";
+
+    // Mock successful user creation only (role should be created separately)
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK")); // PUT user
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, iamRoleArn, operationContext);
+
+    // Assert
+    // Should make calls for user creation
+    Mockito.verify(searchClient, Mockito.atLeast(1))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  @Test
+  public void testCreateAwsOpenSearchUser_IamOnlyAuth_EmptyIamRole() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = null;
+    String iamRoleArn = ""; // Empty IAM role
+    String prefix = "test_";
+
+    // Mock successful user creation only (role should be created separately)
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(200, "OK")); // PUT user
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, iamRoleArn, operationContext);
+
+    // Assert
+    // Should make calls for user creation
+    Mockito.verify(searchClient, Mockito.atLeast(1))
+        .performLowLevelRequest(Mockito.any(Request.class));
+  }
+
+  // ==================== AWS OpenSearch User Error Logging Tests ====================
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchUser_ErrorWithResponseBody() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+
+    // Mock error response with response body
+    org.apache.http.HttpEntity mockEntity = Mockito.mock(org.apache.http.HttpEntity.class);
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(400, "Bad Request"));
+    Mockito.when(rawResponse.getEntity()).thenReturn(mockEntity);
+
+    try {
+      Mockito.when(mockEntity.getContent())
+          .thenReturn(
+              new java.io.ByteArrayInputStream("{\"error\":\"Invalid credentials\"}".getBytes()));
+    } catch (Exception e) {
+      // Handle exception
+    }
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, null, operationContext);
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchUser_ResponseExceptionWithResponseBody() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+
+    // Mock ResponseException with response body
+    org.opensearch.client.Response mockResponse =
+        Mockito.mock(org.opensearch.client.Response.class);
+    org.apache.http.HttpEntity mockEntity = Mockito.mock(org.apache.http.HttpEntity.class);
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse()).thenReturn(mockResponse);
+    Mockito.when(mockResponse.getStatusLine())
+        .thenReturn(createStatusLine(500, "Internal Server Error"));
+    Mockito.when(mockResponse.getEntity()).thenReturn(mockEntity);
+
+    try {
+      Mockito.when(mockEntity.getContent())
+          .thenReturn(new java.io.ByteArrayInputStream("{\"error\":\"Server error\"}".getBytes()));
+    } catch (Exception e) {
+      // Handle exception
+    }
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, null, operationContext);
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchUser_RetryableErrorThenFailure() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+
+    org.apache.http.HttpEntity mockEntity = Mockito.mock(org.apache.http.HttpEntity.class);
+
+    // Mock retryable error (400) returned repeatedly
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(400, "Bad Request"));
+    Mockito.when(rawResponse.getEntity()).thenReturn(mockEntity);
+
+    try {
+      Mockito.when(mockEntity.getContent())
+          .thenReturn(
+              new java.io.ByteArrayInputStream("{\"error\":\"Validation failed\"}".getBytes()));
+    } catch (Exception e) {
+      // Handle exception
+    }
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, null, operationContext);
+  }
+
+  // ==================== AWS OpenSearch Role Mapping Error Logging Tests ====================
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchRoleMapping_ErrorWithResponseBody() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String iamRoleArn = "arn:aws:iam::123456789012:role/test-role";
+
+    // Mock error response with response body
+    org.apache.http.HttpEntity mockEntity = Mockito.mock(org.apache.http.HttpEntity.class);
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(400, "Bad Request"));
+    Mockito.when(rawResponse.getEntity()).thenReturn(mockEntity);
+
+    try {
+      Mockito.when(mockEntity.getContent())
+          .thenReturn(
+              new java.io.ByteArrayInputStream("{\"error\":\"Invalid IAM role\"}".getBytes()));
+    } catch (Exception e) {
+      // Handle exception
+    }
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRoleMapping(esComponents, roleName, iamRoleArn);
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchRoleMapping_ResponseExceptionWithResponseBody()
+      throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String iamRoleArn = "arn:aws:iam::123456789012:role/test-role";
+
+    // Mock ResponseException with response body
+    org.opensearch.client.Response mockResponse =
+        Mockito.mock(org.opensearch.client.Response.class);
+    org.apache.http.HttpEntity mockEntity = Mockito.mock(org.apache.http.HttpEntity.class);
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenThrow(responseException);
+    Mockito.when(responseException.getResponse()).thenReturn(mockResponse);
+    Mockito.when(mockResponse.getStatusLine())
+        .thenReturn(createStatusLine(500, "Internal Server Error"));
+    Mockito.when(mockResponse.getEntity()).thenReturn(mockEntity);
+
+    try {
+      Mockito.when(mockEntity.getContent())
+          .thenReturn(new java.io.ByteArrayInputStream("{\"error\":\"Mapping error\"}".getBytes()));
+    } catch (Exception e) {
+      // Handle exception
+    }
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchRoleMapping(esComponents, roleName, iamRoleArn);
+  }
+
+  // ==================== Response Body Extraction Tests ====================
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchUser_NoEntityReturnsNoResponseBody() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+
+    // Mock error response without entity
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(400, "Bad Request"));
+    // No entity set, so extractResponseBody should return "No response body"
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, null, operationContext);
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testCreateAwsOpenSearchUser_EntityReadException() throws IOException {
+    // Arrange
+    String roleName = "test_role";
+    String username = "test_user";
+    String password = "test_password";
+
+    // Mock error response with entity that throws exception on read
+    org.apache.http.HttpEntity mockEntity = Mockito.mock(org.apache.http.HttpEntity.class);
+
+    Mockito.when(searchClient.performLowLevelRequest(Mockito.any(Request.class)))
+        .thenReturn(rawResponse);
+    Mockito.when(rawResponse.getStatusLine()).thenReturn(createStatusLine(400, "Bad Request"));
+    Mockito.when(rawResponse.getEntity()).thenReturn(mockEntity);
+
+    try {
+      // Entity throws exception when reading
+      Mockito.when(mockEntity.getContent()).thenThrow(new IOException("Cannot read entity"));
+    } catch (IOException e) {
+      // Expected
+    }
+
+    // Act
+    IndexRoleUtils.createAwsOpenSearchUser(
+        esComponents, username, password, roleName, null, operationContext);
+  }
+
+  // ==================== Helper Methods ====================
+
+  /**
+   * Creates a mock StatusLine with the specified status code and reason phrase.
+   *
+   * @param statusCode the HTTP status code
+   * @param reasonPhrase the HTTP reason phrase
+   * @return a mock StatusLine
+   */
+  private org.apache.http.StatusLine createStatusLine(int statusCode, String reasonPhrase) {
+    return new org.apache.http.StatusLine() {
+      @Override
+      public int getStatusCode() {
+        return statusCode;
+      }
+
+      @Override
+      public String getReasonPhrase() {
+        return reasonPhrase;
+      }
+
+      @Override
+      public org.apache.http.ProtocolVersion getProtocolVersion() {
+        return new org.apache.http.ProtocolVersion("HTTP", 1, 1);
+      }
+    };
+  }
+}

--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -218,6 +218,8 @@ Reference Links:
 | `EBEAN_USE_IAM_AUTH`              | `false`                               | Enable cross-cloud IAM authentication (AWS/GCP) | GMS, MCE Consumer, System Update |
 | `EBEAN_CLOUD_PROVIDER`            | `auto`                                | Cloud provider (auto/aws/gcp/traditional)       | GMS, MCE Consumer, System Update |
 | `EBEAN_BATCH_GET_METHOD`          | `IN`                                  | Batch get method (IN or UNION)                  | GMS, MCE Consumer, System Update |
+| `EBEAN_URL`                       | _same as EBEAN_DATASOURCE_URL_        | Alternative property for database URL           | System Update                    |
+| `EBEAN_MAX_TRANSACTION_RETRY`     | `null`                                | Maximum transaction retries for Ebean           | System Update                    |
 
 #### Cross-Cloud IAM Authentication
 
@@ -258,33 +260,41 @@ export EBEAN_CLOUD_PROVIDER=auto
 
 **Required Cloud-Specific Environment Variables:**
 
-| Cloud Provider | Required Variables               | Description                              |
-| -------------- | -------------------------------- | ---------------------------------------- |
-| **AWS**        | `AWS_REGION`                     | AWS region for RDS instances             |
-| **AWS**        | `AWS_ACCESS_KEY_ID`              | AWS access key (or use instance profile) |
-| **AWS**        | `AWS_SECRET_ACCESS_KEY`          | AWS secret key (or use instance profile) |
-| **GCP**        | `INSTANCE_CONNECTION_NAME`       | Cloud SQL instance connection name       |
-| **GCP**        | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON file        |
+| Cloud Provider | Required Variables               | Description                                             |
+| -------------- | -------------------------------- | ------------------------------------------------------- |
+| **AWS**        | `AWS_REGION`                     | AWS region for RDS instances                            |
+| **AWS**        | `AWS_ACCESS_KEY_ID`              | AWS access key (or use instance profile)                |
+| **AWS**        | `AWS_SECRET_ACCESS_KEY`          | AWS secret key (or use instance profile)                |
+| **AWS**        | `AWS_SESSION_TOKEN`              | AWS session token (optional, for temporary credentials) |
+| **GCP**        | `INSTANCE_CONNECTION_NAME`       | Cloud SQL instance connection name                      |
+| **GCP**        | `GOOGLE_APPLICATION_CREDENTIALS` | Path to service account JSON file                       |
+| **GCP**        | `GCP_PROJECT`                    | GCP project ID (optional, for auto-detection)           |
 
 ### SQL Setup Configuration
 
 The SQL Setup system provides automated database initialization and user management capabilities. These environment variables control the behavior of the `SqlSetup` upgrade step.
 
-| Environment Variable         | Default       | Description                                                                 | Components    |
-| ---------------------------- | ------------- | --------------------------------------------------------------------------- | ------------- |
-| `CREATE_TABLES`              | `true`        | Whether to create database tables                                           | System Update |
-| `CREATE_DB`                  | `true`        | Whether to create the database (PostgreSQL only)                            | System Update |
-| `CREATE_USER`                | `false`       | Whether to create a new database user                                       | System Update |
-| `CREATE_USER_USERNAME`       | _none_        | Username for the new database user to create (required if CREATE_USER=true) | System Update |
-| `CREATE_USER_PASSWORD`       | _none_        | Password for the new database user to create (required if CREATE_USER=true) | System Update |
-| `CDC_MCL_PROCESSING_ENABLED` | `false`       | Whether to create a CDC (Change Data Capture) user                          | System Update |
-| `CDC_USER`                   | `datahub_cdc` | Username for the CDC user                                                   | System Update |
-| `CDC_PASSWORD`               | `datahub_cdc` | Password for the CDC user                                                   | System Update |
-| `IAM_ROLE`                   | _none_        | IAM role for new user creation (required if IAM auth enabled)               | System Update |
+| Environment Variable         | Default       | Description                                                                  | Components    |
+| ---------------------------- | ------------- | ---------------------------------------------------------------------------- | ------------- |
+| `DATAHUB_SQL_SETUP_ENABLED`  | `false`       | Enable SQL setup functionality (alternative to passing SqlSetup upgrade arg) | System Update |
+| `CREATE_TABLES`              | `true`        | Whether to create database tables                                            | System Update |
+| `CREATE_DB`                  | `true`        | Whether to create the database (PostgreSQL only)                             | System Update |
+| `CREATE_USER`                | `false`       | Whether to create a new database user                                        | System Update |
+| `CREATE_USER_USERNAME`       | _none_        | Username for the new database user to create (required if CREATE_USER=true)  | System Update |
+| `CREATE_USER_PASSWORD`       | _none_        | Password for the new database user to create (required for traditional auth) | System Update |
+| `CDC_MCL_PROCESSING_ENABLED` | `false`       | Whether to create a CDC (Change Data Capture) user                           | System Update |
+| `CDC_USER`                   | `datahub_cdc` | Username for the CDC user                                                    | System Update |
+| `CDC_PASSWORD`               | `datahub_cdc` | Password for the CDC user                                                    | System Update |
 
-**Note:** When `CREATE_USER=true`, you must explicitly set `CREATE_USER_USERNAME` and `CREATE_USER_PASSWORD` environment variables. The system will not fall back to Ebean connection credentials for security reasons.
+**Note:** When `CREATE_USER=true`, you must explicitly set `CREATE_USER_USERNAME` environment variable. The system will not fall back to Ebean connection credentials for security reasons.
 
-**IAM Authentication:** When using IAM authentication (by setting `IAM_ROLE`), the system will only use `CREATE_USER_USERNAME` and ignore `CREATE_USER_PASSWORD` for security reasons. Traditional username/password authentication and IAM authentication are mutually exclusive.
+**IAM Authentication:** IAM authentication is automatically detected when `CREATE_USER=true` and `CREATE_USER_PASSWORD` is not set or is empty. The system will create users with IAM authentication for supported cloud databases:
+
+- **AWS RDS MySQL**: Creates user with AWSAuthenticationPlugin
+- **AWS RDS PostgreSQL**: Creates user and grants `rds_iam` role
+- **GCP Cloud SQL**: IAM authentication is managed through Cloud SQL IAM database users
+
+When using traditional username/password authentication, both `CREATE_USER_USERNAME` and `CREATE_USER_PASSWORD` must be set.
 
 ### Cassandra Configuration
 
@@ -749,9 +759,10 @@ The following environment variables are used in the codebase but may not be expl
 
 ### System and Version Information
 
-| Environment Variable   | Default | Description               | Components |
-| ---------------------- | ------- | ------------------------- | ---------- |
-| `DATAHUB_GMS_PROTOCOL` | `http`  | GMS protocol (http/https) | GMS        |
+| Environment Variable   | Default | Description               | Components    |
+| ---------------------- | ------- | ------------------------- | ------------- |
+| `DATAHUB_GMS_PROTOCOL` | `http`  | GMS protocol (http/https) | GMS           |
+| `DATAHUB_REVISION`     | `0`     | DataHub revision version  | System Update |
 
 ### Upgrade and Migration
 

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/CrossCloudIamUtils.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/CrossCloudIamUtils.java
@@ -1,0 +1,191 @@
+package com.linkedin.gms.factory.common;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/** Utility class for cross-cloud IAM authentication configuration */
+@Slf4j
+public class CrossCloudIamUtils {
+
+  /** Configuration result for cross-cloud IAM authentication */
+  public static class CrossCloudConfig {
+    public final String driver;
+    public final String url;
+    public final Map<String, String> customProperties;
+
+    public CrossCloudConfig(String driver, String url, Map<String, String> customProperties) {
+      this.driver = driver;
+      this.url = url;
+      this.customProperties = customProperties;
+    }
+  }
+
+  /**
+   * Configure cross-cloud IAM authentication based on environment and settings
+   *
+   * @param originalUrl The original JDBC URL
+   * @param defaultDriver The default JDBC driver to use
+   * @param shouldUseIam Whether IAM authentication should be enabled
+   * @param cloudProvider The cloud provider (aws/gcp/auto/traditional)
+   * @param awsRegion AWS region environment variable
+   * @param awsAccessKeyId AWS access key ID
+   * @param awsSecretAccessKey AWS secret access key
+   * @param awsSessionToken AWS session token
+   * @param googleApplicationCredentials GCP credentials path
+   * @param gcpProject GCP project ID
+   * @param instanceConnectionName The instance connection name (for GCP)
+   * @return CrossCloudConfig with driver, URL, and custom properties
+   */
+  public static CrossCloudConfig configureCrossCloudIam(
+      String originalUrl,
+      String defaultDriver,
+      boolean shouldUseIam,
+      String cloudProvider,
+      String awsRegion,
+      String awsAccessKeyId,
+      String awsSecretAccessKey,
+      String awsSessionToken,
+      String googleApplicationCredentials,
+      String gcpProject,
+      String instanceConnectionName) {
+
+    // Detect cloud provider internally
+    String detectedCloud =
+        detectCloudProvider(
+            originalUrl,
+            cloudProvider,
+            awsRegion,
+            awsAccessKeyId,
+            awsSecretAccessKey,
+            awsSessionToken,
+            googleApplicationCredentials,
+            gcpProject,
+            instanceConnectionName);
+
+    String finalDriver = defaultDriver;
+    String finalUrl = originalUrl;
+    Map<String, String> customProperties = new HashMap<>();
+
+    if (shouldUseIam) {
+      log.info("IAM authentication enabled for cloud provider: {}", detectedCloud);
+
+      if ("aws".equalsIgnoreCase(detectedCloud) || "aws".equalsIgnoreCase(cloudProvider)) {
+        // AWS IAM authentication
+        if (isPostgresUrl(originalUrl)) {
+          // PostgreSQL with AWS IAM
+          customProperties.put("wrapperPlugins", "iam");
+          log.info("Configured PostgreSQL with AWS IAM authentication");
+        } else if (isMysqlUrl(originalUrl)) {
+          // MySQL with AWS IAM - use AWS JDBC Wrapper
+          finalDriver = "software.amazon.jdbc.Driver";
+          String baseUrl = originalUrl.replace("jdbc:mysql://", "jdbc:aws-wrapper:mysql://");
+
+          // Add wrapperPlugins=iam parameter to enable IAM authentication
+          finalUrl =
+              baseUrl.contains("?")
+                  ? baseUrl + "&wrapperPlugins=iam"
+                  : baseUrl + "?wrapperPlugins=iam";
+
+          log.info("Configured MySQL with AWS JDBC Wrapper for IAM authentication: {}", finalUrl);
+        }
+      } else if ("gcp".equalsIgnoreCase(detectedCloud) || "gcp".equalsIgnoreCase(cloudProvider)) {
+        // GCP IAM authentication
+        if (isMysqlUrl(originalUrl)) {
+          // MySQL with GCP Cloud SQL IAM
+          finalDriver = "com.google.cloud.sql.mysql.SocketFactory";
+          finalUrl = originalUrl; // Keep original URL format
+          customProperties.put("socketFactory", "com.google.cloud.sql.mysql.SocketFactory");
+          customProperties.put("cloudSqlInstance", instanceConnectionName);
+          customProperties.put("enableIamAuth", "true");
+          customProperties.put("sslmode", "disable");
+          customProperties.put("cloudSqlRefreshStrategy", "lazy");
+          log.info("Configured MySQL with GCP Cloud SQL IAM authentication");
+        } else if (isPostgresUrl(originalUrl)) {
+          // PostgreSQL with GCP Cloud SQL IAM
+          finalDriver = "com.google.cloud.sql.postgres.SocketFactory";
+          finalUrl = originalUrl; // Keep original URL format
+          customProperties.put("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
+          customProperties.put("cloudSqlInstance", instanceConnectionName);
+          customProperties.put("enableIamAuth", "true");
+          customProperties.put("sslmode", "disable");
+          customProperties.put("cloudSqlRefreshStrategy", "lazy");
+          log.info("Configured PostgreSQL with GCP Cloud SQL IAM authentication");
+        }
+      } else {
+        log.warn(
+            "IAM authentication requested but cloud provider '{}' not supported", detectedCloud);
+      }
+    }
+
+    return new CrossCloudConfig(
+        finalDriver, finalUrl, customProperties.isEmpty() ? null : customProperties);
+  }
+
+  /**
+   * Detect cloud provider based on environment variables and URL
+   *
+   * @param dataSourceUrl The JDBC URL
+   * @param cloudProvider The configured cloud provider
+   * @param awsRegion AWS region environment variable
+   * @param awsAccessKeyId AWS access key ID
+   * @param awsSecretAccessKey AWS secret access key
+   * @param awsSessionToken AWS session token
+   * @param googleApplicationCredentials GCP credentials path
+   * @param gcpProject GCP project ID
+   * @param instanceConnectionName GCP instance connection name
+   * @return The detected cloud provider (aws/gcp/traditional)
+   */
+  public static String detectCloudProvider(
+      String dataSourceUrl,
+      String cloudProvider,
+      String awsRegion,
+      String awsAccessKeyId,
+      String awsSecretAccessKey,
+      String awsSessionToken,
+      String googleApplicationCredentials,
+      String gcpProject,
+      String instanceConnectionName) {
+
+    if (!"auto".equalsIgnoreCase(cloudProvider)) {
+      return cloudProvider;
+    }
+
+    // Check for AWS environment variables (treat empty strings as null)
+    if ((awsRegion != null && !awsRegion.isEmpty())
+        || (awsAccessKeyId != null && !awsAccessKeyId.isEmpty())
+        || (awsSecretAccessKey != null && !awsSecretAccessKey.isEmpty())
+        || (awsSessionToken != null && !awsSessionToken.isEmpty())) {
+      return "aws";
+    }
+
+    // Check for GCP environment variables (treat empty strings as null)
+    if ((googleApplicationCredentials != null && !googleApplicationCredentials.isEmpty())
+        || (gcpProject != null && !gcpProject.isEmpty())
+        || (instanceConnectionName != null && !instanceConnectionName.isEmpty())) {
+      return "gcp";
+    }
+
+    // Check URL patterns
+    if (dataSourceUrl != null) {
+      if (dataSourceUrl.contains("rds.amazonaws.com") || dataSourceUrl.contains("amazonaws.com")) {
+        return "aws";
+      }
+      if (dataSourceUrl.contains("googleapis.com") || dataSourceUrl.contains("cloudsql")) {
+        return "gcp";
+      }
+    }
+
+    return "traditional";
+  }
+
+  /** Check if URL is PostgreSQL */
+  public static boolean isPostgresUrl(String url) {
+    return url != null && url.toLowerCase().contains("postgresql");
+  }
+
+  /** Check if URL is MySQL */
+  public static boolean isMysqlUrl(String url) {
+    return url != null && url.toLowerCase().contains("mysql");
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactory.java
@@ -5,8 +5,6 @@ import io.ebean.config.DatabaseConfig;
 import io.ebean.datasource.DataSourceConfig;
 import io.ebean.datasource.DataSourcePoolListener;
 import java.sql.Connection;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -106,7 +104,21 @@ public class LocalEbeanConfigFactory {
     DataSourceConfig dataSourceConfig = new DataSourceConfig();
 
     // Configure cross-cloud IAM authentication
-    CrossCloudConfig crossCloudConfig = configureCrossCloudIam(dataSourceUrl);
+    boolean shouldUseIam = useIamAuth || postgresUseIamAuth;
+
+    CrossCloudIamUtils.CrossCloudConfig crossCloudConfig =
+        CrossCloudIamUtils.configureCrossCloudIam(
+            dataSourceUrl,
+            ebeanDatasourceDriver,
+            shouldUseIam,
+            cloudProvider,
+            awsRegion,
+            awsAccessKeyId,
+            awsSecretAccessKey,
+            awsSessionToken,
+            googleApplicationCredentials,
+            gcpProject,
+            instanceConnectionName);
 
     dataSourceConfig.setUsername(ebeanDatasourceUsername);
     dataSourceConfig.setPassword(ebeanDatasourcePassword);
@@ -137,127 +149,5 @@ public class LocalEbeanConfigFactory {
     serverConfig.setDdlGenerate(ebeanAutoCreate);
     serverConfig.setDdlRun(ebeanAutoCreate);
     return serverConfig;
-  }
-
-  /** Configuration result for cross-cloud IAM authentication */
-  static class CrossCloudConfig {
-    final String driver;
-    final String url;
-    final Map<String, String> customProperties;
-
-    CrossCloudConfig(String driver, String url, Map<String, String> customProperties) {
-      this.driver = driver;
-      this.url = url;
-      this.customProperties = customProperties;
-    }
-  }
-
-  /** Configure cross-cloud IAM authentication based on environment and settings */
-  CrossCloudConfig configureCrossCloudIam(String originalUrl) {
-    String detectedCloud = detectCloudProvider(originalUrl);
-    String finalDriver = ebeanDatasourceDriver;
-    String finalUrl = originalUrl;
-    Map<String, String> customProperties = new HashMap<>();
-
-    // Determine if IAM authentication should be used
-    boolean shouldUseIam = useIamAuth || postgresUseIamAuth;
-
-    if (shouldUseIam) {
-      log.info("IAM authentication enabled for cloud provider: {}", detectedCloud);
-
-      if ("aws".equalsIgnoreCase(detectedCloud) || "aws".equalsIgnoreCase(cloudProvider)) {
-        // AWS IAM authentication
-        if (isPostgresUrl(originalUrl)) {
-          // PostgreSQL with AWS IAM
-          customProperties.put("wrapperPlugins", "iam");
-          log.info("Configured PostgreSQL with AWS IAM authentication");
-        } else if (isMysqlUrl(originalUrl)) {
-          // MySQL with AWS IAM - use AWS JDBC Wrapper
-          finalDriver = "software.amazon.jdbc.Driver";
-          String baseUrl = originalUrl.replace("jdbc:mysql://", "jdbc:aws-wrapper:mysql://");
-
-          // Add wrapperPlugins=iam parameter to enable IAM authentication
-          finalUrl =
-              baseUrl.contains("?")
-                  ? baseUrl + "&wrapperPlugins=iam"
-                  : baseUrl + "?wrapperPlugins=iam";
-
-          log.info("Configured MySQL with AWS JDBC Wrapper for IAM authentication: {}", finalUrl);
-        }
-      } else if ("gcp".equalsIgnoreCase(detectedCloud) || "gcp".equalsIgnoreCase(cloudProvider)) {
-        // GCP IAM authentication
-        if (isMysqlUrl(originalUrl)) {
-          // MySQL with GCP Cloud SQL IAM
-          finalDriver = "com.google.cloud.sql.mysql.SocketFactory";
-          finalUrl = originalUrl; // Keep original URL format
-          customProperties.put("socketFactory", "com.google.cloud.sql.mysql.SocketFactory");
-          customProperties.put("cloudSqlInstance", instanceConnectionName);
-          customProperties.put("enableIamAuth", "true");
-          customProperties.put("sslmode", "disable");
-          customProperties.put("cloudSqlRefreshStrategy", "lazy");
-          log.info("Configured MySQL with GCP Cloud SQL IAM authentication");
-        } else if (isPostgresUrl(originalUrl)) {
-          // PostgreSQL with GCP Cloud SQL IAM
-          finalDriver = "com.google.cloud.sql.postgres.SocketFactory";
-          finalUrl = originalUrl; // Keep original URL format
-          customProperties.put("socketFactory", "com.google.cloud.sql.postgres.SocketFactory");
-          customProperties.put("cloudSqlInstance", instanceConnectionName);
-          customProperties.put("enableIamAuth", "true");
-          customProperties.put("sslmode", "disable");
-          customProperties.put("cloudSqlRefreshStrategy", "lazy");
-          log.info("Configured PostgreSQL with GCP Cloud SQL IAM authentication");
-        }
-      } else {
-        log.warn(
-            "IAM authentication requested but cloud provider '{}' not supported", detectedCloud);
-      }
-    }
-
-    return new CrossCloudConfig(
-        finalDriver, finalUrl, customProperties.isEmpty() ? null : customProperties);
-  }
-
-  /** Detect cloud provider based on environment variables and URL */
-  String detectCloudProvider(String dataSourceUrl) {
-    if (!"auto".equalsIgnoreCase(cloudProvider)) {
-      return cloudProvider;
-    }
-
-    // Check for AWS environment variables (treat empty strings as null)
-    if ((awsRegion != null && !awsRegion.isEmpty())
-        || (awsAccessKeyId != null && !awsAccessKeyId.isEmpty())
-        || (awsSecretAccessKey != null && !awsSecretAccessKey.isEmpty())
-        || (awsSessionToken != null && !awsSessionToken.isEmpty())) {
-      return "aws";
-    }
-
-    // Check for GCP environment variables (treat empty strings as null)
-    if ((googleApplicationCredentials != null && !googleApplicationCredentials.isEmpty())
-        || (gcpProject != null && !gcpProject.isEmpty())
-        || (instanceConnectionName != null && !instanceConnectionName.isEmpty())) {
-      return "gcp";
-    }
-
-    // Check URL patterns
-    if (dataSourceUrl != null) {
-      if (dataSourceUrl.contains("rds.amazonaws.com") || dataSourceUrl.contains("amazonaws.com")) {
-        return "aws";
-      }
-      if (dataSourceUrl.contains("googleapis.com") || dataSourceUrl.contains("cloudsql")) {
-        return "gcp";
-      }
-    }
-
-    return "traditional";
-  }
-
-  /** Check if URL is PostgreSQL */
-  boolean isPostgresUrl(String url) {
-    return url != null && url.toLowerCase().contains("postgresql");
-  }
-
-  /** Check if URL is MySQL */
-  boolean isMysqlUrl(String url) {
-    return url != null && url.toLowerCase().contains("mysql");
   }
 }

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactoryAwsTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactoryAwsTest.java
@@ -74,14 +74,32 @@ public class LocalEbeanConfigFactoryAwsTest extends AbstractTestNGSpringContextT
   @Test
   public void testDetectCloudProviderAws() {
     String awsResult =
-        localEbeanConfigFactory.detectCloudProvider("jdbc:mysql://localhost:3306/datahub");
+        CrossCloudIamUtils.detectCloudProvider(
+            "jdbc:mysql://localhost:3306/datahub",
+            "auto",
+            "us-west-2", // AWS_REGION
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertEquals(awsResult, "aws");
   }
 
   @Test
   public void testDetectCloudProviderAwsUrl() {
     String urlResult =
-        localEbeanConfigFactory.detectCloudProvider("jdbc:mysql://rds.amazonaws.com:3306/datahub");
+        CrossCloudIamUtils.detectCloudProvider(
+            "jdbc:mysql://rds.amazonaws.com:3306/datahub",
+            "auto",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertEquals(urlResult, "aws");
   }
 
@@ -132,14 +150,21 @@ public class LocalEbeanConfigFactoryAwsTest extends AbstractTestNGSpringContextT
 
   @Test
   public void testConfigureCrossCloudIamWithAwsIam() {
-    // Override non-cloud properties using reflection
-    ReflectionTestUtils.setField(localEbeanConfigFactory, "useIamAuth", true);
-    ReflectionTestUtils.setField(localEbeanConfigFactory, "cloudProvider", "aws");
-
     String originalUrl = "jdbc:mysql://localhost:3306/datahub";
 
-    LocalEbeanConfigFactory.CrossCloudConfig result =
-        localEbeanConfigFactory.configureCrossCloudIam(originalUrl);
+    CrossCloudIamUtils.CrossCloudConfig result =
+        CrossCloudIamUtils.configureCrossCloudIam(
+            originalUrl,
+            "com.mysql.cj.jdbc.Driver",
+            true,
+            "aws",
+            "us-west-2",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
 
     assertNotNull(result);
     assertEquals(result.driver, "software.amazon.jdbc.Driver");

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactoryGcpTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactoryGcpTest.java
@@ -73,7 +73,16 @@ public class LocalEbeanConfigFactoryGcpTest extends AbstractTestNGSpringContextT
   @Test
   public void testDetectCloudProviderGcp() {
     String gcpResult =
-        localEbeanConfigFactory.detectCloudProvider("jdbc:mysql://localhost:3306/datahub");
+        CrossCloudIamUtils.detectCloudProvider(
+            "jdbc:mysql://localhost:3306/datahub",
+            "auto",
+            null,
+            null,
+            null,
+            null,
+            "/path/to/service-account.json", // GOOGLE_APPLICATION_CREDENTIALS
+            null,
+            null);
     assertEquals(gcpResult, "gcp");
   }
 
@@ -132,14 +141,21 @@ public class LocalEbeanConfigFactoryGcpTest extends AbstractTestNGSpringContextT
 
   @Test
   public void testConfigureCrossCloudIamWithGcpIam() {
-    // Override non-cloud properties using reflection
-    ReflectionTestUtils.setField(localEbeanConfigFactory, "useIamAuth", true);
-    ReflectionTestUtils.setField(localEbeanConfigFactory, "cloudProvider", "gcp");
-
     String originalUrl = "jdbc:mysql://localhost:3306/datahub";
 
-    LocalEbeanConfigFactory.CrossCloudConfig result =
-        localEbeanConfigFactory.configureCrossCloudIam(originalUrl);
+    CrossCloudIamUtils.CrossCloudConfig result =
+        CrossCloudIamUtils.configureCrossCloudIam(
+            originalUrl,
+            "com.mysql.cj.jdbc.Driver",
+            true,
+            "gcp",
+            null,
+            null,
+            null,
+            null,
+            "/path/to/service-account.json",
+            null,
+            "project:region:instance");
 
     assertNotNull(result);
     assertEquals(result.driver, "com.google.cloud.sql.mysql.SocketFactory");

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactoryNoCloudTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/common/LocalEbeanConfigFactoryNoCloudTest.java
@@ -75,7 +75,16 @@ public class LocalEbeanConfigFactoryNoCloudTest extends AbstractTestNGSpringCont
   public void testDetectCloudProviderTraditional() {
     // No cloud environment variables should result in "traditional"
     String traditionalResult =
-        localEbeanConfigFactory.detectCloudProvider("jdbc:mysql://localhost:3306/datahub");
+        CrossCloudIamUtils.detectCloudProvider(
+            "jdbc:mysql://localhost:3306/datahub",
+            "auto",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertEquals(traditionalResult, "traditional");
   }
 
@@ -84,7 +93,16 @@ public class LocalEbeanConfigFactoryNoCloudTest extends AbstractTestNGSpringCont
     // Test cloud provider detection when set to "auto" (default)
     // With no cloud environment variables and localhost URL, should detect "traditional"
     String result =
-        localEbeanConfigFactory.detectCloudProvider("jdbc:mysql://localhost:3306/datahub");
+        CrossCloudIamUtils.detectCloudProvider(
+            "jdbc:mysql://localhost:3306/datahub",
+            "auto",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     assertEquals(result, "traditional"); // Should detect traditional when no cloud indicators
   }
 
@@ -112,8 +130,19 @@ public class LocalEbeanConfigFactoryNoCloudTest extends AbstractTestNGSpringCont
   public void testConfigureCrossCloudIam() {
     String originalUrl = "jdbc:mysql://localhost:3306/datahub";
 
-    LocalEbeanConfigFactory.CrossCloudConfig result =
-        localEbeanConfigFactory.configureCrossCloudIam(originalUrl);
+    CrossCloudIamUtils.CrossCloudConfig result =
+        CrossCloudIamUtils.configureCrossCloudIam(
+            originalUrl,
+            "com.mysql.cj.jdbc.Driver",
+            false,
+            "auto",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
 
     assertNotNull(result);
     assertEquals(result.driver, "com.mysql.cj.jdbc.Driver");
@@ -123,14 +152,21 @@ public class LocalEbeanConfigFactoryNoCloudTest extends AbstractTestNGSpringCont
 
   @Test
   public void testConfigureCrossCloudIamWithUnsupportedCloud() {
-    // Override non-cloud properties using reflection
-    ReflectionTestUtils.setField(localEbeanConfigFactory, "useIamAuth", true);
-    ReflectionTestUtils.setField(localEbeanConfigFactory, "cloudProvider", "azure");
-
     String originalUrl = "jdbc:mysql://localhost:3306/datahub";
 
-    LocalEbeanConfigFactory.CrossCloudConfig result =
-        localEbeanConfigFactory.configureCrossCloudIam(originalUrl);
+    CrossCloudIamUtils.CrossCloudConfig result =
+        CrossCloudIamUtils.configureCrossCloudIam(
+            originalUrl,
+            "com.mysql.cj.jdbc.Driver",
+            true,
+            "azure",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
 
     assertNotNull(result);
     assertEquals(result.driver, "com.mysql.cj.jdbc.Driver");
@@ -141,33 +177,31 @@ public class LocalEbeanConfigFactoryNoCloudTest extends AbstractTestNGSpringCont
   @Test
   public void testIsPostgresUrl() {
     // Test PostgreSQL URL
-    boolean result =
-        localEbeanConfigFactory.isPostgresUrl("jdbc:postgresql://localhost:5432/datahub");
+    boolean result = CrossCloudIamUtils.isPostgresUrl("jdbc:postgresql://localhost:5432/datahub");
     assertTrue(result);
 
     // Test MySQL URL
-    boolean mysqlResult =
-        localEbeanConfigFactory.isPostgresUrl("jdbc:mysql://localhost:3306/datahub");
+    boolean mysqlResult = CrossCloudIamUtils.isPostgresUrl("jdbc:mysql://localhost:3306/datahub");
     assertTrue(!mysqlResult);
 
     // Test null URL
-    boolean nullResult = localEbeanConfigFactory.isPostgresUrl((String) null);
+    boolean nullResult = CrossCloudIamUtils.isPostgresUrl((String) null);
     assertTrue(!nullResult);
   }
 
   @Test
   public void testIsMysqlUrl() {
     // Test MySQL URL
-    boolean result = localEbeanConfigFactory.isMysqlUrl("jdbc:mysql://localhost:3306/datahub");
+    boolean result = CrossCloudIamUtils.isMysqlUrl("jdbc:mysql://localhost:3306/datahub");
     assertTrue(result);
 
     // Test PostgreSQL URL
     boolean postgresResult =
-        localEbeanConfigFactory.isMysqlUrl("jdbc:postgresql://localhost:5432/datahub");
+        CrossCloudIamUtils.isMysqlUrl("jdbc:postgresql://localhost:5432/datahub");
     assertTrue(!postgresResult);
 
     // Test null URL
-    boolean nullResult = localEbeanConfigFactory.isMysqlUrl((String) null);
+    boolean nullResult = CrossCloudIamUtils.isMysqlUrl((String) null);
     assertTrue(!nullResult);
   }
 


### PR DESCRIPTION
## Summary
Updates for IAM Support

## Changes Made

### Fixes

- ✅  MCE Consumer should share cloud detection logic with GMS/SystemUpdate

### SQL Setup Configuration
- ✅ Removed incorrect `IAM_ROLE` environment variable - IAM authentication is now auto-detected
- ✅ Added `DATAHUB_SQL_SETUP_ENABLED` - enables SQL setup functionality without CLI arguments
- ✅ Updated IAM authentication documentation with correct auto-detection logic

### Elasticsearch User Create

- ✅  Optionally create an Elasticsearch user or role mapping and policy

### Cloud Provider Configuration
- ✅ Added `AWS_SESSION_TOKEN` - for temporary AWS credentials
- ✅ Added `GCP_PROJECT` - for GCP project auto-detection

## Impact
Documents all environment variables used by datahub-upgrade sql-setup and elasticsearch upgrade steps, correcting IAM authentication behavior.

## Important Notes

Primarily tested RDS MySQL + AWS IAM