### PR TITLE
fix(docs): move DataHub variant entity docs to separate directory

### DIFF
--- a/metadata-ingestion/scripts/modeldocgen.py
+++ b/metadata-ingestion/scripts/modeldocgen.py
@@ -1550,6 +1550,11 @@ def generate(  # noqa: C901
 
     sorted_entity_names = get_sorted_entity_names(entity_names)
 
+    # Create separate directory for DataHub-optimized variants (not for Docusaurus sidebar)
+    datahub_entity_dir = f"{generated_docs_dir}/.datahub-variant/"
+    shutil.rmtree(datahub_entity_dir, ignore_errors=True)
+    os.makedirs(datahub_entity_dir, exist_ok=True)
+
     index = 0
     for _, sorted_entities in sorted_entity_names:
         for entity_name in sorted_entities:
@@ -1564,12 +1569,9 @@ def generate(  # noqa: C901
                 fp.write("---\n")
                 fp.write(generated_documentation[entity_name])
 
-            # Write DataHub variant (simplified, with inline directives expanded)
+            # Write DataHub variant to separate directory (for ingestion only, not for sidebar)
             if entity_name in generated_documentation_datahub:
-                with open(f"{entity_dir}/{entity_name}-datahub.md", "w") as fp:
-                    fp.write("---\n")
-                    fp.write(f"sidebar_position: {index}\n")
-                    fp.write("---\n")
+                with open(f"{datahub_entity_dir}/{entity_name}-datahub.md", "w") as fp:
                     fp.write(generated_documentation_datahub[entity_name])
 
             index += 1


### PR DESCRIPTION
## Summary
Fixes duplicate entity documentation entries in the Docusaurus sidebar by moving DataHub-optimized variant files to a separate directory.

## Problem
PR #15111 introduced DataHub-optimized entity documentation variants (`*-datahub.md` files) that were being written to the same directory as the regular Docusaurus entity docs (`docs/generated/metamodel/entities/`). This caused the Docusaurus sidebar to pick up both variants, creating duplicate entries for each entity.

## Solution
Move the DataHub-optimized variant files to a separate `.datahub-variant/` directory:
- **Regular entity docs** → `docs/generated/metamodel/entities/` (picked up by Docusaurus sidebar)
- **DataHub variants** → `docs/generated/metamodel/.datahub-variant/` (used for ingestion only)

The `.datahub-variant/` directory:
- ✅ Is NOT picked up by the Docusaurus sidebar configuration
- ✅ Is already covered by the existing `.gitignore` rule for `docs/generated/`
- ✅ Follows the dotfile convention for hidden/internal content
- ✅ Still allows the DataHub variant files to be used for metadata ingestion via MCPs

## Changes
- Updated `modeldocgen.py` to write DataHub variant docs to `.datahub-variant/` directory
- Removed Docusaurus frontmatter (sidebar_position) from DataHub variant files since they're not displayed in the sidebar

## Testing
- [x] Regenerated entity documentation with `./gradlew :metadata-ingestion:modelDocGen`
- [x] Verified 61 regular entity docs in `entities/` directory
- [x] Verified 61 DataHub variant docs in `.datahub-variant/` directory
- [x] Confirmed no duplicate `*-datahub.md` files in `entities/` directory
- [x] Successfully ingested metadata model to local DataHub instance
- [x] Linting passes: `./gradlew :metadata-ingestion:lintFix`

## Screenshots
Before: Duplicate entity entries in sidebar (one regular, one `-datahub` variant)
After: Single entry per entity in sidebar

Fixes duplicate entity documentation issue reported in #15111