### PR TITLE
refactor(ui): Remove V1 UI (round 1)

### DIFF
--- a/datahub-web-react/src/CustomThemeProvider.tsx
+++ b/datahub-web-react/src/CustomThemeProvider.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 
-import { useIsThemeV2 } from '@app/useIsThemeV2';
 import { useCustomThemeId } from '@app/useSetAppTheme';
 import themes from '@conf/theme/themes';
 import { Theme } from '@conf/theme/types';
@@ -12,12 +11,9 @@ interface Props {
 }
 
 const CustomThemeProvider = ({ children }: Props) => {
-    // Note: AppConfigContext not provided yet, so both of these calls rely on the DEFAULT_APP_CONFIG
-    const isThemeV2 = useIsThemeV2();
     const customThemeId = useCustomThemeId();
 
-    // Note: If custom theme id is a json file, it will only be loaded later in useSetAppTheme
-    const defaultTheme = isThemeV2 ? themes.themeV2 : themes.themeV1;
+    const defaultTheme = themes.themeV2;
     const customTheme = customThemeId ? themes[customThemeId] : null;
     const [theme, setTheme] = useState<Theme>(customTheme ?? defaultTheme);
 

--- a/datahub-web-react/src/app/ProtectedRoutes.tsx
+++ b/datahub-web-react/src/app/ProtectedRoutes.tsx
@@ -6,7 +6,6 @@ import styled from 'styled-components';
 import DataHubTitle from '@app/DataHubTitle';
 import EmbedRoutes from '@app/EmbedRoutes';
 import { SearchRoutes } from '@app/SearchRoutes';
-import { HomePage } from '@app/home/HomePage';
 import { HomePage as HomePageV2 } from '@app/homeV2/HomePage';
 import { IntroduceYourself } from '@app/homeV2/introduce/IntroduceYourself';
 import { useSetUserPersona } from '@app/homeV2/persona/useUserPersona';
@@ -14,7 +13,7 @@ import { HomePage as HomePageV3 } from '@app/homeV3/HomePage';
 import { useShowHomePageRedesign } from '@app/homeV3/context/hooks/useShowHomePageRedesign';
 import { useSetUserTitle } from '@app/identity/user/useUserTitle';
 import { OnboardingContextProvider } from '@app/onboarding/OnboardingContextProvider';
-import { useIsThemeV2, useSetThemeIsV2 } from '@app/useIsThemeV2';
+import { useSetThemeIsV2 } from '@app/useIsThemeV2';
 import { useSetAppTheme } from '@app/useSetAppTheme';
 import { useSetNavBarRedesignEnabled } from '@app/useShowNavBarRedesign';
 import { NEW_ROUTE_MAP, PageRoutes } from '@conf/Global';
@@ -34,16 +33,9 @@ export const ProtectedRoutes = (): JSX.Element => {
     useSetUserTitle();
     useSetNavBarRedesignEnabled();
 
-    const isThemeV2 = useIsThemeV2();
     const showHomepageRedesign = useShowHomePageRedesign();
+    const FinalHomePage = showHomepageRedesign ? HomePageV3 : HomePageV2;
 
-    let FinalHomePage;
-
-    if (isThemeV2) {
-        FinalHomePage = showHomepageRedesign ? HomePageV3 : HomePageV2;
-    } else {
-        FinalHomePage = HomePage;
-    }
     const location = useLocation();
     const history = useHistory();
 
@@ -57,7 +49,7 @@ export const ProtectedRoutes = (): JSX.Element => {
     return (
         <OnboardingContextProvider>
             <DataHubTitle />
-            <StyledLayout className={isThemeV2 ? 'themeV2' : undefined}>
+            <StyledLayout className="themeV2">
                 <Switch>
                     <Route exact path="/" render={() => <FinalHomePage />} />
                     <Route path={PageRoutes.EMBED} render={() => <EmbedRoutes />} />

--- a/datahub-web-react/src/app/SearchRoutes.tsx
+++ b/datahub-web-react/src/app/SearchRoutes.tsx
@@ -6,22 +6,14 @@ import { ManageApplications } from '@app/applications/ManageApplications';
 import { BrowseResultsPage } from '@app/browse/BrowseResultsPage';
 import { BusinessAttributes } from '@app/businessAttribute/BusinessAttributes';
 import { useUserContext } from '@app/context/useUserContext';
-import DomainRoutes from '@app/domain/DomainRoutes';
-import { ManageDomainsPage } from '@app/domain/ManageDomainsPage';
 import DomainRoutesV2 from '@app/domainV2/DomainRoutes';
 import { ManageDomainsPage as ManageDomainsPageV2 } from '@app/domainV2/ManageDomainsPage';
-import { EntityPage } from '@app/entity/EntityPage';
 import { EntityPage as EntityPageV2 } from '@app/entityV2/EntityPage';
-import GlossaryRoutes from '@app/glossary/GlossaryRoutes';
 import GlossaryRoutesV2 from '@app/glossaryV2/GlossaryRoutes';
 import StructuredProperties from '@app/govern/structuredProperties/StructuredProperties';
-import { ManageIngestionPage } from '@app/ingest/ManageIngestionPage';
 import { ManageIngestionPage as ManageIngestionPageV2 } from '@app/ingestV2/ManageIngestionPage';
-import { SearchPage } from '@app/search/SearchPage';
-import { SearchablePage } from '@app/search/SearchablePage';
 import { SearchPage as SearchPageV2 } from '@app/searchV2/SearchPage';
 import { SearchablePage as SearchablePageV2 } from '@app/searchV2/SearchablePage';
-import { SettingsPage } from '@app/settings/SettingsPage';
 import { SettingsPage as SettingsPageV2 } from '@app/settingsV2/SettingsPage';
 import { NoPageFound } from '@app/shared/NoPageFound';
 import { ManageTags } from '@app/tags/ManageTags';
@@ -32,7 +24,6 @@ import {
     useIsNestedDomainsEnabled,
 } from '@app/useAppConfig';
 import { useEntityRegistry } from '@app/useEntityRegistry';
-import { useIsThemeV2 } from '@app/useIsThemeV2';
 import { PageRoutes } from '@conf/Global';
 
 /**
@@ -46,8 +37,6 @@ export const SearchRoutes = (): JSX.Element => {
         ? entityRegistry.getEntitiesForSearchRoutes()
         : entityRegistry.getNonGlossaryEntities();
     const { config, loaded } = useAppConfig();
-    const isThemeV2 = useIsThemeV2();
-    const FinalSearchablePage = isThemeV2 ? SearchablePageV2 : SearchablePage;
 
     const businessAttributesFlag = useBusinessAttributesFlag();
     const appConfigContextLoaded = useIsAppConfigContextLoaded();
@@ -64,25 +53,16 @@ export const SearchRoutes = (): JSX.Element => {
     const showAnalytics = (config?.analyticsConfig?.enabled && me && me?.platformPrivileges?.viewAnalytics) || false;
 
     return (
-        <FinalSearchablePage>
+        <SearchablePageV2>
             <Switch>
                 {entities.map((entity) => (
                     <Route
                         key={entity.getPathName()}
                         path={`/${entity.getPathName()}/:urn`}
-                        render={() =>
-                            isThemeV2 ? (
-                                <EntityPageV2 entityType={entity.type} />
-                            ) : (
-                                <EntityPage entityType={entity.type} />
-                            )
-                        }
+                        render={() => <EntityPageV2 entityType={entity.type} />}
                     />
                 ))}
-                <Route
-                    path={PageRoutes.SEARCH_RESULTS}
-                    render={() => (isThemeV2 ? <SearchPageV2 /> : <SearchPage />)}
-                />
+                <Route path={PageRoutes.SEARCH_RESULTS} render={() => <SearchPageV2 />} />
                 <Route path={PageRoutes.BROWSE_RESULTS} render={() => <BrowseResultsPage />} />
                 {showTags ? <Route path={PageRoutes.MANAGE_TAGS} render={() => <ManageTags />} /> : null}
                 <Route path={PageRoutes.MANAGE_APPLICATIONS} render={() => <ManageApplications />} />
@@ -97,27 +77,13 @@ export const SearchRoutes = (): JSX.Element => {
                 />
                 <Route path={PageRoutes.PERMISSIONS} render={() => <Redirect to="/settings/permissions" />} />
                 <Route path={PageRoutes.IDENTITIES} render={() => <Redirect to="/settings/identities" />} />
-                {isNestedDomainsEnabled && (
-                    <Route
-                        path={`${PageRoutes.DOMAIN}*`}
-                        render={() => (isThemeV2 ? <DomainRoutesV2 /> : <DomainRoutes />)}
-                    />
-                )}
-                {!isNestedDomainsEnabled && (
-                    <Route
-                        path={PageRoutes.DOMAINS}
-                        render={() => (isThemeV2 ? <ManageDomainsPageV2 /> : <ManageDomainsPage />)}
-                    />
-                )}
+                {isNestedDomainsEnabled && <Route path={`${PageRoutes.DOMAIN}*`} render={() => <DomainRoutesV2 />} />}
+                {!isNestedDomainsEnabled && <Route path={PageRoutes.DOMAINS} render={() => <ManageDomainsPageV2 />} />}
 
-                {!showIngestV2 && <Route path={PageRoutes.INGESTION} render={() => <ManageIngestionPage />} />}
                 {showIngestV2 && <Route path={PageRoutes.INGESTION} render={() => <ManageIngestionPageV2 />} />}
 
-                <Route path={PageRoutes.SETTINGS} render={() => (isThemeV2 ? <SettingsPageV2 /> : <SettingsPage />)} />
-                <Route
-                    path={`${PageRoutes.GLOSSARY}*`}
-                    render={() => (isThemeV2 ? <GlossaryRoutesV2 /> : <GlossaryRoutes />)}
-                />
+                <Route path={PageRoutes.SETTINGS} render={() => <SettingsPageV2 />} />
+                <Route path={`${PageRoutes.GLOSSARY}*`} render={() => <GlossaryRoutesV2 />} />
                 {showStructuredProperties && (
                     <Route path={PageRoutes.STRUCTURED_PROPERTIES} render={() => <StructuredProperties />} />
                 )}
@@ -135,6 +101,6 @@ export const SearchRoutes = (): JSX.Element => {
                 />
                 {me.loaded && loaded && <Route component={NoPageFound} />}
             </Switch>
-        </FinalSearchablePage>
+        </SearchablePageV2>
     );
 };

--- a/datahub-web-react/src/app/analyticsDashboard/components/AnalyticsPage.tsx
+++ b/datahub-web-react/src/app/analyticsDashboard/components/AnalyticsPage.tsx
@@ -9,15 +9,14 @@ import { useUserContext } from '@app/context/useUserContext';
 import { ANTD_GRAY } from '@app/entity/shared/constants';
 import filterSearchQuery from '@app/search/utils/filterSearchQuery';
 import { Message } from '@app/shared/Message';
-import { useIsThemeV2 } from '@app/useIsThemeV2';
 import { useShowNavBarRedesign } from '@src/app/useShowNavBarRedesign';
 
 import { useGetAnalyticsChartsQuery, useGetMetadataAnalyticsChartsQuery } from '@graphql/analytics.generated';
 import { useListDomainsQuery } from '@graphql/domain.generated';
 import { useGetHighlightsQuery } from '@graphql/highlights.generated';
 
-const PageContainer = styled.div<{ isV2: boolean; $isShowNavBarRedesign?: boolean }>`
-    background-color: ${(props) => (props.isV2 ? '#fff' : 'inherit')};
+const PageContainer = styled.div<{ $isShowNavBarRedesign?: boolean }>`
+    background-color: #fff;
     ${(props) =>
         props.$isShowNavBarRedesign &&
         `
@@ -29,12 +28,12 @@ const PageContainer = styled.div<{ isV2: boolean; $isShowNavBarRedesign?: boolea
     ${(props) =>
         !props.$isShowNavBarRedesign &&
         `
-        margin-right: ${props.isV2 ? '24px' : '0'};
-        margin-bottom: ${props.isV2 ? '24px' : '0'};
+        margin-right: 24px;
+        margin-bottom: 24px;
     `}
     border-radius: ${(props) => {
-        if (props.isV2 && props.$isShowNavBarRedesign) return props.theme.styles['border-radius-navbar-redesign'];
-        return props.isV2 ? '8px' : '0';
+        if (props.$isShowNavBarRedesign) return props.theme.styles['border-radius-navbar-redesign'];
+        return '8px';
     }};
 `;
 
@@ -75,7 +74,6 @@ const StyledSearchBar = styled(Input)`
 `;
 
 export const AnalyticsPage = () => {
-    const isV2 = useIsThemeV2();
     const isShowNavBarRedesign = useShowNavBarRedesign();
     const me = useUserContext();
     const canManageDomains = me?.platformPrivileges?.createDomains;
@@ -118,7 +116,7 @@ export const AnalyticsPage = () => {
 
     const isLoading = highlightLoading || chartLoading || domainLoading || metadataAnalyticsLoading;
     return (
-        <PageContainer isV2={isV2} $isShowNavBarRedesign={isShowNavBarRedesign}>
+        <PageContainer $isShowNavBarRedesign={isShowNavBarRedesign}>
             {isLoading && <Message type="loading" content="Loading…" style={{ marginTop: '10%' }} />}
             <HighlightGroup>
                 {highlightError && (

--- a/datahub-web-react/src/app/entity/shared/entityForm/FormByEntity.tsx
+++ b/datahub-web-react/src/app/entity/shared/entityForm/FormByEntity.tsx
@@ -9,7 +9,6 @@ import { useEntityFormContext } from '@app/entity/shared/entityForm/EntityFormCo
 import Form from '@app/entity/shared/entityForm/Form';
 import ProgressBar from '@app/entity/shared/entityForm/ProgressBar';
 import { useEntityRegistry } from '@app/useEntityRegistry';
-import { useIsThemeV2 } from '@app/useIsThemeV2';
 
 const ContentWrapper = styled.div`
     background-color: ${ANTD_GRAY_V2[1]};
@@ -36,15 +35,9 @@ export default function FormByEntity({ formUrn }: Props) {
     const { entityType } = useEntityContext();
     const entityRegistry = useEntityRegistry();
     const sidebarSections = entityRegistry.getSidebarSections(selectedEntity?.type || entityType);
-    const isV2 = useIsThemeV2();
 
-    // Used for v2 - removes repeated entity header (we use EntityInfo in this component)
-    // SidebarEntityHeader is always the first index in sidebarSections, so remove it here
-    // TODO (OBS-677): remove this logic once we get form info into V2 sidebar
     const cleanedSidebarSections = sidebarSections.slice(1);
-
-    // Conditional sections based on theme version
-    const sections = isV2 ? cleanedSidebarSections : sidebarSections;
+    const sections = cleanedSidebarSections;
 
     return (
         <EntityContext.Provider

--- a/datahub-web-react/src/app/entity/shared/tabs/Properties/AddPropertyButton.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Properties/AddPropertyButton.tsx
@@ -9,18 +9,15 @@ import { useEntityData } from '@app/entity/shared/EntityContext';
 import EditStructuredPropertyModal from '@app/entity/shared/tabs/Properties/Edit/EditStructuredPropertyModal';
 import { Icon, Input as InputComponent, Text, colors } from '@src/alchemy-components';
 import { useUserContext } from '@src/app/context/useUserContext';
-import { REDESIGN_COLORS } from '@src/app/entityV2/shared/constants';
 import { getStructuredPropertiesSearchInputs } from '@src/app/govern/structuredProperties/utils';
 import { useEntityRegistry } from '@src/app/useEntityRegistry';
-import { useIsThemeV2 } from '@src/app/useIsThemeV2';
 import { PageRoutes } from '@src/conf/Global';
 import { useGetSearchResultsForMultipleQuery } from '@src/graphql/search.generated';
 import { Maybe, StructuredProperties, StructuredPropertyEntity } from '@src/types.generated';
 
-const AddButton = styled.div<{ isThemeV2: boolean; isV1Drawer?: boolean }>`
+const AddButton = styled.div<{ isV1Drawer?: boolean }>`
     border-radius: 200px;
-    background-color: ${(props) =>
-        props.isThemeV2 ? props.theme.styles['primary-color'] : REDESIGN_COLORS.LINK_HOVER_BLUE};
+    background-color: ${(props) => props.theme.styles['primary-color']};
     width: ${(props) => (props.isV1Drawer ? '24px' : '32px')};
     height: ${(props) => (props.isV1Drawer ? '24px' : '32px')};
     display: flex;
@@ -82,7 +79,6 @@ interface Props {
 const AddPropertyButton = ({ fieldUrn, refetch, fieldProperties, isV1Drawer }: Props) => {
     const [searchQuery, setSearchQuery] = useState('');
     const { entityData, entityType } = useEntityData();
-    const isThemeV2 = useIsThemeV2();
     const me = useUserContext();
     const entityRegistry = useEntityRegistry();
     const [isEditModalVisible, setIsEditModalVisible] = useState(false);
@@ -194,7 +190,7 @@ const AddPropertyButton = ({ fieldUrn, refetch, fieldProperties, isV1Drawer }: P
                 )}
             >
                 <Tooltip title="Add property" placement="left" showArrow={false}>
-                    <AddButton isThemeV2={isThemeV2} isV1Drawer={isV1Drawer} data-testid="add-structured-prop-button">
+                    <AddButton isV1Drawer={isV1Drawer} data-testid="add-structured-prop-button">
                         <Icon icon="Add" size={isV1Drawer ? 'lg' : '2xl'} color="white" />
                     </AddButton>
                 </Tooltip>

--- a/datahub-web-react/src/app/onboarding/OnboardingTour.tsx
+++ b/datahub-web-react/src/app/onboarding/OnboardingTour.tsx
@@ -8,7 +8,6 @@ import { REDESIGN_COLORS } from '@app/entityV2/shared/constants';
 import OnboardingContext from '@app/onboarding/OnboardingContext';
 import useShouldSkipOnboardingTour from '@app/onboarding/useShouldSkipOnboardingTour';
 import { convertStepId, getConditionalStepIdsToAdd, getStepsToRender } from '@app/onboarding/utils';
-import { useIsThemeV2 } from '@app/useIsThemeV2';
 import { EducationStepsContext } from '@providers/EducationStepsContext';
 
 import { useBatchUpdateStepStatesMutation } from '@graphql/step.generated';
@@ -21,10 +20,9 @@ type Props = {
 export const OnboardingTour = ({ stepIds }: Props) => {
     const { educationSteps, setEducationSteps, educationStepIdsAllowlist } = useContext(EducationStepsContext);
     const userUrn = useUserContext()?.user?.urn;
-    const isThemeV2 = useIsThemeV2();
     const { isTourOpen, tourReshow, setTourReshow, setIsTourOpen } = useContext(OnboardingContext);
     const location = useLocation();
-    const accentColor = isThemeV2 ? REDESIGN_COLORS.BACKGROUND_PURPLE : '#5cb7b7';
+    const accentColor = REDESIGN_COLORS.BACKGROUND_PURPLE;
 
     useEffect(() => {
         function handleKeyDown(e) {

--- a/datahub-web-react/src/app/settingsV2/Preferences.tsx
+++ b/datahub-web-react/src/app/settingsV2/Preferences.tsx
@@ -3,14 +3,10 @@ import { message } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 
-import analytics, { EventType } from '@app/analytics';
 import { useUserContext } from '@app/context/useUserContext';
 import { useAppConfig } from '@app/useAppConfig';
-import { useIsThemeV2, useIsThemeV2EnabledForUser, useIsThemeV2Toggleable } from '@app/useIsThemeV2';
 
 import { useUpdateApplicationsSettingsMutation } from '@graphql/app.generated';
-import { useUpdateUserSettingMutation } from '@graphql/me.generated';
-import { UserSetting } from '@types';
 
 const Page = styled.div`
     width: 100%;
@@ -70,22 +66,13 @@ const DescriptionText = styled.div`
 `;
 
 export const Preferences = () => {
-    // Current User Urn
-    const { user, refetchUser } = useUserContext();
-    const isThemeV2 = useIsThemeV2();
-    const [isThemeV2Toggleable] = useIsThemeV2Toggleable();
-    const [isThemeV2EnabledForUser] = useIsThemeV2EnabledForUser();
     const userContext = useUserContext();
     const appConfig = useAppConfig();
 
-    const showSimplifiedHomepage = !!user?.settings?.appearance?.showSimplifiedHomepage;
-
     const applicationsEnabled = appConfig.config?.visualConfig?.application?.showApplicationInNavigation ?? false;
 
-    const [updateUserSettingMutation] = useUpdateUserSettingMutation();
     const [updateApplicationsSettingsMutation] = useUpdateApplicationsSettingsMutation();
 
-    const showSimplifiedHomepageSetting = !isThemeV2;
     const canManageApplicationAppearance = userContext?.platformPrivileges?.manageFeatures;
 
     return (
@@ -96,77 +83,6 @@ export const Preferences = () => {
                         <PageTitle title="Appearance" subTitle="Manage your appearance settings." />
                     </HeaderContainer>
                 </TokensContainer>
-                {showSimplifiedHomepageSetting && (
-                    <StyledCard>
-                        <UserSettingRow>
-                            <TextContainer>
-                                <SettingText>Show simplified homepage </SettingText>
-                                <DescriptionText>
-                                    Limits entity browse cards on homepage to Domains, Charts, Datasets, Dashboards and
-                                    Glossary Terms
-                                </DescriptionText>
-                            </TextContainer>
-                            <Switch
-                                label=""
-                                checked={showSimplifiedHomepage}
-                                onChange={async () => {
-                                    await updateUserSettingMutation({
-                                        variables: {
-                                            input: {
-                                                name: UserSetting.ShowSimplifiedHomepage,
-                                                value: !showSimplifiedHomepage,
-                                            },
-                                        },
-                                    });
-                                    analytics.event({
-                                        type: showSimplifiedHomepage
-                                            ? EventType.ShowStandardHomepageEvent
-                                            : EventType.ShowSimplifiedHomepageEvent,
-                                    });
-                                    message.success({ content: 'Setting updated!', duration: 2 });
-                                    refetchUser?.();
-                                }}
-                            />
-                        </UserSettingRow>
-                    </StyledCard>
-                )}
-                {isThemeV2Toggleable && (
-                    <>
-                        <StyledCard>
-                            <UserSettingRow>
-                                <TextContainer>
-                                    <SettingText>Try New User Experience</SettingText>
-                                    <DescriptionText>
-                                        Enable an early preview of the new DataHub UX - a complete makeover for your app
-                                        with a sleek new design and advanced features.
-                                    </DescriptionText>
-                                </TextContainer>
-                                <Switch
-                                    label=""
-                                    checked={isThemeV2EnabledForUser}
-                                    onChange={async () => {
-                                        await updateUserSettingMutation({
-                                            variables: {
-                                                input: {
-                                                    name: UserSetting.ShowThemeV2,
-                                                    value: !isThemeV2EnabledForUser,
-                                                },
-                                            },
-                                        });
-                                        // clicking this button toggles, so event is whatever is opposite to what isThemeV2EnabledForUser currently is
-                                        analytics.event({
-                                            type: isThemeV2EnabledForUser
-                                                ? EventType.RevertV2ThemeEvent
-                                                : EventType.ShowV2ThemeEvent,
-                                        });
-                                        message.success({ content: 'Setting updated!', duration: 2 });
-                                        refetchUser?.();
-                                    }}
-                                />
-                            </UserSettingRow>
-                        </StyledCard>
-                    </>
-                )}
                 {canManageApplicationAppearance && (
                     <StyledCard>
                         <UserSettingRow>
@@ -195,7 +111,7 @@ export const Preferences = () => {
                         </UserSettingRow>
                     </StyledCard>
                 )}
-                {!showSimplifiedHomepageSetting && !isThemeV2Toggleable && !canManageApplicationAppearance && (
+                {!canManageApplicationAppearance && (
                     <div style={{ color: colors.gray[1700] }}>No appearance settings found.</div>
                 )}
             </SourceContainer>

--- a/datahub-web-react/src/app/settingsV2/SettingsPage.tsx
+++ b/datahub-web-react/src/app/settingsV2/SettingsPage.tsx
@@ -20,7 +20,6 @@ import NavBarMenu from '@app/homeV2/layout/navBarRedesign/NavBarMenu';
 import { NavBarMenuItemTypes, NavBarMenuItems } from '@app/homeV2/layout/navBarRedesign/types';
 import { DEFAULT_PATH, PATHS } from '@app/settingsV2/settingsPaths';
 import { useAppConfig } from '@app/useAppConfig';
-import { useIsThemeV2 } from '@app/useIsThemeV2';
 import { useShowNavBarRedesign } from '@app/useShowNavBarRedesign';
 import { Button, colors } from '@src/alchemy-components';
 
@@ -86,7 +85,6 @@ export const SettingsPage = () => {
     const history = useHistory();
     const subscriptionsEnabled = false;
     const me = useUserContext();
-    const isThemeV2 = useIsThemeV2();
     const isShowNavBarRedesign = useShowNavBarRedesign();
     const { config } = useAppConfig();
 
@@ -246,7 +244,7 @@ export const SettingsPage = () => {
                         <NavBarTitle>Settings</NavBarTitle>
                         <NavBarSubTitle>Manage your settings</NavBarSubTitle>
                     </div>
-                    {isThemeV2 && !isShowNavBarRedesign && (
+                    {!isShowNavBarRedesign && (
                         <a href="/logOut">
                             <Button
                                 variant="outline"

--- a/datahub-web-react/src/app/useBuildEntityRegistry.ts
+++ b/datahub-web-react/src/app/useBuildEntityRegistry.ts
@@ -1,12 +1,9 @@
 import { useMemo } from 'react';
 
-import buildEntityRegistry from '@app/buildEntityRegistry';
 import buildEntityRegistryV2 from '@app/buildEntityRegistryV2';
-import { useIsThemeV2 } from '@app/useIsThemeV2';
 
 export default function useBuildEntityRegistry() {
-    const isThemeV2Enabled = useIsThemeV2();
     return useMemo(() => {
-        return isThemeV2Enabled ? buildEntityRegistryV2() : buildEntityRegistry();
-    }, [isThemeV2Enabled]);
+        return buildEntityRegistryV2();
+    }, []);
 }

--- a/datahub-web-react/src/app/useSetAppTheme.tsx
+++ b/datahub-web-react/src/app/useSetAppTheme.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
 import { useAppConfig } from '@app/useAppConfig';
-import { useIsThemeV2 } from '@app/useIsThemeV2';
 import themes from '@conf/theme/themes';
 import { useCustomTheme } from '@src/customThemeContext';
 
@@ -20,7 +19,6 @@ export function useCustomThemeId(): string | null {
 }
 
 export function useSetAppTheme() {
-    const isThemeV2 = useIsThemeV2();
     const { updateTheme } = useCustomTheme();
     const customThemeId = useCustomThemeId();
 
@@ -44,9 +42,9 @@ export function useSetAppTheme() {
         } else if (customThemeId && themes[customThemeId]) {
             updateTheme(themes[customThemeId]);
         } else {
-            updateTheme(isThemeV2 ? themes.themeV2 : themes.themeV1);
+            updateTheme(themes.themeV2);
         }
-    }, [customThemeId, isThemeV2, updateTheme]);
+    }, [customThemeId, updateTheme]);
 }
 
 function setThemeIdLocalStorage(customThemeId: string | null) {

--- a/datahub-web-react/src/app/useShowNavBarRedesign.tsx
+++ b/datahub-web-react/src/app/useShowNavBarRedesign.tsx
@@ -1,17 +1,15 @@
 import { useEffect } from 'react';
 
 import { useAppConfig } from '@app/useAppConfig';
-import { useIsThemeV2 } from '@app/useIsThemeV2';
 
 export function useShowNavBarRedesign() {
     const appConfig = useAppConfig();
-    const isThemeV2Enabled = useIsThemeV2();
 
     if (!appConfig.loaded) {
         return loadFromLocalStorage();
     }
 
-    return appConfig.config.featureFlags.showNavBarRedesign && isThemeV2Enabled;
+    return appConfig.config.featureFlags.showNavBarRedesign;
 }
 
 export function useSetNavBarRedesignEnabled() {


### PR DESCRIPTION
Removes usages of `useIsThemeV2` to start getting rid of the V1 UI

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
