### PR TITLE
docs(kafka): clarify Kafka topic retention requirements

### DIFF
--- a/docs/deploy/confluent-cloud.md
+++ b/docs/deploy/confluent-cloud.md
@@ -16,10 +16,10 @@ First, you'll need to create following new topics in the [Confluent Control Cent
 6. (Deprecated) **MetadataChangeEvent_v4**: Metadata change proposal messages
 7. (Deprecated) **MetadataAuditEvent_v4**: Metadata change log messages
 8. (Deprecated) **FailedMetadataChangeEvent_v4**: Failed to process #1 event
-9. **MetadataGraphEvent_v4**:
-10. **PlatformEvent_v1**
+9. (Deprecated) **MetadataGraphEvent_v4**: Legacy topic deprecated since 2021, no longer actively used
+10. **PlatformEvent_v1**: High-level semantic events
 11. **DataHubUpgradeHistory_v1**: Notifies the end of DataHub Upgrade job so dependants can act accordingly (_eg_, startup).
-    Note this topic requires special configuration: **Infinite retention**. Also, 1 partition is enough for the occasional traffic.
+    Note this topic requires special configuration: **Recommended: 7-30 day retention** (default config shows infinite retention for safety, but not required if `DATAHUB_SYSTEM_UPDATE_WAIT_FOR_SYSTEM_UPDATE=false`). Also, 1 partition is enough for the occasional traffic.
 
 The first five are the most important, and are explained in more depth in [MCP/MCL](../advanced/mcp-mcl.md). The final topics are
 those which are deprecated but still used under certain circumstances. It is likely that in the future they will be completely

--- a/docs/how/kafka-config.md
+++ b/docs/how/kafka-config.md
@@ -62,11 +62,10 @@ By default, DataHub relies on the a set of Kafka topics to operate. By default, 
 6. (Deprecated) **MetadataChangeEvent_v4**: Metadata change proposal messages
 7. (Deprecated) **MetadataAuditEvent_v4**: Metadata change log messages
 8. (Deprecated) **FailedMetadataChangeEvent_v4**: Failed to process #1 event
-9. **MetadataGraphEvent_v4**:
-10. **MetadataGraphEvent_v4**:
-11. **PlatformEvent_v1**:
-12. **DataHubUpgradeHistory_v1**: Notifies the end of DataHub Upgrade job so dependants can act accordingly (_eg_, startup).
-    Note this topic requires special configuration: **Infinite retention**. Also, 1 partition is enough for the occasional traffic.
+9. (Deprecated) **MetadataGraphEvent_v4**: Legacy topic deprecated since 2021, no longer actively used
+10. **PlatformEvent_v1**: High-level semantic events
+11. **DataHubUpgradeHistory_v1**: Notifies the end of DataHub Upgrade job so dependants can act accordingly (_eg_, startup).
+    Note this topic requires special configuration: **Recommended: 7-30 day retention** (default config shows infinite retention for safety, but not required if `DATAHUB_SYSTEM_UPDATE_WAIT_FOR_SYSTEM_UPDATE=false`). Also, 1 partition is enough for the occasional traffic.
 
 How Metadata Events relate to these topics is discussed at more length in [Metadata Events](../what/mxe.md).
 


### PR DESCRIPTION
## Summary

This PR clarifies Kafka topic retention requirements in the documentation, addressing common questions from users deploying DataHub in environments with Kafka retention restrictions.

## Changes

- Mark `MetadataGraphEvent_v4` as deprecated (schema removed in 2021, PR #3659)
- Fix duplicate `MetadataGraphEvent_v4` entry in kafka-config.md
- Add description for `PlatformEvent_v1` topic
- Update `DataHubUpgradeHistory_v1` retention guidance:
  - Recommend 7-30 days instead of infinite retention
  - Clarify that infinite retention is not required when `DATAHUB_SYSTEM_UPDATE_WAIT_FOR_SYSTEM_UPDATE=false`
  - Explain that GMS only reads the last message on startup, not the entire history

## Context

This PR addresses questions raised in the [Slack community](https://datahubspace.slack.com/archives/CV2UVAPPG/p1761744794018329) about Kafka topic retention requirements for production deployments. Users deploying DataHub at scale often face platform team restrictions on Kafka retention policies. The documentation previously suggested infinite retention for `DataHubUpgradeHistory_v1`, which is not actually required in most configurations.

### Key Findings:

**DataHubUpgradeHistory_v1:**
- GMS seeks to the last message on startup (end offset - 1) to verify the upgrade version
- If the topic is empty, GMS starts normally when `DATAHUB_SYSTEM_UPDATE_WAIT_FOR_SYSTEM_UPDATE=false` (which is the default in many configs)
- 7-30 day retention is sufficient for most deployments

**MetadataGraphEvent_v4:**
- Introduced in July 2020 (PR #1756)
- Deprecated and schema removed in December 2021 (PR #3659)
- Topic name exists for backward compatibility only
- No active DataHub code produces or consumes from it

## Testing

- Documentation changes only, no code changes
- Markdown formatting validated by pre-commit hooks

## Related Links

- Slack discussion: https://datahubspace.slack.com/archives/CV2UVAPPG/p1761744794018329
- Original MetadataGraphEvent introduction: PR #1756 (commit 779eaeed70)
- MetadataGraphEvent deprecation: PR #3659 (commit 8757543be8)