### PR TITLE
fix(cypress): fix cypress test for dataset_health

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_health.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_health.js
@@ -3,6 +3,9 @@ const urn =
 const datasetName = "cypress_health_test";
 
 describe("dataset health test", () => {
+  beforeEach(() => {
+    cy.setIsThemeV2Enabled(true);
+  });
   it("go to dataset with failing assertions and active incidents and verify health of dataset", () => {
     cy.login();
     cy.goToDataset(urn, datasetName);


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-900/oss-dataset-healthjs

**Description:**

Fixes cypress test in `dataset_heath.js` to amake assertions based on V2 UI

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
