### PR TITLE
fix(cypress): fix ingestion_source cypress test

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/mutations/ingestion_source.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/ingestion_source.js
@@ -61,8 +61,8 @@ describe("ingestion source creation flow", () => {
       .should("be.visible");
 
     // Verify ingestion source details are saved correctly
-    cy.get('[data-testid="ingestion-source-table-edit-button"]')
-      .first()
+    cy.contains("tr", ingestion_source_name)
+      .find('[data-testid="ingestion-source-table-edit-button"]')
       .click();
     cy.waitTextVisible("Edit Data Source");
     cy.get("#account_id").should("have.value", accound_id);


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CH-901/ingestion-sourcejs

**Description:**

Fixes flakiness in `ingestion_source.js` by turning ingestion redesign flag to false and fixing the selector for edit button

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
