### PR TITLE
fix(lineage): Use lineage viz methods when ignoreAsHops is specified

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -952,9 +952,17 @@ public class LineageSearchService {
   }
 
   private static boolean isLineageVisualization(@Nullable LineageFlags lineageFlags) {
-    return lineageFlags != null
-        && lineageFlags.getEntitiesExploredPerHopLimit() != null
-        && lineageFlags.getEntitiesExploredPerHopLimit() > 0;
+    if (lineageFlags == null) {
+      return false;
+    }
+
+    boolean hasEntitiesExploredLimit =
+        lineageFlags.getEntitiesExploredPerHopLimit() != null
+            && lineageFlags.getEntitiesExploredPerHopLimit() > 0;
+    boolean hasIgnoreAsHops =
+        lineageFlags.getIgnoreAsHops() != null && !lineageFlags.getIgnoreAsHops().isEmpty();
+
+    return hasEntitiesExploredLimit || hasIgnoreAsHops;
   }
 
   private EntityLineageResult getLineageResult(


### PR DESCRIPTION
Impact analysis code path doesn't support ignoreAsHops; currently, that behavior is only supported for the viz. Thus, it makes sense that when this is specified, we use the old lineage code path.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
