### PR TITLE
fix(ci): cache gradle plugins

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -244,8 +244,10 @@ jobs:
       - uses: actions/cache/restore@v4
         with:
           path: |
-            ~/.gradle/caches
             ~/.gradle/wrapper
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/transforms-*
           key: gradle-plugins-cache
           restore-keys: |
             gradle-plugins-cache
@@ -327,8 +329,10 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           path: |
-            ~/.gradle/caches
             ~/.gradle/wrapper
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/transforms-*
           key: gradle-plugins-cache
 
   scan_images:


### PR DESCRIPTION
While depot provides a remote build cache, gradle plugins dependency jars that are downloaded are not cached. 
Adding this (specifically excluding `./gradle/caches/build-cache-1` since it is served by depot remote cache cut down the build step by almost half (though build step is a small part of the full workflow, so, overall shortens only by a cpl of minutes)
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
