### PR TITLE
feat(docs): Click to expand image

### DIFF
--- a/docs-website/src/theme/Root.js
+++ b/docs-website/src/theme/Root.js
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { useLocation } from '@docusaurus/router';
+import React, { useEffect } from "react";
+import { useLocation } from "@docusaurus/router";
 
 export default function Root({ children }) {
   const location = useLocation();
@@ -18,25 +18,30 @@ export default function Root({ children }) {
   useEffect(() => {
     const transformImages = () => {
       // Find all images in the markdown content
-      const images = document.querySelectorAll('.markdown img, article img, [class*="markdown"] img');
-      
+      const images = document.querySelectorAll(
+        '.markdown img, article img, [class*="markdown"] img'
+      );
+
       images.forEach((img) => {
         // Skip if already processed
         if (img.dataset.modalProcessed) return;
-        img.dataset.modalProcessed = 'true';
-        
+        img.dataset.modalProcessed = "true";
+
         // Make image clickable
-        img.style.cursor = 'pointer';
-        img.addEventListener('click', () => {
+        img.style.cursor = "zoom-in";
+        img.addEventListener("click", () => {
           openImageModal(img);
         });
-        
+
         // Add keyboard support
-        img.setAttribute('tabindex', '0');
-        img.setAttribute('role', 'button');
-        img.setAttribute('aria-label', `Click to enlarge: ${img.alt || img.title || 'image'}`);
-        img.addEventListener('keydown', (e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
+        img.setAttribute("tabindex", "0");
+        img.setAttribute("role", "button");
+        img.setAttribute(
+          "aria-label",
+          `Click to enlarge: ${img.alt || img.title || "image"}`
+        );
+        img.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             openImageModal(img);
           }
@@ -46,7 +51,7 @@ export default function Root({ children }) {
 
     const openImageModal = (img) => {
       // Create modal overlay
-      const modal = document.createElement('div');
+      const modal = document.createElement("div");
       modal.style.cssText = `
         position: fixed;
         top: 0;
@@ -61,9 +66,9 @@ export default function Root({ children }) {
         padding: 20px;
         animation: fadeIn 0.2s ease;
       `;
-      
+
       // Create modal content
-      const modalContent = document.createElement('div');
+      const modalContent = document.createElement("div");
       modalContent.style.cssText = `
         position: relative;
         max-width: 90vw;
@@ -72,41 +77,12 @@ export default function Root({ children }) {
         flex-direction: column;
         align-items: center;
       `;
-      
-      // Close button
-      const closeButton = document.createElement('button');
-      closeButton.innerHTML = '×';
-      closeButton.style.cssText = `
-        position: absolute;
-        top: -40px;
-        right: 0;
-        background: rgba(255, 255, 255, 0.2);
-        border: none;
-        color: white;
-        font-size: 32px;
-        width: 40px;
-        height: 40px;
-        border-radius: 50%;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        line-height: 1;
-        padding: 0;
-      `;
-      closeButton.addEventListener('click', () => closeModal());
-      closeButton.addEventListener('mouseenter', () => {
-        closeButton.style.background = 'rgba(255, 255, 255, 0.3)';
-      });
-      closeButton.addEventListener('mouseleave', () => {
-        closeButton.style.background = 'rgba(255, 255, 255, 0.2)';
-      });
-      
+
       // Modal image
-      const modalImg = document.createElement('img');
+      const modalImg = document.createElement("img");
       modalImg.src = img.src;
-      modalImg.alt = img.alt || '';
-      modalImg.title = img.title || '';
+      modalImg.alt = img.alt || "";
+      modalImg.title = img.title || "";
       modalImg.style.cssText = `
         max-width: 100%;
         max-height: 85vh;
@@ -115,13 +91,15 @@ export default function Root({ children }) {
         object-fit: contain;
         border-radius: 4px;
         box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+        cursor: zoom-out;
       `;
-      modalImg.addEventListener('click', (e) => e.stopPropagation());
-      
+      // Clicking the image closes the modal
+      modalImg.addEventListener("click", () => closeModal());
+
       // Title if present
       let titleDiv = null;
       if (img.title || img.alt) {
-        titleDiv = document.createElement('div');
+        titleDiv = document.createElement("div");
         titleDiv.textContent = img.title || img.alt;
         titleDiv.style.cssText = `
           color: white;
@@ -132,37 +110,36 @@ export default function Root({ children }) {
           padding: 0 20px;
         `;
       }
-      
+
       // Assemble modal
-      modalContent.appendChild(closeButton);
       modalContent.appendChild(modalImg);
       if (titleDiv) modalContent.appendChild(titleDiv);
       modal.appendChild(modalContent);
       document.body.appendChild(modal);
-      
+
       // Close handlers
       const closeModal = () => {
         modal.remove();
-        document.removeEventListener('keydown', handleEscape);
+        document.removeEventListener("keydown", handleEscape);
       };
-      
+
       const handleEscape = (e) => {
-        if (e.key === 'Escape') closeModal();
+        if (e.key === "Escape") closeModal();
       };
-      
-      modal.addEventListener('click', (e) => {
+
+      modal.addEventListener("click", (e) => {
         if (e.target === modal) closeModal();
       });
-      
-      document.addEventListener('keydown', handleEscape);
+
+      document.addEventListener("keydown", handleEscape);
     };
 
     // Run transformation after a short delay to ensure DOM is ready
     const timer = setTimeout(transformImages, 100);
-    
+
     // Also run on navigation
     transformImages();
-    
+
     return () => clearTimeout(timer);
   }, [location]);
 


### PR DESCRIPTION
## Summary

Our docs have a problem with images. Most images in our docs are either

1. Too zoomed in to include useful context
2. too zoomed out and are unreadable

In this PR, I am added the ability to click to expand any image in our docs. This is done on the client, as to be generic across any way an image can end up on a docs page. You can exit the expansion via clicking on the image, clicking outside the image, or `Esc` on your keyboard.

## Preview


https://github.com/user-attachments/assets/f604362f-b032-4b37-9a9f-6d1546e2e2d1

