### PR TITLE
feat(ui): add model signature table for mlmodel summary tab

### DIFF
--- a/datahub-web-react/src/app/entityV2/mlModel/profile/MLModelSummary.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/profile/MLModelSummary.tsx
@@ -47,7 +47,7 @@ const FormattedJson = styled.pre`
     padding: 8px;
     background-color: #f5f5f5;
     border-radius: 4px;
-    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
     white-space: pre-wrap;
     word-wrap: break-word;
     line-height: 1.4;
@@ -61,7 +61,7 @@ const ItemsContent = styled.div<{ isExpanded: boolean }>`
     ${({ isExpanded }) =>
         !isExpanded &&
         `
-        max-height: calc(1.4em * 3 + 16px);
+        max-height: 80px;
         overflow: hidden;
     `}
 `;
@@ -71,60 +71,61 @@ const ReadMoreLink = styled.div`
     margin-top: 4px;
 `;
 
+const renderTypePill = (type: string | object) => {
+    if (!type) return '-';
+    const typeLabel = typeof type === 'object' && type !== null ? JSON.stringify(type) : String(type);
+    return <Pill label={typeLabel} color={ColorValues.gray} variant="filled" clickable={false} />;
+};
+
+const renderRequiredPill = (required: boolean | undefined) => {
+    if (required === undefined) return '-';
+    return (
+        <Pill
+            label={required ? 'True' : 'False'}
+            color={required ? ColorValues.blue : ColorValues.red}
+            variant="filled"
+            clickable={false}
+        />
+    );
+};
+
+const renderDefault = (defaultValue: object) => {
+    if (defaultValue === null || defaultValue === undefined) return '-';
+    return String(defaultValue);
+};
+
+const renderShape = (shape: object) => {
+    if (shape === null || shape === undefined) return '-';
+    if (Array.isArray(shape)) {
+        return `[${shape.join(', ')}]`;
+    }
+    return String(shape);
+};
+
+const propertyTableColumns = [
+    {
+        title: 'Name',
+        dataIndex: 'name',
+        width: 450,
+    },
+    {
+        title: 'Value',
+        dataIndex: 'value',
+    },
+];
+
 export default function MLModelSummary() {
     const baseEntity = useBaseEntity<GetMlModelQuery>();
     const model = baseEntity?.mlModel;
     const entityRegistry = useEntityRegistry();
     const [expandedItemsRows, setExpandedItemsRows] = useState<Set<string>>(new Set());
 
-    const propertyTableColumns = [
-        {
-            title: 'Name',
-            dataIndex: 'name',
-            width: 450,
-        },
-        {
-            title: 'Value',
-            dataIndex: 'value',
-        },
-    ];
-
-    const renderTypePill = (type: string | object) => {
-        if (!type) return '-';
-        const typeLabel = typeof type === 'object' && type !== null ? JSON.stringify(type) : String(type);
-        return <Pill label={typeLabel} color={ColorValues.gray} variant="filled" clickable={false} />;
-    };
-
-    const renderRequiredPill = (required: boolean | undefined) => {
-        if (required === undefined) return '-';
-        return (
-            <Pill
-                label={required ? 'True' : 'False'}
-                color={required ? ColorValues.blue : ColorValues.red}
-                variant="filled"
-                clickable={false}
-            />
-        );
-    };
-
-    const renderDefault = (defaultValue: any) => {
-        if (defaultValue === null || defaultValue === undefined) return '-';
-        return String(defaultValue);
-    };
-
-    const renderShape = (shape: any) => {
-        if (shape === null || shape === undefined) return '-';
-        if (Array.isArray(shape)) {
-            return `[${shape.join(', ')}]`;
-        }
-        return String(shape);
-    };
-
-    const renderItems = (items: any, record: any, index: number) => {
+    const renderItems = (items: object | null, record: object, index: number) => {
         if (!items) return '-';
 
         const itemsJson = JSON.stringify(items, null, 2);
-        const rowKey = `${record?.name || 'item'}-${index}`;
+        const recordObj = record as Record<string, unknown>;
+        const rowKey = `${recordObj?.name || 'item'}-${index}`;
         const isExpanded = expandedItemsRows.has(rowKey);
         const isLong = itemsJson.length > 200;
 
@@ -157,6 +158,113 @@ export default function MLModelSummary() {
         );
     };
 
+    // Parse signature data and create tabs
+    const signatureData = useMemo(() => {
+        const customProperties = model?.properties?.customProperties || [];
+
+        type SignatureItem = {
+            name?: string;
+            type?: string | object;
+            required?: boolean;
+            items?: object;
+            'tensor-spec'?: object;
+        };
+
+        type SignatureParameter = {
+            name?: string;
+            type?: object;
+            default?: object;
+            shape?: object;
+        };
+
+        const transformItem = (item: object, index: number) => {
+            const itemObj: SignatureItem = typeof item === 'object' && item !== null ? (item as SignatureItem) : {};
+            // Special handling for tensor type
+            if (itemObj?.type === 'tensor' && itemObj?.['tensor-spec']) {
+                return {
+                    name: 'tensor',
+                    type: itemObj['tensor-spec'],
+                    required: itemObj?.required,
+                    items: itemObj?.items,
+                };
+            }
+
+            return {
+                name: itemObj?.name ?? `Item ${index + 1}`,
+                type: itemObj?.type ?? '-',
+                required: itemObj?.required,
+                items: itemObj?.items,
+            };
+        };
+
+        const transformParameter = (item: object) => {
+            const itemObj: SignatureParameter =
+                typeof item === 'object' && item !== null ? (item as SignatureParameter) : {};
+            return {
+                name: itemObj?.name ?? '-',
+                type: itemObj?.type ?? '-',
+                default: itemObj?.default,
+                shape: itemObj?.shape,
+            };
+        };
+
+        const getSignatureData = (key: string, isParameters = false) => {
+            const property = customProperties.find((prop) => prop.key === key);
+            if (!property?.value) return null;
+
+            try {
+                const parsed = JSON.parse(property.value);
+
+                if (Array.isArray(parsed)) {
+                    return isParameters ? parsed.map(transformParameter) : parsed.map(transformItem);
+                }
+
+                if (typeof parsed === 'object' && parsed !== null) {
+                    if (isParameters) {
+                        return Object.entries(parsed).map(([name, value]) => {
+                            const valueObj: SignatureParameter =
+                                typeof value === 'object' && value !== null ? (value as SignatureParameter) : {};
+                            return {
+                                name,
+                                type: valueObj?.type ?? '-',
+                                default: valueObj?.default ?? undefined,
+                                shape: valueObj?.shape ?? undefined,
+                            };
+                        });
+                    }
+                    return Object.entries(parsed).map(([name, value]) => {
+                        const valueObj: SignatureItem =
+                            typeof value === 'object' && value !== null ? (value as SignatureItem) : {};
+                        return {
+                            name,
+                            type: valueObj?.type ?? '-',
+                            required: valueObj?.required ?? undefined,
+                            items: valueObj?.items ?? undefined,
+                        };
+                    });
+                }
+
+                if (isParameters) {
+                    return [{ name: key, type: typeof parsed, default: undefined, shape: undefined }];
+                }
+                return [{ name: key, type: typeof parsed, required: undefined, items: undefined }];
+            } catch (e) {
+                if (isParameters) {
+                    return [{ name: key, type: '-', default: undefined, shape: undefined }];
+                }
+                return [{ name: key, type: '-', required: undefined, items: undefined }];
+            }
+        };
+
+        return {
+            inputs: getSignatureData('signature.inputs'),
+            outputs: getSignatureData('signature.outputs'),
+            parameters: getSignatureData('signature.parameters', true),
+        };
+    }, [model?.properties?.customProperties]);
+
+    const hasSignatureData = Object.values(signatureData).some((data) => data && data.length > 0);
+
     const signatureTableColumns = [
         { title: 'Name', dataIndex: 'name', width: 200 },
         { title: 'Type', dataIndex: 'type', width: 200, render: renderTypePill },
@@ -176,160 +284,52 @@ export default function MLModelSummary() {
         { title: 'Shape', dataIndex: 'shape', width: 150, render: renderShape },
     ];
 
-    // Parse signature data and create tabs
-    const signatureData = useMemo(() => {
-        const customProperties = model?.properties?.customProperties || [];
+    const signatureTabs: Array<{ key: string; label: string; children: React.ReactNode }> = [];
 
-        const transformItem = (item: any, index: number) => {
-            // Special handling for tensor type
-            if (item.type === 'tensor' && item['tensor-spec']) {
-                return {
-                    name: 'tensor',
-                    type: item['tensor-spec'],
-                    required: item.required,
-                    items: item.items,
-                };
-            }
+    if (signatureData.inputs && signatureData.inputs.length > 0) {
+        signatureTabs.push({
+            key: 'inputs',
+            label: 'Inputs',
+            children: (
+                <Table
+                    pagination={false}
+                    columns={signatureTableColumns}
+                    dataSource={signatureData.inputs as Array<Record<string, unknown>>}
+                    rowKey={(record, index) => `input-${index}`}
+                />
+            ),
+        });
+    }
 
-            return {
-                name: item.name || `Item ${index + 1}`,
-                type: item.type || '-',
-                required: item.required,
-                items: item.items,
-            };
-        };
+    if (signatureData.outputs && signatureData.outputs.length > 0) {
+        signatureTabs.push({
+            key: 'outputs',
+            label: 'Outputs',
+            children: (
+                <Table
+                    pagination={false}
+                    columns={signatureTableColumns}
+                    dataSource={signatureData.outputs as Array<Record<string, unknown>>}
+                    rowKey={(record, index) => `output-${index}`}
+                />
+            ),
+        });
+    }
 
-        const transformParameter = (item: any) => {
-            return {
-                name: item.name || '-',
-                type: item.type || '-',
-                default: item.default,
-                shape: item.shape,
-            };
-        };
-
-        const getSignatureData = (key: string, isParameters = false) => {
-            const property = customProperties.find((prop) => prop.key === key);
-            if (!property?.value) return null;
-
-            try {
-                const parsed = JSON.parse(property.value);
-
-                if (Array.isArray(parsed)) {
-                    return isParameters ? parsed.map(transformParameter) : parsed.map(transformItem);
-                }
-
-                if (typeof parsed === 'object' && parsed !== null) {
-                    if (isParameters) {
-                        return Object.entries(parsed).map(([name, value]) => {
-                            const valueObj = typeof value === 'object' && value !== null ? value : {};
-                            return {
-                                name,
-                                type: 'type' in valueObj ? String(valueObj.type) : '-',
-                                default: 'default' in valueObj ? valueObj.default : undefined,
-                                shape: 'shape' in valueObj ? valueObj.shape : undefined,
-                            };
-                        });
-                    }
-                    return Object.entries(parsed).map(([name, value]) => {
-                        const valueObj = typeof value === 'object' && value !== null ? value : {};
-                        return {
-                            name,
-                            type: 'type' in valueObj ? String(valueObj.type) : '-',
-                            required: 'required' in valueObj ? valueObj.required : undefined,
-                            items: 'items' in valueObj ? valueObj.items : undefined,
-                        };
-                    });
-                }
-
-                if (isParameters) {
-                    return [{ name: key, type: typeof parsed, default: undefined, shape: undefined }];
-                }
-                return [{ name: key, type: typeof parsed, required: undefined, items: undefined }];
-            } catch (e) {
-                if (isParameters) {
-                    return [{ name: key, type: '-', default: undefined, shape: undefined }];
-                }
-                return [{ name: key, type: '-', required: undefined, items: undefined }];
-            }
-        };
-
-        return {
-            inputs: getSignatureData('signature.inputs') as Array<{
-                name: any;
-                type: any;
-                required: any;
-                items: any;
-            }> | null,
-            outputs: getSignatureData('signature.outputs') as Array<{
-                name: any;
-                type: any;
-                required: any;
-                items: any;
-            }> | null,
-            parameters: getSignatureData('signature.parameters', true) as Array<{
-                name: any;
-                type: any;
-                default: any;
-                shape: any;
-            }> | null,
-        };
-    }, [model?.properties?.customProperties]);
-
-    const hasSignatureData = useMemo(() => {
-        return Object.values(signatureData).some((data) => data && data.length > 0);
-    }, [signatureData]);
-
-    const renderModelSignature = () => {
-        const tabs: Array<{ key: string; label: string; children: React.ReactNode }> = [];
-
-        if (signatureData.inputs && signatureData.inputs.length > 0) {
-            tabs.push({
-                key: 'inputs',
-                label: 'Inputs',
-                children: (
-                    <Table
-                        pagination={false}
-                        columns={signatureTableColumns}
-                        dataSource={signatureData.inputs}
-                        rowKey={(record, index) => `input-${index}`}
-                    />
-                ),
-            });
-        }
-
-        if (signatureData.outputs && signatureData.outputs.length > 0) {
-            tabs.push({
-                key: 'outputs',
-                label: 'Outputs',
-                children: (
-                    <Table
-                        pagination={false}
-                        columns={signatureTableColumns}
-                        dataSource={signatureData.outputs}
-                        rowKey={(record, index) => `output-${index}`}
-                    />
-                ),
-            });
-        }
-
-        if (signatureData.parameters && signatureData.parameters.length > 0) {
-            tabs.push({
-                key: 'parameters',
-                label: 'Parameters',
-                children: (
-                    <Table
-                        pagination={false}
-                        columns={parametersTableColumns}
-                        dataSource={signatureData.parameters}
-                        rowKey={(record, index) => `parameter-${index}`}
-                    />
-                ),
-            });
-        }
-
-        return tabs.length > 0 ? <Tabs items={tabs} /> : null;
-    };
+    if (signatureData.parameters && signatureData.parameters.length > 0) {
+        signatureTabs.push({
+            key: 'parameters',
+            label: 'Parameters',
+            children: (
+                <Table
+                    pagination={false}
+                    columns={parametersTableColumns}
+                    dataSource={signatureData.parameters as Array<Record<string, unknown>>}
+                    rowKey={(record, index) => `parameter-${index}`}
+                />
+            ),
+        });
+    }
 
     const renderTrainingJobs = () => {
         const trainingJobs =
@@ -404,7 +404,7 @@ export default function MLModelSummary() {
                 {hasSignatureData && (
                     <>
                         <Typography.Title level={3}>Model Signature</Typography.Title>
-                        {renderModelSignature()}
+                        {signatureTabs.length > 0 ? <Tabs items={signatureTabs} /> : null}
                     </>
                 )}
             </Space>


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

Add model signature table  

For ColSpec - 

Unity catalog UI : 
<img width="606" height="336" alt="Screenshot 2025-11-05 at 5 35 50 PM" src="https://github.com/user-attachments/assets/b362e56e-f8ff-41c0-8f8b-951bbc9125a5" />

DataHub UI : 

<img width="928" height="672" alt="image" src="https://github.com/user-attachments/assets/3e9a1cbc-4cd3-4afb-a113-e6e90a56e13f" /> 

<img width="940" height="557" alt="image" src="https://github.com/user-attachments/assets/52a16471-9bb5-46c1-bce7-7097e7f1579d" />

<img width="886" height="318" alt="Screenshot 2025-11-06 at 10 58 54 AM" src="https://github.com/user-attachments/assets/fe396348-008e-471f-a818-61d0375a7c06" />


For TensorSpec
Unity Catalog UI : 
<img width="833" height="167" alt="Screenshot 2025-11-05 at 5 35 44 PM" src="https://github.com/user-attachments/assets/f556bb09-3837-408e-8c63-5c051c49f417" />

DataHub UI : 

<img width="757" height="236" alt="Screenshot 2025-11-05 at 4 34 59 PM" src="https://github.com/user-attachments/assets/35b76ebf-c6f1-478a-81b6-37ea7209a406" />
<img width="856" height="237" alt="Screenshot 2025-11-05 at 4 35 48 PM" src="https://github.com/user-attachments/assets/cd062f39-16be-4fcc-8853-d2c50cfcdce0" />

