### PR TITLE
feat(datasetSummaryTab): add feature flag

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -276,6 +276,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
             .setLogicalModelsEnabled(_featureFlags.isLogicalModelsEnabled())
             .setShowHomepageUserRole(_featureFlags.isShowHomepageUserRole())
             .setAssetSummaryPageV1(_featureFlags.isAssetSummaryPageV1())
+            .setDatasetSummaryPageV1(_featureFlags.isDatasetSummaryPageV1())
             .setDocumentationFileUploadV1(isDocumentationFileUploadV1Enabled())
             .build();
 

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -825,6 +825,11 @@ type FeatureFlagsConfig {
   assetSummaryPageV1: Boolean!
 
   """
+  Enables displaying the dataset summary page
+  """
+  datasetSummaryPageV1: Boolean!
+
+  """
   If enabled, allows uploading of files for documentation.
   """
   documentationFileUploadV1: Boolean!

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolverTest.java
@@ -141,6 +141,7 @@ public class AppConfigResolverTest {
     when(mockFeatureFlags.isLogicalModelsEnabled()).thenReturn(false);
     when(mockFeatureFlags.isShowHomepageUserRole()).thenReturn(false);
     when(mockFeatureFlags.isAssetSummaryPageV1()).thenReturn(false);
+    when(mockFeatureFlags.isDatasetSummaryPageV1()).thenReturn(false);
     when(mockFeatureFlags.isDocumentationFileUploadV1()).thenReturn(false);
   }
 

--- a/datahub-web-react/src/app/entityV2/summary/__tests__/useShowDatasetSummaryPage.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/__tests__/useShowDatasetSummaryPage.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { MockedFunction, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useShowDatasetSummaryPage } from '@app/entityV2/summary/useShowDatasetSummaryPage';
+import { useAppConfig } from '@app/useAppConfig';
+
+vi.mock('@app/useAppConfig', () => ({
+    useAppConfig: vi.fn(),
+}));
+
+const mockedUseAppConfig = useAppConfig as MockedFunction<typeof useAppConfig>;
+
+describe('useShowDatasetSummaryPage', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should return true when loaded is true and flag is true', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: true,
+            config: { featureFlags: { datasetSummaryPageV1: true } },
+        } as any);
+
+        const { result } = renderHook(() => useShowDatasetSummaryPage());
+        expect(result.current).toBe(true);
+    });
+
+    it('should return false when loaded is true and flag is false', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: true,
+            config: { featureFlags: { datasetSummaryPageV1: false } },
+        } as any);
+
+        const { result } = renderHook(() => useShowDatasetSummaryPage());
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false when loaded is false regardless of the flag', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: false,
+            config: { featureFlags: { datasetSummaryPageV1: true } },
+        } as any);
+
+        const { result } = renderHook(() => useShowDatasetSummaryPage());
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false when loaded is true but flag is missing', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: true,
+            config: { featureFlags: { datasetSummaryPageV1: false } },
+        } as any);
+
+        const { result } = renderHook(() => useShowDatasetSummaryPage());
+        expect(result.current).toBe(false);
+    });
+
+    it('should return false when loaded is false and flag is missing', () => {
+        mockedUseAppConfig.mockReturnValue({
+            loaded: false,
+            config: { featureFlags: { datasetSummaryPageV1: false } },
+        } as any);
+
+        const { result } = renderHook(() => useShowDatasetSummaryPage());
+        expect(result.current).toBe(false);
+    });
+});

--- a/datahub-web-react/src/app/entityV2/summary/useShowDatasetSummaryPage.ts
+++ b/datahub-web-react/src/app/entityV2/summary/useShowDatasetSummaryPage.ts
@@ -1,0 +1,6 @@
+import { useFeatureFlag } from '@app/sharedV2/hooks/useFeatureFlag';
+
+export function useShowDatasetSummaryPage() {
+    const datasetSummaryPageV1 = useFeatureFlag('datasetSummaryPageV1');
+    return datasetSummaryPageV1;
+}

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -94,6 +94,7 @@ export const DEFAULT_APP_CONFIG = {
         logicalModelsEnabled: false,
         showHomepageUserRole: false,
         assetSummaryPageV1: false,
+        datasetSummaryPageV1: false,
         documentationFileUploadV1: false,
     },
     chromeExtensionConfig: {

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -116,6 +116,7 @@ query appConfig {
             logicalModelsEnabled
             showHomepageUserRole
             assetSummaryPageV1
+            datasetSummaryPageV1
             documentationFileUploadV1
         }
         chromeExtensionConfig {

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -466,6 +466,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "featureFlags.alwaysEmitChangeLog",
           "featureFlags.alternateMCPValidation",
           "featureFlags.assetSummaryPageV1",
+          "featureFlags.datasetSummaryPageV1",
           "featureFlags.businessAttributeEntityEnabled",
           "featureFlags.cdcModeChangeLog",
           "featureFlags.dataContractsEnabled",

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -51,6 +51,7 @@ public class FeatureFlags {
   private boolean logicalModelsEnabled = false;
   private boolean showHomepageUserRole = false;
   private boolean assetSummaryPageV1 = false;
+  private boolean datasetSummaryPageV1 = false;
   private boolean showDefaultExternalLinks = true;
   private boolean documentationFileUploadV1 = false;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -865,6 +865,7 @@ featureFlags:
   showHomepageUserRole: ${SHOW_HOMEPAGE_USER_ROLE:false}  # Enables displaying the homepage user role underneath the name. Only relevant for custom home page
   fineGrainedLineageNotAllowedForPlatforms: ${FINE_GRAINED_LINEAGE_NOT_ALLOWED_FOR_PLATFORMS:} # Comma separated list of platforms for which schemaFields entity edges will not be allowed to be created. for example: "hdfs, s3"
   assetSummaryPageV1: ${ASSET_SUMMARY_PAGE_V1:false} # Enables displaying the asset summary page
+  datasetSummaryPageV1: ${DATASET_SUMMARY_PAGE_V1:false} # Enables displaying the dataset summary page
   showDefaultExternalLinks: ${SHOW_DEFAULT_EXTERNAL_LINKS:true} # If turned on, show the default external links on the entity page
   documentationFileUploadV1: ${DOCUMENTATION_FILE_UPLOAD_V1:false} # Enables uploading of files for documentation
 


### PR DESCRIPTION
This PR adds a new feature flag `datasetSummaryPageV1` to toggle summary tab for datasets

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
