### PR TITLE
improvement(ui/file-upload): handle file previews when there's no permission to view or error occurs

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/FileNodeView.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/FileNodeView.tsx
@@ -9,6 +9,7 @@ import {
     FILE_ATTRS,
     FILE_TYPES_TO_PREVIEW,
     FileNodeAttributes,
+    TEXT_FILE_TYPES_TO_PREVIEW,
     getExtensionFromFileName,
     getFileIconFromExtension,
     getFileTypeFromFilename,
@@ -151,34 +152,37 @@ export const FileNodeView: React.FC<FileNodeViewProps> = ({ node, onFileDownload
 
     // Text-based files for which preview should be shown
     const shouldShowPreview = FILE_TYPES_TO_PREVIEW.some((t) => fileType?.startsWith(t));
+    const isTextFile = TEXT_FILE_TYPES_TO_PREVIEW.some((t) => fileType?.startsWith(t));
 
     useEffect(() => {
         if (!url) return;
 
         setHasLoaded(false);
 
-        fetch(url)
-            .then((res) => {
-                if (!res.ok) {
-                    setHasError(true);
+        if (shouldShowPreview) {
+            fetch(url)
+                .then((res) => {
+                    if (!res.ok) {
+                        setHasError(true);
+                        return null;
+                    }
+                    if (isTextFile) {
+                        return res.text();
+                    }
                     return null;
-                }
-                if (shouldShowPreview) {
-                    return res.text();
-                }
-                return null;
-            })
-            .then((text) => {
-                if (text) setFileContent(text);
-            })
-            .catch(() => {
-                setHasError(true);
-                setFileContent(null);
-            })
-            .finally(() => {
-                setHasLoaded(true);
-            });
-    }, [url, hasError, shouldShowPreview]);
+                })
+                .then((text) => {
+                    if (text) setFileContent(text);
+                })
+                .catch(() => {
+                    setHasError(true);
+                    setFileContent(null);
+                })
+                .finally(() => {
+                    setHasLoaded(true);
+                });
+        }
+    }, [url, hasError, shouldShowPreview, isTextFile]);
 
     // Show loading state if no URL yet (file is being uploaded)
     if (!url) {

--- a/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/fileUtils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Editor/extensions/fileDragDrop/fileUtils.ts
@@ -105,7 +105,8 @@ const EXTENSION_TO_FILE_TYPE = {
     sh: 'application/x-sh',
 };
 
-export const FILE_TYPES_TO_PREVIEW = ['text/', 'application/json'];
+export const FILE_TYPES_TO_PREVIEW = ['video/', 'application/pdf', 'text/', 'application/json'];
+export const TEXT_FILE_TYPES_TO_PREVIEW = ['text/', 'application/json'];
 
 /**
  * Generate a unique ID for file nodes


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-864/handle-file-that-someone-does-not-have-permission-to-view

**Description:**

This handles the scenario when the user doesn't have permission to view a file. File previews for text, pdf and video files are not shown and on clicking them, it redirects to a new tab with the error message.

It also pulls up the repeating code for preview toggle button to keep it only once.
And changes the icon from CaretUp to CaretRight.

**Screenshots:**

Before:
<img width="1512" height="982" alt="Screenshot 2025-11-05 at 5 01 37 PM" src="https://github.com/user-attachments/assets/aa4fe2c5-462e-4f85-990d-3c63fb957161" />

After:
<img width="1047" height="460" alt="Screenshot 2025-11-05 at 6 22 18 PM" src="https://github.com/user-attachments/assets/a5e545c2-a6f8-46ee-b511-caec20e33db1" />


Changed icon:
<img width="1043" height="494" alt="image" src="https://github.com/user-attachments/assets/55bf8db2-1520-43e7-882e-946337dc040c" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
