### PR TITLE
bug(unity-catalog): update parameter key in UnityCatalogApiProxy for MLFlow Model files

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
@@ -336,24 +336,18 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
                             except (json.JSONDecodeError, TypeError) as e:
                                 logger.debug(f"Failed to parse outputs JSON: {e}")
 
-                        if "parameters" in signature_raw:
+                        if "params" in signature_raw:
                             try:
-                                signature_data["parameters"] = json.loads(
-                                    signature_raw["parameters"]
+                                signature_data["params"] = json.loads(
+                                    signature_raw["params"]
                                 )
                             except (json.JSONDecodeError, TypeError) as e:
-                                logger.debug(f"Failed to parse parameters JSON: {e}")
+                                logger.debug(f"Failed to parse params JSON: {e}")
 
                         return ModelSignature(
-                            inputs=signature_data["inputs"]
-                            if "inputs" in signature_raw
-                            else None,
-                            outputs=signature_data["outputs"]
-                            if "outputs" in signature_raw
-                            else None,
-                            parameters=signature_data["parameters"]
-                            if "parameters" in signature_raw
-                            else None,
+                            inputs=signature_data.get("inputs"),
+                            outputs=signature_data.get("outputs"),
+                            parameters=signature_data.get("params"),
                         )
                     else:
                         logger.debug(

--- a/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
+++ b/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
@@ -133,6 +133,7 @@ model_uuid: abc123
 signature:
   inputs: '[{"name": "feature1", "type": "double"}, {"name": "feature2", "type": "double"}, {"name": "feature3", "type": "long"}]'
   outputs: '[{"name": "prediction", "type": "long"}]'
+  params: '[{"name": "temperature", "type": "float", "default": 0.7}]'
 """
 
     mock_download_response = mock.MagicMock()

--- a/metadata-ingestion/tests/integration/unity/unity_catalog_ml_model_mces_golden.json
+++ b/metadata-ingestion/tests/integration/unity/unity_catalog_ml_model_mces_golden.json
@@ -2255,6 +2255,7 @@
             "customProperties": {
                 "signature.inputs": "[{\"name\": \"feature1\", \"type\": \"double\"}, {\"name\": \"feature2\", \"type\": \"double\"}, {\"name\": \"feature3\", \"type\": \"long\"}]",
                 "signature.outputs": "[{\"name\": \"prediction\", \"type\": \"long\"}]",
+                "signature.parameters": "[{\"name\": \"temperature\", \"type\": \"float\", \"default\": 0.7}]",
                 "mlflow.user": "\"abc@acryl.io\"",
                 "mlflow.source.type": "\"NOTEBOOK\"",
                 "model_type": "\"classifier\""

--- a/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
@@ -1538,7 +1538,7 @@ mlflow_version: 2.0.1
 signature:
   inputs: '[{"name": "text", "type": "string"}]'
   outputs: '[{"name": "label", "type": "string"}]'
-  parameters: '[{"name": "temperature", "type": "float", "default": 0.7}]'
+  params: '[{"name": "temperature", "type": "float", "default": 0.7}]'
 """
 
         mock_download_response = MagicMock()


### PR DESCRIPTION
Changed "parameters" to "params" in UnityCatalogApiProxy for consistency. Updated corresponding test cases and JSON files to reflect this change, ensuring all references to parameters are aligned with the new naming convention.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
