### PR TITLE
fix(system-update): fix opensearch event template index creation

### DIFF
--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/UsageEventIndexUtilsTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/UsageEventIndexUtilsTest.java
@@ -9,12 +9,15 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.opensearch.client.GetAliasesResponse;
 import org.opensearch.client.Request;
 import org.opensearch.client.RequestOptions;
 import org.opensearch.client.ResponseException;
 import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.CreateIndexResponse;
 import org.opensearch.client.indices.GetIndexRequest;
+import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.core.rest.RestStatus;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -26,6 +29,7 @@ public class UsageEventIndexUtilsTest {
   @Mock private SearchClientShim searchClient;
   @Mock private RawResponse rawResponse;
   @Mock private CreateIndexResponse createIndexResponse;
+  @Mock private GetAliasesResponse getAliasesResponse;
   @Mock private ResponseException responseException;
   @Mock private OpenSearchStatusException openSearchStatusException;
   @Mock private OperationContext operationContext;
@@ -916,17 +920,25 @@ public class UsageEventIndexUtilsTest {
                 Mockito.any(GetIndexRequest.class), Mockito.any(RequestOptions.class)))
         .thenReturn(false);
     Mockito.when(
+            searchClient.getIndexAliases(
+                Mockito.any(GetAliasesRequest.class), Mockito.any(RequestOptions.class)))
+        .thenReturn(getAliasesResponse);
+    Mockito.when(getAliasesResponse.getAliases()).thenReturn(java.util.Collections.emptyMap());
+    Mockito.when(
             searchClient.createIndex(
                 Mockito.any(CreateIndexRequest.class), Mockito.any(RequestOptions.class)))
         .thenReturn(createIndexResponse);
     Mockito.when(createIndexResponse.isAcknowledged()).thenReturn(true);
 
     // Act
-    UsageEventIndexUtils.createOpenSearchIndex(esComponents, indexName, prefix);
+    String aliasName = prefix + "datahub_usage_event";
+    UsageEventIndexUtils.createOpenSearchUsageEventIndex(esComponents, indexName, aliasName);
 
     // Assert
     Mockito.verify(searchClient)
         .indexExists(Mockito.any(GetIndexRequest.class), Mockito.any(RequestOptions.class));
+    Mockito.verify(searchClient)
+        .getIndexAliases(Mockito.any(GetAliasesRequest.class), Mockito.any(RequestOptions.class));
     Mockito.verify(searchClient)
         .createIndex(Mockito.any(CreateIndexRequest.class), Mockito.any(RequestOptions.class));
   }
@@ -941,17 +953,25 @@ public class UsageEventIndexUtilsTest {
                 Mockito.any(GetIndexRequest.class), Mockito.any(RequestOptions.class)))
         .thenReturn(false);
     Mockito.when(
+            searchClient.getIndexAliases(
+                Mockito.any(GetAliasesRequest.class), Mockito.any(RequestOptions.class)))
+        .thenReturn(getAliasesResponse);
+    Mockito.when(getAliasesResponse.getAliases()).thenReturn(java.util.Collections.emptyMap());
+    Mockito.when(
             searchClient.createIndex(
                 Mockito.any(CreateIndexRequest.class), Mockito.any(RequestOptions.class)))
         .thenReturn(createIndexResponse);
     Mockito.when(createIndexResponse.isAcknowledged()).thenReturn(false); // Not acknowledged
 
     // Act
-    UsageEventIndexUtils.createOpenSearchIndex(esComponents, indexName, prefix);
+    String aliasName = prefix + "datahub_usage_event";
+    UsageEventIndexUtils.createOpenSearchUsageEventIndex(esComponents, indexName, aliasName);
 
     // Assert
     Mockito.verify(searchClient)
         .indexExists(Mockito.any(GetIndexRequest.class), Mockito.any(RequestOptions.class));
+    Mockito.verify(searchClient)
+        .getIndexAliases(Mockito.any(GetAliasesRequest.class), Mockito.any(RequestOptions.class));
     Mockito.verify(searchClient)
         .createIndex(Mockito.any(CreateIndexRequest.class), Mockito.any(RequestOptions.class));
     // The method should complete without throwing an exception, but log a warning
@@ -968,7 +988,8 @@ public class UsageEventIndexUtilsTest {
         .thenReturn(true);
 
     // Act
-    UsageEventIndexUtils.createOpenSearchIndex(esComponents, indexName, prefix);
+    String aliasName = prefix + "datahub_usage_event";
+    UsageEventIndexUtils.createOpenSearchUsageEventIndex(esComponents, indexName, aliasName);
 
     // Assert
     Mockito.verify(searchClient)
@@ -987,6 +1008,11 @@ public class UsageEventIndexUtilsTest {
                 Mockito.any(GetIndexRequest.class), Mockito.any(RequestOptions.class)))
         .thenReturn(false);
     Mockito.when(
+            searchClient.getIndexAliases(
+                Mockito.any(GetAliasesRequest.class), Mockito.any(RequestOptions.class)))
+        .thenReturn(getAliasesResponse);
+    Mockito.when(getAliasesResponse.getAliases()).thenReturn(java.util.Collections.emptyMap());
+    Mockito.when(
             searchClient.createIndex(
                 Mockito.any(CreateIndexRequest.class), Mockito.any(RequestOptions.class)))
         .thenThrow(openSearchStatusException);
@@ -994,11 +1020,14 @@ public class UsageEventIndexUtilsTest {
         .thenReturn("resource_already_exists_exception");
 
     // Act
-    UsageEventIndexUtils.createOpenSearchIndex(esComponents, indexName, prefix);
+    String aliasName = prefix + "datahub_usage_event";
+    UsageEventIndexUtils.createOpenSearchUsageEventIndex(esComponents, indexName, aliasName);
 
     // Assert - Should not throw exception
     Mockito.verify(searchClient)
         .indexExists(Mockito.any(GetIndexRequest.class), Mockito.any(RequestOptions.class));
+    Mockito.verify(searchClient)
+        .getIndexAliases(Mockito.any(GetAliasesRequest.class), Mockito.any(RequestOptions.class));
     Mockito.verify(searchClient)
         .createIndex(Mockito.any(CreateIndexRequest.class), Mockito.any(RequestOptions.class));
   }
@@ -1013,6 +1042,11 @@ public class UsageEventIndexUtilsTest {
                 Mockito.any(GetIndexRequest.class), Mockito.any(RequestOptions.class)))
         .thenReturn(false);
     Mockito.when(
+            searchClient.getIndexAliases(
+                Mockito.any(GetAliasesRequest.class), Mockito.any(RequestOptions.class)))
+        .thenReturn(getAliasesResponse);
+    Mockito.when(getAliasesResponse.getAliases()).thenReturn(java.util.Collections.emptyMap());
+    Mockito.when(
             searchClient.createIndex(
                 Mockito.any(CreateIndexRequest.class), Mockito.any(RequestOptions.class)))
         .thenThrow(openSearchStatusException);
@@ -1020,7 +1054,45 @@ public class UsageEventIndexUtilsTest {
     Mockito.when(openSearchStatusException.status()).thenReturn(RestStatus.INTERNAL_SERVER_ERROR);
 
     // Act
-    UsageEventIndexUtils.createOpenSearchIndex(esComponents, indexName, prefix);
+    String aliasName = prefix + "datahub_usage_event";
+    UsageEventIndexUtils.createOpenSearchUsageEventIndex(esComponents, indexName, aliasName);
+  }
+
+  @Test
+  public void testCreateOpenSearchUsageEventIndex_AliasExistsButIndexDoesNot() throws IOException {
+    // Arrange
+    String indexName = "test_index-000001";
+    String aliasName = "test_datahub_usage_event";
+    String existingIndexName = "test_index-000002";
+
+    // Index doesn't exist
+    Mockito.when(
+            searchClient.indexExists(
+                Mockito.any(GetIndexRequest.class), Mockito.any(RequestOptions.class)))
+        .thenReturn(false);
+
+    // But alias exists pointing to a different index
+    @SuppressWarnings("unchecked")
+    java.util.Map<String, java.util.Set<AliasMetadata>> aliasMap =
+        Mockito.mock(java.util.Map.class);
+    Mockito.when(aliasMap.isEmpty()).thenReturn(false);
+    Mockito.when(aliasMap.keySet()).thenReturn(java.util.Collections.singleton(existingIndexName));
+    Mockito.when(
+            searchClient.getIndexAliases(
+                Mockito.any(GetAliasesRequest.class), Mockito.any(RequestOptions.class)))
+        .thenReturn(getAliasesResponse);
+    Mockito.when(getAliasesResponse.getAliases()).thenReturn(aliasMap);
+
+    // Act
+    UsageEventIndexUtils.createOpenSearchUsageEventIndex(esComponents, indexName, aliasName);
+
+    // Assert - Should skip creation because alias already exists (map is not empty)
+    Mockito.verify(searchClient)
+        .indexExists(Mockito.any(GetIndexRequest.class), Mockito.any(RequestOptions.class));
+    Mockito.verify(searchClient)
+        .getIndexAliases(Mockito.any(GetAliasesRequest.class), Mockito.any(RequestOptions.class));
+    Mockito.verify(searchClient, Mockito.never())
+        .createIndex(Mockito.any(CreateIndexRequest.class), Mockito.any(RequestOptions.class));
   }
 
   @Test

--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -773,6 +773,7 @@ The following environment variables are used in the codebase but may not be expl
 | `SKIP_REINDEX_DATA_JOB_INPUT_OUTPUT`               | `false` | Skip reindexing data job input/output              | System Update |
 | `SKIP_GENERATE_SCHEMA_FIELDS_FROM_SCHEMA_METADATA` | `false` | Skip generating schema fields from schema metadata | System Update |
 | `SKIP_MIGRATE_SCHEMA_FIELDS_DOC_ID`                | `false` | Skip migrating schema fields doc IDs               | System Update |
+| `SKIP_CREATE_USAGE_EVENT_INDICES_STEP`             | `false` | Skip creating usage event indices/data streams     | System Update |
 | `BACKFILL_BROWSE_PATHS_V2`                         | `false` | Enable backfilling browse paths V2                 | System Update |
 | `READER_POOL_SIZE`                                 | `null`  | Reader pool size for restore operations            | System Update |
 | `WRITER_POOL_SIZE`                                 | `null`  | Writer pool size for restore operations            | System Update |


### PR DESCRIPTION
## Fix OpenSearch Usage Event Index Creation Logic

### Summary
Fixes an issue where the system would attempt to create duplicate usage event indices in OpenSearch when rollover had already occurred. The code was only checking for a specific numbered index (e.g., `datahub_usage_event-000001`) but not checking if any index with the expected alias already existed.

### Changes

1. **Enhanced index creation logic** - Updated `createOpenSearchUsageEventIndex()` to:
   - Check if the specific index exists
   - Check if any index with the expected alias exists (handles rollover scenarios)
   - Renamed method from `createOpenSearchIndex` to reflect usage event specificity
   - Made alias name an explicit parameter instead of deriving from prefix

2. **Added skip environment variable** - Added `SKIP_CREATE_USAGE_EVENT_INDICES_STEP` to skip the step independently of the analytics flag (default: enabled)

3. **Added comprehensive tests** - Added tests for:
   - Alias exists but index doesn't scenario
   - Environment variable skip functionality (3 test cases)

### Files Changed
- `CreateUsageEventIndicesStep.java` - Added env var skip logic and updated method call
- `UsageEventIndexUtils.java` - Enhanced index creation with alias checking
- `CreateUsageEventIndicesStepTest.java` - Added env var tests
- `UsageEventIndexUtilsTest.java` - Added alias existence test and updated existing tests