### PR TITLE
fix(irc): add endpoints field in /v1/config response

### DIFF
--- a/metadata-service/iceberg-catalog/build.gradle
+++ b/metadata-service/iceberg-catalog/build.gradle
@@ -15,8 +15,8 @@ dependencies {
     implementation project(':metadata-operation-context')
     implementation project(':metadata-io')
     implementation project(':metadata-integration:java:datahub-schematron:lib')
-    implementation 'org.apache.iceberg:iceberg-core:1.6.1'
-    implementation 'org.apache.iceberg:iceberg-aws:1.6.1'
+    implementation 'org.apache.iceberg:iceberg-core:1.7.1'
+    implementation 'org.apache.iceberg:iceberg-aws:1.7.1'
     implementation 'software.amazon.awssdk:sts:2.26.12'
     implementation 'software.amazon.awssdk:iam-policy-builder:2.26.12'
     implementation externalDependency.awsS3

--- a/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/rest/secure/IcebergConfigApiController.java
+++ b/metadata-service/iceberg-catalog/src/main/java/io/datahubproject/iceberg/catalog/rest/secure/IcebergConfigApiController.java
@@ -1,7 +1,10 @@
 package io.datahubproject.iceberg.catalog.rest.secure;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -10,16 +13,49 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/iceberg")
 public class IcebergConfigApiController extends AbstractIcebergController {
+
   @GetMapping(value = "/v1/config", produces = MediaType.APPLICATION_JSON_VALUE)
   public ConfigResponse getConfig(
-      HttpServletRequest request,
-      @RequestParam(value = "warehouse", required = true) String warehouse) {
+      HttpServletRequest request, @RequestParam(value = "warehouse") String warehouse) {
     log.info("GET CONFIG for warehouse {}", warehouse);
 
     // check that warehouse exists
     warehouse(warehouse, opContext(request));
-    ConfigResponse response = ConfigResponse.builder().withOverride("prefix", warehouse).build();
+
+    List<Endpoint> endpoints = buildSupportedEndpoints();
+
+    ConfigResponse response =
+        ConfigResponse.builder().withOverride("prefix", warehouse).withEndpoints(endpoints).build();
+
     log.info("GET CONFIG response: {}", response);
     return response;
+  }
+
+  private List<Endpoint> buildSupportedEndpoints() {
+    return Arrays.asList(
+        // Namespace endpoints
+        Endpoint.V1_LIST_NAMESPACES,
+        Endpoint.V1_LOAD_NAMESPACE,
+        Endpoint.V1_CREATE_NAMESPACE,
+        Endpoint.V1_UPDATE_NAMESPACE,
+        Endpoint.V1_DELETE_NAMESPACE,
+        // Table endpoints
+        Endpoint.V1_LIST_TABLES,
+        Endpoint.V1_LOAD_TABLE,
+        Endpoint.V1_CREATE_TABLE,
+        Endpoint.V1_UPDATE_TABLE,
+        Endpoint.V1_DELETE_TABLE,
+        Endpoint.V1_RENAME_TABLE,
+        Endpoint.V1_REGISTER_TABLE,
+        // View endpoints
+        Endpoint.V1_LIST_VIEWS,
+        Endpoint.V1_LOAD_VIEW,
+        Endpoint.V1_CREATE_VIEW,
+        Endpoint.V1_UPDATE_VIEW,
+        Endpoint.V1_DELETE_VIEW,
+        Endpoint.V1_RENAME_VIEW);
+
+    // We have the transaction commit endpoint present but just throws unsupported operation
+    // exception, hence excluding it.
   }
 }

--- a/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/rest/secure/IcebergConfigApiControllerTest.java
+++ b/metadata-service/iceberg-catalog/src/test/java/io/datahubproject/iceberg/catalog/rest/secure/IcebergConfigApiControllerTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.*;
 
 import io.datahubproject.iceberg.catalog.DataHubIcebergWarehouse;
 import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.rest.Endpoint;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -46,6 +47,85 @@ public class IcebergConfigApiControllerTest
           response.overrides().get("prefix"),
           warehouseName,
           "Warehouse name should match in the config override");
+    }
+  }
+
+  @Test
+  public void testGetConfigReturnsExpectedEndpoints() {
+    String warehouseName = "test-warehouse";
+
+    try (MockedStatic<DataHubIcebergWarehouse> warehouseMock =
+        Mockito.mockStatic(DataHubIcebergWarehouse.class)) {
+      warehouseMock
+          .when(() -> DataHubIcebergWarehouse.of(eq(warehouseName), any(), any(), any(), any()))
+          .thenReturn(null);
+      ConfigResponse response = controller.getConfig(request, warehouseName);
+
+      assertNotNull(response.endpoints(), "Endpoints list should not be null");
+      assertFalse(response.endpoints().isEmpty(), "Endpoints list should not be empty");
+
+      // Verify namespace endpoints are present
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_LIST_NAMESPACES),
+          "Should contain V1_LIST_NAMESPACES endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_LOAD_NAMESPACE),
+          "Should contain V1_LOAD_NAMESPACE endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_CREATE_NAMESPACE),
+          "Should contain V1_CREATE_NAMESPACE endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_UPDATE_NAMESPACE),
+          "Should contain V1_UPDATE_NAMESPACE endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_DELETE_NAMESPACE),
+          "Should contain V1_DELETE_NAMESPACE endpoint");
+
+      // Verify table endpoints are present
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_LIST_TABLES),
+          "Should contain V1_LIST_TABLES endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_LOAD_TABLE),
+          "Should contain V1_LOAD_TABLE endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_CREATE_TABLE),
+          "Should contain V1_CREATE_TABLE endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_UPDATE_TABLE),
+          "Should contain V1_UPDATE_TABLE endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_DELETE_TABLE),
+          "Should contain V1_DELETE_TABLE endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_RENAME_TABLE),
+          "Should contain V1_RENAME_TABLE endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_REGISTER_TABLE),
+          "Should contain V1_REGISTER_TABLE endpoint");
+
+      // Verify view endpoints are present
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_LIST_VIEWS),
+          "Should contain V1_LIST_VIEWS endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_LOAD_VIEW),
+          "Should contain V1_LOAD_VIEW endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_CREATE_VIEW),
+          "Should contain V1_CREATE_VIEW endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_UPDATE_VIEW),
+          "Should contain V1_UPDATE_VIEW endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_DELETE_VIEW),
+          "Should contain V1_DELETE_VIEW endpoint");
+      assertTrue(
+          response.endpoints().contains(Endpoint.V1_RENAME_VIEW),
+          "Should contain V1_RENAME_VIEW endpoint");
+
+      // Verify the total count matches expected endpoints
+      assertEquals(response.endpoints().size(), 18, "Should have exactly 18 supported endpoints");
     }
   }
 


### PR DESCRIPTION
Iceberg REST Catalog spec `/v1/config` has an [optional `endpoints` field](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L105), which when not populated, the spec defines the default to be tables and namespace related APIs. 

Datahub IRC also supports views - but some IRC clients that check the endpoints field would report views as unsupported since the endpoints field was not populated. 

This was added in spec version 1.7.0 (and DataHub IRC was built using 1.6.1 which did not include this). This is likely the reason spark does not check this field and allows views to be created without relying on the endpoints field. 

This PR updates the IRC library dependency to 1.7.1 so that the endpoints field is available, and populates it with the supported API. 


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
