### PR TITLE
feat(structured-properties): add version field to StructuredProperties

### DIFF
--- a/metadata-ingestion/examples/structured_properties/structured_properties.yaml
+++ b/metadata-ingestion/examples/structured_properties/structured_properties.yaml
@@ -2,6 +2,7 @@
   # - urn: urn:li:structuredProperty:io.acryl.privacy.retentionTime # optional if id is provided
   qualified_name: io.acryl.privacy.retentionTime # required if urn is provided
   type: number
+  version: "1.0.0"
   cardinality: MULTIPLE
   display_name: Retention Time
   entity_types:

--- a/metadata-ingestion/src/datahub/api/entities/structuredproperties/structuredproperties.py
+++ b/metadata-ingestion/src/datahub/api/entities/structuredproperties/structuredproperties.py
@@ -74,6 +74,7 @@ class StructuredProperties(ConfigModel):
     urn: Optional[str] = Field(None, validate_default=True)
     qualified_name: Optional[str] = None
     type: str
+    version: Optional[str] = None
     value_entity_types: Optional[List[str]] = None
     description: Optional[str] = None
     display_name: Optional[str] = None
@@ -175,6 +176,7 @@ class StructuredProperties(ConfigModel):
                     if self.type_qualifier
                     else None
                 ),
+                version=self.version,
             ),
         )
         return [mcp]
@@ -203,6 +205,7 @@ class StructuredProperties(ConfigModel):
             qualified_name=structured_property.qualifiedName,
             display_name=structured_property.displayName,
             type=structured_property.valueType,
+            version=structured_property.version,
             description=structured_property.description,
             entity_types=structured_property.entityTypes,
             cardinality=structured_property.cardinality,

--- a/metadata-ingestion/tests/unit/api/entities/structuredproperties/example_structured_properties_golden.json
+++ b/metadata-ingestion/tests/unit/api/entities/structuredproperties/example_structured_properties_golden.json
@@ -35,7 +35,8 @@
                 "urn:li:entityType:datahub.dataFlow"
             ],
             "description": "Retention Time is used to figure out how long to retain records in a dataset",
-            "immutable": false
+            "immutable": false,
+            "version": "1.0.0"
         }
     }
 },


### PR DESCRIPTION
## Summary

Add optional version field to StructuredProperties class to support versioning of structured property definitions. This allows tracking changes to property schemas over time.

## Changes

- Add `version` field to StructuredProperties model (optional string)
- Update `generate_mcps()` to include version in metadata change proposals
- Update `from_datahub()` to read version from stored properties
- Add test coverage with example version value in YAML and golden file

## Test Plan

- [x] Updated existing tests to verify version field serialization
- [x] Added example with explicit version value ("1.0.0") to test data
- [x] All unit tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)