### PR TITLE
Improve datahub-web-react build caching

### DIFF
--- a/datahub-web-react/build.gradle
+++ b/datahub-web-react/build.gradle
@@ -48,8 +48,12 @@ node {
   Wrappers around Yarn Tasks.
  */
 task yarnInstall(type: YarnTask) {
-  args = ['install', '--network-timeout', '300000']
-
+  def argsList = ['install', '--network-timeout', '300000']
+  if (System.getenv("CI") == "true") {
+    argsList += ['--frozen-lockfile']
+  }
+  args.set(argsList)
+  
   // The node_modules directory can contain built artifacts, so
   // it's not really safe to cache it.
   outputs.cacheIf { false }
@@ -61,7 +65,7 @@ task yarnInstall(type: YarnTask) {
   outputs.dir('node_modules')
 }
 
-task yarnGenerate(type: YarnTask, dependsOn: yarnInstall) {
+task yarnGenerateCacheable(type: YarnTask, dependsOn: yarnInstall) {
   args = ['run', 'generate']
 
   outputs.cacheIf { true }
@@ -69,17 +73,40 @@ task yarnGenerate(type: YarnTask, dependsOn: yarnInstall) {
   inputs.files(
     yarnInstall.inputs.files,
     file('codegen.yml'),
-    project.fileTree(dir: "../datahub-graphql-core/src/main/resources/", include: "*.graphql"),
+    project.fileTree(dir: "../datahub-graphql-core/src/main/resources/", include: "**/*.graphql"),
     project.fileTree(dir: "src", include: "**/*.graphql"),
   )
 
-  outputs.files(
-    project.fileTree(dir: "src", include: "**/*.generated.ts"),
-  )
+  // Generated files go to build/generated which can be properly cached
+  outputs.dir("${buildDir}/generated").withPropertyName("generatedSources")
 
   doFirst{
+    print("deleting ${buildDir}")
+    delete file("${buildDir}/generated")
+
+    // Delete the generated files from src
     delete fileTree(dir: 'src', include: '**/*.generated.ts')
   }
+
+  doLast {
+    // Move generated files from src/ to build/generated/ while preserving structure
+    copy {
+      from("src") {
+        include "**/*.generated.ts"
+      }
+      into "${buildDir}/generated"
+    }
+  }
+}
+
+// Sync generated files from build/generated to src/
+task yarnGenerate(type: Copy, dependsOn: yarnGenerateCacheable) {
+  from "${buildDir}/generated"
+  into "src"
+  include "**/*.generated.ts"
+
+  // Preserve the directory structure
+  includeEmptyDirs = false
 }
 
 task yarnServe(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
@@ -188,7 +215,6 @@ task yarnBuild(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
     project.fileTree(dir: "public"),
 
     yarnInstall.inputs.files,
-    yarnGenerate.outputs.files,
 
     file('.env'),
     file('vite.config.ts'),


### PR DESCRIPTION
Gradle cannot cache artifacts if the outputs are generated into the same folder as the sources. 
The graphql codegen tool cannot preserve directory structure of generated files if a different output dir is specified (it does write to it, but flattens the folder structure). 
So, generated in place (in src dir) but as a doLast, moved them to a build folder thus giving the yarnGenerate task an exclusive folder for its outputs, thus enabling this task be cached. 
This now enables yarnBuild step to also be cached.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
