### PR TITLE
fix(cypress): fix summary tab tests

### DIFF
--- a/datahub-web-react/src/app/entityV2/summary/properties/property/properties/OwnersProperty.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/properties/property/properties/OwnersProperty.tsx
@@ -22,7 +22,7 @@ export default function OwnersProperty(props: PropertyComponentProps) {
 
         return (
             <HoverEntityTooltip entity={owner} showArrow={false}>
-                <Link to={`${entityRegistry.getEntityUrl(owner.type, owner.urn)}`}>
+                <Link to={`${entityRegistry.getEntityUrl(owner.type, owner.urn)}`} data-testid={`owner-${owner.urn}`}>
                     <Avatar name={displayName} imageUrl={avatarUrl} size="sm" showInPill />
                 </Link>
             </HoverEntityTooltip>

--- a/smoke-test/tests/cypress/cypress/e2e/summaryTab/domainSummary.js
+++ b/smoke-test/tests/cypress/cypress/e2e/summaryTab/domainSummary.js
@@ -1,6 +1,6 @@
 import * as utils from "./utils";
 
-const TEST_USER_DISPLAY_NAME = "jdoe";
+const TEST_USER_URN = "urn:li:corpuser:jdoe";
 const TEST_ASSET_NAME = "Baz Dashboard";
 const TEST_DOMAIN_URN = "urn:li:domain:testing";
 const TEST_SUBDOMAIN_NAME = "Subdomain";
@@ -17,7 +17,7 @@ describe("summary tab - domain", () => {
   it("domain - header section", () => {
     utils.testPropertiesSection([
       { name: "Created", type: "CREATED" },
-      { name: "Owners", type: "OWNERS", value: TEST_USER_DISPLAY_NAME },
+      { name: "Owners", type: "OWNERS", dataTestId: `owner-${TEST_USER_URN}` },
     ]);
   });
 

--- a/smoke-test/tests/cypress/cypress/e2e/summaryTab/glossaryNodeSummary.js
+++ b/smoke-test/tests/cypress/cypress/e2e/summaryTab/glossaryNodeSummary.js
@@ -1,6 +1,6 @@
 import * as utils from "./utils";
 
-const TEST_USER_DISPLAY_NAME = "jdoe";
+const TEST_USER_URN = "urn:li:corpuser:jdoe";
 const TEST_GLOSSARY_NODE_URN = "urn:li:glossaryNode:CypressNode";
 const TEST_GLOSSARY_TERM_NAME = "CypressTerm";
 
@@ -15,7 +15,7 @@ describe("summary tab - glossary node", () => {
   it("glossary node - header section", () => {
     utils.testPropertiesSection([
       { name: "Created", type: "CREATED" },
-      { name: "Owners", type: "OWNERS", value: TEST_USER_DISPLAY_NAME },
+      { name: "Owners", type: "OWNERS", dataTestId: `owner-${TEST_USER_URN}` },
     ]);
   });
 

--- a/smoke-test/tests/cypress/cypress/e2e/summaryTab/glossaryTermSummary.js
+++ b/smoke-test/tests/cypress/cypress/e2e/summaryTab/glossaryTermSummary.js
@@ -1,6 +1,6 @@
 import * as utils from "./utils";
 
-const TEST_USER_DISPLAY_NAME = "John Doe";
+const TEST_USER_URN = "urn:li:corpuser:jdoe";
 const TEST_GLOSSARY_TERM_URN = "urn:li:glossaryTerm:CypressNode.CypressTerm";
 const TEST_DOMAIN_NAME = "Testing";
 const TEST_RELATED_TERM_NAME = "RelatedCypressTerm";
@@ -16,7 +16,7 @@ describe("summary tab - glossary term", () => {
   it("glossary term - header section", () => {
     utils.testPropertiesSection([
       { name: "Created", type: "CREATED" },
-      { name: "Owners", type: "OWNERS", value: TEST_USER_DISPLAY_NAME },
+      { name: "Owners", type: "OWNERS", dataTestId: `owner-${TEST_USER_URN}` },
       { name: "Domain", type: "DOMAIN", value: TEST_DOMAIN_NAME },
     ]);
   });

--- a/smoke-test/tests/cypress/cypress/e2e/summaryTab/utils.js
+++ b/smoke-test/tests/cypress/cypress/e2e/summaryTab/utils.js
@@ -296,6 +296,9 @@ export function ensurePropertyExist(property) {
         expect(text).to.match(new RegExp(property.value, "i"));
       });
     }
+    if (property.dataTestId !== undefined) {
+      cy.getWithTestId(property.dataTestId).should("exist");
+    }
   });
 }
 


### PR DESCRIPTION
This PR adds more reliable way to check the owner property on summary tab

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
