### PR TITLE
test: Trigger Cypress workflow for GitHub runner analysis

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/login/login.js
+++ b/smoke-test/tests/cypress/cypress/e2e/login/login.js
@@ -6,4 +6,6 @@ describe("login", () => {
     cy.contains("Sign In").click();
     cy.contains(`Welcome back, ${Cypress.env("ADMIN_DISPLAYNAME")}`);
   });
+
+  // Test trigger for GitHub runner analysis
 });


### PR DESCRIPTION
## Summary
- Trigger Cypress tests on GitHub runners to analyze failures and crashes

## Test plan
- Monitor Cypress test execution on GitHub runners
- Analyze logs for Electron renderer crash messages
- Identify root causes of test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)