### PR TITLE
fix(theme): Properly set logo url on ErrorSection.tsx

### DIFF
--- a/datahub-web-react/src/app/shared/error/ErrorSection.tsx
+++ b/datahub-web-react/src/app/shared/error/ErrorSection.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import { ANTD_GRAY } from '@app/entity/shared/constants';
-import { resolveRuntimePath } from '@utils/runtimeBasePath';
+
+import dataHubLogo from '@images/datahublogo.png';
 
 const Section = styled.div`
     width: auto;
@@ -60,7 +61,7 @@ const resources = [
 
 export const ErrorSection = (): JSX.Element => {
     const themeConfig = useTheme();
-    const themeLogo = resolveRuntimePath(themeConfig.assets.logoUrl || '@images/datahublogo.png');
+    const themeLogo = themeConfig.assets.logoUrl || dataHubLogo;
 
     return (
         <Section>


### PR DESCRIPTION
https://github.com/datahub-project/datahub/pull/15084 got merged which I believe incorrectly implements what I assume was the desired goal, i.e. using logo url over hard-coded image on this component. We shouldn't need resolve runtime path here and should not be passing in img urls like that anyway.

Should I also remove this from `BASE_PATH.md`?
```
### For Asset URLs

Use the `resolveRuntimePath()` function to resolve any asset path:

```typescript
import { resolveRuntimePath } from '../utils/runtimeBasePath';

// Resolve asset paths
const logoUrl = resolveRuntimePath('/assets/logo.png');
const apiUrl = resolveRuntimePath('/api/graphql');

// Use in components
<img src={resolveRuntimePath('/assets/icons/favicon.ico')} alt="DataHub" />
```

