### PR TITLE
fix(doc): kafka setup doc updates

### DIFF
--- a/docs/deploy/confluent-cloud.md
+++ b/docs/deploy/confluent-cloud.md
@@ -124,21 +124,23 @@ cp-schema-registry:
   enabled: false
 ```
 
-Next, disable the `kafkaSetupJob` service:
+Next, disable the automatic creation of topics by the system update job:
 
 ```
-kafkaSetupJob:
-    enabled: false
+global:
+  kafka:
+    precreateTopics: false
 ```
 
 Then, update the `kafka` configurations to point to your Confluent Cloud broker and schema registry instance, along with the topics you've created in Step 1:
 
 ```
-kafka:
-      bootstrap:
-        server: pkc-g4ml2.eu-west-2.aws.confluent.cloud:9092
-      schemaregistry:
-        url: https://plrm-qwlpp.us-east-2.aws.confluent.cloud
+global:
+  kafka:
+    bootstrap:
+      server: pkc-g4ml2.eu-west-2.aws.confluent.cloud:9092
+    schemaregistry:
+      url: https://plrm-qwlpp.us-east-2.aws.confluent.cloud
 ```
 
 Next, you'll want to create 2 new Kubernetes secrets, one for the JaaS configuration which contains the username and password for Confluent,

--- a/docs/how/kafka-config.md
+++ b/docs/how/kafka-config.md
@@ -87,6 +87,10 @@ the System Update container for topic setup:
 - (Deprecated) `METADATA_AUDIT_EVENT_NAME`: The name of the metadata audit event topic.
 - (Deprecated) `FAILED_METADATA_CHANGE_EVENT_NAME`: The name of the failed metadata change event topic.
 
+#### Topic Setup
+
+- `DATAHUB_PRECREATE_TOPICS`: Defaults to true, set this to false if you intend to create and configure the topics yourself and not have datahub create them.
+
 ### MCE Consumer (datahub-mce-consumer)
 
 - `METADATA_CHANGE_PROPOSAL_TOPIC_NAME`: The name of the topic for Metadata Change Proposals emitted by the ingestion framework.
@@ -273,9 +277,6 @@ Examples:
    `KAFKA_TOPICDEFAULTS_CONFIGPROPERTIES_max_message_bytes=10000`
 
 Configurations specified in `topicDefaults` are applied to all topics by merging them with any configs defined per topic, with the per-topic config taking precedence over those specified in `topicDefault`.
-
-If you intend to create and configure the topics yourself and not have datahub create them, the kafka setup process of
-datahub-system-update can be turned off by setting env var DATAHUB_PRECREATE_TOPICS to false
 
 ## Debugging Kafka
 


### PR DESCRIPTION
After the kafka setup functionality was moved to system update, there still was a reference to kafkaSetupJob in the documentation on using kafka confluent-cloud. Updated this to also match the [updated](https://github.com/acryldata/datahub-helm/pull/633) helm chart updates
Also moved DATAHUB_PRECREATE_TOPICS env var to a relevant section
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
