### PR TITLE
fix(ingestion): Fix confluent cloud test health check

### DIFF
--- a/metadata-ingestion/tests/integration/kafka-connect-confluent-cloud/Dockerfile
+++ b/metadata-ingestion/tests/integration/kafka-connect-confluent-cloud/Dockerfile
@@ -6,9 +6,11 @@ COPY confluent_cloud_mock_api.py ./
 
 RUN pip install --no-cache-dir flask
 
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8888
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:8888/health')"
+    CMD curl -f http://localhost:8888/health || exit 1
 
 CMD ["python", "confluent_cloud_mock_api.py"]

--- a/metadata-ingestion/tests/integration/kafka-connect-confluent-cloud/docker-compose.override.yml
+++ b/metadata-ingestion/tests/integration/kafka-connect-confluent-cloud/docker-compose.override.yml
@@ -12,7 +12,7 @@ services:
       - FLASK_ENV=production
       - PORT=8888
     healthcheck:
-      test: ["CMD-SHELL", "python -c 'import requests; requests.get(\"http://localhost:8888/health\")'"]
+      test: ["CMD-SHELL", "curl -f http://localhost:8888/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Correctly calls the health check end point in ./metadata-ingestion/tests/integration/kafka-connect-confluent-cloud/test_kafka_connect_confluent_cloud.py
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
