### PR TITLE
fix(build): revert default variant for datahub-actions image

### DIFF
--- a/datahub-actions/build.gradle
+++ b/datahub-actions/build.gradle
@@ -143,7 +143,7 @@ docker {
 
   additionalTag("Debug", "${docker_registry}/${docker_repo}:debug")
 
-  defaultVariant = "full"
+  defaultVariant = "slim"
   variants = [
     "full": [suffix: "", args: [APP_ENV: "full", RELEASE_VERSION: python_docker_version, BUNDLED_CLI_VERSION: project.ext.cliVersion, BUNDLED_VENV_SLIM_MODE: "false"]],
     "slim": [suffix: "-slim", args: [APP_ENV: "slim", RELEASE_VERSION: python_docker_version, BUNDLED_CLI_VERSION: project.ext.cliVersion, BUNDLED_VENV_SLIM_MODE: "true"]],


### PR DESCRIPTION
Reverting the default variant for datahub-actions image back to `slim` that was unintentionally changed in https://github.com/datahub-project/datahub/pull/15123
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
