### PR TITLE
fix(actions): handle additional transient exception types to improve actions robustness

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_events_consumer.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_events_consumer.py
@@ -4,7 +4,12 @@ from typing import List, Optional
 
 import requests
 from pydantic import BaseModel, Field
-from requests.exceptions import ConnectionError, HTTPError
+from requests.exceptions import (
+    ChunkedEncodingError,
+    ConnectionError,
+    HTTPError,
+    Timeout,
+)
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -79,7 +84,9 @@ class DataHubEventsConsumer:
             logger.debug("Starting DataHub Events Consumer with no consumer ID.")
 
     @retry(
-        retry=retry_if_exception_type((HTTPError, ConnectionError)),
+        retry=retry_if_exception_type(
+            (HTTPError, ConnectionError, ChunkedEncodingError, Timeout)
+        ),
         wait=wait_exponential(multiplier=1, min=2, max=30),
         stop=stop_after_attempt(3),
         reraise=True,


### PR DESCRIPTION
Handle additional transient exception types (`ChunkedEncodingError` and `Timeout`) that requests library can throw and  enables the consumer to retry and continue to run when these transient exceptions occur. The `ChunkedEncodingError` can occur due to an incomplete read on a connection error/reset.

Reference: https://requests.readthedocs.io/en/latest/_modules/requests/exceptions/

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
