### PR TITLE
fix(snowflake): support conditional multi-table INSERT statements (#14929)

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py
@@ -67,6 +67,7 @@ from datahub.sql_parsing.sql_parsing_aggregator import (
     SqlParsingAggregator,
     TableRename,
     TableSwap,
+    UrnStr,
 )
 from datahub.sql_parsing.sql_parsing_common import QueryType
 from datahub.sql_parsing.sqlglot_lineage import (
@@ -83,6 +84,26 @@ from datahub.utilities.lossy_collections import LossyList
 from datahub.utilities.perf_timer import PerfTimer
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _DownstreamTarget:
+    """One downstream entry from a Snowflake audit log row.
+
+    downstream and column_lineage are both None for usage-only queries
+    (e.g. SELECTs), and both non-None for queries with a downstream table.
+    """
+
+    downstream: Optional[UrnStr]
+    column_lineage: Optional[List[ColumnLineageInfo]]
+    secondary_id: Optional[str]
+
+    def __post_init__(self) -> None:
+        if (self.downstream is None) != (self.column_lineage is None):
+            raise ValueError(
+                "downstream and column_lineage must be both None or both non-None"
+            )
+
 
 # Define a type alias
 UserName = str
@@ -494,21 +515,13 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
 
                 assert isinstance(row, dict)
                 try:
-                    parsed_result = self._parse_audit_log_row(row, users)
+                    yield from self._parse_audit_log_row(row, users)
                 except Exception as e:
                     self.structured_reporter.warning(
                         "Error parsing query log row",
                         context=f"{row}",
                         exc=e,
                     )
-                else:
-                    if parsed_result:
-                        # Handle both single entries and lists of entries (for multi-table INSERT)
-                        if isinstance(parsed_result, list):
-                            for entry in parsed_result:
-                                yield entry
-                        else:
-                            yield parsed_result
 
     @classmethod
     def _has_temp_keyword(cls, query_text: str) -> bool:
@@ -519,15 +532,8 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
 
     def _parse_audit_log_row(
         self, row: Dict[str, Any], users: UsersMapping
-    ) -> Optional[
-        Union[
-            TableRename,
-            TableSwap,
-            PreparsedQuery,
-            ObservedQuery,
-            StoredProcCall,
-            List[PreparsedQuery],
-        ]
+    ) -> Iterable[
+        Union[TableRename, TableSwap, PreparsedQuery, ObservedQuery, StoredProcCall]
     ]:
         json_fields = {
             "DIRECT_OBJECTS_ACCESSED",
@@ -552,8 +558,8 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
             snowflake_query_type, QueryType.UNKNOWN
         )
 
-        direct_objects_accessed = res["direct_objects_accessed"]
-        objects_modified = res["objects_modified"]
+        direct_objects_accessed = res["direct_objects_accessed"] or []
+        objects_modified = res["objects_modified"] or []
         object_modified_by_ddl = res["object_modified_by_ddl"]
 
         if (
@@ -565,7 +571,7 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
             if direct_objects_accessed:
                 pass  # Fall through to normal query processing for usage tracking
             else:
-                return None
+                return
 
         if (
             isinstance(object_modified_by_ddl, dict)
@@ -584,12 +590,13 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
                     snowflake_query_type,
                 )
             if known_ddl_entry:
-                return known_ddl_entry
+                yield known_ddl_entry
+                return
             elif direct_objects_accessed:
                 # Unknown ddl relevant for usage. We want to continue execution here
                 pass
             else:
-                return None
+                return
 
         user = CorpUserUrn(
             self.identifiers.get_user_identifier(
@@ -630,7 +637,7 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
             elif is_create_temp_view:
                 self.report.num_create_temp_view_queries_observed += 1
 
-            return ObservedQuery(
+            yield ObservedQuery(
                 query=query_text,
                 session_id=res["session_id"],
                 timestamp=timestamp,
@@ -642,9 +649,10 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
                 ),
                 extra_info=extra_info,
             )
+            return
 
         if snowflake_query_type == "CALL" and res["root_query_id"] is None:
-            return StoredProcCall(
+            yield StoredProcCall(
                 # This is the top-level query ID that other entries will reference.
                 snowflake_root_query_id=res["query_id"],
                 query_text=query_text,
@@ -653,6 +661,7 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
                 default_db=res["default_db"],
                 default_schema=res["default_schema"],
             )
+            return
 
         upstreams = []
         column_usage = {}
@@ -675,7 +684,7 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
                     self.report.queries_with_empty_column_name.append(query_id)
                     logger.info(f"Query {query_id} has empty column name in audit log.")
 
-                    return ObservedQuery(
+                    yield ObservedQuery(
                         query=query_text,
                         session_id=res["session_id"],
                         timestamp=timestamp,
@@ -687,138 +696,157 @@ class SnowflakeQueriesExtractor(SnowflakeStructuredReportMixin, Closeable):
                         ),
                         extra_info=extra_info,
                     )
+                    return
                 columns.add(self.identifiers.snowflake_identifier(column_name))
 
             upstreams.append(dataset)
             column_usage[dataset] = columns
 
-        # Handle multiple downstream tables (e.g., conditional multi-table INSERT)
-        # If there are multiple objects_modified, create one PreparsedQuery entry per downstream table
-        if len(objects_modified) > 1:
-            downstream_entries = []
+        is_multi_table = len(objects_modified) > 1
+        targets = self._build_downstream_targets(
+            objects_modified,
+            res["query_secondary_fingerprint"],
+            is_multi_table,
+            query_id=res["query_id"],
+        )
 
-            for obj in objects_modified:
-                obj_downstream = self.identifiers.gen_dataset_urn(
-                    self.identifiers.get_dataset_identifier_from_qualified_name(
-                        obj["objectName"]
-                    )
-                )
-                obj_column_lineage = []
-                for modified_column in obj["columns"]:
-                    obj_column_lineage.append(
-                        ColumnLineageInfo(
-                            downstream=DownstreamColumnRef(
-                                dataset=obj_downstream,
-                                column=self.identifiers.snowflake_identifier(
-                                    modified_column["columnName"]
-                                ),
-                            ),
-                            upstreams=[
-                                ColumnRef(
-                                    table=self.identifiers.gen_dataset_urn(
-                                        self.identifiers.get_dataset_identifier_from_qualified_name(
-                                            upstream["objectName"]
-                                        )
-                                    ),
-                                    column=self.identifiers.snowflake_identifier(
-                                        upstream["columnName"]
-                                    ),
-                                )
-                                for upstream in modified_column["directSources"]
-                                if upstream["objectDomain"]
-                                in SnowflakeQuery.ACCESS_HISTORY_TABLE_VIEW_DOMAINS
-                            ],
-                        )
-                    )
+        if objects_modified and not targets:
+            self.structured_reporter.warning(
+                "All downstream objects failed; falling back to SQL-based lineage",
+                context=f"query_id={res['query_id']}, "
+                f"num_objects={len(objects_modified)}",
+            )
+            yield ObservedQuery(
+                query=query_text,
+                session_id=res["session_id"],
+                timestamp=timestamp,
+                user=user,
+                default_db=res["default_db"],
+                default_schema=res["default_schema"],
+                usage_multiplier=res["query_count"],
+                query_hash=get_query_fingerprint(
+                    query_text, self.identifiers.platform, fast=True
+                ),
+                extra_info=extra_info,
+            )
+            return
 
-                entry = PreparsedQuery(
-                    query_id=get_query_fingerprint(
-                        query_text,
-                        self.identifiers.platform,
-                        fast=True,
-                        secondary_id=res["query_secondary_fingerprint"],
-                    ),
-                    query_text=query_text,
-                    upstreams=upstreams,
-                    downstream=obj_downstream,
-                    column_lineage=obj_column_lineage,
-                    column_usage=column_usage,
-                    inferred_schema=None,
-                    confidence_score=1.0,
-                    query_count=res["query_count"],
-                    user=user,
-                    timestamp=timestamp,
-                    session_id=res["session_id"],
-                    query_type=query_type,
-                    extra_info=extra_info,
-                )
-                downstream_entries.append(entry)
+        for i, target in enumerate(targets):
+            # Only the first entry carries query_count; subsequent entries get 0
+            # to avoid double-counting upstream reads when multiple targets are yielded.
+            entry_query_count = res["query_count"] if i == 0 else 0
 
-            # Return list of entries for multi-table INSERT
-            return downstream_entries
+            yield PreparsedQuery(
+                # Use DataHub's own fingerprint instead of Snowflake's opaque
+                # QUERY_SECONDARY_FINGERPRINT. fast=True uses regex-based
+                # normalization instead of full sqlglot parsing.
+                query_id=get_query_fingerprint(
+                    query_text,
+                    self.identifiers.platform,
+                    fast=True,
+                    secondary_id=target.secondary_id,
+                ),
+                query_text=query_text,
+                upstreams=list(upstreams),
+                downstream=target.downstream,
+                column_lineage=target.column_lineage,
+                column_usage=dict(column_usage),
+                inferred_schema=None,
+                confidence_score=1.0,
+                query_count=entry_query_count,
+                user=user,
+                timestamp=timestamp,
+                session_id=res["session_id"],
+                query_type=query_type,
+                extra_info=extra_info,
+            )
 
-        # Single or no downstream table - use original logic (backward compatible)
-        downstream: Optional[str] = None
-        column_lineage: Optional[List[ColumnLineageInfo]] = None
-        for obj in objects_modified:
-            downstream = self.identifiers.gen_dataset_urn(
-                self.identifiers.get_dataset_identifier_from_qualified_name(
-                    obj["objectName"]
+    def _build_downstream_targets(
+        self,
+        objects_modified: List[Dict[str, Any]],
+        query_secondary_fingerprint: Optional[str],
+        is_multi_table: bool,
+        query_id: str,
+    ) -> List[_DownstreamTarget]:
+        """Build one _DownstreamTarget per modified object in an audit log row.
+
+        For multi-table INSERTs (INSERT ALL / INSERT FIRST) this returns N entries;
+        for normal queries it returns one. Each object is isolated so a bad entry
+        doesn't discard siblings. For queries with no objects_modified (e.g. SELECT
+        statements), returns a single entry with downstream=None to preserve
+        upstream usage tracking. If all objects fail to process (e.g. malformed
+        audit log entries), returns an empty list; the caller falls back to
+        SQL-based lineage.
+        """
+        targets: List[_DownstreamTarget] = []
+
+        if not objects_modified:
+            targets.append(
+                _DownstreamTarget(
+                    downstream=None,
+                    column_lineage=None,
+                    secondary_id=query_secondary_fingerprint,
                 )
             )
-            column_lineage = []
-            for modified_column in obj["columns"]:
-                column_lineage.append(
-                    ColumnLineageInfo(
-                        downstream=DownstreamColumnRef(
-                            dataset=downstream,
-                            column=self.identifiers.snowflake_identifier(
-                                modified_column["columnName"]
-                            ),
-                        ),
-                        upstreams=[
-                            ColumnRef(
-                                table=self.identifiers.gen_dataset_urn(
-                                    self.identifiers.get_dataset_identifier_from_qualified_name(
-                                        upstream["objectName"]
-                                    )
-                                ),
-                                column=self.identifiers.snowflake_identifier(
-                                    upstream["columnName"]
-                                ),
-                            )
-                            for upstream in modified_column["directSources"]
-                            if upstream["objectDomain"]
-                            in SnowflakeQuery.ACCESS_HISTORY_TABLE_VIEW_DOMAINS
-                        ],
+        else:
+            for obj in objects_modified:
+                try:
+                    obj_downstream = self.identifiers.gen_dataset_urn(
+                        self.identifiers.get_dataset_identifier_from_qualified_name(
+                            obj["objectName"]
+                        )
                     )
-                )
+                    obj_column_lineage: List[ColumnLineageInfo] = []
+                    for modified_column in obj["columns"]:
+                        obj_column_lineage.append(
+                            ColumnLineageInfo(
+                                downstream=DownstreamColumnRef(
+                                    table=obj_downstream,
+                                    column=self.identifiers.snowflake_identifier(
+                                        modified_column["columnName"]
+                                    ),
+                                ),
+                                upstreams=[
+                                    ColumnRef(
+                                        table=self.identifiers.gen_dataset_urn(
+                                            self.identifiers.get_dataset_identifier_from_qualified_name(
+                                                upstream["objectName"]
+                                            )
+                                        ),
+                                        column=self.identifiers.snowflake_identifier(
+                                            upstream["columnName"]
+                                        ),
+                                    )
+                                    for upstream in modified_column["directSources"]
+                                    if upstream["objectDomain"]
+                                    in SnowflakeQuery.ACCESS_HISTORY_TABLE_VIEW_DOMAINS
+                                ],
+                            )
+                        )
 
-        entry = PreparsedQuery(
-            # Despite having Snowflake's fingerprints available, our own fingerprinting logic does a better
-            # job at eliminating redundant / repetitive queries. As such, we include the fast fingerprint
-            # here
-            query_id=get_query_fingerprint(
-                query_text,
-                self.identifiers.platform,
-                fast=True,
-                secondary_id=res["query_secondary_fingerprint"],
-            ),
-            query_text=query_text,
-            upstreams=upstreams,
-            downstream=downstream,
-            column_lineage=column_lineage,
-            column_usage=column_usage,
-            inferred_schema=None,
-            confidence_score=1.0,
-            query_count=res["query_count"],
-            user=user,
-            timestamp=timestamp,
-            session_id=res["session_id"],
-            query_type=query_type,
-            extra_info=extra_info,
-        )
-        return entry
+                    # Multi-table INSERTs need a unique query_id per downstream table
+                    # so SqlParsingAggregator treats each as a distinct lineage entry.
+                    secondary_id = query_secondary_fingerprint
+                    if is_multi_table:
+                        base = secondary_id or ""
+                        secondary_id = f"{base}_{obj['objectName']}"
+
+                    targets.append(
+                        _DownstreamTarget(
+                            downstream=obj_downstream,
+                            column_lineage=obj_column_lineage,
+                            secondary_id=secondary_id,
+                        )
+                    )
+                except (KeyError, ValueError, TypeError) as e:
+                    self.structured_reporter.warning(
+                        "Failed to process downstream object",
+                        context=f"query_id={query_id}, "
+                        f"object={obj.get('objectName', '<unknown>')}",
+                        exc=e,
+                    )
+
+        return targets
 
     @staticmethod
     def _get_ddl_property(properties: dict, key: str) -> str:

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_queries.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_queries.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 from datetime import datetime, timezone
 from typing import Optional
@@ -692,9 +693,10 @@ class TestSnowflakeQueryParser:
 
         users: dict = {}
 
-        result = extractor._parse_audit_log_row(row, users)
+        results = list(extractor._parse_audit_log_row(row, users))
 
-        # Assert that an ObservedQuery is returned when there's an empty column
+        assert len(results) == 1
+        result = results[0]
         assert isinstance(result, ObservedQuery), (
             f"Expected ObservedQuery but got {type(result)}"
         )
@@ -771,9 +773,10 @@ class TestSnowflakeQueryParser:
 
         users: dict = {}
 
-        result = extractor._parse_audit_log_row(row, users)
+        results = list(extractor._parse_audit_log_row(row, users))
 
-        # Assert that a PreparsedQuery is returned when all columns are valid
+        assert len(results) == 1
+        result = results[0]
         assert isinstance(result, PreparsedQuery), (
             f"Expected PreparsedQuery but got {type(result)}"
         )
@@ -1010,8 +1013,8 @@ class TestParseDdlQuery:
             query_type="ALTER_SESSION",
         )
 
-        result = extractor._parse_audit_log_row(row, {})
-        assert result is None
+        results = list(extractor._parse_audit_log_row(row, {}))
+        assert len(results) == 0
         assert not extractor.structured_reporter.failures
 
     def test_audit_log_row_rename_post_2026_01_bcr(self):
@@ -1027,8 +1030,9 @@ class TestParseDdlQuery:
         }
         row = self._make_row(json.dumps(ddl))
 
-        result = extractor._parse_audit_log_row(row, {})
-        assert isinstance(result, TableRename)
+        results = list(extractor._parse_audit_log_row(row, {}))
+        assert len(results) == 1
+        assert isinstance(results[0], TableRename)
 
 
 class TestSnowflakeQueriesExtractorStatefulTimeWindowIngestion:
@@ -1279,7 +1283,7 @@ class TestMultiTableInsert:
             "ROWS_DELETED": 0,
             "USER_NAME": "TEST_USER",
             "ROLE_NAME": "TEST_ROLE",
-            "SESSION_ID": 12345,
+            "SESSION_ID": "12345",
             "WAREHOUSE_NAME": "TEST_WH",
             "DATABASE_NAME": "REPORTING",
             "SCHEMA_NAME": "PUBLIC",
@@ -1294,7 +1298,7 @@ class TestMultiTableInsert:
             "OBJECT_MODIFIED_BY_DDL": None,
         }
 
-    def test_multi_table_insert_returns_list_with_column_lineage(self):
+    def test_multi_table_insert_yields_entries_with_column_lineage(self):
         """Two downstream tables each get their own PreparsedQuery with correct column lineage."""
         extractor = self._create_mock_extractor()
 
@@ -1363,32 +1367,48 @@ class TestMultiTableInsert:
             ],
         )
 
-        result = extractor._parse_audit_log_row(row, {})
+        results = list(extractor._parse_audit_log_row(row, {}))
 
-        assert isinstance(result, list)
-        assert len(result) == 2
+        assert len(results) == 2
 
-        entry1, entry2 = result
+        entry1, entry2 = results
 
         assert isinstance(entry1, PreparsedQuery)
         assert entry1.downstream == self.DOWNSTREAM_URN_1
         assert entry1.column_lineage is not None
         assert len(entry1.column_lineage) == 1
         assert entry1.column_lineage[0].downstream.column == "id"
+        assert entry1.column_lineage[0].downstream.table == self.DOWNSTREAM_URN_1
+        assert len(entry1.column_lineage[0].upstreams) == 1
+        assert entry1.column_lineage[0].upstreams[0].table == self.UPSTREAM_URN
+        assert entry1.column_lineage[0].upstreams[0].column == "reservation_id"
 
         assert isinstance(entry2, PreparsedQuery)
         assert entry2.downstream == self.DOWNSTREAM_URN_2
         assert entry2.column_lineage is not None
         assert len(entry2.column_lineage) == 1
         assert entry2.column_lineage[0].downstream.column == "created"
+        assert entry2.column_lineage[0].downstream.table == self.DOWNSTREAM_URN_2
+        assert len(entry2.column_lineage[0].upstreams) == 1
+        assert entry2.column_lineage[0].upstreams[0].table == self.UPSTREAM_URN_2
+        assert entry2.column_lineage[0].upstreams[0].column == "created"
 
-        # Both entries share the same query text and upstream tables
         assert entry1.query_text == entry2.query_text
         assert entry1.upstreams == entry2.upstreams
         assert set(entry1.upstreams) == {self.UPSTREAM_URN, self.UPSTREAM_URN_2}
+        assert entry1.column_usage == entry2.column_usage
+
+        # Each downstream table must get a unique query_id so that
+        # SqlParsingAggregator doesn't overwrite lineage data in _query_map.
+        assert entry1.query_id != entry2.query_id
+
+        # Only the first entry carries usage count to avoid double-counting
+        # upstream table reads across N yield iterations.
+        assert entry1.query_count == 1
+        assert entry2.query_count == 0
 
     def test_single_table_insert_returns_single_entry(self):
-        """Single-table INSERT returns a PreparsedQuery, not a list (backward compat)."""
+        """Single-table INSERT yields exactly one PreparsedQuery."""
         extractor = self._create_mock_extractor()
 
         row = self._make_audit_log_row(
@@ -1409,14 +1429,15 @@ class TestMultiTableInsert:
             ],
         )
 
-        result = extractor._parse_audit_log_row(row, {})
+        results = list(extractor._parse_audit_log_row(row, {}))
 
-        assert isinstance(result, PreparsedQuery)
-        assert not isinstance(result, list)
+        assert len(results) == 1
+        assert isinstance(results[0], PreparsedQuery)
         assert (
-            result.downstream
+            results[0].downstream
             == "urn:li:dataset:(urn:li:dataPlatform:snowflake,reporting.public.test_table,PROD)"
         )
+        assert results[0].query_count == 1
 
     def test_multi_table_insert_with_empty_direct_sources(self):
         """Multi-table INSERT where one table has empty directSources still produces lineage."""
@@ -1460,20 +1481,19 @@ class TestMultiTableInsert:
             ],
         )
 
-        result = extractor._parse_audit_log_row(row, {})
+        results = list(extractor._parse_audit_log_row(row, {}))
 
-        assert isinstance(result, list)
-        assert len(result) == 2
+        assert len(results) == 2
 
-        # First entry: has column lineage entry but with no upstream columns
-        entry1 = result[0]
+        entry1 = results[0]
+        assert isinstance(entry1, PreparsedQuery)
         assert entry1.downstream == self.DOWNSTREAM_URN_1
         assert entry1.column_lineage is not None
         assert len(entry1.column_lineage) == 1
         assert entry1.column_lineage[0].upstreams == []
 
-        # Second entry: has full column lineage
-        entry2 = result[1]
+        entry2 = results[1]
+        assert isinstance(entry2, PreparsedQuery)
         assert entry2.downstream == self.DOWNSTREAM_URN_2
         assert entry2.column_lineage is not None
         assert len(entry2.column_lineage) == 1
@@ -1521,37 +1541,455 @@ class TestMultiTableInsert:
             ],
         )
 
-        result = extractor._parse_audit_log_row(row, {})
+        results = list(extractor._parse_audit_log_row(row, {}))
 
-        assert isinstance(result, list)
-        entry1 = result[0]
+        entry1 = results[0]
+        assert isinstance(entry1, PreparsedQuery)
         assert entry1.column_lineage is not None
         assert len(entry1.column_lineage) == 1
-        # Only the Table-domain source should survive, Stage should be filtered
         assert len(entry1.column_lineage[0].upstreams) == 1
         assert entry1.column_lineage[0].upstreams[0].table == self.UPSTREAM_URN
 
-    def test_fetch_query_log_flattens_multi_table_results(self):
-        """fetch_query_log yields individual entries, not lists, for multi-table INSERTs."""
+    def test_multi_table_insert_bad_object_does_not_discard_siblings(self):
+        """If one object in objects_modified is malformed, the others still produce entries."""
         extractor = self._create_mock_extractor()
 
-        entry_a = Mock(spec=PreparsedQuery)
-        entry_b = Mock(spec=PreparsedQuery)
+        row = self._make_audit_log_row(
+            objects_modified=[
+                {
+                    # Missing 'objectName' — will raise KeyError inside the loop
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+                {
+                    "objectName": "REPORTING.PUBLIC.TMP_ORDER_ITEM_CREATED",
+                    "objectDomain": "Table",
+                    "columns": [
+                        {
+                            "columnName": "CREATED",
+                            "directSources": [
+                                {
+                                    "objectName": "MINERVA_PII.PUBLIC.ORDER_ITEM_PII",
+                                    "objectDomain": "Table",
+                                    "columnName": "CREATED",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+            direct_objects_accessed=[
+                {
+                    "objectName": "MINERVA_PII.PUBLIC.ORDER_ITEM_PII",
+                    "objectDomain": "Table",
+                    "columns": [{"columnName": "CREATED"}],
+                },
+            ],
+        )
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+
+        assert len(results) == 1
+        assert isinstance(results[0], PreparsedQuery)
+        assert results[0].downstream == self.DOWNSTREAM_URN_2
+        assert results[0].column_lineage is not None
+        assert len(results[0].column_lineage) == 1
+        assert results[0].query_count == 1
+
+        extractor.structured_reporter.warning.assert_called_once()  # type: ignore[attr-defined]
+        call_args = extractor.structured_reporter.warning.call_args  # type: ignore[attr-defined]
+        assert call_args[0][0] == "Failed to process downstream object"
+        assert "query_id=" in call_args[1]["context"]
+
+    def test_multi_table_insert_query_count_greater_than_one(self):
+        """When query_count > 1 (dedup), only the first entry carries the full count."""
+        extractor = self._create_mock_extractor()
+
+        row = self._make_audit_log_row(
+            objects_modified=[
+                {
+                    "objectName": "REPORTING.PUBLIC.TMP_RESERVATION_IDS",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+                {
+                    "objectName": "REPORTING.PUBLIC.TMP_ORDER_ITEM_CREATED",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.UPDATED_ORDERS",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+        )
+        row["QUERY_COUNT"] = 5
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+
+        assert len(results) == 2
+        assert isinstance(results[0], PreparsedQuery)
+        assert isinstance(results[1], PreparsedQuery)
+        assert results[0].query_count == 5
+        assert results[1].query_count == 0
+
+    def test_empty_objects_modified_yields_usage_only_entry(self):
+        """Query with no downstream (e.g. SELECT) yields one PreparsedQuery with downstream=None."""
+        extractor = self._create_mock_extractor()
+
+        row = self._make_audit_log_row(
+            objects_modified=[],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.UPDATED_ORDERS",
+                    "objectDomain": "Table",
+                    "columns": [{"columnName": "ORDER_NUM"}],
+                },
+            ],
+            query_text="SELECT * FROM reporting.updated_orders",
+        )
+        row["QUERY_TYPE"] = "SELECT"
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+
+        assert len(results) == 1
+        entry = results[0]
+        assert isinstance(entry, PreparsedQuery)
+        assert entry.downstream is None
+        assert entry.query_count == 1
+        assert len(entry.upstreams) == 1
+
+    def test_all_objects_failed_emits_observed_query_fallback(self):
+        """When ALL objects_modified fail, an ObservedQuery is emitted as fallback."""
+        extractor = self._create_mock_extractor()
+
+        row = self._make_audit_log_row(
+            objects_modified=[
+                {
+                    # Missing 'objectName' — will raise KeyError
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+                {
+                    # Also missing 'objectName'
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.UPDATED_ORDERS",
+                    "objectDomain": "Table",
+                    "columns": [{"columnName": "ORDER_NUM"}],
+                },
+            ],
+        )
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+
+        assert len(results) == 1
+        assert isinstance(results[0], ObservedQuery)
+        assert results[0].query == row["QUERY_TEXT"]
+
+        assert extractor.structured_reporter.warning.call_count == 3  # type: ignore[attr-defined]
+
+    def test_single_table_query_id_does_not_include_object_name(self):
+        """Single-table queries must NOT append objectName to secondary_id."""
+        extractor = self._create_mock_extractor()
+
+        row = self._make_audit_log_row(
+            query_text="INSERT INTO reporting.test_table SELECT * FROM reporting.source_table",
+            objects_modified=[
+                {
+                    "objectName": "REPORTING.PUBLIC.TEST_TABLE",
+                    "objectDomain": "Table",
+                    "columns": [],
+                }
+            ],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.SOURCE_TABLE",
+                    "objectDomain": "Table",
+                    "columns": [],
+                }
+            ],
+        )
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+        assert len(results) == 1
+        assert isinstance(results[0], PreparsedQuery)
+
+        results2 = list(extractor._parse_audit_log_row(row, {}))
+        assert isinstance(results2[0], PreparsedQuery)
+        assert results[0].query_id == results2[0].query_id
+
+        row_multi = self._make_audit_log_row(
+            query_text="INSERT INTO reporting.test_table SELECT * FROM reporting.source_table",
+            objects_modified=[
+                {
+                    "objectName": "REPORTING.PUBLIC.TEST_TABLE",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+                {
+                    "objectName": "REPORTING.PUBLIC.OTHER_TABLE",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.SOURCE_TABLE",
+                    "objectDomain": "Table",
+                    "columns": [],
+                }
+            ],
+        )
+        results_multi = list(extractor._parse_audit_log_row(row_multi, {}))
+        assert isinstance(results_multi[0], PreparsedQuery)
+        assert isinstance(results_multi[1], PreparsedQuery)
+        assert results_multi[0].query_id != results_multi[1].query_id
+        assert results[0].query_id != results_multi[0].query_id
+
+    def test_multi_table_insert_with_non_none_secondary_fingerprint(self):
+        """Non-None QUERY_SECONDARY_FINGERPRINT composes as '{fingerprint}_{objectName}'."""
+        extractor = self._create_mock_extractor()
+
+        row = self._make_audit_log_row(
+            objects_modified=[
+                {
+                    "objectName": "REPORTING.PUBLIC.TMP_RESERVATION_IDS",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+                {
+                    "objectName": "REPORTING.PUBLIC.TMP_ORDER_ITEM_CREATED",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.UPDATED_ORDERS",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+        )
+        row["QUERY_SECONDARY_FINGERPRINT"] = "fp_hash_123"
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+
+        assert len(results) == 2
+        assert isinstance(results[0], PreparsedQuery)
+        assert isinstance(results[1], PreparsedQuery)
+        assert results[0].query_id != results[1].query_id
+        row_none = self._make_audit_log_row(
+            objects_modified=[
+                {
+                    "objectName": "REPORTING.PUBLIC.TMP_RESERVATION_IDS",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+                {
+                    "objectName": "REPORTING.PUBLIC.TMP_ORDER_ITEM_CREATED",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.UPDATED_ORDERS",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+        )
+        results_none = list(extractor._parse_audit_log_row(row_none, {}))
+        assert isinstance(results_none[0], PreparsedQuery)
+        assert results[0].query_id != results_none[0].query_id
+
+    def test_three_table_insert_produces_unique_query_ids(self):
+        """With 3+ downstream tables, each gets a unique query_id."""
+        extractor = self._create_mock_extractor()
+
+        row = self._make_audit_log_row(
+            objects_modified=[
+                {
+                    "objectName": "REPORTING.PUBLIC.TABLE_A",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+                {
+                    "objectName": "REPORTING.PUBLIC.TABLE_B",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+                {
+                    "objectName": "REPORTING.PUBLIC.TABLE_C",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.SOURCE",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+        )
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+
+        assert len(results) == 3
+        assert all(isinstance(r, PreparsedQuery) for r in results)
+        query_ids = {r.query_id for r in results if isinstance(r, PreparsedQuery)}
+        assert len(query_ids) == 3
+
+    def test_null_json_objects_modified_treated_as_empty(self):
+        """json.dumps(None) in OBJECTS_MODIFIED is treated as empty list."""
+        extractor = self._create_mock_extractor()
+
+        row = self._make_audit_log_row(
+            objects_modified=[],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.UPDATED_ORDERS",
+                    "objectDomain": "Table",
+                    "columns": [{"columnName": "ORDER_NUM"}],
+                },
+            ],
+            query_text="SELECT * FROM reporting.updated_orders",
+        )
+        row["QUERY_TYPE"] = "SELECT"
+        row["OBJECTS_MODIFIED"] = json.dumps(None)
+        row["DIRECT_OBJECTS_ACCESSED"] = json.dumps(
+            [
+                {
+                    "objectName": "REPORTING.PUBLIC.UPDATED_ORDERS",
+                    "objectDomain": "Table",
+                    "columns": [{"columnName": "ORDER_NUM"}],
+                },
+            ]
+        )
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+
+        assert len(results) == 1
+        assert isinstance(results[0], PreparsedQuery)
+        assert results[0].downstream is None
+        assert len(results[0].upstreams) == 1
+
+    def test_null_json_direct_objects_accessed_treated_as_empty(self):
+        """json.dumps(None) in DIRECT_OBJECTS_ACCESSED is treated as empty list."""
+        extractor = self._create_mock_extractor()
+
+        row = self._make_audit_log_row(
+            objects_modified=[
+                {
+                    "objectName": "REPORTING.PUBLIC.TMP_RESERVATION_IDS",
+                    "objectDomain": "Table",
+                    "columns": [],
+                },
+            ],
+            direct_objects_accessed=[],
+        )
+        row["DIRECT_OBJECTS_ACCESSED"] = json.dumps(None)
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+
+        assert len(results) == 1
+        assert isinstance(results[0], PreparsedQuery)
+        assert results[0].downstream is not None
+        assert results[0].upstreams == []
+
+    def test_single_table_column_lineage_has_downstream_table_set(self):
+        """DownstreamColumnRef.table must be set (not None) — guards against
+        passing the wrong kwarg name to the pydantic model."""
+        extractor = self._create_mock_extractor()
+
+        row = self._make_audit_log_row(
+            query_text="INSERT INTO reporting.target SELECT col1 FROM reporting.source",
+            objects_modified=[
+                {
+                    "objectName": "REPORTING.PUBLIC.TARGET",
+                    "objectDomain": "Table",
+                    "columns": [
+                        {
+                            "columnName": "COL1",
+                            "directSources": [
+                                {
+                                    "objectName": "REPORTING.PUBLIC.SOURCE",
+                                    "objectDomain": "Table",
+                                    "columnName": "COL1",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            direct_objects_accessed=[
+                {
+                    "objectName": "REPORTING.PUBLIC.SOURCE",
+                    "objectDomain": "Table",
+                    "columns": [{"columnName": "COL1"}],
+                }
+            ],
+        )
+
+        results = list(extractor._parse_audit_log_row(row, {}))
+
+        assert len(results) == 1
+        entry = results[0]
+        assert isinstance(entry, PreparsedQuery)
+        assert entry.column_lineage is not None
+        assert len(entry.column_lineage) == 1
+        # Regression guard: DownstreamColumnRef field is 'table', not 'dataset'.
+        # Using the wrong kwarg silently leaves table=None in pydantic v2.
+        assert entry.column_lineage[0].downstream.table is not None
+        assert (
+            entry.column_lineage[0].downstream.table
+            == "urn:li:dataset:(urn:li:dataPlatform:snowflake,reporting.public.target,PROD)"
+        )
+
+    def test_fetch_query_log_catches_generator_errors_and_continues(self):
+        """fetch_query_log's try/except catches errors from _parse_audit_log_row
+        and continues processing remaining rows."""
+        extractor = self._create_mock_extractor()
+
+        good_entry = Mock(spec=PreparsedQuery)
+
+        def side_effect(row, users):
+            if row.get("bad"):
+                raise ValueError("simulated parse failure")
+            yield good_entry
 
         with (
+            patch.object(extractor, "_parse_audit_log_row", side_effect=side_effect),
             patch.object(
-                extractor, "_parse_audit_log_row", return_value=[entry_a, entry_b]
+                extractor.structured_reporter,
+                "report_exc",
+                return_value=contextlib.nullcontext(),
             ),
-            patch.object(extractor.structured_reporter, "report_exc"),
             patch.object(
-                extractor.connection, "query", return_value=[{"dummy": "row"}]
+                extractor.connection,
+                "query",
+                return_value=[
+                    {"bad": False},
+                    {"bad": True},
+                    {"bad": False},
+                ],
             ),
         ):
             entries = list(extractor.fetch_query_log({}))
 
         assert len(entries) == 2
-        assert entries[0] is entry_a
-        assert entries[1] is entry_b
+        assert all(e is good_entry for e in entries)
+        extractor.structured_reporter.warning.assert_called_once()  # type: ignore[attr-defined]
 
 
 class TestBuildPatternFilter:


### PR DESCRIPTION
## Summary

Snowflake's conditional multi-table INSERT statements (`INSERT ALL WHEN ... THEN INTO table1 ... WHEN ... THEN INTO table2 ...`) produce multiple entries in the `objects_modified` array of `ACCESS_HISTORY`.

**Before:** Only the last table in a multi-table INSERT had lineage recorded. A warning was logged: *"Unexpectedly got multiple downstream entities from the Snowflake audit log."* Additionally, a pre-existing bug caused `DownstreamColumnRef.table` to always be `None` for audit-log-derived column lineage (wrong pydantic kwarg name).

**After:** Every downstream table gets its own `PreparsedQuery` entry with correct column lineage, unique query fingerprints, and proper usage attribution. Malformed audit log entries are isolated per-object so one bad entry doesn't discard valid siblings.

## Key Changes

### Generator-based `_parse_audit_log_row`

Refactored from `Optional[Union[...]]` return to `Iterable[Union[...]]` generator. The caller (`fetch_query_log`) uses `yield from` instead of isinstance dispatch, simplifying the control flow.

### `_build_downstream_targets` with per-object error isolation

Extracted downstream table processing into a dedicated method. Each object in `objects_modified` is wrapped in its own `try/except (KeyError, ValueError, TypeError)` so one malformed audit log entry doesn't discard valid siblings. When ALL objects fail, falls back to `ObservedQuery` for SQL-based lineage.

### `_DownstreamTarget` frozen dataclass

New internal type with a `__post_init__` invariant ensuring `downstream` and `column_lineage` are always both `None` (usage-only queries) or both non-`None` (queries with a downstream table).

### Unique `query_id` per downstream table

Multi-table INSERTs append `_{objectName}` to `secondary_id` before fingerprinting, so `SqlParsingAggregator` stores separate lineage metadata for each downstream instead of overwriting in `_query_map`.

### Usage double-counting prevention

Only the first yielded entry carries `query_count`; subsequent entries get `0` to avoid inflating upstream read counts when the same query fans out to N downstream tables.

### Bug fix: `DownstreamColumnRef(dataset=...)` &rarr; `DownstreamColumnRef(table=...)`

The field on `DownstreamColumnRef` is named `table`, not `dataset`. Pydantic v2's default `extra="ignore"` silently dropped the wrong kwarg, leaving `table=None` for ALL audit-log-derived column lineage. This was a pre-existing bug on `master` affecting all Snowflake queries, not just multi-table INSERTs.

### Null JSON protection

Added `or []` coalescing for `objects_modified` and `direct_objects_accessed` to handle Snowflake audit log rows where these fields are JSON `null`.

### `ObservedQuery` fallback preserves `usage_multiplier`

When all downstream objects fail and we fall back to `ObservedQuery`, `usage_multiplier=res["query_count"]` is now passed through so deduplicated query counts are not lost.

## Backward Compatibility

- **Single `objects_modified`**: Takes the same code path — yields a single `PreparsedQuery`
- **No breaking changes** to any public API or configuration
- All 140 tests pass (125 existing + 15 new)

## Tests

Added `TestMultiTableInsert` class with 15 tests in `test_snowflake_queries.py`:

| Test | What it validates |
|---|---|
| `test_multi_table_insert_yields_entries_with_column_lineage` | 2-table INSERT produces 2 entries with correct downstream URNs, column lineage (including upstream column references), shared upstreams, unique query_ids, and query_count split |
| `test_single_table_insert_returns_single_entry` | Single-table INSERT yields exactly one PreparsedQuery (backward compat) |
| `test_multi_table_insert_with_empty_direct_sources` | Empty `directSources` on one table still produces lineage entries |
| `test_multi_table_insert_filters_non_table_domain_sources` | Non-table `objectDomain` (e.g. Stage) filtered from column lineage upstreams |
| `test_multi_table_insert_bad_object_does_not_discard_siblings` | Malformed object (missing `objectName`) doesn't prevent valid siblings from producing entries |
| `test_multi_table_insert_query_count_greater_than_one` | Deduplicated `query_count > 1` only attributed to first entry |
| `test_empty_objects_modified_yields_usage_only_entry` | SELECT/usage-only query yields PreparsedQuery with `downstream=None` |
| `test_all_objects_failed_emits_observed_query_fallback` | All objects malformed triggers ObservedQuery fallback with proper warnings |
| `test_single_table_query_id_does_not_include_object_name` | Single-table queries don't get `_{objectName}` suffix (fingerprint stability) |
| `test_multi_table_insert_with_non_none_secondary_fingerprint` | Non-None `QUERY_SECONDARY_FINGERPRINT` composes correctly with objectName |
| `test_three_table_insert_produces_unique_query_ids` | 3+ downstream tables each get unique query fingerprints |
| `test_null_json_objects_modified_treated_as_empty` | `null` JSON in `OBJECTS_MODIFIED` treated as empty list |
| `test_null_json_direct_objects_accessed_treated_as_empty` | `null` JSON in `DIRECT_OBJECTS_ACCESSED` treated as empty list |
| `test_single_table_column_lineage_has_downstream_table_set` | Regression guard: `DownstreamColumnRef.table` is set (not `None`) |
| `test_fetch_query_log_catches_generator_errors_and_continues` | `fetch_query_log` try/except catches generator errors and continues to next row |

## Fixes #14929
