### PR TITLE
fix(datahub-actions): make config in ActionConfig optional

### DIFF
--- a/datahub-actions/src/datahub_actions/pipeline/pipeline_config.py
+++ b/datahub-actions/src/datahub_actions/pipeline/pipeline_config.py
@@ -45,7 +45,7 @@ class FilterConfig(ConfigModel):
 
 class ActionConfig(ConfigModel):
     type: str
-    config: Optional[dict]
+    config: Optional[Dict[str, Any]] = None
 
 
 class PipelineOptions(BaseModel):

--- a/datahub-actions/tests/unit/pipeline/test_pipeline.py
+++ b/datahub-actions/tests/unit/pipeline/test_pipeline.py
@@ -187,6 +187,14 @@ def test_failed_events_file():
     os.remove(failed_events_file_path)
 
 
+def test_minimal_create():
+    valid_config = _build_minimal_pipeline_config()
+    try:
+        Pipeline.create(valid_config)
+    except ValidationError:
+        pytest.fail("Should not get validation error")
+
+
 def _build_valid_pipeline_config() -> dict:
     return {
         "name": "sample-pipeline",
@@ -199,6 +207,15 @@ def _build_valid_pipeline_config() -> dict:
             "failure_mode": "CONTINUE",
             "failed_events_dir": "/tmp/datahub/test",
         },
+    }
+
+
+def _build_minimal_pipeline_config() -> dict:
+    return {
+        "name": "sample-pipeline",
+        "source": {"type": "test_source"},
+        "transform": [{"type": "test_transformer"}],
+        "action": {"type": "test_action"},
     }
 
 


### PR DESCRIPTION
Without None it is mandatory to specify it. That
should not be needed, better to set it to None as
default.

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)