### PR TITLE
fix(actions): increase retries

### DIFF
--- a/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_events_consumer.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_events_consumer.py
@@ -83,12 +83,15 @@ class DataHubEventsConsumer:
         else:
             logger.debug("Starting DataHub Events Consumer with no consumer ID.")
 
+    # The consumer pool that services this request can have upto 10 consumers. IF there is some reason that causes
+    # the connections in the consumer to go stale (transient kafka disconnects), upto 10 consumers have to reconnect
+    # and hence upto 10 calls may fail/timeout. So increasing max retries.
     @retry(
         retry=retry_if_exception_type(
             (HTTPError, ConnectionError, ChunkedEncodingError, Timeout)
         ),
-        wait=wait_exponential(multiplier=1, min=2, max=30),
-        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=60),
+        stop=stop_after_attempt(15),
         reraise=True,
     )
     def poll_events(


### PR DESCRIPTION
When there are transient kafka errors, the consumer on the externalEventsSource need to reconnect -- and there is a pool of such consumers that get allocated LIFO thus potentially requiring upto 10 retries to get to a consumer that has gone through a reconnect. 


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
