### PR TITLE
feat(auth): Add LDAP groups check during OIDC login

### DIFF
--- a/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
@@ -84,7 +84,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import play.mvc.Result;
 import utils.SerializationUtils;
-import auth.sso.oidc.RequiredGroupsException;
 
 /**
  * This class contains the logic that is executed when an OpenID Connect Identity Provider redirects
@@ -246,7 +245,8 @@ public class OidcCallbackLogic extends DefaultCallbackLogic {
       final String userName = extractUserNameOrThrow(oidcConfigs, profile);
       final CorpuserUrn corpUserUrn = new CorpuserUrn(userName);
 
-      // If RequiredGroups has groups, ensure that the user belongs to at least one of the required groups.
+      // If RequiredGroups has groups, ensure that the user belongs to at least one of the required
+      // groups.
       checkRequiredGroups(profile, userName, oidcConfigs);
 
       try {
@@ -305,7 +305,8 @@ public class OidcCallbackLogic extends DefaultCallbackLogic {
         "Failed to authenticate current user. Cannot find valid identity provider profile in session.");
   }
 
-  public static void checkRequiredGroups(CommonProfile profile, String userName, OidcConfigs oidcConfigs) {
+  public static void checkRequiredGroups(
+      CommonProfile profile, String userName, OidcConfigs oidcConfigs) {
     if (!oidcConfigs.getRequiredGroups().isEmpty()) {
       final Set<String> required = oidcConfigs.getRequiredGroups();
       final String claimName = oidcConfigs.getGroupsClaimName();
@@ -330,7 +331,7 @@ public class OidcCallbackLogic extends DefaultCallbackLogic {
             String.format(
                 "Access denied: User %s does not have any of the required groups. Required (any): %s",
                 userName, required));
-            }
+      }
 
       log.debug(
           "User {} passed IAM group check. Matching groups={}, User groups={}",

--- a/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
@@ -4,8 +4,12 @@ import static auth.AuthUtils.*;
 import static auth.ConfigUtil.*;
 
 import auth.sso.SsoConfigs;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Getter;
 
 /** Class responsible for extracting and validating OIDC related configurations. */
@@ -46,6 +50,7 @@ public class OidcConfigs extends SsoConfigs {
   public static final String OIDC_ACR_VALUES = "auth.oidc.acrValues";
   public static final String OIDC_HTTP_RETRY_ATTEMPTS = "auth.oidc.httpRetryAttempts";
   public static final String OIDC_HTTP_RETRY_DELAY = "auth.oidc.httpRetryDelay";
+  public static final String OIDC_REQUIRED_GROUPS_CONFIG_PATH = "auth.oidc.requiredGroups";
 
   /** Default values */
   private static final String DEFAULT_OIDC_USERNAME_CLAIM = "email";
@@ -90,6 +95,9 @@ public class OidcConfigs extends SsoConfigs {
   private final String httpRetryAttempts;
   private final String httpRetryDelay;
 
+  /* Group Access Control */
+  private final Set<String> requiredGroups;
+
   public OidcConfigs(Builder builder) {
     super(builder);
     this.clientId = builder.clientId;
@@ -116,6 +124,11 @@ public class OidcConfigs extends SsoConfigs {
     this.grantType = builder.grantType;
     this.httpRetryAttempts = builder.httpRetryAttempts;
     this.httpRetryDelay = builder.httpRetryDelay;
+    this.requiredGroups = builder.requiredGroups;
+  }
+
+  public Set<String> getRequiredGroups() {
+    return requiredGroups;
   }
 
   public String getHttpRetryAttempts() {
@@ -154,6 +167,7 @@ public class OidcConfigs extends SsoConfigs {
     private Optional<String> acrValues = Optional.empty();
     private String httpRetryAttempts = DEFAULT_OIDC_HTTP_RETRY_ATTEMPTS;
     private String httpRetryDelay = DEFAULT_OIDC_HTTP_RETRY_DELAY;
+    private Set<String> requiredGroups = Collections.emptySet();
 
     public Builder from(final com.typesafe.config.Config configs) {
       super.from(configs);
@@ -206,6 +220,15 @@ public class OidcConfigs extends SsoConfigs {
       httpRetryAttempts =
           getOptional(configs, OIDC_HTTP_RETRY_ATTEMPTS, DEFAULT_OIDC_HTTP_RETRY_ATTEMPTS);
       httpRetryDelay = getOptional(configs, OIDC_HTTP_RETRY_DELAY, DEFAULT_OIDC_HTTP_RETRY_DELAY);
+      requiredGroups =
+          getOptional(configs, OIDC_REQUIRED_GROUPS_CONFIG_PATH)
+              .map(
+                  s ->
+                      Arrays.stream(s.split(","))
+                          .map(String::trim)
+                          .filter(str -> !str.isEmpty())
+                          .collect(Collectors.toSet()))
+              .orElse(Collections.emptySet());
       return this;
     }
 

--- a/datahub-frontend/app/auth/sso/oidc/RequiredGroupsException.java
+++ b/datahub-frontend/app/auth/sso/oidc/RequiredGroupsException.java
@@ -1,0 +1,10 @@
+package auth.sso.oidc;
+
+/**
+ * Exception thrown when a user does not belong to any of the required groups for OIDC login.
+ */
+public class RequiredGroupsException extends RuntimeException {
+	public RequiredGroupsException(String message) {
+		super(message);
+	}
+}

--- a/datahub-frontend/app/auth/sso/oidc/RequiredGroupsException.java
+++ b/datahub-frontend/app/auth/sso/oidc/RequiredGroupsException.java
@@ -1,10 +1,8 @@
 package auth.sso.oidc;
 
-/**
- * Exception thrown when a user does not belong to any of the required groups for OIDC login.
- */
+/** Exception thrown when a user does not belong to any of the required groups for OIDC login. */
 public class RequiredGroupsException extends RuntimeException {
-	public RequiredGroupsException(String message) {
-		super(message);
-	}
+  public RequiredGroupsException(String message) {
+    super(message);
+  }
 }

--- a/datahub-frontend/app/controllers/SsoCallbackController.java
+++ b/datahub-frontend/app/controllers/SsoCallbackController.java
@@ -4,6 +4,7 @@ import auth.CookieConfigs;
 import auth.sso.SsoManager;
 import auth.sso.SsoProvider;
 import auth.sso.oidc.OidcCallbackLogic;
+import auth.sso.oidc.RequiredGroupsException;
 import client.AuthServiceClient;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.utils.BasePathUtils;
@@ -29,7 +30,6 @@ import org.pac4j.play.context.PlayFrameworkParameters;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
-import auth.sso.oidc.RequiredGroupsException;
 
 /**
  * A dedicated Controller for handling redirects to DataHub by 3rd-party Identity Providers after
@@ -58,9 +58,10 @@ public class SsoCallbackController extends CallbackController {
     this.ssoManager = ssoManager;
     this.config = config;
     this.configs = configs;
-    this.accessDeniedMessage = configs.hasPath("auth.oidc.accessDeniedMessage")
-      ? configs.getString("auth.oidc.accessDeniedMessage")
-      : null;
+    this.accessDeniedMessage =
+        configs.hasPath("auth.oidc.accessDeniedMessage")
+            ? configs.getString("auth.oidc.accessDeniedMessage")
+            : null;
 
     // Set default URL with proper base path - redirects to Home Page on log in
     String basePath = BasePathUtils.normalizeBasePath(configs.getString("datahub.basePath"));
@@ -94,6 +95,7 @@ public class SsoCallbackController extends CallbackController {
         },
         this.ec.current());
   }
+
   public CompletionStage<Result> handleCallback(String protocol, Http.Request request) {
     if (shouldHandleCallback(protocol)) {
       log.debug(
@@ -103,28 +105,24 @@ public class SsoCallbackController extends CallbackController {
           .handle(
               (res, e) -> {
                 if (e != null) {
-                  log.error(
-                      "Caught exception while attempting to handle SSO callback! It's likely that SSO integration is mis-configured.",
-                      e);
-
-                  String basePath = BasePathUtils.normalizeBasePath(configs.getString("datahub.basePath"));
+                  String basePath =
+                      BasePathUtils.normalizeBasePath(configs.getString("datahub.basePath"));
                   String loginUrl = BasePathUtils.addBasePath("/login", basePath);
                   String message;
                   if (e.getCause() instanceof RequiredGroupsException) {
                     log.warn("User missing required groups.");
-                    message = (accessDeniedMessage != null && !accessDeniedMessage.isEmpty())
-                      ? accessDeniedMessage
-                      : "Access Denied: You do not belong to the required groups to access this application. Please contact your administrator.";
+                    message =
+                        (accessDeniedMessage != null && !accessDeniedMessage.isEmpty())
+                            ? accessDeniedMessage
+                            : "Access Denied: You do not belong to the required groups to access this application. Please contact your administrator.";
                   } else {
-                    message = "Failed to sign in using Single Sign-On provider. Please try again, or contact your DataHub Administrator.";
+                    message =
+                        "Failed to sign in using Single Sign-On provider. Please try again, or contact your DataHub Administrator.";
                   }
                   return Results.redirect(
                           String.format(
                               "%s?error_msg=%s",
-                              loginUrl,
-                              URLEncoder.encode(
-                                  message,
-                                  StandardCharsets.UTF_8)))
+                              loginUrl, URLEncoder.encode(message, StandardCharsets.UTF_8)))
                       .discardingCookie("actor")
                       .withNewSession();
                 }

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -213,6 +213,8 @@ auth.oidc.acrValues = ${?AUTH_OIDC_ACR_VALUES}
 auth.oidc.grantType = ${?AUTH_OIDC_GRANT_TYPE}
 auth.oidc.httpRetryAttempts = ${?AUTH_OIDC_HTTP_RETRY_ATTEMPTS} # Number of retry attempts for OIDC HTTP requests (token, userinfo). Defaults to 3.
 auth.oidc.httpRetryDelay = ${?AUTH_OIDC_HTTP_RETRY_DELAY} # Initial delay in milliseconds between retry attempts. Defaults to 1000.
+auth.oidc.accessDeniedMessage = ${?AUTH_OIDC_ACCESS_DENIED_MESSAGE} # Optional: Message to display if user is missing required groups. If not set, shows default error message.
+auth.oidc.requiredGroups = ${?AUTH_OIDC_REQUIRED_GROUPS} # Optional: Comma-separated list of required IAM groups for login. If set, users must have ANY of the specified groups. Leave unset to disable group enforcement.
 
 #
 # By default, the callback URL that should be registered with the identity provider is computed as {$baseUrl}/callback/oidc.

--- a/datahub-frontend/test/oidc/OidcCallbackLogicTest.java
+++ b/datahub-frontend/test/oidc/OidcCallbackLogicTest.java
@@ -1,27 +1,26 @@
 package oidc;
 
-import static auth.sso.oidc.OidcCallbackLogic.getGroupNames;
 import static auth.sso.oidc.OidcCallbackLogic.checkRequiredGroups;
-
-import auth.sso.oidc.OidcConfigs;
-import auth.sso.oidc.RequiredGroupsException;
+import static auth.sso.oidc.OidcCallbackLogic.getGroupNames;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import auth.sso.oidc.OidcConfigs;
+import auth.sso.oidc.RequiredGroupsException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Set;
 import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.pac4j.core.profile.CommonProfile;
 
 public class OidcCallbackLogicTest {
 
-
   @Test
   public void testCheckRequiredGroups_UserHasRequiredGroup() {
-    CommonProfile profile = createMockProfileWithAttribute("[\"group1\", \"group2\"]", "groupsClaimName");
+    CommonProfile profile =
+        createMockProfileWithAttribute("[\"group1\", \"group2\"]", "groupsClaimName");
     when(profile.containsAttribute("groupsClaimName")).thenReturn(true);
     String userName = "testuser";
 
@@ -31,12 +30,13 @@ public class OidcCallbackLogicTest {
     when(oidcConfigs.getGroupsClaimName()).thenReturn("groupsClaimName");
 
     org.junit.jupiter.api.Assertions.assertDoesNotThrow(
-      () -> checkRequiredGroups(profile, userName, oidcConfigs));
+        () -> checkRequiredGroups(profile, userName, oidcConfigs));
   }
 
   @Test
   public void testCheckRequiredGroups_UserHasNoRequiredGroup_Throws() {
-    CommonProfile profile = createMockProfileWithAttribute("[\"group3\", \"group4\"]", "groupsClaimName");
+    CommonProfile profile =
+        createMockProfileWithAttribute("[\"group3\", \"group4\"]", "groupsClaimName");
     when(profile.containsAttribute("groupsClaimName")).thenReturn(true);
     String userName = "testuser";
     OidcConfigs oidcConfigs = mock(OidcConfigs.class);
@@ -45,8 +45,7 @@ public class OidcCallbackLogicTest {
     when(oidcConfigs.getGroupsClaimName()).thenReturn("groupsClaimName");
 
     org.junit.jupiter.api.Assertions.assertThrows(
-      RequiredGroupsException.class,
-      () -> checkRequiredGroups(profile, userName, oidcConfigs));
+        RequiredGroupsException.class, () -> checkRequiredGroups(profile, userName, oidcConfigs));
   }
 
   @Test

--- a/datahub-frontend/test/oidc/OidcCallbackLogicTest.java
+++ b/datahub-frontend/test/oidc/OidcCallbackLogicTest.java
@@ -1,16 +1,53 @@
 package oidc;
 
 import static auth.sso.oidc.OidcCallbackLogic.getGroupNames;
+import static auth.sso.oidc.OidcCallbackLogic.checkRequiredGroups;
+
+import auth.sso.oidc.OidcConfigs;
+import auth.sso.oidc.RequiredGroupsException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Set;
+import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 import org.pac4j.core.profile.CommonProfile;
 
 public class OidcCallbackLogicTest {
+
+
+  @Test
+  public void testCheckRequiredGroups_UserHasRequiredGroup() {
+    CommonProfile profile = createMockProfileWithAttribute("[\"group1\", \"group2\"]", "groupsClaimName");
+    when(profile.containsAttribute("groupsClaimName")).thenReturn(true);
+    String userName = "testuser";
+
+    OidcConfigs oidcConfigs = mock(OidcConfigs.class);
+    Set<String> requiredGroups = new HashSet<>(Arrays.asList("group1", "group3"));
+    when(oidcConfigs.getRequiredGroups()).thenReturn(requiredGroups);
+    when(oidcConfigs.getGroupsClaimName()).thenReturn("groupsClaimName");
+
+    org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+      () -> checkRequiredGroups(profile, userName, oidcConfigs));
+  }
+
+  @Test
+  public void testCheckRequiredGroups_UserHasNoRequiredGroup_Throws() {
+    CommonProfile profile = createMockProfileWithAttribute("[\"group3\", \"group4\"]", "groupsClaimName");
+    when(profile.containsAttribute("groupsClaimName")).thenReturn(true);
+    String userName = "testuser";
+    OidcConfigs oidcConfigs = mock(OidcConfigs.class);
+    Set<String> requiredGroups = new HashSet<>(Arrays.asList("group1", "group2"));
+    when(oidcConfigs.getRequiredGroups()).thenReturn(requiredGroups);
+    when(oidcConfigs.getGroupsClaimName()).thenReturn("groupsClaimName");
+
+    org.junit.jupiter.api.Assertions.assertThrows(
+      RequiredGroupsException.class,
+      () -> checkRequiredGroups(profile, userName, oidcConfigs));
+  }
 
   @Test
   public void testGetGroupsClaimNamesJsonArray() {
@@ -52,9 +89,9 @@ public class OidcCallbackLogicTest {
     when(profile.getAttribute(attributeName)).thenReturn(attribute);
 
     // Mock for getAttribute(String, Class<T>)
-    if (attribute instanceof Collection) {
+    if (attribute instanceof Collection<?>) {
       when(profile.getAttribute(attributeName, Collection.class))
-          .thenReturn((Collection) attribute);
+          .thenReturn((Collection<?>) attribute);
     } else if (attribute instanceof String) {
       when(profile.getAttribute(attributeName, String.class)).thenReturn((String) attribute);
     }

--- a/docs/authentication/guides/sso/configure-oidc-react.md
+++ b/docs/authentication/guides/sso/configure-oidc-react.md
@@ -108,6 +108,20 @@ AUTH_OIDC_CLIENT_AUTHENTICATION_METHOD=authentication-method
 | AUTH_OIDC_CLIENT_AUTHENTICATION_METHOD | a string representing the token authentication method to use with the identity provider. Default value is `client_secret_basic`, which uses HTTP Basic authentication. Another option is `client_secret_post`, which includes the client_id and secret_id as form parameters in the HTTP POST request. For more info, see [OAuth 2.0 Client Authentication](https://darutk.medium.com/oauth-2-0-client-authentication-4b5f929305d4) | client_secret_basic |
 | AUTH_OIDC_PREFERRED_JWS_ALGORITHM      | Can be used to select a preferred signing algorithm for id tokens. Examples include: `RS256` or `HS256`. If your IdP includes `none` before `RS256`/`HS256` in the list of signing algorithms, then this value **MUST** be set.                                                                                                                                                                                                     |                     |
 
+## SSO Group-Based Access Control and Custom Messaging
+
+DataHub's SSO (Single Sign-On) integration supports group-based access control and customizable access denied messages using the following environment variables:
+
+- `AUTH_OIDC_REQUIRED_GROUPS`: A comma-separated list of required groups, extracted from the OIDC groups claim, for login. If set, users must have ANY of the specified groups to access DataHub. If unset, group enforcement is disabled and any authenticated user can log in.
+- `AUTH_OIDC_ACCESS_DENIED_MESSAGE`: The message displayed to users who are denied access because they do not belong to the required groups. If not set, a default error message is shown.
+
+**Example usage:**
+
+```
+AUTH_OIDC_REQUIRED_GROUPS=engineering,admins
+AUTH_OIDC_ACCESS_DENIED_MESSAGE=Access Denied: You do not belong to the required groups to access this application. Please contact your administrator.
+```
+
 ### User & Group Provisioning (JIT Provisioning)
 
 By default, DataHub will optimistically attempt to provision users and groups that do not already exist at the time of login.

--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -1096,6 +1096,8 @@ Reference Links:
 | `AUTH_OIDC_JIT_PROVISIONING_ENABLED`        | `true`                | Whether DataHub users should be provisioned on login if they don't exist | Frontend   |
 | `AUTH_OIDC_PRE_PROVISIONING_REQUIRED`       | `false`               | Whether the user should already exist in DataHub on login                | Frontend   |
 | `AUTH_OIDC_EXTRACT_GROUPS_ENABLED`          | `true`                | Whether groups should be extracted from a claim in the OIDC profile      | Frontend   |
+| `AUTH_OIDC_REQUIRED_GROUPS`                 | `null`                | Comma-separated list of required groups, from the OIDC groups claim.     | Frontend   |
+| `AUTH_OIDC_ACCESS_DENIED_MESSAGE`           | `null`                | Message shown to users when denied access for missing required groups.   | Frontend   |
 | `AUTH_OIDC_GROUPS_CLAIM`                    | `groups`              | The OIDC claim to extract groups information from                        | Frontend   |
 | `AUTH_OIDC_RESPONSE_TYPE`                   | `null`                | OIDC response type                                                       | Frontend   |
 | `AUTH_OIDC_RESPONSE_MODE`                   | `null`                | OIDC response mode                                                       | Frontend   |


### PR DESCRIPTION
In our organization we have a security requirement that access to datahub is blocked if the user doesn't have a specific LDAP group.
To achieve this, we have extended the current OIDC callback logic so that, after authentication, it now also checks if the user is part of at least one group, from a configurable list of groups. If not, an exception is raised and the login page shows the usual error message ("Failed to sign in using Single Sign-On provider. Please try again, or contact your DataHub Administrator."). We also made this message configurable.
The change is fully backwards compatible as it is optional, configurable through env vars, and by default the flow remains the same.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [X] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [X] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
