### PR TITLE
fix(graphql): listUsers resolver incorrect access check

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/user/ListUsersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/user/ListUsersResolver.java
@@ -5,9 +5,7 @@ import static com.linkedin.metadata.Constants.*;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
-import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.CorpUser;
 import com.linkedin.datahub.graphql.generated.ListUsersInput;
 import com.linkedin.datahub.graphql.generated.ListUsersResult;
@@ -45,55 +43,49 @@ public class ListUsersResolver implements DataFetcher<CompletableFuture<ListUser
 
     final QueryContext context = environment.getContext();
 
-    if (AuthorizationUtils.canManageUsersAndGroups(context)) {
-      final ListUsersInput input =
-          bindArgument(environment.getArgument("input"), ListUsersInput.class);
-      final Integer start = input.getStart() == null ? DEFAULT_START : input.getStart();
-      final Integer count = input.getCount() == null ? DEFAULT_COUNT : input.getCount();
-      final String query = input.getQuery() == null ? DEFAULT_QUERY : input.getQuery();
+    final ListUsersInput input =
+        bindArgument(environment.getArgument("input"), ListUsersInput.class);
+    final Integer start = input.getStart() == null ? DEFAULT_START : input.getStart();
+    final Integer count = input.getCount() == null ? DEFAULT_COUNT : input.getCount();
+    final String query = input.getQuery() == null ? DEFAULT_QUERY : input.getQuery();
 
-      return GraphQLConcurrencyUtils.supplyAsync(
-          () -> {
-            try {
-              // First, get all policy Urns.
-              final SearchResult gmsResult =
-                  _entityClient.search(
-                      context
-                          .getOperationContext()
-                          .withSearchFlags(flags -> flags.setFulltext(true)),
-                      CORP_USER_ENTITY_NAME,
-                      query,
-                      Collections.emptyMap(),
-                      start,
-                      count);
+    return GraphQLConcurrencyUtils.supplyAsync(
+        () -> {
+          try {
+            // First, get all policy Urns.
+            final SearchResult gmsResult =
+                _entityClient.search(
+                    context.getOperationContext().withSearchFlags(flags -> flags.setFulltext(true)),
+                    CORP_USER_ENTITY_NAME,
+                    query,
+                    Collections.emptyMap(),
+                    start,
+                    count);
 
-              // Then, get hydrate all users.
-              final Map<Urn, EntityResponse> entities =
-                  _entityClient.batchGetV2(
-                      context.getOperationContext(),
-                      CORP_USER_ENTITY_NAME,
-                      new HashSet<>(
-                          gmsResult.getEntities().stream()
-                              .map(SearchEntity::getEntity)
-                              .collect(Collectors.toList())),
-                      null);
+            // Then, get hydrate all users.
+            final Map<Urn, EntityResponse> entities =
+                _entityClient.batchGetV2(
+                    context.getOperationContext(),
+                    CORP_USER_ENTITY_NAME,
+                    new HashSet<>(
+                        gmsResult.getEntities().stream()
+                            .map(SearchEntity::getEntity)
+                            .collect(Collectors.toList())),
+                    null);
 
-              // Now that we have entities we can bind this to a result.
-              final ListUsersResult result = new ListUsersResult();
-              result.setStart(gmsResult.getFrom());
-              result.setCount(gmsResult.getPageSize());
-              result.setTotal(gmsResult.getNumEntities());
-              result.setUsers(mapEntities(context, entities.values()));
-              return result;
-            } catch (Exception e) {
-              throw new RuntimeException("Failed to list users", e);
-            }
-          },
-          this.getClass().getSimpleName(),
-          "get");
-    }
-    throw new AuthorizationException(
-        "Unauthorized to perform this action. Please contact your DataHub administrator.");
+            // Now that we have entities we can bind this to a result.
+            final ListUsersResult result = new ListUsersResult();
+            result.setStart(gmsResult.getFrom());
+            result.setCount(gmsResult.getPageSize());
+            result.setTotal(gmsResult.getNumEntities());
+            result.setUsers(mapEntities(context, entities.values()));
+            return result;
+          } catch (Exception e) {
+            throw new RuntimeException("Failed to list users", e);
+          }
+        },
+        this.getClass().getSimpleName(),
+        "get");
   }
 
   private static List<CorpUser> mapEntities(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/user/ListUsersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/user/ListUsersResolverTest.java
@@ -1,0 +1,188 @@
+package com.linkedin.datahub.graphql.resolvers.user;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static com.linkedin.metadata.Constants.CORP_USER_ENTITY_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.testng.Assert.*;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.ListUsersInput;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.identity.CorpUserInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.key.CorpUserKey;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class ListUsersResolverTest {
+
+  private static final Urn TEST_USER_URN = Urn.createFromTuple("corpuser", "test");
+
+  private static final ListUsersInput TEST_INPUT = new ListUsersInput();
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    // Mock search result
+    SearchResult searchResult =
+        new SearchResult()
+            .setFrom(0)
+            .setPageSize(1)
+            .setNumEntities(1)
+            .setEntities(
+                new SearchEntityArray(
+                    ImmutableSet.of(new SearchEntity().setEntity(TEST_USER_URN))));
+
+    Mockito.when(
+            mockClient.search(
+                any(),
+                Mockito.eq(CORP_USER_ENTITY_NAME),
+                Mockito.eq(""),
+                Mockito.eq(Collections.emptyMap()),
+                Mockito.eq(0),
+                Mockito.eq(20)))
+        .thenReturn(searchResult);
+
+    // Mock batchGetV2 result
+    EntityResponse entityResponse = createMockEntityResponse(TEST_USER_URN);
+    Map<Urn, EntityResponse> entityMap = new HashMap<>();
+    entityMap.put(TEST_USER_URN, entityResponse);
+
+    Mockito.when(
+            mockClient.batchGetV2(
+                any(), Mockito.eq(CORP_USER_ENTITY_NAME), any(), Mockito.isNull()))
+        .thenReturn(entityMap);
+
+    ListUsersResolver resolver = new ListUsersResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    // Data Assertions
+    var result = resolver.get(mockEnv).get();
+    assertEquals((int) result.getStart(), 0);
+    assertEquals((int) result.getCount(), 1);
+    assertEquals((int) result.getTotal(), 1);
+    assertNotNull(result.getUsers());
+    assertEquals(result.getUsers().size(), 1);
+    assertEquals(result.getUsers().get(0).getUrn(), TEST_USER_URN.toString());
+  }
+
+  @Test
+  public void testGetWithCustomInput() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    // Create custom input
+    ListUsersInput customInput = new ListUsersInput();
+    customInput.setStart(10);
+    customInput.setCount(5);
+    customInput.setQuery("test query");
+
+    // Mock search result
+    SearchResult searchResult =
+        new SearchResult()
+            .setFrom(10)
+            .setPageSize(5)
+            .setNumEntities(0)
+            .setEntities(new SearchEntityArray(ImmutableSet.of()));
+
+    Mockito.when(
+            mockClient.search(
+                any(),
+                Mockito.eq(CORP_USER_ENTITY_NAME),
+                Mockito.eq("test query"),
+                Mockito.eq(Collections.emptyMap()),
+                Mockito.eq(10),
+                Mockito.eq(5)))
+        .thenReturn(searchResult);
+
+    // Mock batchGetV2 result (empty)
+    Mockito.when(
+            mockClient.batchGetV2(
+                any(), Mockito.eq(CORP_USER_ENTITY_NAME), any(), Mockito.isNull()))
+        .thenReturn(Collections.emptyMap());
+
+    ListUsersResolver resolver = new ListUsersResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(customInput);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    // Data Assertions
+    var result = resolver.get(mockEnv).get();
+    assertEquals((int) result.getStart(), 10);
+    assertEquals((int) result.getCount(), 5);
+    assertEquals((int) result.getTotal(), 0);
+    assertNotNull(result.getUsers());
+    assertEquals(result.getUsers().size(), 0);
+  }
+
+  @Test
+  public void testGetEntityClientException() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.doThrow(RemoteInvocationException.class)
+        .when(mockClient)
+        .search(any(), any(), Mockito.eq(""), Mockito.anyMap(), Mockito.anyInt(), Mockito.anyInt());
+    ListUsersResolver resolver = new ListUsersResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+
+  private EntityResponse createMockEntityResponse(Urn userUrn) {
+    EntityResponse entityResponse = new EntityResponse();
+    entityResponse.setUrn(userUrn);
+
+    // Create CorpUserKey aspect
+    CorpUserKey corpUserKey = new CorpUserKey();
+    corpUserKey.setUsername(userUrn.getId());
+
+    EnvelopedAspect keyAspect = new EnvelopedAspect();
+    keyAspect.setValue(new Aspect(corpUserKey.data()));
+
+    // Create CorpUserInfo aspect
+    CorpUserInfo corpUserInfo = new CorpUserInfo();
+    corpUserInfo.setActive(true);
+    corpUserInfo.setFullName("Test User");
+    corpUserInfo.setEmail("test@example.com");
+
+    EnvelopedAspect infoAspect = new EnvelopedAspect();
+    infoAspect.setValue(new Aspect(corpUserInfo.data()));
+
+    Map<String, EnvelopedAspect> aspects = new HashMap<>();
+    aspects.put(Constants.CORP_USER_KEY_ASPECT_NAME, keyAspect);
+    aspects.put(Constants.CORP_USER_INFO_ASPECT_NAME, infoAspect);
+
+    entityResponse.setAspects(new EnvelopedAspectMap(aspects));
+    return entityResponse;
+  }
+}


### PR DESCRIPTION
# Remove Authorization Check from listUsers GraphQL Resolver

## Summary

This PR removes the authorization check from the `listUsers` GraphQL resolver, allowing all users to access the `listUsers` operation without requiring `MANAGE` privileges on `CORP_USER` and `CORP_GROUP` entities.

## Changes

### Removed Authorization Check

- **File**: `datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/user/ListUsersResolver.java`
  - Removed `AuthorizationUtils.canManageUsersAndGroups(context)` check that was blocking access
  - Removed unused imports: `AuthorizationUtils` and `AuthorizationException`
  - The resolver now executes the user listing logic directly without authorization gates

## Impact

- **Before**: Users without `MANAGE` privileges on `CORP_USER` and `CORP_GROUP` entities would receive an `AuthorizationException` when calling `listUsers`
- **After**: All authenticated users can now call `listUsers` without authorization restrictions

## Related Context

This change aligns with the broader authorization strategy where entity-level access controls are enforced at the data layer (e.g., through `EntityService` and `OperationContext`) rather than at the GraphQL resolver level for user listing operations.