### PR TITLE
fix(csv-enricher): Add HTTP status code checking for remote file fetches

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
@@ -632,6 +632,7 @@ class CSVEnricherSource(Source):
         if parsed_location.scheme in ("http", "https"):
             try:
                 resp = requests.get(self.config.filename)
+                resp.raise_for_status()  # Raise an exception for HTTP error status codes
                 decoded_content = resp.content.decode("utf-8-sig")
                 rows = list(
                     csv.DictReader(


### PR DESCRIPTION
## Summary

Fixes a bug in the `csv-enricher` source where HTTP error responses were being parsed as CSV data, causing cryptic `KeyError: 'resource'` exceptions.

## Problem

When fetching remote CSV files via HTTP/HTTPS URLs (e.g., S3 presigned URLs), the code was missing HTTP status validation. This caused confusing errors when:
- S3 presigned URLs expired
- Access was denied (403 Forbidden)  
- Files didn't exist (404 Not Found)
- Any other HTTP error occurred

Without status checking, the code would attempt to parse HTML/XML error responses as CSV data, leading to `KeyError: 'resource'` instead of meaningful error messages.

## Solution

- Added `resp.raise_for_status()` after the `requests.get()` call
- Now fails fast with clear HTTP error messages (403, 404, 500, etc.)
- Error is still wrapped in the existing try/except block for proper `ConfigurationError` reporting

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
