### PR TITLE
fix: Duplicate key DefaultEntitySpec(name=dashboard)

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESBrowseDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESBrowseDAO.java
@@ -601,8 +601,7 @@ public class ESBrowseDAO {
       @Nullable Filter filter,
       @Nonnull String input) {
 
-    // Deduplicate entity names to prevent duplicate EntitySpec objects
-    // which cause IllegalStateException when collecting to map
+    // Deduplicate entity names to prevent duplicate EntitySpec objects using .distinct()
     List<EntitySpec> entitySpecs =
         entities.stream()
             .distinct()

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESSearchDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESSearchDAO.java
@@ -345,8 +345,7 @@ public class ESSearchDAO {
 
     final String finalInput = input.isEmpty() ? "*" : input;
 
-    // Deduplicate entity names to prevent duplicate EntitySpec objects
-    // which cause IllegalStateException when collecting to map
+    // Deduplicate entity names to prevent duplicate EntitySpec objects using .distinct()
     List<EntitySpec> entitySpecs =
         entityNames.stream()
             .distinct()
@@ -519,8 +518,7 @@ public class ESSearchDAO {
     if (entityNames == null || entityNames.isEmpty()) {
       entitySpecs = QueryUtils.getQueryByDefaultEntitySpecs(opContext.getEntityRegistry());
     } else {
-      // Deduplicate entity names to prevent duplicate EntitySpec objects
-      // which cause IllegalStateException when collecting to map
+      // Deduplicate entity names to prevent duplicate EntitySpec objects using .distinct()
       entitySpecs =
           entityNames.stream()
               .distinct()
@@ -545,7 +543,7 @@ public class ESSearchDAO {
       List<String> indexPatterns = indexConvention.getAllEntityIndicesPatterns();
       searchRequest.indices(indexPatterns.toArray(new String[0]));
     } else {
-      // Deduplicate entity names to prevent duplicate EntitySpec objects
+      // Deduplicate entity names to prevent duplicate EntitySpec objects using .distinct()
       Stream<String> stream =
           entityNames.stream()
               .distinct()
@@ -632,8 +630,7 @@ public class ESSearchDAO {
       @Nonnull List<String> facets) {
     final String finalInput = input.isEmpty() ? "*" : input;
 
-    // Deduplicate entity names to prevent duplicate EntitySpec objects
-    // which cause IllegalStateException when collecting to map
+    // Deduplicate entity names to prevent duplicate EntitySpec objects using .distinct()
     List<EntitySpec> entitySpecs =
         entities.stream()
             .distinct()


### PR DESCRIPTION
closes #15438

Root Cause
The error occurred when duplicate entity type names were passed to the search engine. 
When these duplicate names were converted to EntitySpec objects using .map(name -> getEntitySpec(name)), the duplicate EntitySpec objects caused an IllegalStateException when the code attempted Collectors.toMap() without a merge function.

Solution
Added `.distinct()` calls to deduplicate entity names before converting them to EntitySpec objects in all relevant search and browse methods. This ensures that each entity type appears only once in the list, preventing the duplicate key error.