### PR TITLE
fix(es): Fix role name for Opensearch user

### DIFF
--- a/datahub-upgrade/src/main/resources/index/user/user_data_es_cloud.json
+++ b/datahub-upgrade/src/main/resources/index/user/user_data_es_cloud.json
@@ -1,4 +1,4 @@
 {
     "password": "ELASTICSEARCH_PASSWORD",
- 	  "roles":["PREFIXaccess"]
+ 	  "roles":["PREFIX"]
  }


### PR DESCRIPTION
## Summary

Fixed bug where Elasticsearch Cloud user role name was being doubled (e.g., `prefix_accessaccess` instead of `prefix_access`).

## Root Cause

The user template files had `"roles":["PREFIXaccess"]` instead of `"roles":["PREFIX"]`. When the code substituted `PREFIX` with the full role name (which already includes the `_access` suffix like `dh_access`), it resulted in a doubled suffix: `dh_accessaccess`.

## Impact

This caused authentication failures when DataHub tried to connect to Elasticsearch with security exceptions like:
```
action [indices:data/read/search] is unauthorized for user [dh] 
with effective roles [] (assigned roles [dh_accessaccess] were not found)
```


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
