### PR TITLE
feat(ingestion/grafana) add option to pass grafana user email as dashboard owner

### DIFF
--- a/metadata-ingestion/docs/sources/grafana/grafana_pre.md
+++ b/metadata-ingestion/docs/sources/grafana/grafana_pre.md
@@ -1,14 +1,14 @@
 ### Concept Mapping
 
-| Source Concept              | DataHub Concept                                           | Notes                                                                    |
-| --------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `"grafana"`                 | [Data Platform](../../metamodel/entities/dataPlatform.md) |                                                                          |
-| Grafana Folder              | [Container](../../metamodel/entities/container.md)        | Subtype `Folder`                                                         |
-| Grafana Dashboard           | [Container](../../metamodel/entities/container.md)        | Subtype `Dashboard`                                                      |
-| Grafana Panel/Visualization | [Chart](../../metamodel/entities/chart.md)                | Various types mapped based on panel type (e.g., graph → LINE, pie → PIE) |
-| Grafana Data Source         | [Dataset](../../metamodel/entities/dataset.md)            | Created for each panel's data source                                     |
-| Dashboard Owner             | [Corp User](../../metamodel/entities/corpuser.md)         | Derived from dashboard UID and creator                                   |
-| Dashboard Tags              | [Tag](../../metamodel/entities/tag.md)                    | Supports both simple tags and key:value tags                             |
+| Source Concept              | DataHub Concept                                           | Notes                                                                                                      |
+| --------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `"grafana"`                 | [Data Platform](../../metamodel/entities/dataPlatform.md) |                                                                                                            |
+| Grafana Folder              | [Container](../../metamodel/entities/container.md)        | Subtype `Folder`                                                                                           |
+| Grafana Dashboard           | [Container](../../metamodel/entities/container.md)        | Subtype `Dashboard`                                                                                        |
+| Grafana Panel/Visualization | [Chart](../../metamodel/entities/chart.md)                | Various types mapped based on panel type (e.g., graph → LINE, pie → PIE)                                   |
+| Grafana Data Source         | [Dataset](../../metamodel/entities/dataset.md)            | Created for each panel's data source                                                                       |
+| Dashboard Owner             | [Corp User](../../metamodel/entities/corpuser.md)         | Dashboard creator assigned as TECHNICAL_OWNER; email suffix removal configurable via `remove_email_suffix` |
+| Dashboard Tags              | [Tag](../../metamodel/entities/tag.md)                    | Supports both simple tags and key:value tags                                                               |
 
 ### Compatibility
 
@@ -108,3 +108,27 @@ source:
 - **SQL parsing**: Supports parsing of SQL queries for detailed lineage extraction
 
 **Performance Note:** Lineage extraction can be disabled (`include_lineage: false`) to improve ingestion performance when lineage information is not needed.
+
+#### Ownership Configuration
+
+The Grafana source extracts dashboard ownership from the dashboard creator and assigns them as a Technical Owner.
+
+```yaml
+source:
+  type: grafana
+  config:
+    url: "https://grafana.company.com"
+    service_account_token: "your_token"
+
+    # Ownership extraction (default: true)
+    ingest_owners: true
+
+    # Email suffix removal like @acryl.io (default: true)
+    remove_email_suffix: true
+```
+
+**Ownership Features:**
+
+- **Technical Owner assignment**: Dashboard creators are automatically assigned as Technical Owners
+- **Email suffix control**: Configure how user email addresses are converted to DataHub user URNs via `remove_email_suffix`
+- **Disable ownership**: Set `ingest_owners: false` to skip ownership extraction entirely

--- a/metadata-ingestion/docs/sources/grafana/grafana_recipe.yml
+++ b/metadata-ingestion/docs/sources/grafana/grafana_recipe.yml
@@ -10,6 +10,10 @@ source:
     # SSL verification for HTTPS connections
     verify_ssl: true # optional, default is true
 
+    # Ownership configuration
+    ingest_owners: true # optional, default is true - extract dashboard ownership
+    remove_email_suffix: true # optional, default is true - remove email suffix like @acryl.io
+
     # Source type mapping for lineage
     connection_to_platform_map:
       postgres:

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/entity_mcp_builder.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/entity_mcp_builder.py
@@ -167,6 +167,7 @@ def build_dashboard_mcps(
     chart_urns: List[str],
     base_url: str,
     ingest_owners: bool,
+    remove_email_suffix: bool,
     ingest_tags: bool,
 ) -> Tuple[str, List[MetadataChangeProposalWrapper]]:
     """Build dashboard metadata change proposals"""
@@ -206,7 +207,7 @@ def build_dashboard_mcps(
 
     # Ownership aspect
     if dashboard.uid and ingest_owners:
-        owner = _build_ownership(dashboard)
+        owner = _build_ownership(dashboard, remove_email_suffix)
         if owner:
             mcps.append(
                 MetadataChangeProposalWrapper(
@@ -378,24 +379,22 @@ def _build_dashboard_properties(dashboard: Dashboard) -> Dict[str, str]:
     return props
 
 
-def _build_ownership(dashboard: Dashboard) -> Optional[OwnershipClass]:
+def _build_ownership(
+    dashboard: Dashboard, remove_email_suffix: bool
+) -> Optional[OwnershipClass]:
     """Build ownership information"""
     owners = []
 
-    if dashboard.uid:
-        owners.append(
-            OwnerClass(
-                owner=make_user_urn(dashboard.uid),
-                type=OwnershipTypeClass.TECHNICAL_OWNER,
-            )
-        )
-
     if dashboard.created_by:
-        owner_id = dashboard.created_by.split("@")[0]
+        if remove_email_suffix:
+            owner_id = dashboard.created_by.split("@")[0]
+        else:
+            owner_id = dashboard.created_by
+
         owners.append(
             OwnerClass(
                 owner=make_user_urn(owner_id),
-                type=OwnershipTypeClass.DATAOWNER,
+                type=OwnershipTypeClass.TECHNICAL_OWNER,
             )
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_config.py
@@ -83,6 +83,11 @@ class GrafanaSourceConfig(
     ingest_owners: bool = Field(
         default=True, description="Whether to ingest dashboard ownership information"
     )
+    remove_email_suffix: bool = Field(
+        True,
+        description="Remove Grafana user email suffix for example, @acryl.io, "
+        "when assigning ownership.",
+    )
     skip_text_panels: bool = Field(
         default=False,
         description="Whether to skip text panels during ingestion. "

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -109,9 +109,7 @@ class GrafanaSource(StatefulIngestionSourceBase):
     - Tags and Ownership:
         - Dashboard and chart tags
         - Ownership information derived from:
-            - Dashboard creators
-            - Technical owners based on dashboard UIDs
-            - Custom ownership assignments
+            - Dashboard creators (Technical owner)
 
     The source supports the following capabilities:
     - Platform instance support for multi-Grafana deployments
@@ -392,6 +390,7 @@ class GrafanaSource(StatefulIngestionSourceBase):
             chart_urns=chart_urns,
             base_url=self.config.url,
             ingest_owners=self.config.ingest_owners,
+            remove_email_suffix=self.config.remove_email_suffix,
             ingest_tags=self.config.ingest_tags,
         )
 

--- a/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
@@ -2222,32 +2222,6 @@
     "entityType": "dashboard",
     "entityUrn": "urn:li:dashboard:(grafana,local-grafana.default)",
     "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:default",
-                    "type": "TECHNICAL_OWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dashboard",
-    "entityUrn": "urn:li:dashboard:(grafana,local-grafana.default)",
-    "changeType": "UPSERT",
     "aspectName": "globalTags",
     "aspect": {
         "json": {

--- a/metadata-ingestion/tests/unit/grafana/test_grafana_entity_mcp_builder.py
+++ b/metadata-ingestion/tests/unit/grafana/test_grafana_entity_mcp_builder.py
@@ -72,12 +72,20 @@ def test_build_dashboard_properties(mock_dashboard):
 
 
 def test_build_ownership(mock_dashboard):
-    ownership = _build_ownership(mock_dashboard)
+    ownership = _build_ownership(mock_dashboard, True)
     assert isinstance(ownership, OwnershipClass)
-    assert len(ownership.owners) == 2
+    assert len(ownership.owners) == 1
     assert {owner.owner for owner in ownership.owners} == {
-        "urn:li:corpuser:dash1",
         "urn:li:corpuser:test",
+    }
+
+
+def test_build_ownership_full_email(mock_dashboard):
+    ownership = _build_ownership(mock_dashboard, False)
+    assert isinstance(ownership, OwnershipClass)
+    assert len(ownership.owners) == 1
+    assert {owner.owner for owner in ownership.owners} == {
+        "urn:li:corpuser:test@test.com",
     }
 
 
@@ -147,6 +155,7 @@ def test_build_dashboard_mcps(mock_dashboard):
         chart_urns=chart_urns,
         base_url="http://grafana.test",
         ingest_owners=True,
+        remove_email_suffix=True,
         ingest_tags=True,
     )
 
@@ -193,7 +202,7 @@ def test_build_dashboard_mcps(mock_dashboard):
     )
     assert ownership_mcp is not None
     assert isinstance(ownership_mcp.aspect, OwnershipClass)  # type safety
-    assert len(ownership_mcp.aspect.owners) == 2
+    assert len(ownership_mcp.aspect.owners) == 1
 
 
 def test_build_chart_mcps_no_tags(mock_panel, mock_dashboard):
@@ -222,6 +231,7 @@ def test_build_dashboard_mcps_no_owners(mock_dashboard):
         chart_urns=[],
         base_url="http://grafana.test",
         ingest_owners=True,
+        remove_email_suffix=True,
         ingest_tags=True,
     )
 


### PR DESCRIPTION
This MR add a option like for the powerbi source to use the user email for the corpuser URN or just the part before @. Default to the part before @ as that is the behavior before this change. 

Also so not add the unique dashboard id as a dashboard owner. I really do not understand why that was added in the first place. If someone really need it, it can be added by a transformer as the dashboard id is part of the dashboard URN. 

```
yaml
*Example Grafana recipe configuration*

source:
  type: grafana
  config:
    url: "https://your-grafana.com/"
    
    # Example 1: Default behavior (strip emails to usernames)
    # This creates: urn:li:corpuser:john
    remove_email_suffix: true  # or omit (this is default)
    
    # Example 2: Keep full email as corporate user identifier
    # This creates: urn:li:corpuser:john@company.com
    # Use this if your company's SSO/LDAP uses full emails as user IDs
    remove_email_suffix: false
```

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
