### PR TITLE
test: make flaky neo4j integration test less flaky

### DIFF
--- a/metadata-ingestion/tests/integration/neo4j/test_neo4j.py
+++ b/metadata-ingestion/tests/integration/neo4j/test_neo4j.py
@@ -46,7 +46,10 @@ def check_neo4j_setup_completed() -> bool:
             count = record["count"]
 
             driver.close()
-            return count > 0  # Data is loaded if there are any nodes
+            # Waiting for count > 0 is not enough, the test is very flaky with that
+            # check. count > 9 typically take one extra pause (2s) to satisfy and makes
+            # the test a lot less flaky.
+            return count > 9
     except Exception:
         return False
 


### PR DESCRIPTION
I have noticed that tests/integration/neo4j/test_neo4j.py (in testIntegrationBatch2) is flaky and often fails with one or two of the Urns missing below:
Urn removed, urn:li:dataset:(urn:li:dataPlatform:neo4j,test_instance.SIMILAR_TO,TEST)
Urn removed, urn:li:dataset:(urn:li:dataPlatform:neo4j,test_instance.FOLLOWS,TEST)

It looks to me like the data is not always ready when the test starts. Wait for more objects to be ready in the database should make it less flaky.

It has failed about 10% (33 of 319) of all the runs the last 2 weeks.

I did run this test repeatedly locally (while having some random load on my computer) and every time it failed after 10-20 runs. I also noticed that then it only gets a few results from the `MATCH (n) RETURN count(n) as count` query. When I changed the threshold to wait for a count of at least 10 the test ran without errors. From my logging I saw that it typically only took one extra check to get from 2-4 to 17-19  (19 seems to be max). 

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Tests for the changes have been added/updated (if applicable)
