### PR TITLE
docs: Update GraqhQL query in external OAuth authentication docs

### DIFF
--- a/docs/authentication/external-oauth-providers.md
+++ b/docs/authentication/external-oauth-providers.md
@@ -170,7 +170,7 @@ Once configured, include your JWT token in the Authorization header when making 
 curl -H "Authorization: Bearer YOUR_JWT_TOKEN" \
      -H "Content-Type: application/json" \
      https://your-datahub.com/api/graphql \
-     -d '{"query": "{ corpUsers { total } }"}'
+     -d '{"query": "{ me { corpUser { urn username }}}"}'
 ```
 
 For Python applications:
@@ -186,7 +186,7 @@ headers = {
 response = requests.post(
     'https://your-datahub.com/api/graphql',
     headers=headers,
-    json={'query': '{ corpUsers { total } }'}
+    json={'query': '{ me { corpUser { urn username }}}'}
 )
 ```
 


### PR DESCRIPTION
The existing query in in the docs `{ corpUsers { total } }` does not work in current version of Datahub. Update the sample query to one that works and are relevant when trying to connect with a service account. 

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
