### PR TITLE
feat(ingestion): add advanced settings section

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/components/AntdCompatibleCheckbox.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/components/AntdCompatibleCheckbox.tsx
@@ -1,0 +1,35 @@
+import { Checkbox, Text } from '@components';
+import React from 'react';
+import styled from 'styled-components';
+
+const CheckboxWithHelper = styled.div`
+    // compensate checkbox container size
+    // see datahub-web-react/src/alchemy-components/components/Checkbox/components.ts -> CheckboxBase for details
+    position: relative;
+    left: -5px;
+
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+    align-items: center;
+`;
+
+interface Props {
+    id?: string;
+    checked?: boolean;
+    onChange?: (newValue: boolean) => void;
+    helper?: string;
+}
+
+export function AntdFormCompatibleCheckbox({ id, checked, onChange, helper }: Props) {
+    return (
+        <CheckboxWithHelper>
+            <Checkbox id={id} isChecked={checked} onCheckboxChange={onChange} justifyContent="flex-start" />
+            {helper && (
+                <Text size="sm" color="gray" colorLevel={600}>
+                    {helper}
+                </Text>
+            )}
+        </CheckboxWithHelper>
+    );
+}

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/components/ExpandCollapseButton.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/components/ExpandCollapseButton.tsx
@@ -1,0 +1,21 @@
+import { Button, Icon } from '@components';
+import React from 'react';
+
+interface Props {
+    expanded?: boolean;
+    onToggle?: () => void;
+}
+
+export function ExpandCollapseButton({ expanded, onToggle }: Props) {
+    return (
+        <Button variant="link" color="gray" onClick={onToggle}>
+            <Icon
+                source="phosphor"
+                icon={expanded ? 'CaretUp' : 'CaretDown'}
+                size="2xl"
+                color="gray"
+                colorLevel={1800}
+            />
+        </Button>
+    );
+}

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/components/SectionName.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/components/SectionName.tsx
@@ -7,17 +7,31 @@ const Wrapper = styled.div`
     flex-direction: column;
 `;
 
+const TopRow = styled.div`
+    display: flex;
+    flex-direction: row;
+`;
+
+const Spacer = styled.div`
+    flex: 1;
+`;
+
 interface Props {
     name: string;
     description?: string;
+    topRowRightItems?: React.ReactNode;
 }
 
-export function SectionName({ name, description }: Props) {
+export function SectionName({ name, description, topRowRightItems }: Props) {
     return (
         <Wrapper>
-            <Text weight="semiBold" size="lg">
-                {name}
-            </Text>
+            <TopRow>
+                <Text weight="semiBold" size="lg">
+                    {name}
+                </Text>
+                <Spacer />
+                {topRowRightItems}
+            </TopRow>
             {description && <Text color="gray">{description}</Text>}
         </Wrapper>
     );

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/SelectSourceStep.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/SelectSourceStep.tsx
@@ -91,6 +91,12 @@ export function SelectSourceStep() {
         }
         updateState({
             type: platformName,
+            // Reset state of the connection details form
+            isConnectionDetailsValid: false,
+            config: undefined,
+            name: undefined,
+            owners: undefined,
+            schedule: undefined,
         });
         goToNext();
     };

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/AdvansedSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/AdvansedSection.tsx
@@ -1,0 +1,147 @@
+import { Input, spacing, transition } from '@components';
+import { Form } from 'antd';
+import useFormInstance from 'antd/lib/form/hooks/useFormInstance';
+import React, { useCallback, useMemo, useState } from 'react';
+import styled from 'styled-components';
+
+import { AntdFormCompatibleCheckbox } from '@app/ingestV2/source/multiStepBuilder/components/AntdCompatibleCheckbox';
+import { ExpandCollapseButton } from '@app/ingestV2/source/multiStepBuilder/components/ExpandCollapseButton';
+import { SectionName } from '@app/ingestV2/source/multiStepBuilder/components/SectionName';
+import { MAX_FORM_WIDTH } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/constants';
+import { CustomLabelFormItem } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/components/CustomFormItem';
+import { MultiStepSourceBuilderState } from '@app/ingestV2/source/multiStepBuilder/types';
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: ${spacing.sm};
+`;
+
+const FormContainer = styled(Container)<{ $expanded?: boolean }>`
+    max-width: ${MAX_FORM_WIDTH};
+    max-height: ${(props) => (props.$expanded ? '100%' : '0px')};
+    transform-origin: top;
+    opacity: ${(props) => (props.$expanded ? 1 : 0)};
+    transform: ${(props) => (props.$expanded ? 'scaleY(1)' : 'scaleY(0)')};
+    transition:
+        transform ${transition.duration.normal} ${transition.easing['ease-in-out']},
+        opacity ${transition.duration.normal} ${transition.easing['ease-in-out']};
+`;
+
+interface Props {
+    state: MultiStepSourceBuilderState;
+    updateState: (newState: Partial<MultiStepSourceBuilderState>) => void;
+}
+
+const ExtraEnvKey = 'extra_env_vars';
+const ExtraReqKey = 'extra_pip_requirements';
+const ExtraPluginKey = 'extra_pip_plugins';
+
+export function AdvancedSection({ state, updateState }: Props) {
+    const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
+    const toggleIsExpanded = useCallback(() => {
+        setIsExpanded((prev) => !prev);
+    }, []);
+
+    function retrieveValueFromExtraArgs(builderState: MultiStepSourceBuilderState, key: string) {
+        return builderState.config?.extraArgs?.find((entry) => entry.key === key)?.value ?? '';
+    }
+
+    const initialState = useMemo(() => {
+        return {
+            executor_id: state.config?.executorId ?? '',
+            cli_version: state.config?.version ?? '',
+            debug_mode: state.config?.debugMode ?? '',
+            extra_args: retrieveValueFromExtraArgs(state, ExtraEnvKey),
+            extra_pip_plugin: retrieveValueFromExtraArgs(state, ExtraPluginKey),
+            extra_pip_reqs: retrieveValueFromExtraArgs(state, ExtraReqKey),
+        };
+    }, [state]);
+
+    const form = useFormInstance();
+
+    const onValuesChange = useCallback(
+        (_, values) => {
+            updateState({
+                ...state,
+                config: {
+                    ...state.config,
+                    executorId: values.executor_id,
+                    version: values.cli_version,
+                    debugMode: values.debug_mode,
+                    extraArgs: [
+                        { key: ExtraEnvKey, value: values.extra_args },
+                        { key: ExtraPluginKey, value: values.extra_pip_plugin },
+                        { key: ExtraReqKey, value: values.extra_pip_reqs },
+                    ],
+                },
+            });
+        },
+        [updateState, state],
+    );
+
+    return (
+        <Form form={form} layout="vertical" initialValues={initialState} onValuesChange={onValuesChange}>
+            <Container>
+                <SectionName
+                    name="Advanced Settings"
+                    topRowRightItems={<ExpandCollapseButton expanded={isExpanded} onToggle={toggleIsExpanded} />}
+                />
+
+                <FormContainer $expanded={isExpanded}>
+                    {/* NOTE: Executor ID is OSS-only, used by actions pod */}
+                    <CustomLabelFormItem
+                        label="Executor ID"
+                        help="Provide the ID of the executor that should execute this ingestion recipe. This ID is used to route
+                    execution requests of the recipe to the executor of the same ID. The built-in DataHub executor ID is
+                    'default'. Do not change this unless you have configured a custom executor via actions
+                    framework."
+                        name="executor_id"
+                    >
+                        <Input placeholder="default" value={state.config?.executorId || ''} />
+                    </CustomLabelFormItem>
+
+                    <CustomLabelFormItem
+                        label="CLI Version"
+                        help="Advanced: Provide a custom CLI version to use for ingestion."
+                        name="cli_version"
+                    >
+                        <Input data-testid="cli-version-input" placeholder="(e.g. 0.15.0)" />
+                    </CustomLabelFormItem>
+
+                    <CustomLabelFormItem label="Debug Mode" name="debug_mode">
+                        <AntdFormCompatibleCheckbox
+                            checked={state.config?.debugMode || false}
+                            helper="Advanced: Turn on debug mode in order to get more verbose logs."
+                        />
+                    </CustomLabelFormItem>
+
+                    <CustomLabelFormItem
+                        label="Extra Enviroment Variables"
+                        help="Advanced: Set extra environment variables to an ingestion execution"
+                        name="extra_args"
+                    >
+                        <Input data-testid="extra-args-input" placeholder='{"MY_CUSTOM_ENV": "my_custom_value2"}' />
+                    </CustomLabelFormItem>
+
+                    <CustomLabelFormItem
+                        label="Extra DataHub plugins"
+                        help="Advanced: Set extra DataHub plugins for an ingestion execution"
+                        name="extra_pip_plugin"
+                    >
+                        <Input data-testid="extra-pip-plugin-input" placeholder='["debug"]' />
+                    </CustomLabelFormItem>
+
+                    <CustomLabelFormItem
+                        label="Extra Pip Libraries"
+                        help="Advanced: Add extra pip libraries for an ingestion execution"
+                        name="extra_pip_reqs"
+                    >
+                        <Input data-testid="extra-pip-reqs-input" placeholder='["sqlparse==0.4.3"]' />
+                    </CustomLabelFormItem>
+                </FormContainer>
+            </Container>
+        </Form>
+    );
+}

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/RecipeSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/RecipeSection.tsx
@@ -1,29 +1,14 @@
-import { typography } from '@components';
 import { message } from 'antd';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import styled from 'styled-components';
 import YAML from 'yamljs';
 
 import { Tab, Tabs } from '@components/components/Tabs/Tabs';
 
-import { ANTD_GRAY } from '@app/entityV2/shared/constants';
 import { CONNECTORS_WITH_FORM } from '@app/ingestV2/source/builder/RecipeForm/constants';
-import { YamlEditor } from '@app/ingestV2/source/builder/YamlEditor';
 import { SourceConfig } from '@app/ingestV2/source/builder/types';
+import { YamlEditor } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/YamlEditor';
 import RecipeForm from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/RecipeForm';
 import { MultiStepSourceBuilderState } from '@app/ingestV2/source/multiStepBuilder/types';
-
-const BorderedSection = styled.div`
-    display: flex;
-    flex-direction: column;
-    padding-bottom: 16px;
-    border: solid ${ANTD_GRAY[4]} 0.5px;
-
-    && .view-line > span > span {
-        font-family: ${typography.fonts.mono} !important;
-        font-size: ${typography.fontSizes.md} !important;
-    }
-`;
 
 interface Props {
     state: MultiStepSourceBuilderState;
@@ -35,13 +20,14 @@ interface Props {
 
 export function RecipeSection({ state, displayRecipe, sourceConfigs, setStagedRecipe, setIsRecipeValid }: Props) {
     const { type } = state;
+    const isEditing = !!state.isEditing;
     const hasForm = useMemo(() => type && CONNECTORS_WITH_FORM.has(type), [type]);
     const [selectedTabKey, setSelectedTabKey] = useState<string>('form');
 
     // FYI: We don't have form validation for sources without a form
     useEffect(() => {
-        setIsRecipeValid?.(!hasForm);
-    }, [hasForm, setIsRecipeValid]);
+        setIsRecipeValid?.(!hasForm || isEditing || !!state.isConnectionDetailsValid);
+    }, [hasForm, isEditing, setIsRecipeValid, state.isConnectionDetailsValid]);
 
     const onTabClick = useCallback(
         (activeKey) => {
@@ -83,11 +69,7 @@ export function RecipeSection({ state, displayRecipe, sourceConfigs, setStagedRe
             {
                 key: 'yaml',
                 name: 'YAML',
-                component: (
-                    <BorderedSection>
-                        <YamlEditor initialText={displayRecipe} onChange={setStagedRecipe} />
-                    </BorderedSection>
-                ),
+                component: <YamlEditor value={displayRecipe} onChange={setStagedRecipe} />,
             },
         ],
         [displayRecipe, state, sourceConfigs, setStagedRecipe, setIsRecipeValid],
@@ -98,9 +80,5 @@ export function RecipeSection({ state, displayRecipe, sourceConfigs, setStagedRe
         return <Tabs tabs={tabs} selectedTab={selectedTabKey} onTabClick={onTabClick} destroyInactiveTabPane />;
     }
 
-    return (
-        <BorderedSection>
-            <YamlEditor initialText={displayRecipe} onChange={setStagedRecipe} />
-        </BorderedSection>
-    );
+    return <YamlEditor value={displayRecipe} onChange={setStagedRecipe} />;
 }

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/YamlEditor.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/YamlEditor.tsx
@@ -1,0 +1,150 @@
+import { Button, Icon, Text, borders, colors, radius, spacing, typography } from '@components';
+import Editor, { loader } from '@monaco-editor/react';
+import { message } from 'antd';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { resolveRuntimePath } from '@utils/runtimeBasePath';
+
+loader.config({
+    paths: {
+        vs: resolveRuntimePath('/node_modules/monaco-editor/min/vs'),
+    },
+});
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    border-radius: ${radius.lg};
+    border: ${borders['1px']} ${colors.gray[100]};
+    height: 100%;
+`;
+
+const Header = styled.div`
+    display: flex;
+    flex-direction: row;
+    gap: ${spacing.md};
+    background: ${colors.gray[1500]};
+    padding: ${spacing.xsm} ${spacing.md};
+    border-radius: ${radius.lg} ${radius.lg} 0 0;
+    border-bottom: ${borders['1px']} ${colors.gray[100]};
+`;
+
+const Spacer = styled.div`
+    flex: 1;
+`;
+
+const EditorWrapper = styled.div`
+    && .view-line > span > span {
+        font-family: ${typography.fonts.mono} !important;
+        font-size: ${typography.fontSizes.md} !important;
+    }
+
+    padding-bottom: 8px;
+    height: 100%;
+`;
+
+const NoPaddingButton = styled(Button)`
+    padding: 0;
+`;
+
+const LINE_HEIGHT = 19;
+
+type Props = {
+    value: string;
+    onChange: (value: any) => void;
+};
+
+export function YamlEditor({ value, onChange }: Props) {
+    const [isExpanded, setIsExpanded] = useState<boolean>(false);
+
+    const onCopy = useCallback(() => {
+        navigator.clipboard.writeText(value);
+        message.success('Copied!');
+    }, [value]);
+
+    const toggleExpanded = useCallback(() => {
+        setIsExpanded((currentIsExpanded) => !currentIsExpanded);
+    }, []);
+
+    const handleEditorWillMount = (monaco) => {
+        const commentColor = colors.gray[1700].slice(1);
+        const primaryColor = colors.primary[500].slice(1);
+
+        monaco.editor.defineTheme('my-custom-theme', {
+            base: 'vs',
+            inherit: false,
+            rules: [
+                { token: 'comment', foreground: commentColor, fontStyle: 'italic' },
+                { token: 'string', foreground: primaryColor },
+                { token: 'string.key.yaml', foreground: primaryColor, fontStyle: 'bold' },
+                { token: 'keyword', foreground: primaryColor },
+                { token: 'number', foreground: primaryColor },
+                { token: 'operator', foreground: primaryColor },
+                { token: 'delimiter', foreground: primaryColor },
+                { token: 'type', foreground: primaryColor, fontStyle: 'bold' },
+            ],
+            colors: {
+                'editor.background': colors.gray[0],
+                'editor.foreground': colors.primary[500],
+                'editor.selectionBackground': colors.primary[100],
+                'editorLineNumber.foreground': colors.primary[500],
+                'editorCursor.foreground': colors.gray[600],
+            },
+        });
+
+        monaco.editor.setTheme('my-custom-theme');
+    };
+
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const fullContentHeight = useMemo(() => {
+        return `${value.split('\n').length * LINE_HEIGHT}px`;
+    }, [value]);
+
+    return (
+        <Container ref={containerRef}>
+            <Header>
+                <Text weight="semiBold" color="gray" colorLevel={600}>
+                    YAML
+                </Text>
+                <Spacer />
+                <NoPaddingButton variant="text" size="md" color="gray" onClick={onCopy}>
+                    <Icon source="phosphor" size="md" icon="Copy" /> Copy
+                </NoPaddingButton>
+                <NoPaddingButton variant="text" size="md" color="gray" onClick={toggleExpanded}>
+                    {isExpanded ? (
+                        <Icon source="phosphor" size="lg" icon="ArrowsInLineVertical" />
+                    ) : (
+                        <Icon source="phosphor" size="lg" icon="ArrowsOutLineVertical" />
+                    )}
+                </NoPaddingButton>
+            </Header>
+            <EditorWrapper>
+                <Editor
+                    options={{
+                        minimap: { enabled: false },
+                        scrollbar: {
+                            vertical: 'hidden',
+                            horizontal: 'hidden',
+                        },
+                        overviewRulerLanes: 0,
+                        overviewRulerBorder: false,
+                        lineNumbers: 'off',
+                        fontFamily: typography.fonts.mono,
+                        renderIndentGuides: false,
+                        theme: 'my-custom-theme',
+                        renderLineHighlight: 'none',
+                        scrollBeyondLastLine: false,
+                    }}
+                    height={isExpanded ? fullContentHeight : '30vh'}
+                    defaultLanguage="yaml"
+                    theme="my-custom-theme"
+                    defaultValue={value}
+                    onChange={onChange}
+                    beforeMount={handleEditorWillMount}
+                />
+            </EditorWrapper>
+        </Container>
+    );
+}

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/fields/CheckboxField.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/fields/CheckboxField.tsx
@@ -1,41 +1,8 @@
-import { Checkbox, Text } from '@components';
 import React from 'react';
-import styled from 'styled-components';
 
+import { AntdFormCompatibleCheckbox } from '@app/ingestV2/source/multiStepBuilder/components/AntdCompatibleCheckbox';
 import { RecipeFormItem } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/fields/RecipeFormItem';
 import { CommonFieldProps } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/fields/types';
-
-const CheckboxWithHelper = styled.div`
-    // compensate checkbox container size
-    // see datahub-web-react/src/alchemy-components/components/Checkbox/components.ts -> CheckboxBase for details
-    position: relative;
-    left: -5px;
-
-    display: flex;
-    flex-direction: row;
-    gap: 4px;
-    align-items: center;
-`;
-
-interface Props {
-    id?: string;
-    checked?: boolean;
-    onChange?: (newValue: boolean) => void;
-    helper?: string;
-}
-
-function AntdFormCompatibleCheckbox({ id, checked, onChange, helper }: Props) {
-    return (
-        <CheckboxWithHelper>
-            <Checkbox id={id} isChecked={checked} onCheckboxChange={onChange} justifyContent="flex-start" />
-            {helper && (
-                <Text size="sm" color="gray" colorLevel={600}>
-                    {helper}
-                </Text>
-            )}
-        </CheckboxWithHelper>
-    );
-}
 
 export function CheckboxField({ field }: CommonFieldProps) {
     return (

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/types.ts
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/types.ts
@@ -12,6 +12,8 @@ export interface MultiStepSourceBuilderState extends SourceBuilderState {
     shouldRun?: boolean;
     ingestionSource?: IngestionSource;
     isEditing?: boolean;
+    // To restore last validation state after moving back
+    isConnectionDetailsValid?: boolean;
 }
 
 export interface SubmitOptions {


### PR DESCRIPTION
Linear: https://linear.app/acryl-data/issue/CAT-965/implement-advanced-settings-form

Depends on: https://github.com/datahub-project/datahub/pull/15474

This PR adds the Advanced settings section to the step 2 of create/update ingestion source flow


https://github.com/user-attachments/assets/09ed0050-a166-43dc-81be-844f7eb6748c



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/da

https://github.com/user-attachments/assets/add3774c-1658-4b96-9998-895be20b07df

tahub/blob/master/docs/how/updating-datahub.md)

-->
