### PR TITLE
fix(platformsModule): do not show add sources button when an user doesn't have permissions to manage ingestions

### DIFF
--- a/datahub-web-react/src/app/homeV3/modules/platforms/PlatformsModule.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/platforms/PlatformsModule.tsx
@@ -1,5 +1,5 @@
 import { Text, Tooltip } from '@components';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { useUserContext } from '@app/context/useUserContext';
 import { useGetPlatforms } from '@app/homeV2/content/tabs/discovery/sections/platform/useGetPlatforms';
@@ -9,13 +9,22 @@ import LargeModule from '@app/homeV3/module/components/LargeModule';
 import { ModuleProps } from '@app/homeV3/module/types';
 import usePlatformModuleUtils from '@app/homeV3/modules/platforms/usePlatformsModuleUtils';
 import { formatNumber, formatNumberWithoutAbbreviation } from '@app/shared/formatNumber';
+import { useAppConfig } from '@app/useAppConfig';
 
 import { DataHubPageModuleType, Entity } from '@types';
 
 const NUMBER_OF_PLATFORMS = 15;
 
 const PlatformsModule = (props: ModuleProps) => {
-    const { user } = useUserContext();
+    const { user, platformPrivileges } = useUserContext();
+
+    const { config } = useAppConfig();
+
+    const hasPermissionsToManageIngestion = useMemo(() => {
+        const isIngestionEnabled = config?.managedIngestionConfig?.enabled;
+        return isIngestionEnabled && platformPrivileges?.manageIngestion;
+    }, [config?.managedIngestionConfig?.enabled, platformPrivileges?.manageIngestion]);
+
     const { platforms, loading } = useGetPlatforms(user, NUMBER_OF_PLATFORMS);
     const { navigateToDataSources, handleEntityClick } = usePlatformModuleUtils();
 
@@ -53,7 +62,7 @@ const PlatformsModule = (props: ModuleProps) => {
                     icon="Database"
                     title="No Platforms Yet"
                     description="You have not ingested any data."
-                    linkText="Add data sources"
+                    linkText={hasPermissionsToManageIngestion ? 'Add data sources' : undefined}
                     onLinkClick={navigateToDataSources}
                 />
             ) : (


### PR DESCRIPTION
Linear: https://linear.app/acryl-data/issue/CAT-1006/bug-hide-cta-to-ingestion-page-in-modules-if-user-does-not-have

This PR hides "Add data sources" button when an user doesn't have permissions to manage ingestions

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
