### PR TITLE
feat(assertion): enforce strict urns for assertions

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -9,6 +9,8 @@
 - #13726: Default search results per page (new: 5000, old: 10000) can be configured with environment variable `ELASTICSEARCH_LIMIT_RESULTS_API_DEFAULT`
 - #13726: Maximum lineage visualization hops (new: 20, old: 1000) can be configured with environment variable `ELASTICSEARCH_SEARCH_GRAPH_LINEAGE_MAX_HOPS`
 - #15044: If using the new system-update sqlSetup, the system-update job must be granted privileges to create users, databases, and tables.
+- #15512: Assertion related data models will enforce strict urn validation including selective existence, format, and supported entity types. This may impact
+          existing assertions which would need to be removed from the system.
 
 ### Known Issues
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/AssertionUrnValidationAnnotationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/AssertionUrnValidationAnnotationTest.java
@@ -1,0 +1,361 @@
+package com.linkedin.metadata.aspect.validation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.assertion.AssertionInfo;
+import com.linkedin.assertion.AssertionRunEvent;
+import com.linkedin.assertion.AssertionRunStatus;
+import com.linkedin.assertion.AssertionStdOperator;
+import com.linkedin.assertion.AssertionType;
+import com.linkedin.assertion.CustomAssertionInfo;
+import com.linkedin.assertion.DatasetAssertionInfo;
+import com.linkedin.assertion.DatasetAssertionScope;
+import com.linkedin.assertion.FreshnessAssertionInfo;
+import com.linkedin.assertion.FreshnessAssertionSchedule;
+import com.linkedin.assertion.FreshnessAssertionScheduleType;
+import com.linkedin.assertion.FreshnessAssertionType;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.BatchItem;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Tests that verify the UrnAnnotationValidator correctly validates URN fields in assertion aspects.
+ * These tests use real assertion record templates with the actual AspectSpec from the entity
+ * registry.
+ *
+ * <p>Note: All assertion aspects have exist=false (entity type validation only).
+ */
+public class AssertionUrnValidationAnnotationTest {
+
+  private static final EntityRegistry ENTITY_REGISTRY =
+      TestOperationContexts.defaultEntityRegistry();
+  private static final AspectPluginConfig TEST_PLUGIN_CONFIG =
+      AspectPluginConfig.builder()
+          .className(UrnAnnotationValidator.class.getName())
+          .enabled(true)
+          .supportedOperations(List.of("UPSERT"))
+          .supportedEntityAspectNames(List.of(AspectPluginConfig.EntityAspectName.ALL))
+          .build();
+
+  private static final Urn TEST_ASSERTION_URN = UrnUtils.getUrn("urn:li:assertion:test-assertion");
+  private static final Urn TEST_DATASET_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,testDataset,PROD)");
+  private static final Urn TEST_DATAJOB_URN =
+      UrnUtils.getUrn("urn:li:dataJob:(urn:li:dataFlow:(airflow,test_dag,PROD),test_task)");
+  private static final Urn TEST_SCHEMA_FIELD_URN =
+      UrnUtils.getUrn(
+          "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,testDataset,PROD),fieldName)");
+  private static final Urn INVALID_ENTITY_TYPE_URN = UrnUtils.getUrn("urn:li:corpuser:testUser");
+
+  @Mock private BatchItem mockBatchItem;
+  @Mock private RetrieverContext mockRetrieverContext;
+  @Mock private AspectRetriever mockAspectRetriever;
+
+  private UrnAnnotationValidator validator;
+  private EntitySpec assertionEntitySpec;
+
+  @BeforeMethod
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    validator = new UrnAnnotationValidator();
+    validator.setConfig(TEST_PLUGIN_CONFIG);
+    assertionEntitySpec = ENTITY_REGISTRY.getEntitySpec("assertion");
+
+    when(mockRetrieverContext.getAspectRetriever()).thenReturn(mockAspectRetriever);
+    when(mockAspectRetriever.getEntityRegistry()).thenReturn(ENTITY_REGISTRY);
+    // Default: no entities exist (tests override as needed)
+    when(mockAspectRetriever.entityExists(any())).thenReturn(Collections.emptyMap());
+  }
+
+  // ==================== DatasetAssertionInfo Tests ====================
+
+  @Test
+  public void testDatasetAssertionInfo_ValidDatasetUrn() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.DATASET);
+    DatasetAssertionInfo datasetAssertion = new DatasetAssertionInfo();
+    datasetAssertion.setDataset(TEST_DATASET_URN);
+    datasetAssertion.setScope(DatasetAssertionScope.DATASET_ROWS);
+    datasetAssertion.setOperator(AssertionStdOperator.EQUAL_TO);
+    assertionInfo.setDatasetAssertion(datasetAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertTrue(exceptions.isEmpty(), "No exceptions expected for valid dataset URN");
+  }
+
+  @Test
+  public void testDatasetAssertionInfo_InvalidEntityType() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.DATASET);
+    DatasetAssertionInfo datasetAssertion = new DatasetAssertionInfo();
+    datasetAssertion.setDataset(INVALID_ENTITY_TYPE_URN); // corpuser instead of dataset
+    datasetAssertion.setScope(DatasetAssertionScope.DATASET_ROWS);
+    datasetAssertion.setOperator(AssertionStdOperator.EQUAL_TO);
+    assertionInfo.setDatasetAssertion(datasetAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertFalse(exceptions.isEmpty(), "Should fail for invalid entity type");
+    assertTrue(
+        exceptions.get(0).getMessage().contains("Invalid entity type"),
+        "Error should indicate invalid entity type");
+  }
+
+  @Test
+  public void testDatasetAssertionInfo_ValidSchemaFieldUrns() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.DATASET);
+    DatasetAssertionInfo datasetAssertion = new DatasetAssertionInfo();
+    datasetAssertion.setDataset(TEST_DATASET_URN);
+    datasetAssertion.setScope(DatasetAssertionScope.DATASET_COLUMN);
+    datasetAssertion.setOperator(AssertionStdOperator.EQUAL_TO);
+    datasetAssertion.setFields(new UrnArray(TEST_SCHEMA_FIELD_URN));
+    assertionInfo.setDatasetAssertion(datasetAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertTrue(exceptions.isEmpty(), "No exceptions for valid schemaField URNs");
+  }
+
+  @Test
+  public void testDatasetAssertionInfo_InvalidSchemaFieldEntityType() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.DATASET);
+    DatasetAssertionInfo datasetAssertion = new DatasetAssertionInfo();
+    datasetAssertion.setDataset(TEST_DATASET_URN);
+    datasetAssertion.setScope(DatasetAssertionScope.DATASET_COLUMN);
+    datasetAssertion.setOperator(AssertionStdOperator.EQUAL_TO);
+    datasetAssertion.setFields(new UrnArray(TEST_DATASET_URN)); // dataset instead of schemaField
+    assertionInfo.setDatasetAssertion(datasetAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertFalse(exceptions.isEmpty(), "Should fail for invalid schemaField entity type");
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+  }
+
+  // ==================== CustomAssertionInfo Tests ====================
+
+  @Test
+  public void testCustomAssertionInfo_ValidUrns() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.CUSTOM);
+    CustomAssertionInfo customAssertion = new CustomAssertionInfo();
+    customAssertion.setType("custom-type");
+    customAssertion.setEntity(TEST_DATASET_URN);
+    customAssertion.setField(TEST_SCHEMA_FIELD_URN);
+    assertionInfo.setCustomAssertion(customAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertTrue(exceptions.isEmpty(), "No exceptions for valid custom assertion URNs");
+  }
+
+  @Test
+  public void testCustomAssertionInfo_InvalidEntityType_ForEntity() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.CUSTOM);
+    CustomAssertionInfo customAssertion = new CustomAssertionInfo();
+    customAssertion.setType("custom-type");
+    customAssertion.setEntity(INVALID_ENTITY_TYPE_URN); // corpuser instead of dataset
+    assertionInfo.setCustomAssertion(customAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertFalse(exceptions.isEmpty(), "Should fail for invalid entity type on entity field");
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+  }
+
+  @Test
+  public void testCustomAssertionInfo_InvalidEntityType_ForField() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.CUSTOM);
+    CustomAssertionInfo customAssertion = new CustomAssertionInfo();
+    customAssertion.setType("custom-type");
+    customAssertion.setEntity(TEST_DATASET_URN);
+    customAssertion.setField(TEST_DATASET_URN); // dataset instead of schemaField
+    assertionInfo.setCustomAssertion(customAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertFalse(exceptions.isEmpty(), "Should fail for invalid entity type on field");
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+  }
+
+  // ==================== FreshnessAssertionInfo Tests ====================
+
+  @Test
+  public void testFreshnessAssertionInfo_ValidDatasetUrn() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.FRESHNESS);
+    FreshnessAssertionInfo freshnessAssertion = new FreshnessAssertionInfo();
+    freshnessAssertion.setType(FreshnessAssertionType.DATASET_CHANGE);
+    freshnessAssertion.setEntity(TEST_DATASET_URN);
+    freshnessAssertion.setSchedule(
+        new FreshnessAssertionSchedule().setType(FreshnessAssertionScheduleType.FIXED_INTERVAL));
+    assertionInfo.setFreshnessAssertion(freshnessAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertTrue(exceptions.isEmpty(), "No exceptions for valid dataset URN in freshness assertion");
+  }
+
+  @Test
+  public void testFreshnessAssertionInfo_ValidDataJobUrn() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.FRESHNESS);
+    FreshnessAssertionInfo freshnessAssertion = new FreshnessAssertionInfo();
+    freshnessAssertion.setType(FreshnessAssertionType.DATA_JOB_RUN);
+    freshnessAssertion.setEntity(TEST_DATAJOB_URN);
+    freshnessAssertion.setSchedule(
+        new FreshnessAssertionSchedule().setType(FreshnessAssertionScheduleType.FIXED_INTERVAL));
+    assertionInfo.setFreshnessAssertion(freshnessAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertTrue(exceptions.isEmpty(), "No exceptions for valid dataJob URN in freshness assertion");
+  }
+
+  @Test
+  public void testFreshnessAssertionInfo_InvalidEntityType() {
+    AssertionInfo assertionInfo = new AssertionInfo();
+    assertionInfo.setType(AssertionType.FRESHNESS);
+    FreshnessAssertionInfo freshnessAssertion = new FreshnessAssertionInfo();
+    freshnessAssertion.setType(FreshnessAssertionType.DATASET_CHANGE);
+    freshnessAssertion.setEntity(INVALID_ENTITY_TYPE_URN); // corpuser not allowed
+    freshnessAssertion.setSchedule(
+        new FreshnessAssertionSchedule().setType(FreshnessAssertionScheduleType.FIXED_INTERVAL));
+    assertionInfo.setFreshnessAssertion(freshnessAssertion);
+
+    setupMockBatchItem(assertionInfo, "assertionInfo");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertFalse(exceptions.isEmpty(), "Should fail for invalid entity type");
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+  }
+
+  // ==================== AssertionRunEvent Tests (exist=false, entity type validation only)
+  // ====================
+
+  @Test
+  public void testAssertionRunEvent_ValidUrns() {
+    AssertionRunEvent runEvent = new AssertionRunEvent();
+    runEvent.setTimestampMillis(System.currentTimeMillis());
+    runEvent.setRunId("test-run-id");
+    runEvent.setAsserteeUrn(TEST_DATASET_URN);
+    runEvent.setAssertionUrn(TEST_ASSERTION_URN);
+    runEvent.setStatus(AssertionRunStatus.COMPLETE);
+
+    setupMockBatchItem(runEvent, "assertionRunEvent");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertTrue(exceptions.isEmpty(), "No exceptions for valid URN entity types");
+  }
+
+  @Test
+  public void testAssertionRunEvent_InvalidAsserteeEntityType() {
+    AssertionRunEvent runEvent = new AssertionRunEvent();
+    runEvent.setTimestampMillis(System.currentTimeMillis());
+    runEvent.setRunId("test-run-id");
+    runEvent.setAsserteeUrn(INVALID_ENTITY_TYPE_URN); // corpuser not allowed
+    runEvent.setAssertionUrn(TEST_ASSERTION_URN);
+    runEvent.setStatus(AssertionRunStatus.COMPLETE);
+
+    setupMockBatchItem(runEvent, "assertionRunEvent");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertFalse(exceptions.isEmpty(), "Should fail for invalid assertee entity type");
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+  }
+
+  @Test
+  public void testAssertionRunEvent_InvalidAssertionEntityType() {
+    AssertionRunEvent runEvent = new AssertionRunEvent();
+    runEvent.setTimestampMillis(System.currentTimeMillis());
+    runEvent.setRunId("test-run-id");
+    runEvent.setAsserteeUrn(TEST_DATASET_URN);
+    runEvent.setAssertionUrn(TEST_DATASET_URN); // dataset instead of assertion
+    runEvent.setStatus(AssertionRunStatus.COMPLETE);
+
+    setupMockBatchItem(runEvent, "assertionRunEvent");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertFalse(exceptions.isEmpty(), "Should fail for invalid assertion entity type");
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+  }
+
+  @Test
+  public void testAssertionRunEvent_DataJobAsAssertee_InvalidEntityType() {
+    AssertionRunEvent runEvent = new AssertionRunEvent();
+    runEvent.setTimestampMillis(System.currentTimeMillis());
+    runEvent.setRunId("test-run-id");
+    runEvent.setAsserteeUrn(TEST_DATAJOB_URN); // dataJob not allowed, only dataset
+    runEvent.setAssertionUrn(TEST_ASSERTION_URN);
+    runEvent.setStatus(AssertionRunStatus.COMPLETE);
+
+    setupMockBatchItem(runEvent, "assertionRunEvent");
+
+    List<AspectValidationException> exceptions = runValidation();
+    assertFalse(exceptions.isEmpty(), "DataJob should not be valid as assertee");
+    assertTrue(exceptions.get(0).getMessage().contains("Invalid entity type"));
+  }
+
+  // ==================== Helper Methods ====================
+
+  private void setupMockBatchItem(
+      com.linkedin.data.template.RecordTemplate recordTemplate, String aspectName) {
+    when(mockBatchItem.getAspectSpec()).thenReturn(assertionEntitySpec.getAspectSpec(aspectName));
+    when(mockBatchItem.getRecordTemplate()).thenReturn(recordTemplate);
+  }
+
+  private void mockEntityExists(Map<Urn, Boolean> existenceMap) {
+    when(mockAspectRetriever.entityExists(any()))
+        .thenAnswer(
+            invocation -> {
+              Set<Urn> requestedUrns = invocation.getArgument(0);
+              Map<Urn, Boolean> result = new HashMap<>();
+              for (Urn urn : requestedUrns) {
+                result.put(urn, existenceMap.getOrDefault(urn, false));
+              }
+              return result;
+            });
+  }
+
+  private List<AspectValidationException> runValidation() {
+    Stream<AspectValidationException> result =
+        validator.validateProposedAspects(
+            Collections.singletonList(mockBatchItem), mockRetrieverContext);
+    return result.collect(Collectors.toList());
+  }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/assertion/AssertionRunEvent.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/assertion/AssertionRunEvent.pdl
@@ -33,6 +33,11 @@ record AssertionRunEvent {
   * Urn of entity on which the assertion is applicable
   */
   @TimeseriesField = {}
+  @UrnValidation = {
+    "exist": false,
+    "strict": true,
+    "entityTypes": [ "dataset" ]
+  }
   asserteeUrn: Urn
 
   /**
@@ -60,6 +65,11 @@ record AssertionRunEvent {
   * Urn of assertion which is evaluated
   */
   @TimeseriesField = {}
+  @UrnValidation = {
+    "exist": false,
+    "strict": true,
+    "entityTypes": [ "assertion" ]
+  }
   assertionUrn: Urn
 
   /**

--- a/metadata-models/src/main/pegasus/com/linkedin/assertion/CustomAssertionInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/assertion/CustomAssertionInfo.pdl
@@ -23,6 +23,11 @@ record CustomAssertionInfo {
       "name": "Asserts",
       "entityTypes": [ "dataset" ]
     }
+    @UrnValidation = {
+      "exist": false,
+      "strict": true,
+      "entityTypes": [ "dataset" ]
+    }
     entity: Urn
 
     /**
@@ -32,6 +37,11 @@ record CustomAssertionInfo {
     */
     @Relationship = {
       "name": "Asserts",
+      "entityTypes": [ "schemaField" ]
+    }
+    @UrnValidation = {
+      "exist": false,
+      "strict": true,
       "entityTypes": [ "schemaField" ]
     }
     field: optional Urn

--- a/metadata-models/src/main/pegasus/com/linkedin/assertion/DatasetAssertionInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/assertion/DatasetAssertionInfo.pdl
@@ -13,6 +13,11 @@ record DatasetAssertionInfo {
       "name": "Asserts",
       "entityTypes": [ "dataset" ]
     }
+    @UrnValidation = {
+      "exist": false,
+      "strict": true,
+      "entityTypes": [ "dataset" ]
+    }
     dataset: Urn
 
     /**
@@ -61,6 +66,11 @@ record DatasetAssertionInfo {
       "/*": {
         "fieldType": "URN"
       }
+    }
+    @UrnValidation = {
+      "exist": false,
+      "strict": true,
+      "entityTypes": [ "schemaField" ]
     }
     fields: optional array[Urn]
 

--- a/metadata-models/src/main/pegasus/com/linkedin/assertion/FieldAssertionInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/assertion/FieldAssertionInfo.pdl
@@ -33,6 +33,11 @@ record FieldAssertionInfo {
       "name": "Asserts",
       "entityTypes": [ "dataset" ]
     }
+    @UrnValidation = {
+      "exist": false,
+      "strict": true,
+      "entityTypes": [ "dataset" ]
+    }
     entity: Urn
 
     /**

--- a/metadata-models/src/main/pegasus/com/linkedin/assertion/FreshnessAssertionInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/assertion/FreshnessAssertionInfo.pdl
@@ -33,6 +33,11 @@ record FreshnessAssertionInfo {
       "name": "Asserts",
       "entityTypes": [ "dataset", "dataJob" ]
     }
+    @UrnValidation = {
+      "exist": false,
+      "strict": true,
+      "entityTypes": [ "dataset", "dataJob" ]
+    }
     entity: Urn
 
     /**

--- a/metadata-models/src/main/pegasus/com/linkedin/assertion/SchemaAssertionInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/assertion/SchemaAssertionInfo.pdl
@@ -17,6 +17,11 @@ record SchemaAssertionInfo {
       "name": "Asserts",
       "entityTypes": [ "dataset", "dataJob" ]
     }
+    @UrnValidation = {
+      "exist": false,
+      "strict": true,
+      "entityTypes": [ "dataset", "dataJob" ]
+    }
     entity: Urn
 
     /**

--- a/metadata-models/src/main/pegasus/com/linkedin/assertion/SqlAssertionInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/assertion/SqlAssertionInfo.pdl
@@ -33,6 +33,11 @@ record SqlAssertionInfo {
       "name": "Asserts",
       "entityTypes": [ "dataset" ]
     }
+    @UrnValidation = {
+      "exist": false,
+      "strict": true,
+      "entityTypes": [ "dataset" ]
+    }
     entity: Urn
 
     /**

--- a/metadata-models/src/main/pegasus/com/linkedin/assertion/VolumeAssertionInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/assertion/VolumeAssertionInfo.pdl
@@ -47,6 +47,11 @@ record VolumeAssertionInfo {
       "name": "Asserts",
       "entityTypes": [ "dataset" ]
     }
+    @UrnValidation = {
+      "exist": false,
+      "strict": true,
+      "entityTypes": [ "dataset" ]
+    }
     entity: Urn
 
     /**

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/UrnValidationUtil.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/UrnValidationUtil.java
@@ -221,6 +221,14 @@ public class UrnValidationUtil {
       // Recursively traverse nested DataMaps
       if (value instanceof DataMap) {
         traverseDataMap((DataMap) value, fieldPath, urnValidationSpecs, result);
+      } else if (value instanceof DataList) {
+        // Recursively traverse DataMaps within arrays (e.g., array[RecordType])
+        DataList list = (DataList) value;
+        for (Object item : list) {
+          if (item instanceof DataMap) {
+            traverseDataMap((DataMap) item, fieldPath + "/*", urnValidationSpecs, result);
+          }
+        }
       }
     }
   }

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/UrnValidationUtilTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/UrnValidationUtilTest.java
@@ -1,7 +1,18 @@
 package com.linkedin.metadata.utils;
 
+import static org.mockito.Mockito.*;
+
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.DataList;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.PathSpec;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.aspect.batch.BatchItem;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.UrnValidationFieldSpec;
+import com.linkedin.metadata.models.annotation.UrnValidationAnnotation;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.io.BufferedReader;
@@ -11,6 +22,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.testng.Assert;
@@ -44,6 +56,196 @@ public class UrnValidationUtilTest {
   @Test(expectedExceptions = NullPointerException.class)
   public void testUrnNull() {
     UrnValidationUtil.validateUrn(entityRegistry, null, true);
+  }
+
+  // ==================== findUrnValidationFields Tests ====================
+
+  @Test
+  public void testFindUrnValidationFields_DirectField() {
+    // Test finding a URN field directly on the aspect
+    String testUrn = "urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)";
+    DataMap dataMap = new DataMap();
+    dataMap.put("entity", testUrn);
+
+    UrnValidationAnnotation annotation =
+        new UrnValidationAnnotation(true, true, List.of("dataset"));
+    PathSpec pathSpec = new PathSpec("entity");
+    DataSchema dataSchema = mock(DataSchema.class);
+    UrnValidationFieldSpec fieldSpec = new UrnValidationFieldSpec(pathSpec, annotation, dataSchema);
+
+    AspectSpec aspectSpec = mock(AspectSpec.class);
+    when(aspectSpec.getUrnValidationFieldSpecMap()).thenReturn(Map.of("/entity", fieldSpec));
+
+    RecordTemplate recordTemplate = mock(RecordTemplate.class);
+    when(recordTemplate.data()).thenReturn(dataMap);
+
+    BatchItem batchItem = mock(BatchItem.class);
+    when(batchItem.getRecordTemplate()).thenReturn(recordTemplate);
+    when(batchItem.getAspectSpec()).thenReturn(aspectSpec);
+
+    Set<UrnValidationUtil.UrnValidationEntry> entries =
+        UrnValidationUtil.findUrnValidationFields(batchItem, aspectSpec);
+
+    Assert.assertEquals(entries.size(), 1);
+    UrnValidationUtil.UrnValidationEntry entry = entries.iterator().next();
+    Assert.assertEquals(entry.getUrn(), testUrn);
+    Assert.assertEquals(entry.getFieldPath(), "/entity");
+  }
+
+  @Test
+  public void testFindUrnValidationFields_NestedRecord() {
+    // Test finding a URN field in a nested record (e.g., source.sourceUrn)
+    String testUrn = "urn:li:assertion:test-assertion";
+    DataMap sourceMap = new DataMap();
+    sourceMap.put("sourceUrn", testUrn);
+    sourceMap.put("type", "INFERRED_ASSERTION_FAILURE");
+
+    DataMap dataMap = new DataMap();
+    dataMap.put("source", sourceMap);
+
+    UrnValidationAnnotation annotation =
+        new UrnValidationAnnotation(true, true, List.of("assertion"));
+    PathSpec pathSpec = new PathSpec("source", "sourceUrn");
+    DataSchema dataSchema = mock(DataSchema.class);
+    UrnValidationFieldSpec fieldSpec = new UrnValidationFieldSpec(pathSpec, annotation, dataSchema);
+
+    AspectSpec aspectSpec = mock(AspectSpec.class);
+    when(aspectSpec.getUrnValidationFieldSpecMap())
+        .thenReturn(Map.of("/source/sourceUrn", fieldSpec));
+
+    RecordTemplate recordTemplate = mock(RecordTemplate.class);
+    when(recordTemplate.data()).thenReturn(dataMap);
+
+    BatchItem batchItem = mock(BatchItem.class);
+    when(batchItem.getRecordTemplate()).thenReturn(recordTemplate);
+    when(batchItem.getAspectSpec()).thenReturn(aspectSpec);
+
+    Set<UrnValidationUtil.UrnValidationEntry> entries =
+        UrnValidationUtil.findUrnValidationFields(batchItem, aspectSpec);
+
+    Assert.assertEquals(entries.size(), 1);
+    UrnValidationUtil.UrnValidationEntry entry = entries.iterator().next();
+    Assert.assertEquals(entry.getUrn(), testUrn);
+    Assert.assertEquals(entry.getFieldPath(), "/source/sourceUrn");
+  }
+
+  @Test
+  public void testFindUrnValidationFields_ArrayOfRecords() {
+    // Test finding URN fields inside an array of records (e.g., assertions[*].assertion)
+    String testUrn1 = "urn:li:assertion:assertion-1";
+    String testUrn2 = "urn:li:assertion:assertion-2";
+
+    DataMap record1 = new DataMap();
+    record1.put("assertion", testUrn1);
+
+    DataMap record2 = new DataMap();
+    record2.put("assertion", testUrn2);
+
+    DataList arrayList = new DataList();
+    arrayList.add(record1);
+    arrayList.add(record2);
+
+    DataMap dataMap = new DataMap();
+    dataMap.put("assertions", arrayList);
+
+    UrnValidationAnnotation annotation =
+        new UrnValidationAnnotation(true, true, List.of("assertion"));
+    PathSpec pathSpec = new PathSpec("assertions", PathSpec.WILDCARD, "assertion");
+    DataSchema dataSchema = mock(DataSchema.class);
+    UrnValidationFieldSpec fieldSpec = new UrnValidationFieldSpec(pathSpec, annotation, dataSchema);
+
+    AspectSpec aspectSpec = mock(AspectSpec.class);
+    when(aspectSpec.getUrnValidationFieldSpecMap())
+        .thenReturn(Map.of("/assertions/*/assertion", fieldSpec));
+
+    RecordTemplate recordTemplate = mock(RecordTemplate.class);
+    when(recordTemplate.data()).thenReturn(dataMap);
+
+    BatchItem batchItem = mock(BatchItem.class);
+    when(batchItem.getRecordTemplate()).thenReturn(recordTemplate);
+    when(batchItem.getAspectSpec()).thenReturn(aspectSpec);
+
+    Set<UrnValidationUtil.UrnValidationEntry> entries =
+        UrnValidationUtil.findUrnValidationFields(batchItem, aspectSpec);
+
+    Assert.assertEquals(entries.size(), 2, "Should find URNs in both array elements");
+    Set<String> urns =
+        entries.stream()
+            .map(UrnValidationUtil.UrnValidationEntry::getUrn)
+            .collect(java.util.stream.Collectors.toSet());
+    Assert.assertTrue(urns.contains(testUrn1));
+    Assert.assertTrue(urns.contains(testUrn2));
+  }
+
+  @Test
+  public void testFindUrnValidationFields_ArrayOfUrns() {
+    // Test finding URN fields that are directly an array of URNs (e.g., fields: array[Urn])
+    String testUrn1 = "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD),f1)";
+    String testUrn2 = "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD),f2)";
+
+    DataList urnList = new DataList();
+    urnList.add(testUrn1);
+    urnList.add(testUrn2);
+
+    DataMap dataMap = new DataMap();
+    dataMap.put("fields", urnList);
+
+    UrnValidationAnnotation annotation =
+        new UrnValidationAnnotation(false, true, List.of("schemaField"));
+    PathSpec pathSpec = new PathSpec("fields");
+    DataSchema dataSchema = mock(DataSchema.class);
+    UrnValidationFieldSpec fieldSpec = new UrnValidationFieldSpec(pathSpec, annotation, dataSchema);
+
+    AspectSpec aspectSpec = mock(AspectSpec.class);
+    when(aspectSpec.getUrnValidationFieldSpecMap()).thenReturn(Map.of("/fields", fieldSpec));
+
+    RecordTemplate recordTemplate = mock(RecordTemplate.class);
+    when(recordTemplate.data()).thenReturn(dataMap);
+
+    BatchItem batchItem = mock(BatchItem.class);
+    when(batchItem.getRecordTemplate()).thenReturn(recordTemplate);
+    when(batchItem.getAspectSpec()).thenReturn(aspectSpec);
+
+    Set<UrnValidationUtil.UrnValidationEntry> entries =
+        UrnValidationUtil.findUrnValidationFields(batchItem, aspectSpec);
+
+    Assert.assertEquals(entries.size(), 2, "Should find both URNs in the array");
+    Set<String> urns =
+        entries.stream()
+            .map(UrnValidationUtil.UrnValidationEntry::getUrn)
+            .collect(java.util.stream.Collectors.toSet());
+    Assert.assertTrue(urns.contains(testUrn1));
+    Assert.assertTrue(urns.contains(testUrn2));
+  }
+
+  @Test
+  public void testFindUrnValidationFields_EmptyArray() {
+    // Test with an empty array - should return no entries
+    DataList emptyList = new DataList();
+    DataMap dataMap = new DataMap();
+    dataMap.put("assertions", emptyList);
+
+    UrnValidationAnnotation annotation =
+        new UrnValidationAnnotation(true, true, List.of("assertion"));
+    PathSpec pathSpec = new PathSpec("assertions", PathSpec.WILDCARD, "assertion");
+    DataSchema dataSchema = mock(DataSchema.class);
+    UrnValidationFieldSpec fieldSpec = new UrnValidationFieldSpec(pathSpec, annotation, dataSchema);
+
+    AspectSpec aspectSpec = mock(AspectSpec.class);
+    when(aspectSpec.getUrnValidationFieldSpecMap())
+        .thenReturn(Map.of("/assertions/*/assertion", fieldSpec));
+
+    RecordTemplate recordTemplate = mock(RecordTemplate.class);
+    when(recordTemplate.data()).thenReturn(dataMap);
+
+    BatchItem batchItem = mock(BatchItem.class);
+    when(batchItem.getRecordTemplate()).thenReturn(recordTemplate);
+    when(batchItem.getAspectSpec()).thenReturn(aspectSpec);
+
+    Set<UrnValidationUtil.UrnValidationEntry> entries =
+        UrnValidationUtil.findUrnValidationFields(batchItem, aspectSpec);
+
+    Assert.assertEquals(entries.size(), 0, "Empty array should return no entries");
   }
 
   /**


### PR DESCRIPTION
## Add URN Validation Annotations to Assertion PDL Models

### Summary
Added `@UrnValidation` annotations to assertion-related PDL models to enforce entity type validation on URN fields at ingestion time.

### PDL Changes

**Entity type validation only (`exist: false`):**
- `DatasetAssertionInfo.pdl` - `dataset` field (dataset), `fields` array (schemaField)
- `CustomAssertionInfo.pdl` - `entity` field (dataset), `field` field (schemaField)
- `FreshnessAssertionInfo.pdl` - `entity` field (dataset, dataJob)
- `VolumeAssertionInfo.pdl` - `entity` field (dataset)
- `SqlAssertionInfo.pdl` - `entity` field (dataset)
- `FieldAssertionInfo.pdl` - `entity` field (dataset)
- `SchemaAssertionInfo.pdl` - `entity` field (dataset, dataJob)
- `AssertionRunEvent.pdl` - `asserteeUrn` (dataset), `assertionUrn` (assertion)

### Test Coverage
Added `AssertionUrnValidationAnnotationTest.java` with 16 tests verifying:
- Valid entity types pass validation
- Invalid entity types fail with "Invalid entity type" error