### PR TITLE
fix(ingestion/grafana): fix broken ownership ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/entity_mcp_builder.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/entity_mcp_builder.py
@@ -206,7 +206,7 @@ def build_dashboard_mcps(
     )
 
     # Ownership aspect
-    if dashboard.uid and ingest_owners:
+    if ingest_owners:
         owner = _build_ownership(dashboard, remove_email_suffix)
         if owner:
             mcps.append(

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/models.py
@@ -240,7 +240,6 @@ class Dashboard(_GrafanaBaseModel):
         result.setdefault("version", None)
         result.setdefault("timezone", None)
         result.setdefault("refresh", None)
-        result.setdefault("created_by", None)
 
     @staticmethod
     def _cleanup_dashboard_metadata(result: Dict[str, Any]) -> None:
@@ -276,12 +275,13 @@ class Dashboard(_GrafanaBaseModel):
             else:
                 panels = _panel_data
 
-            meta = dashboard_data.get("meta", {})
-            folder_id = meta.get("folderId") if meta else None
-
             result = {**dashboard_data, "panels": panels}
-            if folder_id is not None:
-                result["folder_id"] = folder_id
+
+            if (meta := data.get("meta")) is not None:
+                # We only want to set folder_id and created_by from meta if we get it
+                # from json and not when creating Dashboard(uid=...) like in tests.
+                result["folder_id"] = meta.get("folderId")
+                result["created_by"] = meta.get("createdBy")
 
             cls._set_dashboard_defaults(result)
             cls._cleanup_dashboard_metadata(result)

--- a/metadata-ingestion/tests/integration/grafana/grafana_basic_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/grafana/grafana_basic_mcps_golden.json
@@ -1,83 +1,18 @@
 [
 {
     "entityType": "container",
-    "entityUrn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
+    "entityUrn": "urn:li:container:839d480ae59afad9450be04d22794390",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
         "json": {
             "customProperties": {
                 "platform": "grafana",
-                "dashboard_id": "default"
+                "dashboard_id": "default",
+                "folder_id": "0"
             },
             "name": "Test Integration Dashboard",
             "description": "A comprehensive test dashboard for integration testing with various panel types and data sources"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:grafana"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Dashboard"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": []
         }
     },
     "systemMetadata": {
@@ -94,6 +29,93 @@
     "aspect": {
         "json": {
             "platform": "urn:li:dataPlatform:grafana"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:839d480ae59afad9450be04d22794390",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:839d480ae59afad9450be04d22794390",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:grafana"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:839d480ae59afad9450be04d22794390",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:839d480ae59afad9450be04d22794390",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:839d480ae59afad9450be04d22794390",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Dashboard"
+            ]
         }
     },
     "systemMetadata": {
@@ -374,7 +396,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -443,7 +465,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -619,7 +641,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -653,8 +675,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }
@@ -730,7 +756,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -748,8 +774,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }
@@ -806,8 +836,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }
@@ -827,8 +861,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }
@@ -1026,7 +1064,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -1044,8 +1082,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }
@@ -1288,7 +1330,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -1306,8 +1348,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }
@@ -1575,7 +1621,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -1591,7 +1637,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -1609,8 +1655,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }
@@ -1630,8 +1680,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }
@@ -1769,7 +1823,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -1787,8 +1841,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }
@@ -1881,7 +1939,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+            "container": "urn:li:container:839d480ae59afad9450be04d22794390"
         }
     },
     "systemMetadata": {
@@ -1899,8 +1957,12 @@
         "json": {
             "path": [
                 {
-                    "id": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099",
-                    "urn": "urn:li:container:15a4d4f049d1fb26674e0b66dfa58099"
+                    "id": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08",
+                    "urn": "urn:li:container:b56143fc7b8d27b753f35d6ebff39d08"
+                },
+                {
+                    "id": "urn:li:container:839d480ae59afad9450be04d22794390",
+                    "urn": "urn:li:container:839d480ae59afad9450be04d22794390"
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
@@ -1,7 +1,7 @@
 [
 {
     "entityType": "container",
-    "entityUrn": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
+    "entityUrn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
@@ -9,82 +9,11 @@
             "customProperties": {
                 "platform": "grafana",
                 "instance": "local-grafana",
-                "dashboard_id": "default"
+                "dashboard_id": "default",
+                "folder_id": "0"
             },
             "name": "Test Integration Dashboard",
             "description": "A comprehensive test dashboard for integration testing with various panel types and data sources"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:grafana",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Dashboard"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1720785600000,
-        "runId": "grafana-test",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
-                }
-            ]
         }
     },
     "systemMetadata": {
@@ -102,6 +31,98 @@
         "json": {
             "platform": "urn:li:dataPlatform:grafana",
             "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:grafana",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
+                },
+                {
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Dashboard"
+            ]
         }
     },
     "systemMetadata": {
@@ -449,7 +470,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -522,7 +543,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -687,7 +708,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -748,8 +769,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -887,7 +912,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -988,8 +1013,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -1013,8 +1042,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -1038,8 +1071,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -1244,7 +1281,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -1266,8 +1303,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -1534,7 +1575,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -1556,8 +1597,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -1776,7 +1821,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -1837,8 +1882,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -1931,7 +1980,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -2058,8 +2107,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -2124,7 +2177,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -2146,8 +2199,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -2264,7 +2321,7 @@
     "aspectName": "container",
     "aspect": {
         "json": {
-            "container": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+            "container": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
         }
     },
     "systemMetadata": {
@@ -2286,8 +2343,12 @@
                     "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:grafana,local-grafana)"
                 },
                 {
-                    "id": "urn:li:container:ae0ac23df7f392b003891eb008eea810",
-                    "urn": "urn:li:container:ae0ac23df7f392b003891eb008eea810"
+                    "id": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7",
+                    "urn": "urn:li:container:3f7f0ee1c1c6a62d266aa117b9a9bbc7"
+                },
+                {
+                    "id": "urn:li:container:a43000865444793eb86e9a7c2f1978cf",
+                    "urn": "urn:li:container:a43000865444793eb86e9a7c2f1978cf"
                 }
             ]
         }
@@ -2322,6 +2383,32 @@
     "aspect": {
         "json": {
             "name": "test-tag"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(grafana,local-grafana.default)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:Anonymous",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/unit/grafana/test_grafana_entity_mcp_builder.py
+++ b/metadata-ingestion/tests/unit/grafana/test_grafana_entity_mcp_builder.py
@@ -41,7 +41,7 @@ def mock_dashboard():
         tags=["tag1", "environment:prod"],
         timezone="UTC",
         schemaVersion="1.0",
-        meta={"folderId": "123"},
+        folder_id="123",
         created_by="test@test.com",
     )
 

--- a/metadata-ingestion/tests/unit/grafana/test_grafana_validation.py
+++ b/metadata-ingestion/tests/unit/grafana/test_grafana_validation.py
@@ -352,6 +352,27 @@ def test_realistic_grafana_api_response():
     """Test validation with a realistic Grafana API response format."""
     # Simulates a typical Grafana API response with some optional fields missing
     real_response = {
+        "meta": {
+            "type": "db",
+            "canSave": True,
+            "canEdit": True,
+            "slug": "production-metrics",
+            "url": "/d/real-dashboard/production-metrics",
+            "expires": "0001-01-01T00:00:00Z",
+            "created": "2024-01-01T10:00:00Z",
+            "updated": "2024-01-15T14:30:00Z",
+            "updatedBy": "admin@localhost",
+            "createdBy": "admin@localhost",
+            "version": 5,
+            "hasAcl": False,
+            "isFolder": False,
+            "folderId": 1,
+            "folderUid": "general",
+            "folderTitle": "General",
+            "folderUrl": "",
+            "provisioned": False,
+            "provisionedExternalId": "",
+        },
         "dashboard": {
             "id": 450,
             "uid": "real-dashboard",
@@ -378,29 +399,8 @@ def test_realistic_grafana_api_response():
             "refresh": "30s",
             "schemaVersion": 30,
             "version": 5,
-            "meta": {
-                "type": "db",
-                "canSave": True,
-                "canEdit": True,
-                "slug": "production-metrics",
-                "url": "/d/real-dashboard/production-metrics",
-                "expires": "0001-01-01T00:00:00Z",
-                "created": "2024-01-01T10:00:00Z",
-                "updated": "2024-01-15T14:30:00Z",
-                "updatedBy": "admin",
-                "createdBy": "admin",
-                "version": 5,
-                "hasAcl": False,
-                "isFolder": False,
-                "folderId": 1,
-                "folderUid": "general",
-                "folderTitle": "General",
-                "folderUrl": "",
-                "provisioned": False,
-                "provisionedExternalId": "",
-            },
             # Note: 'tags' and 'description' fields are not included
-        }
+        },
     }
 
     dashboard = Dashboard.model_validate(real_response)
@@ -411,6 +411,7 @@ def test_realistic_grafana_api_response():
     assert dashboard.version == "5"  # Should be converted to string
     assert dashboard.refresh == "30s"
     assert dashboard.folder_id == "1"  # Extracted from meta
+    assert dashboard.created_by == "admin@localhost"  # Extracted from meta
     assert len(dashboard.panels) == 2
 
     # Verify panels are processed correctly


### PR DESCRIPTION
`meta` where folder_id and created_by is extracted from is located at the top level not under dashboard, from [`/api/dashboards/uid/:uid`](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/dashboard/#get-dashboard-by-uid). https://github.com/grafana/grafana/blob/4ab198b201acc42077463518d1697ed79a0ce77e/pkg/api/dashboard.go#L261C2-L264C3

Fixes: #15524 

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
