### PR TITLE
fix(ui) Fix two spots that need resolveRuntimePath

### DIFF
--- a/datahub-web-react/src/app/ingestV2/shared/hooks/useCapabilitySummary.ts
+++ b/datahub-web-react/src/app/ingestV2/shared/hooks/useCapabilitySummary.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { type CapabilitySummary, type PluginDetails } from '@app/ingestV2/shared/capabilitySummary';
+import { resolveRuntimePath } from '@utils/runtimeBasePath';
 
 export const useCapabilitySummary = () => {
     const [capabilitySummary, setCapabilitySummary] = useState<CapabilitySummary | null>(null);
@@ -13,7 +14,7 @@ export const useCapabilitySummary = () => {
             setError(null);
 
             try {
-                const response = await fetch('/assets/ingestion/capability_summary.json');
+                const response = await fetch(resolveRuntimePath('/assets/ingestion/capability_summary.json'));
                 if (!response.ok) {
                     throw new Error(`Failed to fetch capability summary: ${response.status} ${response.statusText}`);
                 }

--- a/datahub-web-react/src/app/mfeframework/mfeConfigLoader.tsx
+++ b/datahub-web-react/src/app/mfeframework/mfeConfigLoader.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { Route } from 'react-router';
 
 import { MFEBaseConfigurablePage } from '@app/mfeframework/MFEConfigurableContainer';
+import { resolveRuntimePath } from '@utils/runtimeBasePath';
 
 export interface MFEFlags {
     enabled: boolean;
@@ -101,7 +102,7 @@ export function useMFEConfigFromBackend(): MFESchema | null {
     useEffect(() => {
         async function fetchConfig() {
             try {
-                const response = await fetch('/mfe/config');
+                const response = await fetch(resolveRuntimePath('/mfe/config'));
                 if (!response.ok) throw new Error(`Failed to fetch YAML: ${response.statusText}`);
                 const yamlText = await response.text();
 


### PR DESCRIPTION
If we are manually constructing a URL internally to make a request against, we need to wrap it in a `resolveRuntimePath` function to support base path prefixes to an instance.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
