### PR TITLE
fix(ui): Adding a fallback icon for failed images on Lineage cards

### DIFF
--- a/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
+++ b/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
@@ -126,7 +126,7 @@ const PlatformIcon = ({ src, alt }: { src: string; alt: string }) => {
     const [errored, setErrored] = React.useState(false);
 
     if (errored) {
-        return <Icon size="4xl" source="phosphor" icon="Placeholder" />;
+        return <Icon size="lg" source="phosphor" icon="Placeholder" />;
     }
 
     return <StyledPlatformIcon src={src} alt={alt} onError={() => setErrored(true)} />;


### PR DESCRIPTION
The platform icons can fail to load because of CORS errors or missing resources. Adding fallback icons for such cases so that
- We have a better UX of seeing the placeholder icon instead of a failed image logo. We've used this placeholder icon for EntityHeader previously.
- The screenshot functionality doesn't break ( It currently fails if any of the platform icons fail to load)

<img width="2000" height="582" alt="reactflow_2025-12-12_125736" src="https://github.com/user-attachments/assets/b3a3da2b-f1fb-4cf6-b809-281778f78cb6" />

### Note: Reduced the size to 16px from 24px shown in the image.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
