### PR TITLE
feat(ingestion): add discard changes confirmation

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceBuilder.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceBuilder.tsx
@@ -1,14 +1,32 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { IngestionSourceBuilderLayout } from '@app/ingestV2/source/multiStepBuilder/IngestionSourceBuilderLayout';
 import { IngestionSourceForm } from '@app/ingestV2/source/multiStepBuilder/IngestionSourceForm';
 import { MultiStepSourceBuilderState, SubmitOptions } from '@app/ingestV2/source/multiStepBuilder/types';
+import { useDiscardUnsavedChangesConfirmationContext } from '@app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext';
 import { MultiStepFormProvider } from '@app/sharedV2/forms/multiStepForm/MultiStepFormContext';
-import { MultiStepFormProviderProps } from '@app/sharedV2/forms/multiStepForm/types';
+import { MultiStepFormProviderProps, OnCancelArguments } from '@app/sharedV2/forms/multiStepForm/types';
 
 export function IngestionSourceBuilder(props: MultiStepFormProviderProps<MultiStepSourceBuilderState, SubmitOptions>) {
+    const { onCancel } = props;
+    const { showConfirmation } = useDiscardUnsavedChangesConfirmationContext();
+
+    const onCancelWithDiscardUnsavedChangesConfirmation = useCallback(
+        (args: OnCancelArguments) => {
+            if (args.isDirty) {
+                showConfirmation({ onConfirm: () => onCancel?.(args) });
+            } else {
+                onCancel?.(args);
+            }
+        },
+        [onCancel, showConfirmation],
+    );
+
     return (
-        <MultiStepFormProvider<MultiStepSourceBuilderState, SubmitOptions> {...props}>
+        <MultiStepFormProvider<MultiStepSourceBuilderState, SubmitOptions>
+            {...props}
+            onCancel={onCancelWithDiscardUnsavedChangesConfirmation}
+        >
             <IngestionSourceBuilderLayout>
                 <IngestionSourceForm />
             </IngestionSourceBuilderLayout>

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
@@ -1,6 +1,7 @@
 import { useApolloClient } from '@apollo/client';
+import { Text } from '@components';
 import { message } from 'antd';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useHistory } from 'react-router';
 
 import analytics, { EventType } from '@app/analytics';
@@ -23,6 +24,7 @@ import {
     getIngestionSourceSystemFilter,
     getNewIngestionSourcePlaceholder,
 } from '@app/ingestV2/source/utils';
+import { DiscardUnsavedChangesConfirmationProvider } from '@app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext';
 import { useOwnershipTypes } from '@app/sharedV2/owners/useOwnershipTypes';
 import { PageRoutes } from '@conf/Global';
 
@@ -53,6 +55,7 @@ const STEPS: IngestionSourceFormStep[] = [
 export function IngestionSourceCreatePage() {
     const history = useHistory();
     const client = useApolloClient();
+    const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
     const createIngestionSource = useCreateSource();
 
@@ -67,6 +70,7 @@ export function IngestionSourceCreatePage() {
     const onSubmit = useCallback(
         async (data: MultiStepSourceBuilderState | undefined, options: SubmitOptions | undefined) => {
             if (!data) return undefined;
+            setIsSubmitting(true);
             const shouldRun = options?.shouldRun;
             const input = getIngestionSourceMutationInput(data);
 
@@ -117,6 +121,7 @@ export function IngestionSourceCreatePage() {
                 }
             }
 
+            setIsSubmitting(false);
             return undefined;
         },
         [createIngestionSource, history, client, defaultOwnershipType],
@@ -126,5 +131,20 @@ export function IngestionSourceCreatePage() {
         history.push(PageRoutes.INGESTION);
     }, [history]);
 
-    return <IngestionSourceBuilder steps={STEPS} onSubmit={onSubmit} onCancel={onCancel} initialState={initialState} />;
+    return (
+        <DiscardUnsavedChangesConfirmationProvider
+            enableRedirectHandling={!isSubmitting}
+            confirmationModalTitle="You have unsaved change"
+            confirmationModalText={
+                <>
+                    <Text type="span">You have unsaved changes to your new source. </Text>
+                    <Text type="span" weight="bold">
+                        Are you sure you want to leave and discard your unsaved changes?
+                    </Text>
+                </>
+            }
+        >
+            <IngestionSourceBuilder steps={STEPS} onSubmit={onSubmit} onCancel={onCancel} initialState={initialState} />
+        </DiscardUnsavedChangesConfirmationProvider>
+    );
 }

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceForm.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceForm.tsx
@@ -1,9 +1,13 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
+import { useDiscardUnsavedChangesConfirmationContext } from '@app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext';
 import { useMultiStepContext } from '@app/sharedV2/forms/multiStepForm/MultiStepFormContext';
 
 export function IngestionSourceForm() {
-    const { getCurrentStep } = useMultiStepContext();
+    const { getCurrentStep, isDirty } = useMultiStepContext();
+
+    const { setIsDirty } = useDiscardUnsavedChangesConfirmationContext();
+    useEffect(() => setIsDirty(isDirty()), [isDirty, setIsDirty]);
 
     const currentStep = useMemo(() => getCurrentStep?.(), [getCurrentStep]);
 

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceUpdatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceUpdatePage.tsx
@@ -1,7 +1,8 @@
 import { useApolloClient } from '@apollo/client';
-import { Loader } from '@components';
+import { Loader, Text } from '@components';
 import { message } from 'antd';
-import React, { useCallback, useMemo } from 'react';
+import deepEqual from 'fast-deep-equal';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router';
 
 import analytics, { EventType } from '@app/analytics';
@@ -22,6 +23,7 @@ import {
     mapSourceTypeAliases,
     removeExecutionsFromIngestionSource,
 } from '@app/ingestV2/source/utils';
+import { DiscardUnsavedChangesConfirmationProvider } from '@app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext';
 import { useOwnershipTypes } from '@app/sharedV2/owners/useOwnershipTypes';
 import { PageRoutes } from '@conf/Global';
 
@@ -47,6 +49,7 @@ export function IngestionSourceUpdatePage() {
     const history = useHistory();
     const location = useLocation();
     const client = useApolloClient();
+    const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
     const ingestionSourcesListQueryInputs = useMemo(() => location.state?.queryInputs, [location.state]);
     const ingestionSourcesListBackUrl = useMemo(() => location.state?.backUrl, [location.state]);
@@ -66,6 +69,7 @@ export function IngestionSourceUpdatePage() {
     const onSubmit = useCallback(
         async (data: MultiStepSourceBuilderState | undefined, options: SubmitOptions | undefined) => {
             if (!data) return undefined;
+            setIsSubmitting(true);
 
             const shouldRun = options?.shouldRun;
             try {
@@ -118,6 +122,8 @@ export function IngestionSourceUpdatePage() {
                     });
                 }
             }
+
+            setIsSubmitting(false);
             return undefined;
         },
         [
@@ -136,19 +142,68 @@ export function IngestionSourceUpdatePage() {
         history.push(ingestionSourcesListBackUrl ?? PageRoutes.INGESTION);
     }, [history, ingestionSourcesListBackUrl]);
 
+    const isDirtyChecker = useCallback(
+        (
+            initialStateToCheck: MultiStepSourceBuilderState | undefined,
+            currentStateToCheck: MultiStepSourceBuilderState | undefined,
+        ) => {
+            // These fields could have differences without real changes so we exclude them from deepEqual comparison
+            const excludedFieldsFromComparison = {
+                isConnectionDetailsValid: null,
+                owners: null,
+                ingestionSource: null,
+            };
+            const initialStateToCompare = {
+                ...(initialStateToCheck ?? {}),
+                ...excludedFieldsFromComparison,
+            };
+            const currentStateToCompare = { ...(currentStateToCheck ?? {}), ...excludedFieldsFromComparison };
+
+            if (!deepEqual(initialStateToCompare, currentStateToCompare)) {
+                return true;
+            }
+
+            const initialOwnersUrns = new Set(
+                initialStateToCheck?.ingestionSource?.ownership?.owners?.map((owner) => owner.owner.urn) ?? [],
+            );
+            const currentOwnersUrns = new Set(currentStateToCheck?.owners?.map((owner) => owner.urn) ?? []);
+
+            // Check if the owner sets are different
+            return !(
+                initialOwnersUrns.size === currentOwnersUrns.size &&
+                [...initialOwnersUrns].every((value) => currentOwnersUrns.has(value))
+            );
+        },
+        [],
+    );
+
     if (!ingestionSourceData?.ingestionSource || loading) {
         return <Loader />;
     }
 
     return (
-        <IngestionSourceBuilder
-            steps={STEPS}
-            onSubmit={onSubmit}
-            onCancel={onCancel}
-            initialState={{
-                ...mapSourceTypeAliases(removeExecutionsFromIngestionSource(ingestionSourceData.ingestionSource)),
-                ...{ isEditing: true, ingestionSource: ingestionSourceData.ingestionSource as IngestionSource },
-            }}
-        />
+        <DiscardUnsavedChangesConfirmationProvider
+            enableRedirectHandling={!isSubmitting}
+            confirmationModalTitle="You have unsaved change"
+            confirmationModalText={
+                <>
+                    <Text type="span">You have unsaved changes to this source. </Text>
+                    <Text type="span" weight="bold">
+                        Are you sure you want to leave and discard your changes?
+                    </Text>
+                </>
+            }
+        >
+            <IngestionSourceBuilder
+                steps={STEPS}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+                initialState={{
+                    ...mapSourceTypeAliases(removeExecutionsFromIngestionSource(ingestionSourceData.ingestionSource)),
+                    ...{ isEditing: true, ingestionSource: ingestionSourceData.ingestionSource as IngestionSource },
+                }}
+                isDirtyChecker={isDirtyChecker}
+            />
+        </DiscardUnsavedChangesConfirmationProvider>
     );
 }

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/FiltersSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/FiltersSection.tsx
@@ -2,7 +2,7 @@ import { Button, Input, SimpleSelect, spacing } from '@components';
 import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
-import { FilterRecipeField, FilterRule } from '@app/ingestV2/source/builder/RecipeForm/common';
+import { FilterRecipeField } from '@app/ingestV2/source/builder/RecipeForm/common';
 import { SectionName } from '@app/ingestV2/source/multiStepBuilder/components/SectionName';
 import { RemoveIcon } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/fields/shared/RemoveIcon';
 import { Filter } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/types';
@@ -58,11 +58,8 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
     // FYI: assuming that each filter has both allow and deny version
     const subtypeSelectOptions = useMemo(() => getSubtypeOptions(supportedFields), [supportedFields]);
     const defaultRule = useMemo(() => {
-        if (ruleSelectOptions.length > 0) {
-            return ruleSelectOptions[0].value;
-        }
-        return undefined;
-    }, [ruleSelectOptions]);
+        return 'exclude';
+    }, []);
 
     const defaultSubtype = useMemo(() => {
         if (subtypeSelectOptions.length > 0) {
@@ -70,6 +67,13 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
         }
         return undefined;
     }, [subtypeSelectOptions]);
+
+    const defaultSubtypeSelectValues = useMemo(() => {
+        if (defaultSubtype) {
+            return [defaultSubtype];
+        }
+        return [];
+    }, [defaultSubtype]);
 
     const defaultsForEmptyFilter = useMemo(
         () => ({
@@ -153,6 +157,8 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
         [updateFilters],
     );
 
+    if (fields.length === 0) return null;
+
     return (
         <>
             <SectionName
@@ -181,7 +187,7 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
                         <SelectWrapper>
                             <SimpleSelect
                                 options={ruleSelectOptions}
-                                values={filter.rule ? [filter.rule] : [FilterRule.INCLUDE]}
+                                values={filter.rule ? [filter.rule] : [defaultRule]}
                                 onUpdate={(values) => updateFilterRule(filter.key, values?.[0])}
                                 showClear={false}
                                 width="full"
@@ -192,7 +198,7 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
                         <SelectWrapper>
                             <SimpleSelect
                                 options={subtypeSelectOptions}
-                                values={filter.subtype ? [filter.subtype] : [subtypeSelectOptions?.[0].value]}
+                                values={filter.subtype ? [filter.subtype] : defaultSubtypeSelectValues}
                                 onUpdate={(values) => updateFilterSubtype(filter.key, values?.[0])}
                                 showClear={false}
                                 width="full"

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/__tests__/utils.test.ts
@@ -202,7 +202,7 @@ source:
     });
 
     describe('getSubtypeOptions', () => {
-        it('should return unique subtype options from fields', () => {
+        it('should return unique subtype options from fields and sort them alphabetically by label', () => {
             const fields: FilterRecipeField[] = [
                 {
                     name: 'field1',
@@ -213,7 +213,7 @@ source:
                     type: FieldType.LIST,
                     fieldPath: 'path1',
                     rules: null,
-                    section: 'Database',
+                    section: 'Zoo', // Z comes last alphabetically
                     rule: FilterRule.INCLUDE,
                     setValueOnRecipeOverride: vi.fn(),
                 },
@@ -226,7 +226,7 @@ source:
                     type: FieldType.LIST,
                     fieldPath: 'path2',
                     rules: null,
-                    section: 'Schema',
+                    section: 'Alpha', // A comes first alphabetically
                     rule: FilterRule.EXCLUDE,
                     setValueOnRecipeOverride: vi.fn(),
                 },
@@ -239,7 +239,20 @@ source:
                     type: FieldType.LIST,
                     fieldPath: 'path3',
                     rules: null,
-                    section: 'Database', // Duplicate section
+                    section: 'Database', // D comes in middle alphabetically
+                    rule: FilterRule.INCLUDE,
+                    setValueOnRecipeOverride: vi.fn(),
+                },
+                {
+                    name: 'field4',
+                    label: 'Field 4',
+                    helper: 'Helper 4',
+                    tooltip: 'Tooltip 4',
+                    placeholder: 'placeholder4',
+                    type: FieldType.LIST,
+                    fieldPath: 'path4',
+                    rules: null,
+                    section: 'Zoo', // Duplicate section
                     rule: FilterRule.INCLUDE,
                     setValueOnRecipeOverride: vi.fn(),
                 },
@@ -248,15 +261,73 @@ source:
             const result = getSubtypeOptions(fields);
 
             expect(result).toEqual([
+                { label: 'Alpha', value: 'Alpha' },
                 { label: 'Database', value: 'Database' },
-                { label: 'Schema', value: 'Schema' },
+                { label: 'Zoo', value: 'Zoo' },
             ]);
+
+            // Verify that the results are indeed sorted alphabetically by label
+            const labels = result.map((option) => option.label);
+            const sortedLabels = [...labels].sort((a, b) => a.localeCompare(b));
+            expect(labels).toEqual(sortedLabels);
         });
 
         it('should return empty array when no fields provided', () => {
             const result = getSubtypeOptions([]);
 
             expect(result).toEqual([]);
+        });
+
+        it('should maintain correct alphabetical order with mixed casing', () => {
+            const fields: FilterRecipeField[] = [
+                {
+                    name: 'field1',
+                    label: 'Field 1',
+                    helper: 'Helper 1',
+                    tooltip: 'Tooltip 1',
+                    placeholder: 'placeholder1',
+                    type: FieldType.LIST,
+                    fieldPath: 'path1',
+                    rules: null,
+                    section: 'zebra', // lowercase z
+                    rule: FilterRule.INCLUDE,
+                    setValueOnRecipeOverride: vi.fn(),
+                },
+                {
+                    name: 'field2',
+                    label: 'Field 2',
+                    helper: 'Helper 2',
+                    tooltip: 'Tooltip 2',
+                    placeholder: 'placeholder2',
+                    type: FieldType.LIST,
+                    fieldPath: 'path2',
+                    rules: null,
+                    section: 'Apple', // capitalized A
+                    rule: FilterRule.EXCLUDE,
+                    setValueOnRecipeOverride: vi.fn(),
+                },
+                {
+                    name: 'field3',
+                    label: 'Field 3',
+                    helper: 'Helper 3',
+                    tooltip: 'Tooltip 3',
+                    placeholder: 'placeholder3',
+                    type: FieldType.LIST,
+                    fieldPath: 'path3',
+                    rules: null,
+                    section: 'banana', // lowercase b
+                    rule: FilterRule.INCLUDE,
+                    setValueOnRecipeOverride: vi.fn(),
+                },
+            ];
+
+            const result = getSubtypeOptions(fields);
+
+            expect(result).toEqual([
+                { label: 'Apple', value: 'Apple' },
+                { label: 'banana', value: 'banana' },
+                { label: 'zebra', value: 'zebra' },
+            ]);
         });
     });
 

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/utils.ts
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/utils.ts
@@ -63,10 +63,12 @@ export function getOptionsForTypeSelect(): SelectOption[] {
 }
 
 export function getSubtypeOptions(fields: FilterRecipeField[]): SelectOption[] {
-    return [...new Set(fields.map((field) => field.section))].map((section) => ({
-        label: section,
-        value: section,
-    }));
+    return [...new Set(fields.map((field) => field.section))]
+        .map((section) => ({
+            label: section,
+            value: section,
+        }))
+        .sort((optionA, optionB) => optionA.label.localeCompare(optionB.label));
 }
 
 export function filterOutUnsupportedFields(fields: FilterRecipeField[]) {

--- a/datahub-web-react/src/app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext.tsx
+++ b/datahub-web-react/src/app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext.tsx
@@ -1,0 +1,129 @@
+import { Location } from 'history';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Prompt, useHistory } from 'react-router';
+
+import { ConfirmationModal } from '@app/sharedV2/modals/ConfirmationModal';
+
+interface Props {
+    enableTabClosingHandling?: boolean;
+    enableRedirectHandling?: boolean;
+    confirmationModalTitle?: string;
+    confirmationModalText?: React.ReactNode;
+    confirmButtonText?: string;
+}
+
+interface ConfirmationArgs {
+    onConfirm: (() => void) | undefined;
+}
+
+interface DiscardUnsavedChangesConfirmationContextType {
+    setIsDirty: (isDirty: boolean) => void;
+    showConfirmation: (args: ConfirmationArgs) => void;
+}
+
+const DiscardUnsavedChangesConfirmationContext = React.createContext<DiscardUnsavedChangesConfirmationContextType>({
+    setIsDirty: () => {},
+    showConfirmation: () => {},
+});
+
+export function useDiscardUnsavedChangesConfirmationContext() {
+    return React.useContext<DiscardUnsavedChangesConfirmationContextType>(DiscardUnsavedChangesConfirmationContext);
+}
+
+export function DiscardUnsavedChangesConfirmationProvider({
+    children,
+    enableTabClosingHandling = true,
+    enableRedirectHandling = true,
+    confirmationModalTitle,
+    confirmationModalText,
+    confirmButtonText,
+}: React.PropsWithChildren<Props>) {
+    const [isDirty, setIsDirty] = useState<boolean>(false);
+    const [isConfirmationShown, setIsConfirmationShown] = useState<boolean>(false);
+    const [onConfirmHandler, setOnConfirmHandler] = useState<(() => void) | undefined>(undefined);
+
+    const [lastRedirectLocation, setLastRedirectLocation] = useState<string | undefined>();
+    const [isRedirectConfirmed, setIsRedirectConfirmed] = useState<boolean>(false);
+    const [isRedirectConfirmationShown, setIsRedirectConfirmationShown] = useState<boolean>(false);
+
+    const history = useHistory();
+
+    // Show the browser's default confirmation on tab closing
+    useEffect(() => {
+        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            if (isDirty && enableTabClosingHandling) {
+                e.preventDefault();
+                e.returnValue = '';
+            }
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, [isDirty, enableTabClosingHandling]);
+
+    const showConfirmation = useCallback((args: ConfirmationArgs) => {
+        setIsConfirmationShown(true);
+        setOnConfirmHandler(() => args.onConfirm);
+        setIsRedirectConfirmed(true); // prevent showing confirmation on redirect
+    }, []);
+
+    const onRedirectHandler = useCallback(
+        (location: Location) => {
+            if (isDirty && !isRedirectConfirmed && enableRedirectHandling) {
+                setIsRedirectConfirmationShown(true);
+                setLastRedirectLocation(location.pathname + location.search);
+                return false; // Block redirect
+            }
+            return true; // Allow redirect
+        },
+        [isDirty, isRedirectConfirmed, enableRedirectHandling],
+    );
+
+    const onRedirectConfrirm = useCallback(() => {
+        setIsRedirectConfirmationShown(false);
+        setIsRedirectConfirmed(true);
+        // Defer redirect to the next tick
+        setTimeout(() => {
+            if (lastRedirectLocation) {
+                history.push(lastRedirectLocation);
+            }
+        }, 0);
+    }, [history, lastRedirectLocation]);
+
+    return (
+        <DiscardUnsavedChangesConfirmationContext.Provider value={{ setIsDirty, showConfirmation }}>
+            {children}
+
+            <ConfirmationModal
+                isOpen={isConfirmationShown}
+                modalTitle={confirmationModalTitle ?? 'Discard unsaved changes?'}
+                modalText={confirmationModalText ?? 'Your changes will be lost. Are you sure you want to leave?'}
+                closeButtonColor="gray"
+                handleClose={() => {
+                    setIsConfirmationShown(false);
+                    setIsRedirectConfirmed(false); // restore redirect handling
+                }}
+                confirmButtonText={confirmButtonText ?? 'Confirm'}
+                handleConfirm={() => onConfirmHandler?.()}
+            />
+
+            {enableRedirectHandling && (
+                <>
+                    <Prompt when={isDirty} message={onRedirectHandler} />
+
+                    <ConfirmationModal
+                        isOpen={isRedirectConfirmationShown}
+                        modalTitle={confirmationModalTitle ?? 'Discard unsaved changes?'}
+                        modalText={
+                            confirmationModalText ?? 'Your changes will be lost. Are you sure you want to leave?'
+                        }
+                        closeButtonColor="gray"
+                        handleClose={() => setIsRedirectConfirmationShown(false)}
+                        confirmButtonText={confirmButtonText ?? 'Confirm'}
+                        handleConfirm={onRedirectConfrirm}
+                    />
+                </>
+            )}
+        </DiscardUnsavedChangesConfirmationContext.Provider>
+    );
+}

--- a/datahub-web-react/src/app/sharedV2/confirmation/__tests__/DiscardUnsavedChangesConfirmationContext.test.tsx
+++ b/datahub-web-react/src/app/sharedV2/confirmation/__tests__/DiscardUnsavedChangesConfirmationContext.test.tsx
@@ -1,0 +1,212 @@
+import { act, render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    DiscardUnsavedChangesConfirmationProvider,
+    useDiscardUnsavedChangesConfirmationContext,
+} from '@app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext';
+
+// Wrapper component for the provider with Router context
+const wrapper: React.FC<React.PropsWithChildren<Record<string, never>>> = ({ children }) => (
+    <BrowserRouter>
+        <DiscardUnsavedChangesConfirmationProvider>{children}</DiscardUnsavedChangesConfirmationProvider>
+    </BrowserRouter>
+);
+
+describe('DiscardUnsavedChangesConfirmationContext', () => {
+    beforeEach(() => {
+        // Reset any mocks before each test
+        vi.clearAllMocks();
+        // Reset the window event listeners
+        Object.defineProperty(window, 'addEventListener', {
+            value: vi.fn(),
+            writable: true,
+        });
+        Object.defineProperty(window, 'removeEventListener', {
+            value: vi.fn(),
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('useDiscardUnsavedChangesConfirmationContext', () => {
+        it('should provide setIsDirty and showConfirmation functions', () => {
+            const { result } = renderHook(() => useDiscardUnsavedChangesConfirmationContext(), { wrapper });
+
+            expect(result.current).toHaveProperty('setIsDirty');
+            expect(result.current).toHaveProperty('showConfirmation');
+            expect(typeof result.current.setIsDirty).toBe('function');
+            expect(typeof result.current.showConfirmation).toBe('function');
+        });
+
+        it('should setIsDirty to update the dirty state', () => {
+            const { result } = renderHook(() => useDiscardUnsavedChangesConfirmationContext(), { wrapper });
+
+            act(() => {
+                result.current.setIsDirty(true);
+            });
+
+            expect(result.current.setIsDirty).toBeDefined();
+
+            // We can't directly test the internal state, but we can verify the function exists and can be called
+            expect(typeof result.current.setIsDirty).toBe('function');
+        });
+    });
+
+    describe('Confirmation Modal Display', () => {
+        it('should render the provider and children without errors', () => {
+            const TestComponent = () => {
+                const { setIsDirty, showConfirmation } = useDiscardUnsavedChangesConfirmationContext();
+
+                return (
+                    <div>
+                        <button type="button" onClick={() => setIsDirty(true)}>
+                            Set Dirty
+                        </button>
+                        <button type="button" onClick={() => showConfirmation({ onConfirm: vi.fn() })}>
+                            Show Confirmation
+                        </button>
+                    </div>
+                );
+            };
+
+            const { getByText } = render(
+                <BrowserRouter>
+                    <DiscardUnsavedChangesConfirmationProvider>
+                        <TestComponent />
+                    </DiscardUnsavedChangesConfirmationProvider>
+                </BrowserRouter>,
+            );
+
+            expect(getByText('Set Dirty')).toBeInTheDocument();
+            expect(getByText('Show Confirmation')).toBeInTheDocument();
+        });
+    });
+
+    describe('Browser Tab Closing Handling', () => {
+        it('should add and remove beforeunload event listener when isDirty changes', () => {
+            const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+            const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+            const { unmount } = renderHook(() => useDiscardUnsavedChangesConfirmationContext(), {
+                wrapper: ({ children }) => (
+                    <BrowserRouter>
+                        <DiscardUnsavedChangesConfirmationProvider>
+                            {children}
+                        </DiscardUnsavedChangesConfirmationProvider>
+                    </BrowserRouter>
+                ),
+            });
+
+            // Check that event listener was added
+            expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+
+            // Check that event listener is removed on unmount
+            unmount();
+            expect(removeEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+        });
+
+        it('should prevent default and set return value when tab closing and is dirty', () => {
+            const preventDefaultSpy = vi.fn();
+            const returnValueSetter = vi.fn();
+
+            Object.defineProperty(window, 'addEventListener', {
+                value: (event: string, handler: any) => {
+                    if (event === 'beforeunload') {
+                        // Simulate the event handler being called
+                        const mockEvent = {
+                            preventDefault: preventDefaultSpy,
+                            returnValue: '',
+                        } as unknown as BeforeUnloadEvent;
+
+                        // Set the returnValue property
+                        Object.defineProperty(mockEvent, 'returnValue', {
+                            set: returnValueSetter,
+                            get: () => mockEvent.returnValue,
+                        });
+
+                        handler(mockEvent);
+                    }
+                },
+                writable: true,
+            });
+
+            const { result } = renderHook(() => useDiscardUnsavedChangesConfirmationContext(), {
+                wrapper: ({ children }) => (
+                    <BrowserRouter>
+                        <DiscardUnsavedChangesConfirmationProvider>
+                            {children}
+                        </DiscardUnsavedChangesConfirmationProvider>
+                    </BrowserRouter>
+                ),
+            });
+
+            // First set dirty to true
+            act(() => {
+                result.current.setIsDirty(true);
+            });
+
+            // Verify that preventDefault was called and returnValue was set
+            expect(preventDefaultSpy).toHaveBeenCalled();
+            expect(returnValueSetter).toHaveBeenCalledWith('');
+        });
+    });
+
+    describe('showConfirmation function', () => {
+        it('should set confirmation state when showConfirmation is called', () => {
+            const mockOnConfirm = vi.fn();
+
+            const { result } = renderHook(() => useDiscardUnsavedChangesConfirmationContext(), { wrapper });
+
+            // We can't directly test the internal state changes,
+            // but we can verify that the function is available
+            expect(typeof result.current.showConfirmation).toBe('function');
+
+            act(() => {
+                result.current.showConfirmation({ onConfirm: mockOnConfirm });
+            });
+
+            // The function should accept a confirmation object with an onConfirm callback
+            expect(result.current.showConfirmation).toBeDefined();
+        });
+    });
+
+    describe('Provider props', () => {
+        it('should accept all expected props', () => {
+            render(
+                <BrowserRouter>
+                    <DiscardUnsavedChangesConfirmationProvider
+                        enableTabClosingHandling
+                        enableRedirectHandling
+                        confirmationModalTitle="Custom Title"
+                        confirmationModalText="Custom Text"
+                    >
+                        <div>Test Child</div>
+                    </DiscardUnsavedChangesConfirmationProvider>
+                </BrowserRouter>,
+            );
+
+            // Just check that the component renders without crashing
+            expect(document.querySelector('div')).toBeInTheDocument();
+        });
+
+        it('should work with default props', () => {
+            render(
+                <BrowserRouter>
+                    <DiscardUnsavedChangesConfirmationProvider enableTabClosingHandling enableRedirectHandling>
+                        <div>Test Child</div>
+                    </DiscardUnsavedChangesConfirmationProvider>
+                </BrowserRouter>,
+            );
+
+            // Just check that the component renders without crashing
+            expect(document.querySelector('div')).toBeInTheDocument();
+        });
+    });
+});

--- a/datahub-web-react/src/app/sharedV2/forms/multiStepForm/types.ts
+++ b/datahub-web-react/src/app/sharedV2/forms/multiStepForm/types.ts
@@ -37,11 +37,18 @@ export interface MultiStepFormContextType<TState, TStep extends Step = Step, TSu
     isCurrentStepCompleted: () => boolean;
     setCurrentStepCompleted: () => void;
     setCurrentStepUncompleted: () => void;
+
+    isDirty: () => boolean;
 }
+
+export type OnCancelArguments = {
+    isDirty?: boolean;
+};
 
 export interface MultiStepFormProviderProps<TState, TSubmitOptions = any> {
     steps: Step[];
     initialState?: TState;
     onSubmit?: (state: TState | undefined, options?: TSubmitOptions | undefined) => Promise<void>;
-    onCancel?: () => void;
+    onCancel?: (args: OnCancelArguments) => void;
+    isDirtyChecker?: (initialState: TState | undefined, state: TState | undefined) => boolean;
 }

--- a/datahub-web-react/src/app/sharedV2/modals/ConfirmationModal.tsx
+++ b/datahub-web-react/src/app/sharedV2/modals/ConfirmationModal.tsx
@@ -2,6 +2,8 @@ import { Modal, Text, typography } from '@components';
 import React from 'react';
 import styled from 'styled-components';
 
+import { ModalButton } from '@components/components/Modal/Modal';
+
 export const StyledModal = styled(Modal)`
     font-family: ${typography.fonts.body};
 
@@ -28,6 +30,7 @@ interface Props {
     modalTitle?: string;
     modalText?: string | React.ReactNode;
     closeButtonText?: string;
+    closeButtonColor?: ModalButton['color'];
     confirmButtonText?: string;
     isDeleteModal?: boolean;
 }
@@ -39,6 +42,7 @@ export const ConfirmationModal = ({
     modalTitle,
     modalText,
     closeButtonText,
+    closeButtonColor,
     confirmButtonText,
     isDeleteModal,
 }: Props) => {
@@ -53,6 +57,7 @@ export const ConfirmationModal = ({
                     onClick: handleClose,
                     buttonDataTestId: 'modal-cancel-button',
                     text: closeButtonText || 'Cancel',
+                    color: closeButtonColor,
                 },
                 {
                     variant: 'filled',


### PR DESCRIPTION
Linear: https://linear.app/acryl-data/issue/CAT-1024/add-modal-to-confirm-user-wants-to-leave-in-createedit-source-after-an

This PR adds confirmation to discard unsaved changes when an user presses Cancel, clicks another link, closes the tab
Also added a few fixes for filters


https://github.com/user-attachments/assets/edd9aeaa-3579-40f3-a0e8-b4c920ebb3f3


Updated confirmation modal:

<img width="561" height="226" alt="image" src="https://github.com/user-attachments/assets/55320a7b-e70f-4434-9f7b-d4f2a674a4d1" />

<img width="561" height="226" alt="image" src="https://github.com/user-attachments/assets/373335df-8cc8-4da0-8eec-6d31faad0a1a" />



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
