### PR TITLE
feat(ui/ingestion): bring ingestion page redirection changes back to OSS

### DIFF
--- a/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavSidebar.tsx
+++ b/datahub-web-react/src/app/homeV2/layout/navBarRedesign/NavSidebar.tsx
@@ -38,6 +38,8 @@ import { getMfeMenuDropdownItems, getMfeMenuItems } from '@app/mfeframework/mfeN
 import OnboardingContext from '@app/onboarding/OnboardingContext';
 import { useOnboardingTour } from '@app/onboarding/OnboardingTourContext.hooks';
 import { useIsHomePage } from '@app/shared/useIsHomePage';
+import { useGetIngestionLink } from '@app/sharedV2/ingestionSources/useGetIngestionLink';
+import { useHasIngestionSources } from '@app/sharedV2/ingestionSources/useHasIngestionSources';
 import { useAppConfig, useBusinessAttributesFlag } from '@app/useAppConfig';
 import { colors } from '@src/alchemy-components';
 import { getColor } from '@src/alchemy-components/theme/utils';
@@ -144,6 +146,9 @@ export const NavSidebar = () => {
     const { showOnboardingTour } = useHandleOnboardingTour();
     const { config } = useAppConfig();
     const logout = useGetLogoutHandler();
+
+    const { hasIngestionSources } = useHasIngestionSources();
+    const ingestionLink = useGetIngestionLink(hasIngestionSources);
 
     const showAnalytics = (config?.analyticsConfig?.enabled && me && me?.platformPrivileges?.viewAnalytics) || false;
     const showStructuredProperties =
@@ -302,7 +307,7 @@ export const NavSidebar = () => {
                         isHidden: !showDataSources,
                         icon: <Plugs />,
                         selectedIcon: <Plugs weight="fill" />,
-                        link: PageRoutes.INGESTION,
+                        link: ingestionLink,
                     },
                     {
                         type: NavBarMenuItemTypes.Item,

--- a/datahub-web-react/src/app/sharedV2/ingestionSources/__tests__/useGetIngestionLink.test.ts
+++ b/datahub-web-react/src/app/sharedV2/ingestionSources/__tests__/useGetIngestionLink.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useIngestionOnboardingRedesignV1 } from '@app/ingestV2/hooks/useIngestionOnboardingRedesignV1';
+import { useGetIngestionLink } from '@app/sharedV2/ingestionSources/useGetIngestionLink';
+import { PageRoutes } from '@conf/Global';
+
+vi.mock('@app/ingestV2/hooks/useIngestionOnboardingRedesignV1', () => ({
+    useIngestionOnboardingRedesignV1: vi.fn(),
+}));
+
+describe('useGetIngestionLink', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should return INGESTION when feature flag is off and hasSources = true', () => {
+        (useIngestionOnboardingRedesignV1 as any).mockReturnValue(false);
+
+        const { result } = renderHook(() => useGetIngestionLink(true));
+
+        expect(result.current).toBe(PageRoutes.INGESTION);
+    });
+
+    it('should return INGESTION when feature flag is off and hasSources = false', () => {
+        (useIngestionOnboardingRedesignV1 as any).mockReturnValue(false);
+
+        const { result } = renderHook(() => useGetIngestionLink(false));
+
+        expect(result.current).toBe(PageRoutes.INGESTION);
+    });
+
+    it('should return INGESTION when feature flag is on and ingestion sources exist', () => {
+        (useIngestionOnboardingRedesignV1 as any).mockReturnValue(true);
+
+        const { result } = renderHook(() => useGetIngestionLink(true));
+
+        expect(result.current).toBe(PageRoutes.INGESTION);
+    });
+
+    it('should return INGESTION_CREATE when feature flag is on and no ingestion sources exist', () => {
+        (useIngestionOnboardingRedesignV1 as any).mockReturnValue(true);
+
+        const { result } = renderHook(() => useGetIngestionLink(false));
+
+        expect(result.current).toBe(PageRoutes.INGESTION_CREATE);
+    });
+
+    it('should not throw when called multiple times', () => {
+        (useIngestionOnboardingRedesignV1 as any).mockReturnValue(true);
+
+        const { result, rerender } = renderHook(({ value }) => useGetIngestionLink(value), {
+            initialProps: { value: true },
+        });
+
+        expect(result.current).toBe(PageRoutes.INGESTION);
+
+        rerender({ value: false });
+        expect(result.current).toBe(PageRoutes.INGESTION_CREATE);
+
+        rerender({ value: true });
+        expect(result.current).toBe(PageRoutes.INGESTION);
+    });
+
+    it('should return a valid string route always', () => {
+        (useIngestionOnboardingRedesignV1 as any).mockReturnValue(true);
+
+        const { result } = renderHook(() => useGetIngestionLink(false));
+
+        expect(typeof result.current).toBe('string');
+        expect(result.current.length).toBeGreaterThan(0);
+    });
+
+    it('should remain stable across re-renders when flag does not change', () => {
+        (useIngestionOnboardingRedesignV1 as any).mockReturnValue(true);
+
+        const { result, rerender } = renderHook(({ val }) => useGetIngestionLink(val), { initialProps: { val: true } });
+
+        const firstValue = result.current;
+
+        rerender({ val: true });
+        expect(result.current).toBe(firstValue);
+    });
+
+    it('should not crash when invoked with any random boolean', () => {
+        (useIngestionOnboardingRedesignV1 as any).mockReturnValue(true);
+
+        expect(() => renderHook(() => useGetIngestionLink(Math.random() > 0.5))).not.toThrow();
+    });
+
+    it('should prioritize feature flag logic over default branch', () => {
+        (useIngestionOnboardingRedesignV1 as any).mockReturnValue(true);
+
+        const { result } = renderHook(() => useGetIngestionLink(false));
+
+        expect(result.current).toBe(PageRoutes.INGESTION_CREATE);
+    });
+});

--- a/datahub-web-react/src/app/sharedV2/ingestionSources/__tests__/useHasIngestionSources.test.tsx
+++ b/datahub-web-react/src/app/sharedV2/ingestionSources/__tests__/useHasIngestionSources.test.tsx
@@ -1,0 +1,164 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { waitFor } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+
+import { SYSTEM_INTERNAL_SOURCE_TYPE } from '@app/ingestV2/constants';
+import { useHasIngestionSources } from '@app/sharedV2/ingestionSources/useHasIngestionSources';
+
+import { GetNoOfIngestionSourcesDocument } from '@graphql/ingestion.generated';
+
+const queryVariables = {
+    input: {
+        start: 0,
+        count: 0,
+        filters: [
+            {
+                field: 'sourceType',
+                values: [SYSTEM_INTERNAL_SOURCE_TYPE],
+                negated: true,
+            },
+        ],
+    },
+};
+
+const mockSuccess = (total: number) => ({
+    request: {
+        query: GetNoOfIngestionSourcesDocument,
+        variables: queryVariables,
+    },
+    result: {
+        data: {
+            listIngestionSources: {
+                total,
+                __typename: 'ListIngestionSourcesResult',
+            },
+        },
+    },
+});
+
+const mockError = () => ({
+    request: {
+        query: GetNoOfIngestionSourcesDocument,
+        variables: queryVariables,
+    },
+    error: new Error('Network error'),
+});
+
+describe('useHasIngestionSources', () => {
+    it('should return loading state initially', async () => {
+        const { result } = renderHook(() => useHasIngestionSources(), {
+            wrapper: ({ children }) => (
+                <MockedProvider mocks={[mockSuccess(0)]} addTypename={false}>
+                    {children}
+                </MockedProvider>
+            ),
+        });
+
+        expect(result.current.loading).toBe(true);
+        expect(result.current.error).toBeUndefined();
+        expect(result.current.totalSources).toBe(0);
+        expect(result.current.hasIngestionSources).toBe(false);
+    });
+
+    it('should handle total = 0 correctly', async () => {
+        const { result } = renderHook(() => useHasIngestionSources(), {
+            wrapper: ({ children }) => (
+                <MockedProvider mocks={[mockSuccess(0)]} addTypename={false}>
+                    {children}
+                </MockedProvider>
+            ),
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.totalSources).toBe(0);
+        expect(result.current.hasIngestionSources).toBe(false);
+    });
+
+    it('should handle total > 0 correctly', async () => {
+        const { result } = renderHook(() => useHasIngestionSources(), {
+            wrapper: ({ children }) => (
+                <MockedProvider mocks={[mockSuccess(5)]} addTypename={false}>
+                    {children}
+                </MockedProvider>
+            ),
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.totalSources).toBe(5);
+        expect(result.current.hasIngestionSources).toBe(true);
+    });
+
+    it('should default correctly when listIngestionSources is null or missing', async () => {
+        const mocks = [
+            {
+                request: {
+                    query: GetNoOfIngestionSourcesDocument,
+                    variables: queryVariables,
+                },
+                result: {
+                    data: {
+                        listIngestionSources: null, // simulate backend returning null
+                    },
+                },
+            },
+        ];
+
+        const { result } = renderHook(() => useHasIngestionSources(), {
+            wrapper: ({ children }) => (
+                <MockedProvider mocks={mocks} addTypename={false}>
+                    {children}
+                </MockedProvider>
+            ),
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.totalSources).toBe(0);
+        expect(result.current.hasIngestionSources).toBe(false);
+    });
+
+    it('should return error state correctly', async () => {
+        const { result } = renderHook(() => useHasIngestionSources(), {
+            wrapper: ({ children }) => (
+                <MockedProvider mocks={[mockError()]} addTypename={false}>
+                    {children}
+                </MockedProvider>
+            ),
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.error).toBeTruthy();
+        expect(result.current.hasIngestionSources).toBe(false);
+        expect(result.current.totalSources).toBe(0);
+    });
+
+    it('should ensure fetchPolicy is cache-and-network', async () => {
+        // Ensures hook does not crash or misbehave
+        const { result } = renderHook(() => useHasIngestionSources(), {
+            wrapper: ({ children }) => (
+                <MockedProvider mocks={[mockSuccess(2)]} addTypename={false}>
+                    {children}
+                </MockedProvider>
+            ),
+        });
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.totalSources).toBe(2);
+        expect(result.current.hasIngestionSources).toBe(true);
+    });
+});

--- a/datahub-web-react/src/app/sharedV2/ingestionSources/useGetIngestionLink.ts
+++ b/datahub-web-react/src/app/sharedV2/ingestionSources/useGetIngestionLink.ts
@@ -1,0 +1,14 @@
+import { useIngestionOnboardingRedesignV1 } from '@app/ingestV2/hooks/useIngestionOnboardingRedesignV1';
+import { PageRoutes } from '@conf/Global';
+
+export const useGetIngestionLink = (hasIngestionSources: boolean) => {
+    const showIngestionOnboardingRedesign = useIngestionOnboardingRedesignV1();
+
+    let ingestionLink = PageRoutes.INGESTION;
+
+    if (showIngestionOnboardingRedesign) {
+        ingestionLink = hasIngestionSources ? PageRoutes.INGESTION : PageRoutes.INGESTION_CREATE;
+    }
+
+    return ingestionLink;
+};

--- a/datahub-web-react/src/app/sharedV2/ingestionSources/useHasIngestionSources.ts
+++ b/datahub-web-react/src/app/sharedV2/ingestionSources/useHasIngestionSources.ts
@@ -1,0 +1,32 @@
+import { SYSTEM_INTERNAL_SOURCE_TYPE } from '@app/ingestV2/constants';
+
+import { useGetNoOfIngestionSourcesQuery } from '@graphql/ingestion.generated';
+
+export const useHasIngestionSources = () => {
+    const { data, loading, error } = useGetNoOfIngestionSourcesQuery({
+        variables: {
+            input: {
+                start: 0,
+                count: 0,
+                filters: [
+                    {
+                        field: 'sourceType',
+                        values: [SYSTEM_INTERNAL_SOURCE_TYPE],
+                        negated: true,
+                    },
+                ],
+            },
+        },
+        fetchPolicy: 'cache-and-network',
+    });
+
+    const totalSources = data?.listIngestionSources?.total ?? 0;
+    const hasIngestionSources = totalSources > 0;
+
+    return {
+        totalSources,
+        hasIngestionSources,
+        loading,
+        error,
+    };
+};

--- a/datahub-web-react/src/graphql/ingestion.graphql
+++ b/datahub-web-react/src/graphql/ingestion.graphql
@@ -20,6 +20,12 @@ query listIngestionSources($input: ListIngestionSourcesInput!) {
     }
 }
 
+query getNoOfIngestionSources($input: ListIngestionSourcesInput!) {
+    listIngestionSources(input: $input) {
+        total
+    }
+}
+
 query getIngestionSource($urn: String!, $runStart: Int, $runCount: Int) {
     ingestionSource(urn: $urn) {
         ...ingestionSourceFields


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-995/show-step-1-of-create-source-popup-modal-first-time-with-no-sources

**Description:**

Brings changes related to redirecting to create ingestion flow when no sources are present back to OSS from this [PR](https://github.com/acryldata/datahub-fork/pull/7428)

The folder is different here than SaaS for the new files, would need to unify once this also goes in there. Created [this](https://linear.app/acryl-data/issue/CAT-1039/unify-the-new-files-created-in-different-folders-in-oss-and-saas) backlog ticket for the same.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
