### PR TITLE
feat(ingestion): add analytics events

### DIFF
--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -173,6 +173,8 @@ export enum EventType {
     MoveDocumentEvent,
     EditDocumentEvent,
     DeleteDocumentEvent,
+    IngestionTestConnectionClickEvent,
+    IngestionTestConnectionCloseEvent,
 }
 
 /**
@@ -649,6 +651,22 @@ export interface IngestionTestConnectionEvent extends BaseEvent {
     outcome?: string;
 }
 
+export interface IngestionTestConnectionClickEvent extends BaseEvent {
+    type: EventType.IngestionTestConnectionClickEvent;
+    sourceType: string;
+    sourceUrn?: string;
+    ingestionOnboardingRedesignV1?: boolean;
+}
+
+export interface IngestionTestConnectionCloseEvent extends BaseEvent {
+    type: EventType.IngestionTestConnectionCloseEvent;
+    sourceType: string;
+    sourceUrn?: string;
+    hasCompleted?: boolean;
+    status?: 'success' | 'failure' | 'partialSuccess' | 'running';
+    ingestionOnboardingRedesignV1?: boolean;
+}
+
 export interface IngestionViewAllClickEvent extends BaseEvent {
     type: EventType.IngestionViewAllClickEvent;
     executionUrn?: string;
@@ -680,6 +698,7 @@ export interface CreateIngestionSourceEvent extends BaseEvent {
     interval?: string;
     numOwners?: number;
     outcome?: string;
+    ingestionOnboardingRedesignV1?: boolean;
 }
 
 export interface UpdateIngestionSourceEvent extends BaseEvent {
@@ -689,6 +708,7 @@ export interface UpdateIngestionSourceEvent extends BaseEvent {
     interval?: string;
     numOwners?: number;
     outcome?: string;
+    ingestionOnboardingRedesignV1?: boolean;
 }
 
 export interface DeleteIngestionSourceEvent extends BaseEvent {
@@ -1438,4 +1458,6 @@ export type Event =
     | CreateDocumentEvent
     | MoveDocumentEvent
     | EditDocumentEvent
-    | DeleteDocumentEvent;
+    | DeleteDocumentEvent
+    | IngestionTestConnectionClickEvent
+    | IngestionTestConnectionCloseEvent;

--- a/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/TestConnection/TestConnectionButton.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/TestConnection/TestConnectionButton.tsx
@@ -6,6 +6,7 @@ import { FontWeightOptions, SizeOptions } from '@components/theme/config';
 
 import analytics, { EventType } from '@app/analytics';
 import { EXECUTION_REQUEST_STATUS_FAILURE, EXECUTION_REQUEST_STATUS_RUNNING } from '@app/ingestV2/executions/constants';
+import { useIngestionOnboardingRedesignV1 } from '@app/ingestV2/hooks/useIngestionOnboardingRedesignV1';
 import { TestConnectionResult } from '@app/ingestV2/source/builder/RecipeForm/TestConnection/types';
 import { SourceConfig } from '@app/ingestV2/source/builder/types';
 import { yamlToJson } from '@app/ingestV2/source/utils';
@@ -79,6 +80,7 @@ function TestConnectionButton({
     const [hasEmittedAnalytics, setHasEmittedAnalytics] = useState(false);
     const [createTestConnectionRequest, { data: requestData }] = useCreateTestConnectionRequestMutation();
     const [getIngestionExecutionRequest, { data: resultData, loading }] = useGetIngestionExecutionRequestLazyQuery();
+    const ingestionOnboardingRedesignV1 = useIngestionOnboardingRedesignV1();
 
     useEffect(() => {
         if (requestData && requestData.createTestConnectionRequest) {
@@ -149,6 +151,13 @@ function TestConnectionButton({
                     );
                 });
 
+            analytics.event({
+                type: EventType.IngestionTestConnectionClickEvent,
+                sourceType: getSourceTypeFromRecipeJson(recipeJson) || '',
+                sourceUrn: selectedSource?.urn,
+                ingestionOnboardingRedesignV1,
+            });
+
             setIsLoading(true);
             setIsModalVisible(true);
         }
@@ -157,6 +166,38 @@ function TestConnectionButton({
     const internalFailure = !!testConnectionResult?.internal_failure;
     const basicConnectivityFailure = testConnectionResult?.basic_connectivity?.capable === false;
     const testConnectionFailed = internalFailure || basicConnectivityFailure;
+
+    function hideModal() {
+        // Emit analytics event for closing the modal with status and completion status
+        const hasCompleted = testConnectionResult !== null;
+        let status: 'success' | 'failure' | 'partialSuccess' | 'running' = 'running';
+        const recipeJson = getRecipeJson(recipe);
+
+        if (testConnectionResult) {
+            // Determine status based on test connection results
+            const basicConnectivity = testConnectionResult?.basic_connectivity?.capable;
+            if (basicConnectivity) {
+                status = 'success';
+            } else {
+                // Use testConnectionFailed to determine if it's failure or partial success
+                status = testConnectionFailed ? 'failure' : 'partialSuccess';
+            }
+        } else {
+            // If no test results, determine from hasEmittedAnalytics
+            status = hasEmittedAnalytics ? 'success' : 'running';
+        }
+
+        analytics.event({
+            type: EventType.IngestionTestConnectionCloseEvent,
+            sourceType: selectedSource?.type || getSourceTypeFromRecipeJson(recipeJson) || '',
+            sourceUrn: selectedSource?.urn,
+            hasCompleted,
+            status,
+            ingestionOnboardingRedesignV1,
+        });
+
+        setIsModalVisible(false);
+    }
 
     return (
         <>
@@ -172,7 +213,7 @@ function TestConnectionButton({
                     testConnectionFailed,
                     sourceConfig: sourceConfigs,
                     testConnectionResult,
-                    hideModal: () => setIsModalVisible(false),
+                    hideModal,
                 })}
         </>
     );

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
@@ -95,6 +95,7 @@ export function IngestionSourceCreatePage() {
                     interval: input.schedule?.interval,
                     numOwners: data.owners?.length,
                     outcome: shouldRun ? 'save_and_run' : 'save',
+                    ingestionOnboardingRedesignV1: true,
                 });
 
                 message.success({

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceUpdatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceUpdatePage.tsx
@@ -97,6 +97,7 @@ export function IngestionSourceUpdatePage() {
                     interval: input.schedule?.interval,
                     numOwners: data.owners?.length,
                     outcome: shouldRun ? 'save_and_run' : 'save',
+                    ingestionOnboardingRedesignV1: true,
                 });
 
                 message.success({

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -56,6 +56,8 @@ public enum DataHubUsageEventType {
   CREATE_DOMAIN_EVENT("CreateDomainEvent"),
   MOVE_DOMAIN_EVENT("MoveDomainEvent"),
   INGESTION_TEST_CONNECTION_EVENT("IngestionTestConnectionEvent"),
+  INGESTION_TEST_CONNECTION_CLICK_EVENT("IngestionTestConnectionClickEvent"),
+  INGESTION_TEST_CONNECTION_CLOSE_EVENT("IngestionTestConnectionCloseEvent"),
   INGESTION_EXECUTION_RESULT_VIEWED_EVENT("IngestionExecutionResultViewedEvent"),
   INGESTION_SOURCE_CONFIGURATION_IMPRESSION_EVENT("IngestionSourceConfigurationImpressionEvent"),
   INGESTION_VIEW_ALL_CLICK_EVENT("IngestionViewAllClickEvent"),


### PR DESCRIPTION
Linera:
- https://linear.app/acryl-data/issue/CAT-961/add-telemetry-for-test-connection-button
- https://linear.app/acryl-data/issue/CAT-1005/capture-events-on-source-create-and-source-edit

This PR adds/updates analytics events:
- when an user clicks Test connection button
- when an user closes Test connection modal
- when an user creates an Ingestion Source
- when an user updates an Ingestion Source



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
