### PR TITLE
feat(ci): add workflow monitor for automatic retrigger on first failure

### DIFF
--- a/.github/workflows/workflow-monitor.yml
+++ b/.github/workflows/workflow-monitor.yml
@@ -57,6 +57,9 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
@@ -66,13 +69,13 @@ jobs:
           echo "✅ **Retriggering workflow** (first failure detected)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          echo "Retriggering '${{ github.event.workflow_run.name }}' (Run ID: ${{ github.event.workflow_run.id }})..."
+          echo "Retriggering '${WORKFLOW_NAME}' (Run ID: ${RUN_ID})..."
 
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/rerun-failed-jobs
+            "/repos/${REPOSITORY}/actions/runs/${RUN_ID}/rerun-failed-jobs"
 
           EXIT_CODE=$?
 


### PR DESCRIPTION
Implements an automated workflow monitoring system that:
- Watches docker-unified.yml for completion events
- Automatically retriggers workflows on first failure (run_attempt == 1)
- Limits to single retry to prevent loops

When a workflow fails on first attempt, the monitor automatically retriggers it.

Pending work in follow-on PRs:
 - extend retries to other workflows that are flaky
 - Publish metrics for longer term analysis 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
