### PR TITLE
feat(ui) Show ingestion onboarding popup on new select source screen

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/CreateSourceEducationModal.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/CreateSourceEducationModal.tsx
@@ -1,0 +1,38 @@
+import { Modal, Text } from '@components';
+import React from 'react';
+
+import { INGESTION_SELECT_SOURCE_ID } from '@app/onboarding/config/IngestionOnboardingConfig';
+import useHasSeenEducationStep from '@providers/hooks/useHasSeenEducationStep';
+import useUpdateEducationStep from '@providers/hooks/useUpdateEducationStep';
+
+export default function CreateSourceEducationModal() {
+    const hasSeenStep = useHasSeenEducationStep(INGESTION_SELECT_SOURCE_ID);
+    const { updateEducationStep } = useUpdateEducationStep();
+
+    function handleClose() {
+        updateEducationStep(INGESTION_SELECT_SOURCE_ID);
+    }
+
+    return (
+        <Modal
+            open={!hasSeenStep}
+            onCancel={handleClose}
+            centered
+            buttons={[
+                {
+                    variant: 'filled',
+                    onClick: handleClose,
+                    buttonDataTestId: 'modal-confirm-button',
+                    text: 'Get Started',
+                    color: 'primary',
+                },
+            ]}
+            title="About Metadata Collection"
+            maskStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.1)', backdropFilter: 'blur(2px)' }}
+        >
+            <Text color="gray" size="md">
+                Choose the ingestion approach that works best for your security and infrastructure needs.
+            </Text>
+        </Modal>
+    );
+}

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/SelectSourceStep.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/SelectSourceStep.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import sourcesJson from '@app/ingestV2/source/builder/sources.json';
 import { SourceConfig } from '@app/ingestV2/source/builder/types';
+import CreateSourceEducationModal from '@app/ingestV2/source/multiStepBuilder/CreateSourceEducationModal';
 import EmptySearchResults from '@app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/EmptySearchResults';
 import ShowAllCard from '@app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/ShowAllCard';
 import SourcePlatformCard from '@app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/SourcePlatformCard';
@@ -192,6 +193,7 @@ export function SelectSourceStep() {
                         })}
                 </CardsContainer>
             )}
+            <CreateSourceEducationModal />
         </StepContainer>
     );
 }

--- a/datahub-web-react/src/app/onboarding/config/IngestionOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/IngestionOnboardingConfig.tsx
@@ -5,6 +5,7 @@ import { OnboardingStep } from '@app/onboarding/OnboardingStep';
 
 export const INGESTION_CREATE_SOURCE_ID = 'ingestion-create-source';
 export const INGESTION_REFRESH_SOURCES_ID = 'ingestion-refresh-sources';
+export const INGESTION_SELECT_SOURCE_ID = 'ingestion-select-source';
 
 export const IngestionOnboardingConfig: OnboardingStep[] = [
     {
@@ -41,5 +42,9 @@ export const IngestionOnboardingConfig: OnboardingStep[] = [
                 <p>Click to force a refresh of running ingestion sources.</p>
             </Typography.Paragraph>
         ),
+    },
+    {
+        id: INGESTION_SELECT_SOURCE_ID,
+        selector: `#${INGESTION_SELECT_SOURCE_ID}`,
     },
 ];

--- a/datahub-web-react/src/providers/hooks/__tests__/useHasSeenEducationStep.test.tsx
+++ b/datahub-web-react/src/providers/hooks/__tests__/useHasSeenEducationStep.test.tsx
@@ -1,0 +1,161 @@
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+
+import { useUserContext } from '@app/context/useUserContext';
+import { EducationStepsContext } from '@providers/EducationStepsContext';
+import useHasSeenEducationStep from '@providers/hooks/useHasSeenEducationStep';
+
+import { StepStateResult } from '@types';
+
+// Mock dependencies
+vi.mock('@app/context/useUserContext', () => ({
+    useUserContext: vi.fn(),
+}));
+
+vi.mock('@app/onboarding/utils', () => ({
+    convertStepId: vi.fn((stepId: string, userUrn: string) => `${userUrn}-${stepId}`),
+}));
+
+const mockUseUserContext = useUserContext as ReturnType<typeof vi.fn>;
+
+describe('useHasSeenEducationStep', () => {
+    const mockSetEducationSteps = vi.fn();
+    const mockSetEducationStepIdsAllowlist = vi.fn();
+    const testUserUrn = 'urn:li:corpuser:test-user';
+    const testStepId = 'test-step';
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('when user is not loaded', () => {
+        beforeEach(() => {
+            mockUseUserContext.mockReturnValue({ user: null });
+        });
+
+        it('should return true when isForUser=true and user is not loaded', () => {
+            const educationSteps: StepStateResult[] = [];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: mockSetEducationStepIdsAllowlist,
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useHasSeenEducationStep(testStepId, true), { wrapper });
+
+            expect(result.current).toBe(true);
+        });
+
+        it('should check for non-user-specific step when isForUser=false', () => {
+            const educationSteps: StepStateResult[] = [{ id: testStepId, properties: [] }];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: mockSetEducationStepIdsAllowlist,
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useHasSeenEducationStep(testStepId, false), { wrapper });
+
+            expect(result.current).toBe(true);
+        });
+    });
+
+    describe('when user is loaded', () => {
+        beforeEach(() => {
+            mockUseUserContext.mockReturnValue({ user: { urn: testUserUrn } });
+        });
+
+        it('should return true when the step has been seen', () => {
+            const educationSteps: StepStateResult[] = [{ id: `${testUserUrn}-${testStepId}`, properties: [] }];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: mockSetEducationStepIdsAllowlist,
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useHasSeenEducationStep(testStepId), { wrapper });
+
+            expect(result.current).toBe(true);
+        });
+
+        it('should return false when the step has not been seen', () => {
+            const educationSteps: StepStateResult[] = [{ id: `${testUserUrn}-other-step`, properties: [] }];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: mockSetEducationStepIdsAllowlist,
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useHasSeenEducationStep(testStepId), { wrapper });
+
+            expect(result.current).toBe(false);
+        });
+
+        it('should return true when educationSteps is null (loading state)', () => {
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps: null,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: mockSetEducationStepIdsAllowlist,
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useHasSeenEducationStep(testStepId), { wrapper });
+
+            expect(result.current).toBe(true);
+        });
+
+        it('should use non-converted stepId when isForUser=false', () => {
+            const educationSteps: StepStateResult[] = [{ id: testStepId, properties: [] }];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: mockSetEducationStepIdsAllowlist,
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useHasSeenEducationStep(testStepId, false), { wrapper });
+
+            expect(result.current).toBe(true);
+        });
+    });
+});

--- a/datahub-web-react/src/providers/hooks/__tests__/useUpdateEducationStep.test.tsx
+++ b/datahub-web-react/src/providers/hooks/__tests__/useUpdateEducationStep.test.tsx
@@ -1,0 +1,223 @@
+import { waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+
+import { useUserContext } from '@app/context/useUserContext';
+import { EducationStepsContext } from '@providers/EducationStepsContext';
+import useUpdateEducationStep from '@providers/hooks/useUpdateEducationStep';
+
+import { useBatchUpdateStepStatesMutation } from '@graphql/step.generated';
+import { StepStateResult } from '@types';
+
+// Mock dependencies
+vi.mock('@app/context/useUserContext', () => ({
+    useUserContext: vi.fn(),
+}));
+
+vi.mock('@app/onboarding/utils', () => ({
+    convertStepId: vi.fn((stepId: string, userUrn: string) => `${userUrn}-${stepId}`),
+}));
+
+vi.mock('@graphql/step.generated', () => ({
+    useBatchUpdateStepStatesMutation: vi.fn(),
+}));
+
+const mockUseUserContext = useUserContext as ReturnType<typeof vi.fn>;
+const mockUseBatchUpdateStepStatesMutation = useBatchUpdateStepStatesMutation as ReturnType<typeof vi.fn>;
+
+describe('useUpdateEducationStep', () => {
+    const testUserUrn = 'urn:li:corpuser:test-user';
+    const testStepId = 'test-step';
+    let mockSetEducationSteps: ReturnType<typeof vi.fn>;
+    let mockBatchUpdateStepStates: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockSetEducationSteps = vi.fn();
+        mockBatchUpdateStepStates = vi.fn(() => Promise.resolve({ data: {} }));
+
+        mockUseBatchUpdateStepStatesMutation.mockReturnValue([mockBatchUpdateStepStates]);
+    });
+
+    describe('updateEducationStep for user', () => {
+        beforeEach(() => {
+            mockUseUserContext.mockReturnValue({ urn: testUserUrn });
+        });
+
+        it('should call mutation with converted stepId when isForUser=true', async () => {
+            const educationSteps: StepStateResult[] = [];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: vi.fn(),
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useUpdateEducationStep(), { wrapper });
+
+            await act(async () => {
+                result.current.updateEducationStep(testStepId, true);
+            });
+
+            await waitFor(() => {
+                expect(mockBatchUpdateStepStates).toHaveBeenCalledWith({
+                    variables: {
+                        input: {
+                            states: [{ id: `${testUserUrn}-${testStepId}`, properties: [] }],
+                        },
+                    },
+                });
+            });
+        });
+
+        it('should update educationSteps after successful mutation', async () => {
+            const existingSteps: StepStateResult[] = [{ id: 'existing-step', properties: [] }];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps: existingSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: vi.fn(),
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useUpdateEducationStep(), { wrapper });
+
+            await act(async () => {
+                result.current.updateEducationStep(testStepId, true);
+            });
+
+            await waitFor(() => {
+                expect(mockSetEducationSteps).toHaveBeenCalled();
+            });
+
+            // Verify the updater function adds the new step
+            const updaterFunction = mockSetEducationSteps.mock.calls[0][0];
+            const updatedSteps = updaterFunction(existingSteps);
+            expect(updatedSteps).toHaveLength(2);
+            expect(updatedSteps[1]).toEqual({
+                id: `${testUserUrn}-${testStepId}`,
+                properties: [],
+            });
+        });
+
+        it('should initialize educationSteps array when null', async () => {
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps: null,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: vi.fn(),
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useUpdateEducationStep(), { wrapper });
+
+            await act(async () => {
+                result.current.updateEducationStep(testStepId, true);
+            });
+
+            await waitFor(() => {
+                expect(mockSetEducationSteps).toHaveBeenCalled();
+            });
+
+            // Verify the updater function creates a new array when existing is null
+            const updaterFunction = mockSetEducationSteps.mock.calls[0][0];
+            const updatedSteps = updaterFunction(null);
+            expect(updatedSteps).toEqual([
+                {
+                    id: `${testUserUrn}-${testStepId}`,
+                    properties: [],
+                },
+            ]);
+        });
+    });
+
+    describe('updateEducationStep for non-user steps', () => {
+        beforeEach(() => {
+            mockUseUserContext.mockReturnValue({ urn: testUserUrn });
+        });
+
+        it('should use non-converted stepId when isForUser=false', async () => {
+            const educationSteps: StepStateResult[] = [];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: vi.fn(),
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useUpdateEducationStep(), { wrapper });
+
+            await act(async () => {
+                result.current.updateEducationStep(testStepId, false);
+            });
+
+            await waitFor(() => {
+                expect(mockBatchUpdateStepStates).toHaveBeenCalledWith({
+                    variables: {
+                        input: {
+                            states: [{ id: testStepId, properties: [] }],
+                        },
+                    },
+                });
+            });
+        });
+    });
+
+    describe('updateEducationStep with no user', () => {
+        it('should handle empty user urn gracefully', async () => {
+            mockUseUserContext.mockReturnValue({ urn: null });
+
+            const educationSteps: StepStateResult[] = [];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: vi.fn(),
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useUpdateEducationStep(), { wrapper });
+
+            await act(async () => {
+                result.current.updateEducationStep(testStepId, true);
+            });
+
+            await waitFor(() => {
+                expect(mockBatchUpdateStepStates).toHaveBeenCalledWith({
+                    variables: {
+                        input: {
+                            states: [{ id: `-${testStepId}`, properties: [] }],
+                        },
+                    },
+                });
+            });
+        });
+    });
+});

--- a/datahub-web-react/src/providers/hooks/useHasSeenEducationStep.ts
+++ b/datahub-web-react/src/providers/hooks/useHasSeenEducationStep.ts
@@ -1,0 +1,20 @@
+import { useContext } from 'react';
+
+import { useUserContext } from '@app/context/useUserContext';
+import { convertStepId } from '@app/onboarding/utils';
+import { EducationStepsContext } from '@providers/EducationStepsContext';
+
+export default function useHasSeenEducationStep(stepId: string, isForUser = true) {
+    const { educationSteps } = useContext(EducationStepsContext);
+    const { user } = useUserContext();
+
+    if (isForUser && !user?.urn) {
+        // assume they have seen the step while user loads
+        return true;
+    }
+
+    const finalStepId = isForUser && user?.urn ? convertStepId(stepId, user.urn) : stepId;
+
+    // always assume they've seen the step while steps are loading
+    return educationSteps?.some((step) => step.id === finalStepId) ?? true;
+}

--- a/datahub-web-react/src/providers/hooks/useUpdateEducationStep.ts
+++ b/datahub-web-react/src/providers/hooks/useUpdateEducationStep.ts
@@ -1,0 +1,27 @@
+import { useCallback, useContext } from 'react';
+
+import { useUserContext } from '@app/context/useUserContext';
+import { convertStepId } from '@app/onboarding/utils';
+import { EducationStepsContext } from '@providers/EducationStepsContext';
+
+import { useBatchUpdateStepStatesMutation } from '@graphql/step.generated';
+import { StepStateResult } from '@types';
+
+export default function useUpdateEducationStep() {
+    const { setEducationSteps } = useContext(EducationStepsContext);
+    const user = useUserContext();
+    const [batchUpdateStepStates] = useBatchUpdateStepStatesMutation();
+
+    const updateEducationStep = useCallback(
+        (stepId: string, isForUser = true) => {
+            const finalStepId = isForUser ? convertStepId(stepId, user.urn || '') : stepId;
+            const finalStep: StepStateResult = { id: finalStepId, properties: [] };
+            batchUpdateStepStates({ variables: { input: { states: [finalStep] } } }).then(() => {
+                setEducationSteps((existingSteps) => (existingSteps ? [...existingSteps, finalStep] : [finalStep]));
+            });
+        },
+        [batchUpdateStepStates, setEducationSteps, user?.urn],
+    );
+
+    return { updateEducationStep };
+}


### PR DESCRIPTION
This PR shows a new ingestion onboarding modal when a user first sees the ingestion create flow. The contents are still TBD here but this adds the new modal that we can fill in later.

This will show the popup for any new user that is seeing this for the first time, regardless of free trials or not which is desired.

<img width="1726" height="906" alt="Screenshot 2025-12-15 at 9 45 26 PM" src="https://github.com/user-attachments/assets/386349f6-e3d6-4a4d-a11e-49fcef3b0ed1" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
