### PR TITLE
feat(ui) Update styling of the filters section in new ingestion forms

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/components/SectionName.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/components/SectionName.tsx
@@ -10,6 +10,7 @@ const Wrapper = styled.div`
 const TopRow = styled.div`
     display: flex;
     flex-direction: row;
+    margin-top: 12px;
 `;
 
 const Spacer = styled.div`

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/FiltersSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/FiltersSection.tsx
@@ -3,8 +3,8 @@ import React, { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 import { FilterRecipeField, FilterRule } from '@app/ingestV2/source/builder/RecipeForm/common';
-import { FieldWrapper } from '@app/ingestV2/source/multiStepBuilder/components/FieldWrapper';
 import { SectionName } from '@app/ingestV2/source/multiStepBuilder/components/SectionName';
+import { FieldLabel } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/components/FieldLabel';
 import { RemoveIcon } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/fields/shared/RemoveIcon';
 import { Filter } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/types';
 import {
@@ -32,6 +32,14 @@ const FilterFieldsWrapper = styled.div`
     gap: ${spacing.md};
     width: 100%;
     align-items: start;
+`;
+
+const SelectLabelWrapper = styled.div`
+    min-width: 175px;
+`;
+
+const Spacer = styled.div`
+    width: 16px;
 `;
 
 const SelectWrapper = styled.div`
@@ -155,45 +163,48 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
                     </Button>
                 }
             />
+            <FilterRow>
+                <FilterFieldsWrapper>
+                    <SelectLabelWrapper>
+                        <FieldLabel label="Rule" />
+                    </SelectLabelWrapper>
+                    <SelectLabelWrapper>
+                        <FieldLabel label="Subtype" />
+                    </SelectLabelWrapper>
+                    <FieldLabel label="Regex Entry" />
+                </FilterFieldsWrapper>
+                <Spacer />
+            </FilterRow>
             {filters.map((filter) => (
                 <FilterRow>
                     <FilterFieldsWrapper>
                         <SelectWrapper>
-                            <FieldWrapper label="Rule" help="Include or exclude matching entities">
-                                <SimpleSelect
-                                    options={ruleSelectOptions}
-                                    values={filter.rule ? [filter.rule] : [FilterRule.INCLUDE]}
-                                    onUpdate={(values) => updateFilterRule(filter.key, values?.[0])}
-                                    showClear={false}
-                                    width="full"
-                                    placeholder="Rule"
-                                    size="lg"
-                                />
-                            </FieldWrapper>
+                            <SimpleSelect
+                                options={ruleSelectOptions}
+                                values={filter.rule ? [filter.rule] : [FilterRule.INCLUDE]}
+                                onUpdate={(values) => updateFilterRule(filter.key, values?.[0])}
+                                showClear={false}
+                                width="full"
+                                placeholder="Rule"
+                                size="lg"
+                            />
                         </SelectWrapper>
                         <SelectWrapper>
-                            <FieldWrapper label="Subtype" required help="Type of entity to filter">
-                                <SimpleSelect
-                                    options={subtypeSelectOptions}
-                                    values={filter.subtype ? [filter.subtype] : [subtypeSelectOptions?.[0].value]}
-                                    onUpdate={(values) => updateFilterSubtype(filter.key, values?.[0])}
-                                    showClear={false}
-                                    width="full"
-                                    placeholder="[Table]"
-                                    size="lg"
-                                />
-                            </FieldWrapper>
-                        </SelectWrapper>
-                        <FieldWrapper
-                            label="Regex Entry"
-                            help="Regular expressions (regex) for pattern matching within strings"
-                        >
-                            <Input
-                                value={filter.value}
-                                setValue={(value) => updateFilterValue(filter.key, value)}
-                                placeholder='apple: Matches the literal string "apple"'
+                            <SimpleSelect
+                                options={subtypeSelectOptions}
+                                values={filter.subtype ? [filter.subtype] : [subtypeSelectOptions?.[0].value]}
+                                onUpdate={(values) => updateFilterSubtype(filter.key, values?.[0])}
+                                showClear={false}
+                                width="full"
+                                placeholder={filter.subtype ? `[${filter.subtype}]` : '[Table]'}
+                                size="lg"
                             />
-                        </FieldWrapper>
+                        </SelectWrapper>
+                        <Input
+                            value={filter.value}
+                            setValue={(value) => updateFilterValue(filter.key, value)}
+                            placeholder="^my_db$"
+                        />
                     </FilterFieldsWrapper>
                     <RemoveIcon onClick={() => removeFilter(filter.key)} />
                 </FilterRow>


### PR DESCRIPTION
Updates the styling of the filters section to remove the difficult to make look nice subtext and only show one header above the input fields. Also spaces the sections out a bit more by adding margin to section header titles.

<img width="1723" height="905" alt="Screenshot 2025-12-16 at 11 46 32 AM" src="https://github.com/user-attachments/assets/d9dfb2ad-8520-425e-9527-35e4f9f1e151" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
