### PR TITLE
fix(structured-properties): fix property definition version type

### DIFF
--- a/metadata-ingestion/retention_time_property.yaml
+++ b/metadata-ingestion/retention_time_property.yaml
@@ -1,0 +1,20 @@
+- id: io.acryl.privacy.retentionTime
+  qualified_name: io.acryl.privacy.retentionTime
+  type: number
+  cardinality: SINGLE
+  version: 20240614080001
+  display_name: Retention Time
+  entity_types:
+    - dataset
+    - dataFlow
+  description: "Retention Time is used to figure out how long to retain records in a dataset"
+  allowed_values:
+    - value: 30
+      description: 30 days, usually reserved for datasets that are ephemeral and contain pii
+    - value: 60
+      description: Use this for datasets that drive monthly reporting but contain pii
+    - value: 90
+      description: 90 days retention for medium-term data
+    - value: 365
+      description: Use this for non-sensitive data that can be retained for longer
+

--- a/metadata-ingestion/src/datahub/api/entities/structuredproperties/structuredproperties.py
+++ b/metadata-ingestion/src/datahub/api/entities/structuredproperties/structuredproperties.py
@@ -84,6 +84,13 @@ class StructuredProperties(ConfigModel):
     type_qualifier: Optional[TypeQualifierAllowedTypes] = None
     immutable: Optional[bool] = False
 
+    @field_validator("version", mode="before")
+    @classmethod
+    def _coerce_version_to_str(cls, v: Union[str, int, None]) -> Optional[str]:
+        if v is None:
+            return None
+        return str(v)
+
     @field_validator("entity_types", mode="before")
     @classmethod
     def _check_entity_types(cls, v: Union[str, List[str]]) -> Union[str, List[str]]:

--- a/metadata-ingestion/src/datahub/specific/structured_property.py
+++ b/metadata-ingestion/src/datahub/specific/structured_property.py
@@ -123,3 +123,15 @@ class StructuredPropertyPatchBuilder(MetadataPatchProposal):
             value=immutable,
         )
         return self
+
+    def set_version(
+        self, version: Optional[str] = None
+    ) -> "StructuredPropertyPatchBuilder":
+        if version is not None:
+            self._add_patch(
+                StructuredPropertyDefinition.ASPECT_NAME,
+                "add",
+                path=("version",),
+                value=version,
+            )
+        return self


### PR DESCRIPTION
Stronger python typing prevented the documented example in yaml from working as expected. This fix does the conversion from number to string to ensure property typing.