### PR TITLE
feat: Add useFinalSidebarTabs hook for entity sidebar extensibility

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/EntityProfile.tsx
@@ -22,8 +22,8 @@ import useGetDataForProfile from '@app/entityV2/shared/containers/profile/useGet
 import {
     defaultTabDisplayConfig,
     getEntityPath,
-    getFinalSidebarTabs,
     getOnboardingStepIdsForEntityType,
+    useFinalSidebarTabs,
     useRoutedTab,
     useUpdateGlossaryEntityDataOnChange,
 } from '@app/entityV2/shared/containers/profile/utils';
@@ -293,11 +293,20 @@ export const EntityProfile = <T, U>({
         }
     }, [routedTab?.supportsFullsize, setTabFullsize]);
 
+    // Different contexts require different sidebar behaviors (e.g., search results need compact views,
+    // lineage views have space constraints, profile sidebars support full feature sets)
+    let contextType = TabContextType.PROFILE_SIDEBAR;
+    if (isInSearch) {
+        contextType = TabContextType.SEARCH_SIDEBAR;
+    } else if (isCompact) {
+        contextType = TabContextType.LINEAGE_SIDEBAR;
+    }
+
+    const finalTabs = useFinalSidebarTabs(sidebarTabs, sidebarSections || [], contextType);
+
     if (entityData?.exists === false) {
         return <NonExistentEntityPage />;
     }
-
-    const finalTabs = getFinalSidebarTabs(sidebarTabs, sidebarSections || []);
 
     if (isCompact) {
         return (
@@ -324,7 +333,7 @@ export const EntityProfile = <T, U>({
                             type={isInSearch ? 'card' : undefined}
                             focused={isInSearch}
                             tabs={finalTabs}
-                            contextType={isInSearch ? TabContextType.SEARCH_SIDEBAR : TabContextType.LINEAGE_SIDEBAR}
+                            contextType={contextType}
                             width={width}
                             headerDropdownItems={headerDropdownItems}
                         />

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/utils.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/utils.tsx
@@ -1,7 +1,7 @@
 import { BookOpen } from '@phosphor-icons/react';
 import { isEqual } from 'lodash';
 import queryString from 'query-string';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router';
 
 import { GenericEntityProperties } from '@app/entity/shared/types';
@@ -14,7 +14,7 @@ import {
     PopularityTier,
     getBarsStatusFromPopularityTier,
 } from '@app/entityV2/shared/containers/profile/sidebar/shared/utils';
-import { EntitySidebarSection, EntitySidebarTab, EntityTab } from '@app/entityV2/shared/types';
+import { EntitySidebarSection, EntitySidebarTab, EntityTab, TabContextType } from '@app/entityV2/shared/types';
 import { SEPARATE_SIBLINGS_URL_PARAM, useIsSeparateSiblingsMode } from '@app/entityV2/shared/useIsSeparateSiblingsMode';
 import useIsLineageMode from '@app/lineage/utils/useIsLineageMode';
 import {
@@ -305,4 +305,17 @@ export function getPopularityColumn(tier: PopularityTier): SidebarStatsColumn | 
         };
     }
     return null;
+}
+
+/**
+ * Hook to get final sidebar tabs with all additions applied.
+ * In OSS, this is a simple wrapper around getFinalSidebarTabs.
+ * In SaaS, additional tabs like "Ask DataHub" are added on top.
+ */
+export function useFinalSidebarTabs(
+    baseTabs: EntitySidebarTab[],
+    sidebarSections: EntitySidebarSection[] | undefined,
+    _contextType: TabContextType,
+) {
+    return useMemo(() => getFinalSidebarTabs(baseTabs, sidebarSections || []), [baseTabs, sidebarSections]);
 }

--- a/datahub-web-react/src/app/entityV2/shared/embed/EmbeddedProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/embed/EmbeddedProfile.tsx
@@ -7,7 +7,7 @@ import { EntityContext } from '@app/entity/shared/EntityContext';
 import { GenericEntityProperties } from '@app/entity/shared/types';
 import EntityProfileSidebar from '@app/entityV2/shared/containers/profile/sidebar/EntityProfileSidebar';
 import useGetDataForProfile from '@app/entityV2/shared/containers/profile/useGetDataForProfile';
-import { getFinalSidebarTabs } from '@app/entityV2/shared/containers/profile/utils';
+import { useFinalSidebarTabs } from '@app/entityV2/shared/containers/profile/utils';
 import NonExistentEntityPage from '@app/entityV2/shared/entity/NonExistentEntityPage';
 import { TabContextType } from '@app/entityV2/shared/types';
 import EntitySidebarContext, { entitySidebarContextDefaults } from '@app/sharedV2/EntitySidebarContext';
@@ -52,15 +52,17 @@ export default function EmbeddedProfile<T>({ urn, entityType, getOverridePropert
     const { entityData, dataPossiblyCombinedWithSiblings, dataNotCombinedWithSiblings, loading, refetch } =
         useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties });
 
+    // Only compute sidebar tabs when entityData.type is available to avoid unnecessary work during loading.
+    const sidebarTabs = entityData?.type ? entityRegistry.getSidebarTabs(entityData.type) : [];
+    const sidebarSections = entityData?.type ? entityRegistry.getSidebarSections(entityData.type) : [];
+
+    const finalTabs = useFinalSidebarTabs(sidebarTabs, sidebarSections, TabContextType.CHROME_SIDEBAR);
+
     if (entityData?.exists === false) {
         return <NonExistentEntityPage />;
     }
 
     if (!entityData?.type) return null;
-
-    const sidebarTabs = entityRegistry.getSidebarTabs(entityData.type);
-    const sidebarSections = entityRegistry.getSidebarSections(entityData.type);
-    const finalTabs = getFinalSidebarTabs(sidebarTabs, sidebarSections);
 
     return (
         <EntityContext.Provider


### PR DESCRIPTION
- Add useFinalSidebarTabs hook to utils.tsx as a simple wrapper around getFinalSidebarTabs
- Update EntityProfile.tsx to use useFinalSidebarTabs with contextType parameter
- Update EmbeddedProfile.tsx to use useFinalSidebarTabs with TabContextType.CHROME_SIDEBAR
- Restructure EmbeddedProfile to call hooks before early returns (React hooks rule)

This change aligns the OSS interface with SaaS, enabling SaaS to add the Ask DataHub tab on top of the base OSS behavior without merge conflicts.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
