### PR TITLE
Improve disable states and Modal compatibility

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Button/Button.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Button/Button.stories.tsx
@@ -107,10 +107,10 @@ const meta = {
                 type: 'boolean',
             },
         },
-        isDisabled: {
+        disabled: {
             description: 'Whether the Button is disabled.',
             table: {
-                defaultValue: { summary: buttonDefaults?.isDisabled?.toString() },
+                defaultValue: { summary: 'false' },
             },
             control: {
                 type: 'boolean',
@@ -144,7 +144,7 @@ const meta = {
         iconPosition: buttonDefaults.iconPosition,
         isCircle: buttonDefaults.isCircle,
         isLoading: buttonDefaults.isLoading,
-        isDisabled: buttonDefaults.isDisabled,
+        disabled: false,
         isActive: buttonDefaults.isActive,
         onClick: () => console.log('Button clicked'),
     },
@@ -168,7 +168,7 @@ export const states = () => (
         <Button>Default</Button>
         <Button isLoading>Loading State</Button>
         <Button isActive>Active/Focus State</Button>
-        <Button isDisabled>Disabled State</Button>
+        <Button disabled>Disabled State</Button>
     </GridList>
 );
 

--- a/datahub-web-react/src/alchemy-components/components/Button/Button.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Button/Button.tsx
@@ -12,7 +12,6 @@ export const buttonDefaults: ButtonPropsDefaults = {
     iconPosition: 'left',
     isCircle: false,
     isLoading: false,
-    isDisabled: false,
     isActive: false,
 };
 
@@ -24,7 +23,6 @@ export const Button = ({
     iconPosition = buttonDefaults.iconPosition,
     isCircle = buttonDefaults.isCircle,
     isLoading = buttonDefaults.isLoading,
-    isDisabled = buttonDefaults.isDisabled,
     isActive = buttonDefaults.isActive,
     children,
     ...props
@@ -36,7 +34,6 @@ export const Button = ({
         isCircle,
         isLoading,
         isActive,
-        isDisabled,
         hasChildren: !!children,
     };
 

--- a/datahub-web-react/src/alchemy-components/components/Button/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/components.ts
@@ -1,3 +1,4 @@
+import { ButtonHTMLAttributes } from 'react';
 import styled from 'styled-components';
 
 import { ButtonStyleProps } from '@components/components/Button/types';
@@ -6,7 +7,7 @@ import { spacing } from '@components/theme';
 
 export const ButtonBase = styled.button(
     // Dynamic styles
-    (props: ButtonStyleProps) => ({ ...getButtonStyle(props) }),
+    (props: ButtonStyleProps & ButtonHTMLAttributes<HTMLButtonElement>) => ({ ...getButtonStyle(props) }),
     {
         // Base root styles
         display: 'flex',

--- a/datahub-web-react/src/alchemy-components/components/Button/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/types.ts
@@ -21,7 +21,6 @@ export interface ButtonPropsDefaults {
     iconPosition: 'left' | 'right';
     isCircle: boolean;
     isLoading: boolean;
-    isDisabled: boolean;
     isActive: boolean;
 }
 
@@ -31,4 +30,7 @@ export interface ButtonProps
     icon?: IconProps;
 }
 
-export type ButtonStyleProps = Omit<ButtonPropsDefaults, 'iconPosition'> & { hasChildren: boolean; theme?: Theme };
+export type ButtonStyleProps = Omit<ButtonPropsDefaults, 'iconPosition'> & {
+    hasChildren: boolean;
+    theme?: Theme;
+};

--- a/datahub-web-react/src/alchemy-components/components/Button/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/utils.ts
@@ -1,6 +1,7 @@
 /*
  * Button Style Utilities
  */
+import { ButtonHTMLAttributes } from 'react';
 import { CSSObject } from 'styled-components';
 
 import { ButtonStyleProps, ButtonVariant } from '@components/components/Button/types';
@@ -274,8 +275,8 @@ const getButtonLoadingStyles = (): CSSObject => ({
 /*
  * Main function to generate styles for button
  */
-export const getButtonStyle = (props: ButtonStyleProps): CSSObject => {
-    const { variant, color, size, isCircle, isActive, isLoading, isDisabled, hasChildren, theme } = props;
+export const getButtonStyle = (props: ButtonStyleProps & ButtonHTMLAttributes<HTMLButtonElement>): CSSObject => {
+    const { variant, color, size, isCircle, isActive, isLoading, disabled, hasChildren, theme } = props;
 
     // Get map of colors
     const colorStyles = getButtonColorStyles(variant, color, theme);
@@ -296,7 +297,7 @@ export const getButtonStyle = (props: ButtonStyleProps): CSSObject => {
 
     // Focus & Active styles are the same, but active styles are applied conditionally & override prevs styles
     const activeStyles = { ...getButtonActiveStyles(colorStyles) };
-    if (!isDisabled && isActive) {
+    if (!disabled && isActive) {
         styles['&:focus'] = activeStyles;
         styles['&:active'] = activeStyles;
         styles = { ...styles, ...activeStyles };

--- a/datahub-web-react/src/alchemy-components/components/Input/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Input/components.ts
@@ -70,6 +70,7 @@ export const InputField = styled.input({
 
     '&:disabled': {
         backgroundColor: colors.gray[1500],
+        cursor: 'not-allowed',
     },
 });
 

--- a/datahub-web-react/src/alchemy-components/components/Modal/Modal.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Modal/Modal.tsx
@@ -42,6 +42,7 @@ const StyledModal = styled(AntModal)<{ hasChildren: boolean }>`
 const ModalHeader = styled.div<{ hasChildren: boolean }>`
     display: flex;
     flex-direction: column;
+    width: 100%;
 `;
 
 const TitleRow = styled.div`
@@ -49,6 +50,7 @@ const TitleRow = styled.div`
     flex-direction: row;
     align-items: center;
     gap: 8px;
+    width: 100%;
 `;
 
 const ButtonsContainer = styled.div`
@@ -73,6 +75,7 @@ export interface ModalProps {
     onCancel: () => void;
     dataTestId?: string;
     titleIcon?: React.ReactNode;
+    closable?: boolean;
 }
 
 export function Modal({
@@ -83,30 +86,36 @@ export function Modal({
     children,
     onCancel,
     dataTestId,
+    closable = true,
     ...props
 }: ModalProps & AntModalProps) {
     return (
         <StyledModal
             open
             centered
+            closable={closable}
             onCancel={onCancel}
-            closeIcon={<Icon icon="X" source="phosphor" data-testid="modal-close-icon" />}
+            closeIcon={closable ? <Icon icon="X" source="phosphor" data-testid="modal-close-icon" /> : null}
             hasChildren={!!children}
             data-testid={dataTestId}
             title={
-                <ModalHeader hasChildren={!!children}>
-                    <TitleRow>
-                        <Heading type="h1" color="gray" colorLevel={600} weight="bold" size="lg">
-                            {title}
-                        </Heading>
-                        {titlePill}
-                    </TitleRow>
-                    {!!subtitle && (
-                        <Text type="span" color="gray" colorLevel={1700} weight="medium">
-                            {subtitle}
-                        </Text>
-                    )}
-                </ModalHeader>
+                typeof title === 'string' ? (
+                    <ModalHeader hasChildren={!!children}>
+                        <TitleRow>
+                            <Heading type="h1" color="gray" colorLevel={600} weight="bold" size="lg">
+                                {title}
+                            </Heading>
+                            {titlePill}
+                        </TitleRow>
+                        {!!subtitle && (
+                            <Text type="span" color="gray" colorLevel={1700} weight="medium">
+                                {subtitle}
+                            </Text>
+                        )}
+                    </ModalHeader>
+                ) : (
+                    <div style={{ marginRight: closable ? '20px' : '0' }}>{title}</div>
+                )
             }
             footer={
                 !!buttons?.length && (

--- a/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsDrawer.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsDrawer.tsx
@@ -352,7 +352,7 @@ const StructuredPropsDrawer = ({
                             <Button
                                 style={{ display: 'block', width: '100%' }}
                                 onClick={handleUpdateAllowedValues}
-                                isDisabled={!canEditProps}
+                                disabled={!canEditProps}
                             >
                                 Update Allowed Values
                             </Button>
@@ -360,7 +360,7 @@ const StructuredPropsDrawer = ({
                             <Button
                                 style={{ display: 'block', width: '100%' }}
                                 onClick={handleSubmit}
-                                isDisabled={isLoading || !canEditProps}
+                                disabled={isLoading || !canEditProps}
                                 data-testid="structured-props-create-update-button"
                             >
                                 {isEditMode ? 'Update' : 'Create'}


### PR DESCRIPTION
## Summary

1. Remove the custom `isDisabled` prop on `Button` and use the web-native `disabled` prop instead. Avoid redundancy, and is likely more accessible
2. Disabled inputs now have the `not-allowed` hover effect
3. Make the close button optional on `Modal` and add better support for non-string titles

Not really any visual difference for any of these changes - I inspected callsites and they all seem compatible