### PR TITLE
fix(ci): handle empty smoke-test matrix

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -831,9 +831,9 @@ jobs:
 
   publish_images:
     name: Push images after tests pass
-    runs-on: ${{ needs.setup.outputs.test_runner_type_small }}
+    runs-on: ${{ needs.setup.outputs.test_runner_type_small || 'ubuntu-latest' }}
     needs: [setup, smoke_test, base_build]
-    if: ${{ always() && !failure() && !cancelled() }}
+    if: ${{ always() && !failure() && !cancelled() && needs.setup.result != 'skipped' }}
     steps:
       - name: Check if tests have passed
         id: tests_passed


### PR DESCRIPTION
In certain cases when no code changes are detected by ci-optimization  or on some label event, the smoke test matrix is empty and setup step is skipped. While it workflow fails fast within a few seconds, the workflow is still marked as failure and not skipped. 
This fix makes the workflow status get reported as skipped

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
