### PR TITLE
chore: add dinesh-verma-datahub to pr-labeler team members

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -65,7 +65,8 @@ jobs:
           "kyungsoo-datahub",
           "AdrianMachado",
           "pdruley",
-          "alokr-dhub"
+          "alokr-dhub",
+          "dinesh-verma-datahub"
           ]'),
           github.actor
           )


### PR DESCRIPTION
This will stop the community-contribution label for my PRs

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
