### PR TITLE
fix(ui): update button styles for login/signup screens

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Button/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/utils.ts
@@ -132,6 +132,8 @@ const getButtonVariantStyles = (
     theme?: Theme,
 ): CSSObject => {
     const isPrimary = color === 'violet' || color === 'primary';
+    // Adding a hack here for login/signup pages where v1 styles are still loaded by default
+    // Once we move to remove v1 styles we can revert this hack and always use styles from theme only
     const resolvedPrimaryColor =
         theme?.styles?.['primary-color'] === themeV1PrimaryColor
             ? themeV2PrimaryColor


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-1061/update-button-styling-on-the-new-loginsign-up-pages

**Description:**

When appConfig and flags are not available before login, themeV1 is considered by default and its primary color gets used in gradient of button styles.
This fixes using only v2 primary color in such instances in button component.
This is a temp fix for button component. We can have a better solution app-wide to have theme V2 by default instead of V1 now.

**Screenshots:**

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/65028014-d5df-4ab2-a14a-6a1d46bd185d" />


<img width="1512" height="856" alt="image" src="https://github.com/user-attachments/assets/e2023a34-3a9f-423d-8814-30ab660a4b2c" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
