### PR TITLE
fix(actions): Added support for pydantic v2 to actions framework

### DIFF
--- a/datahub-actions/src/datahub_actions/pipeline/pipeline_config.py
+++ b/datahub-actions/src/datahub_actions/pipeline/pipeline_config.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from datahub.configuration import ConfigModel
 from datahub.configuration.common import ConfigEnum
@@ -30,29 +30,29 @@ class FailureMode(ConfigEnum):
 
 class SourceConfig(ConfigModel):
     type: str
-    config: Optional[Dict[str, Any]] = None
+    config: Optional[Dict[str, Any]] = Field(default=None)
 
 
 class TransformConfig(ConfigModel):
     type: str
-    config: Optional[Dict[str, Any]] = None
+    config: Optional[Dict[str, Any]] = Field(default=None)
 
 
 class FilterConfig(ConfigModel):
     event_type: Union[str, List[str]]
-    event: Optional[Dict[str, Any]] = None
+    event: Optional[Dict[str, Any]] = Field(default=None)
 
 
 class ActionConfig(ConfigModel):
     type: str
-    config: Optional[Dict[str, Any]] = None
+    config: Optional[Dict[str, Any]] = Field(default=None)
 
 
 class PipelineOptions(BaseModel):
-    retry_count: Optional[int] = None
-    failure_mode: Optional[FailureMode] = None
-    failed_events_dir: Optional[str] = (
-        None  # The path where failed events should be logged.
+    retry_count: Optional[int] = Field(default=None)
+    failure_mode: Optional[FailureMode] = Field(default=None)
+    failed_events_dir: Optional[str] = Field(
+        default=None, description="The path where failed events should be logged."
     )
 
 

--- a/datahub-actions/src/datahub_actions/plugin/action/snowflake/tag_propagator.py
+++ b/datahub-actions/src/datahub_actions/plugin/action/snowflake/tag_propagator.py
@@ -15,6 +15,8 @@
 import logging
 from typing import Optional
 
+from pydantic import Field
+
 from datahub.configuration.common import ConfigModel
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
 from datahub_actions.action.action import Action
@@ -36,8 +38,8 @@ logger = logging.getLogger(__name__)
 
 class SnowflakeTagPropagatorConfig(ConfigModel):
     snowflake: SnowflakeV2Config
-    tag_propagation: Optional[TagPropagationConfig] = None
-    term_propagation: Optional[TermPropagationConfig] = None
+    tag_propagation: Optional[TagPropagationConfig] = Field(default=None)
+    term_propagation: Optional[TermPropagationConfig] = Field(default=None)
 
 
 class SnowflakeTagPropagatorAction(Action):

--- a/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/acryl/datahub_cloud_event_source.py
@@ -4,6 +4,8 @@ import time
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional, Union, cast
 
+from pydantic import Field
+
 from datahub.configuration import ConfigModel
 from datahub.emitter.serialization_helper import post_json_transform
 from datahub.ingestion.graph.client import DataHubGraph
@@ -59,8 +61,10 @@ def build_metadata_change_log_event(msg: ExternalEvent) -> MetadataChangeLogEven
 
 class DataHubEventsSourceConfig(ConfigModel):
     topics: Union[str, List[str]] = PLATFORM_EVENT_TOPIC_NAME
-    consumer_id: Optional[str] = None  # Used to store offset for the consumer.
-    lookback_days: Optional[int] = None
+    consumer_id: Optional[str] = Field(
+        default=None, description="Used to store offset for the consumer."
+    )
+    lookback_days: Optional[int] = Field(default=None)
     reset_offsets: Optional[bool] = False
     infinite_retry: Optional[bool] = False
 

--- a/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
@@ -22,6 +22,7 @@ from confluent_kafka import KafkaError, KafkaException, TopicPartition
 from confluent_kafka.schema_registry.avro import AvroDeserializer
 from confluent_kafka.schema_registry.schema_registry_client import SchemaRegistryClient
 from prometheus_client import Counter, Gauge
+from pydantic import Field
 
 from datahub.configuration import ConfigModel
 from datahub.configuration.kafka import KafkaConsumerConnectionConfig
@@ -94,7 +95,7 @@ def build_entity_change_event(payload: GenericPayloadClass) -> EntityChangeEvent
 
 class KafkaEventSourceConfig(ConfigModel):
     connection: KafkaConsumerConnectionConfig = KafkaConsumerConnectionConfig()
-    topic_routes: Optional[Dict[str, str]]
+    topic_routes: Optional[Dict[str, str]] = Field(default=None)
     async_commit_enabled: bool = False
     async_commit_interval: int = 10000
     commit_retry_count: int = 5

--- a/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
+++ b/datahub-actions/src/datahub_actions/plugin/transform/filter/filter_transformer.py
@@ -16,6 +16,8 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, Union
 
+from pydantic import Field
+
 from datahub.configuration import ConfigModel
 from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.pipeline.pipeline_context import PipelineContext
@@ -26,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 class FilterTransformerConfig(ConfigModel):
     event_type: Union[str, List[str]]
-    event: Optional[Dict[str, Any]]
+    event: Optional[Dict[str, Any]] = Field(default=None)
 
 
 class FilterTransformer(Transformer):


### PR DESCRIPTION
# Add Pydantic v2 compatibility for optional ConfigModel fields

## Summary
Fixed Pydantic v2 compatibility issues in DataHub Actions framework by updating all optional ConfigModel fields to use Field(default=None) instead of = None.
## Problem
DataHub Actions requires Pydantic v2 (pydantic>=2.0.0,<3.0.0), but several config classes used the Pydantic v1 pattern for optional fields (field: Optional[Type] = None), which doesn't work in v2. This caused validation errors when users omitted optional configuration parameters.