### PR TITLE
docs(observe): smart assertions profiling

### DIFF
--- a/docs/managed-datahub/observe/smart-assertions.md
+++ b/docs/managed-datahub/observe/smart-assertions.md
@@ -64,7 +64,7 @@ When an anomaly is flagged by the smart assertion, you may hover over the result
 If an anomaly is not caught by our Smart Assertions, we recommend doing a few things:
 
 1. You can click `Mark as Anomaly` to flag this specific data point as an anomaly. This will exclude that data point from the training data.
-2. You should look back at the historical stats on the `Stats` tab of the table, and see if there were any periods of anomalous data that may be polluting the training set. If so, add an `Exclusion Window` in the **Settings tab** of the assertion, to remove this polluted period of data from the training data.
+2. Click **Tune Predictions** on the assertion, then exclude any “bad” historical periods from the training set (by adding an `Exclusion Window`). This is useful if older incidents or one-off events are polluting the model’s notion of “normal”.
 3. Finally, consider increasing the sensitivity of the assertion in the **Settings tab** which will reduce the range of allowable values.
 
 <p align="left">


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
docs: Update Smart Assertions tuning instructions

Updates the documentation for Smart Assertions to reflect the current workflow for tuning predictions. Previously, users were directed to the table's `Stats` tab to identify anomalous data. This change guides users to use the `Tune Predictions` feature and `Exclusion Window` directly within the assertion settings, improving the accuracy and usability of the documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b78a416-7b89-4185-9632-3d37bdac80b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4b78a416-7b89-4185-9632-3d37bdac80b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

