### PR TITLE
Add mTLS Support and Truststore Handling to GMS

### DIFF
--- a/metadata-ingestion/docs/sources/dbt/dbt.md
+++ b/metadata-ingestion/docs/sources/dbt/dbt.md
@@ -293,6 +293,24 @@ source:
       test_results: No
 ```
 
+:::note Tests not showing up in the Assertion UI?
+
+Double check you are using the same `job_id` for your `test_results: Only` and `test_results: No` recipes. Otherwise you might end up reporting `tests_results` for tests that haven't had their `test_definitions` ingested yet. This can lead to orphaned assertions that do not show up under your dataset.
+
+If you choose not to share a `job_id`, you should adjust your recipe to also ingest the `test_definitions`
+
+```yaml
+entities_enabled:
+  models: No
+  sources: No
+  seeds: No
+  snapshots: No
+  test_definitions: Yes
+  test_results: Yes
+```
+
+:::
+
 ### Multiple dbt projects
 
 In more complex dbt setups, you may have multiple dbt projects, where models from one project are used as sources in another project.

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
@@ -53,8 +53,8 @@ OPERATION_STATEMENT_TYPES = {
     "CREATE": OperationTypeClass.CREATE,
     "CREATE_TABLE": OperationTypeClass.CREATE,
     "CREATE_TABLE_AS_SELECT": OperationTypeClass.CREATE,
-    "MERGE": OperationTypeClass.CUSTOM,
-    "COPY": OperationTypeClass.CUSTOM,
+    "MERGE": OperationTypeClass.UPDATE,  # Upsert semantics - aligns with BigQuery
+    "COPY": OperationTypeClass.INSERT,  # Bulk load semantics
     "TRUNCATE_TABLE": OperationTypeClass.CUSTOM,
     # TODO: Dataset for below query types are not detected by snowflake in snowflake.access_history.objects_modified.
     # However it seems possible to support these using sql parsing in future.


### PR DESCRIPTION
Summary
This PR adds support for mutual TLS (mTLS) and truststore-based client certificate validation in the GMS Jetty server, while keeping the default behavior as HTTP‑only when no SSL configuration is provided.

Key Changes
Added support for server.ssl.client-auth (NONE, WANT, NEED) to enable optional or required client certificates.
Added loading of truststore properties (trust-store, trust-store-password, trust-store-type) to validate client certificates when mTLS is enabled.
HTTPS is enabled only when a keystore is configured; truststore is used only when present.
Added warnings when client-auth=NEED is enabled but no truststore is provided.
Default mode remains HTTP-only when no SSL-related config is passed.
Result
GMS now cleanly supports:

HTTP (default)
TLS (server authentication)
mTLS (mutual certificate authentication)