### PR TITLE
fix(ui) Fix yaml editor cursor alignment issues

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/YamlEditor.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/YamlEditor.tsx
@@ -37,7 +37,6 @@ const Spacer = styled.div`
 const EditorWrapper = styled.div`
     && .view-line > span > span {
         font-family: ${typography.fonts.mono} !important;
-        font-size: ${typography.fontSizes.md} !important;
     }
 
     padding-bottom: 8px;
@@ -132,6 +131,7 @@ export function YamlEditor({ value, onChange }: Props) {
                         overviewRulerBorder: false,
                         lineNumbers: 'off',
                         fontFamily: typography.fonts.mono,
+                        fontSize: 14,
                         renderIndentGuides: false,
                         theme: 'my-custom-theme',
                         renderLineHighlight: 'none',


### PR DESCRIPTION
There were some issues with the font size we were rendering and what the underlying editor thought the font size was so the cursor was not aligned properly. Now we're on the same page.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
