### PR TITLE
fix(log): message of checkV2TableExists

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -112,9 +112,7 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
       return true;
     }
     if (!AspectStorageValidationUtil.checkV2TableExists(server)) {
-      log.error(
-          "GMS is on a newer version than your storage layer. Please refer to "
-              + "https://docs.datahub.com/docs/advanced/no-code-upgrade to view the upgrade guide.");
+      log.error("Table metadata_aspect_v2 does not exist.");
       canWrite = false;
       return false;
     } else {


### PR DESCRIPTION
## What:
* We saw an error when I deployed datahub with `1.3.0.1` version

  * <img width="3492" height="444" alt="image" src="https://github.com/user-attachments/assets/6d2ad268-8300-4ee5-aa59-70cf1dcbaafb" />

  * `GMS is on a newer version than your storage layer. Please refer to https://docs.datahub.com/docs/advanced/no-code-upgrade to view the upgrade guide.`

* Then I checked the release note of datahub, I saw `https://docs.datahub.com/docs/advanced/no-code-upgrade` was removed at 1.1.0([#13186](https://github.com/datahub-project/datahub/pull/13186)). Then I checked pods and jobs, and I realized that postgresqlSetupJob had failed, and metadata_aspect_v2 wasn't created.

## How:
* From my side, this log should be `Table metadata_aspect_v2 does not exist.`