### PR TITLE
Update pr-labeler to include myself as DH team member

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -68,7 +68,8 @@ jobs:
           "alokr-dhub",
           "alfiyas-datahub",
           "dinesh-verma-datahub",
-          "rob-1019"
+          "rob-1019",
+          "kewats"
           ]'),
           github.actor
           )


### PR DESCRIPTION
Added myself as a DataHub team member. 

This removes the community contribution label from my PRs.