### PR TITLE
fix(ui) Refresh user data after user signs up

### DIFF
--- a/datahub-web-react/src/app/auth/__tests__/usePostSignupPolling.test.ts
+++ b/datahub-web-react/src/app/auth/__tests__/usePostSignupPolling.test.ts
@@ -1,0 +1,124 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { USER_SIGNED_UP_KEY } from '@app/auth/constants';
+import { usePostSignupPolling } from '@app/auth/usePostSignupPolling';
+
+describe('usePostSignupPolling', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it('should not poll when signup flag is not present', () => {
+        const onPoll = vi.fn();
+
+        renderHook(() => usePostSignupPolling({ onPoll }));
+
+        vi.advanceTimersByTime(10000);
+
+        expect(onPoll).not.toHaveBeenCalled();
+    });
+
+    it('should poll at specified interval when signup flag is present', () => {
+        const onPoll = vi.fn();
+        localStorage.setItem(USER_SIGNED_UP_KEY, Date.now().toString());
+
+        renderHook(() => usePostSignupPolling({ onPoll, pollIntervalMs: 5000 }));
+
+        // Should not call immediately
+        expect(onPoll).not.toHaveBeenCalled();
+
+        // After first interval
+        vi.advanceTimersByTime(5000);
+        expect(onPoll).toHaveBeenCalledTimes(1);
+
+        // After second interval
+        vi.advanceTimersByTime(5000);
+        expect(onPoll).toHaveBeenCalledTimes(2);
+    });
+
+    it('should stop polling after max duration', () => {
+        const onPoll = vi.fn();
+        localStorage.setItem(USER_SIGNED_UP_KEY, Date.now().toString());
+
+        renderHook(() =>
+            usePostSignupPolling({
+                onPoll,
+                pollIntervalMs: 5000,
+                maxPollDurationMs: 15000,
+            }),
+        );
+
+        // Poll at 5s, 10s
+        vi.advanceTimersByTime(10000);
+        expect(onPoll).toHaveBeenCalledTimes(2);
+
+        // At 15s, should stop polling
+        vi.advanceTimersByTime(5000);
+        expect(onPoll).toHaveBeenCalledTimes(3);
+
+        // After 20s, no more polls
+        vi.advanceTimersByTime(5000);
+        expect(onPoll).toHaveBeenCalledTimes(3);
+    });
+
+    it('should remove localStorage flag after max duration', () => {
+        const onPoll = vi.fn();
+        localStorage.setItem(USER_SIGNED_UP_KEY, Date.now().toString());
+
+        renderHook(() =>
+            usePostSignupPolling({
+                onPoll,
+                pollIntervalMs: 5000,
+                maxPollDurationMs: 10000,
+            }),
+        );
+
+        expect(localStorage.getItem(USER_SIGNED_UP_KEY)).toBeTruthy();
+
+        // Advance past max duration
+        vi.advanceTimersByTime(15000);
+
+        expect(localStorage.getItem(USER_SIGNED_UP_KEY)).toBeNull();
+    });
+
+    it('should not start polling if signup time has already exceeded max duration', () => {
+        const onPoll = vi.fn();
+        const oldTimestamp = Date.now() - 70000; // 70 seconds ago
+        localStorage.setItem(USER_SIGNED_UP_KEY, oldTimestamp.toString());
+
+        renderHook(() =>
+            usePostSignupPolling({
+                onPoll,
+                maxPollDurationMs: 60000,
+            }),
+        );
+
+        vi.advanceTimersByTime(10000);
+
+        expect(onPoll).not.toHaveBeenCalled();
+        expect(localStorage.getItem(USER_SIGNED_UP_KEY)).toBeNull();
+    });
+
+    it('should cleanup interval on unmount', () => {
+        const onPoll = vi.fn();
+        localStorage.setItem(USER_SIGNED_UP_KEY, Date.now().toString());
+
+        const { unmount } = renderHook(() => usePostSignupPolling({ onPoll, pollIntervalMs: 5000 }));
+
+        vi.advanceTimersByTime(5000);
+        expect(onPoll).toHaveBeenCalledTimes(1);
+
+        unmount();
+
+        // After unmount, no more polls
+        vi.advanceTimersByTime(10000);
+        expect(onPoll).toHaveBeenCalledTimes(1);
+    });
+});

--- a/datahub-web-react/src/app/auth/constants.ts
+++ b/datahub-web-react/src/app/auth/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * LocalStorage key used to track when a user has just signed up.
+ * This triggers polling to fetch updated permissions.
+ */
+export const USER_SIGNED_UP_KEY = 'userJustSignedUp';

--- a/datahub-web-react/src/app/auth/usePostSignupPolling.ts
+++ b/datahub-web-react/src/app/auth/usePostSignupPolling.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+
+import { USER_SIGNED_UP_KEY } from '@app/auth/constants';
+
+const POLL_INTERVAL_MS = 5000; // Poll every 5 seconds
+const MAX_POLL_DURATION_MS = 60000; // Stop polling after 60 seconds
+
+type UsePostSignupPollingOptions = {
+    onPoll: () => void;
+    pollIntervalMs?: number;
+    maxPollDurationMs?: number;
+};
+
+/**
+ * Hook that polls for updated user permissions after signup.
+ *
+ * When a user signs up with an invite token, their role permissions may take
+ * a few seconds to propagate due to backend caching. This hook detects when
+ * a user has just signed up (via localStorage flag) and periodically refetches
+ * their user data until the max duration is reached.
+ *
+ * @param options.onPoll - Callback to execute on each poll (typically refetches user data)
+ * @param options.pollIntervalMs - How often to poll in milliseconds (default: 7000)
+ * @param options.maxPollDurationMs - Maximum time to poll in milliseconds (default: 60000)
+ */
+export function usePostSignupPolling({
+    onPoll,
+    pollIntervalMs = POLL_INTERVAL_MS,
+    maxPollDurationMs = MAX_POLL_DURATION_MS,
+}: UsePostSignupPollingOptions) {
+    useEffect(() => {
+        const signupTimestamp = localStorage.getItem(USER_SIGNED_UP_KEY);
+        if (!signupTimestamp) return undefined;
+
+        const signupTime = parseInt(signupTimestamp, 10);
+        const elapsed = Date.now() - signupTime;
+
+        // Stop polling if max duration already exceeded
+        if (elapsed > maxPollDurationMs) {
+            localStorage.removeItem(USER_SIGNED_UP_KEY);
+            return undefined;
+        }
+
+        // Start polling interval
+        const intervalId = setInterval(() => {
+            const currentElapsed = Date.now() - signupTime;
+            if (currentElapsed > maxPollDurationMs) {
+                clearInterval(intervalId);
+                localStorage.removeItem(USER_SIGNED_UP_KEY);
+                return;
+            }
+
+            onPoll();
+        }, pollIntervalMs);
+
+        return () => clearInterval(intervalId);
+    }, [onPoll, pollIntervalMs, maxPollDurationMs]);
+}

--- a/datahub-web-react/src/app/context/UserContextProvider.tsx
+++ b/datahub-web-react/src/app/context/UserContextProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
+import { usePostSignupPolling } from '@app/auth/usePostSignupPolling';
 import { DEFAULT_STATE, LocalState, State, UserContext } from '@app/context/userContext';
 
 import { useGetGlobalViewsSettingsLazyQuery } from '@graphql/app.generated';
@@ -42,6 +43,15 @@ const UserContextProvider = ({ children }: { children: React.ReactNode }) => {
      */
     const [getMe, { data: meData, refetch }] = useGetMeLazyQuery({ fetchPolicy: 'cache-first' });
     useEffect(() => getMe(), [getMe]);
+
+    /**
+     * Poll for updated permissions after signup.
+     * This handles the case where the user signs up with an invite token
+     * and their role permissions take a few seconds to propagate.
+     */
+    usePostSignupPolling({
+        onPoll: () => getMe({ fetchPolicy: 'network-only' }),
+    });
 
     /**
      * Retrieve the Global View settings once on component mount.


### PR DESCRIPTION
This fixes a bug where if a user signs up using an invite token granting them a role, the UI would not reflect that role in what the user can see until after some time (~15-20 seconds) passes and they refresh the page. After digging deeper I believe this is due to caching in the authorization layer, but busting that cache is complex and could lead to performance issues.

This solution simply checks if a user has just signed up using a new key: value in localStorage and refetches the user using the getMe query every 5 seconds until a max of 60 seconds ensuring we get the updated permissions without the user having to refresh the page.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
