### PR TITLE
improvement(ui/ingestion): update copy of abandonment flow modal

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
@@ -144,15 +144,14 @@ export function IngestionSourceCreatePage() {
     return (
         <DiscardUnsavedChangesConfirmationProvider
             enableRedirectHandling={!isSubmitting}
-            confirmationModalTitle="You have unsaved change"
-            confirmationModalText={
-                <>
-                    <Text type="span">You have unsaved changes to your new source. </Text>
-                    <Text type="span" weight="bold">
-                        Are you sure you want to leave and discard your unsaved changes?
-                    </Text>
-                </>
+            confirmationModalTitle="You have unsaved changes"
+            confirmationModalContent={
+                <Text color="gray" colorLevel={1700}>
+                    Exiting now will discard your configuration. You can continue setup or exit and start over later
+                </Text>
             }
+            confirmButtonText="Continue Setup"
+            closeButtonText="Exit Without Saving"
         >
             <IngestionSourceBuilder steps={STEPS} onSubmit={onSubmit} onCancel={onCancel} initialState={initialState} />
         </DiscardUnsavedChangesConfirmationProvider>

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceUpdatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceUpdatePage.tsx
@@ -195,15 +195,14 @@ export function IngestionSourceUpdatePage() {
     return (
         <DiscardUnsavedChangesConfirmationProvider
             enableRedirectHandling={!isSubmitting}
-            confirmationModalTitle="You have unsaved change"
-            confirmationModalText={
-                <>
-                    <Text type="span">You have unsaved changes to this source. </Text>
-                    <Text type="span" weight="bold">
-                        Are you sure you want to leave and discard your changes?
-                    </Text>
-                </>
+            confirmationModalTitle="You have unsaved changes"
+            confirmationModalContent={
+                <Text color="gray" colorLevel={1700}>
+                    Exiting now will discard your configuration. You can continue setup or exit and start over later
+                </Text>
             }
+            confirmButtonText="Continue Setup"
+            closeButtonText="Exit Without Saving"
         >
             <IngestionSourceBuilder
                 steps={STEPS}

--- a/datahub-web-react/src/app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext.tsx
+++ b/datahub-web-react/src/app/sharedV2/confirmation/DiscardUnsavedChangesConfirmationContext.tsx
@@ -8,8 +8,9 @@ interface Props {
     enableTabClosingHandling?: boolean;
     enableRedirectHandling?: boolean;
     confirmationModalTitle?: string;
-    confirmationModalText?: React.ReactNode;
+    confirmationModalContent?: React.ReactNode;
     confirmButtonText?: string;
+    closeButtonText?: string;
 }
 
 interface ConfirmationArgs {
@@ -35,8 +36,9 @@ export function DiscardUnsavedChangesConfirmationProvider({
     enableTabClosingHandling = true,
     enableRedirectHandling = true,
     confirmationModalTitle,
-    confirmationModalText,
+    confirmationModalContent,
     confirmButtonText,
+    closeButtonText,
 }: React.PropsWithChildren<Props>) {
     const [isDirty, setIsDirty] = useState<boolean>(false);
     const [isConfirmationShown, setIsConfirmationShown] = useState<boolean>(false);
@@ -79,7 +81,7 @@ export function DiscardUnsavedChangesConfirmationProvider({
         [isDirty, isRedirectConfirmed, enableRedirectHandling],
     );
 
-    const onRedirectConfrirm = useCallback(() => {
+    const onRedirectConfirm = useCallback(() => {
         setIsRedirectConfirmationShown(false);
         setIsRedirectConfirmed(true);
         // Defer redirect to the next tick
@@ -96,15 +98,20 @@ export function DiscardUnsavedChangesConfirmationProvider({
 
             <ConfirmationModal
                 isOpen={isConfirmationShown}
-                modalTitle={confirmationModalTitle ?? 'Discard unsaved changes?'}
-                modalText={confirmationModalText ?? 'Your changes will be lost. Are you sure you want to leave?'}
+                modalTitle={confirmationModalTitle ?? 'You have unsaved changes'}
+                modalText={
+                    confirmationModalContent ??
+                    'Exiting now will discard your changes. You can continue or exit and start over later'
+                }
                 closeButtonColor="gray"
-                handleClose={() => {
+                handleConfirm={() => {
                     setIsConfirmationShown(false);
                     setIsRedirectConfirmed(false); // restore redirect handling
                 }}
-                confirmButtonText={confirmButtonText ?? 'Confirm'}
-                handleConfirm={() => onConfirmHandler?.()}
+                confirmButtonText={confirmButtonText ?? 'Continue'}
+                handleClose={() => onConfirmHandler?.()}
+                closeButtonText={closeButtonText ?? 'Exit'}
+                closeOnPrimaryAction
             />
 
             {enableRedirectHandling && (
@@ -113,14 +120,17 @@ export function DiscardUnsavedChangesConfirmationProvider({
 
                     <ConfirmationModal
                         isOpen={isRedirectConfirmationShown}
-                        modalTitle={confirmationModalTitle ?? 'Discard unsaved changes?'}
+                        modalTitle={confirmationModalTitle ?? 'You have unsaved changes'}
                         modalText={
-                            confirmationModalText ?? 'Your changes will be lost. Are you sure you want to leave?'
+                            confirmationModalContent ??
+                            'Exiting now will discard your changes. You can continue or exit and start over later'
                         }
                         closeButtonColor="gray"
-                        handleClose={() => setIsRedirectConfirmationShown(false)}
-                        confirmButtonText={confirmButtonText ?? 'Confirm'}
-                        handleConfirm={onRedirectConfrirm}
+                        handleConfirm={() => setIsRedirectConfirmationShown(false)}
+                        confirmButtonText={confirmButtonText ?? 'Continue'}
+                        handleClose={onRedirectConfirm}
+                        closeButtonText={closeButtonText ?? 'Exit'}
+                        closeOnPrimaryAction
                     />
                 </>
             )}

--- a/datahub-web-react/src/app/sharedV2/confirmation/__tests__/DiscardUnsavedChangesConfirmationContext.test.tsx
+++ b/datahub-web-react/src/app/sharedV2/confirmation/__tests__/DiscardUnsavedChangesConfirmationContext.test.tsx
@@ -185,7 +185,7 @@ describe('DiscardUnsavedChangesConfirmationContext', () => {
                         enableTabClosingHandling
                         enableRedirectHandling
                         confirmationModalTitle="Custom Title"
-                        confirmationModalText="Custom Text"
+                        confirmationModalContent="Custom Text"
                     >
                         <div>Test Child</div>
                     </DiscardUnsavedChangesConfirmationProvider>

--- a/datahub-web-react/src/app/sharedV2/modals/ConfirmationModal.tsx
+++ b/datahub-web-react/src/app/sharedV2/modals/ConfirmationModal.tsx
@@ -33,6 +33,7 @@ interface Props {
     closeButtonColor?: ModalButton['color'];
     confirmButtonText?: string;
     isDeleteModal?: boolean;
+    closeOnPrimaryAction?: boolean;
 }
 
 export const ConfirmationModal = ({
@@ -45,11 +46,12 @@ export const ConfirmationModal = ({
     closeButtonColor,
     confirmButtonText,
     isDeleteModal,
+    closeOnPrimaryAction,
 }: Props) => {
     return (
         <StyledModal
             open={isOpen}
-            onCancel={handleClose}
+            onCancel={closeOnPrimaryAction ? handleConfirm : handleClose}
             centered
             buttons={[
                 {


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-1118/update-copy-of-the-abandonment-flow-modal

**Description:**

Brings back [this](https://github.com/acryldata/datahub-fork/pull/7687) PR to OSS

Updates the copy for content and buttons in abandonment flow modal used in create/edit ingestion sources. Also, switches the confirm and cancel buttons. Primary button is now to stay on the page and secondary (cancel) button is to discard the changes and leave.

**Screenshot:**

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/734f3839-df6d-4b74-af90-9dfb1afb7197" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
