### PR TITLE
config(quickstart): 3 partitions for quickstart topics

### DIFF
--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -90,6 +90,7 @@ x-datahub-system-update-service: &datahub-system-update-service
     KAFKA_BOOTSTRAP_SERVER: broker:29092
     USE_CONFLUENT_SCHEMA_REGISTRY: false
     DATAHUB_SQL_SETUP_ENABLED: ${DATAHUB_SQL_SETUP_ENABLED:-true}
+    PARTITIONS: ${DATAHUB_PARTITIONS:-3}
   volumes:
     - ${HOME}/.datahub/plugins:/etc/datahub/plugins
   labels:

--- a/docker/quickstart/docker-compose.quickstart-profile.yml
+++ b/docker/quickstart/docker-compose.quickstart-profile.yml
@@ -434,6 +434,7 @@ services:
       NEO4J_PASSWORD: datahub
       NEO4J_URI: bolt://neo4j
       NEO4J_USERNAME: neo4j
+      PARTITIONS: '3'
       REPROCESS_DEFAULT_BROWSE_PATHS_V2: 'false'
       SCHEMA_REGISTRY_SYSTEM_UPDATE: 'true'
       SCHEMA_REGISTRY_TYPE: INTERNAL


### PR DESCRIPTION
Set quickstart topic partitions to 3 for local development. Doesn't impact existing topics.