### PR TITLE
refactor(kafka): rename field variables to idiomatic Java naming

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/ConfluentSchemaRegistryCleanupPolicyStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/ConfluentSchemaRegistryCleanupPolicyStep.java
@@ -24,17 +24,17 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 @Slf4j
 public class ConfluentSchemaRegistryCleanupPolicyStep implements UpgradeStep {
 
-  private final OperationContext _opContext;
-  private final KafkaConfiguration _kafkaConfiguration;
-  private final KafkaProperties _kafkaProperties;
+  private final OperationContext opContext;
+  private final KafkaConfiguration kafkaConfiguration;
+  private final KafkaProperties kafkaProperties;
 
   public ConfluentSchemaRegistryCleanupPolicyStep(
       OperationContext opContext,
       KafkaConfiguration kafkaConfiguration,
       KafkaProperties kafkaProperties) {
-    this._opContext = opContext;
-    this._kafkaConfiguration = kafkaConfiguration;
-    this._kafkaProperties = kafkaProperties;
+    this.opContext = opContext;
+    this.kafkaConfiguration = kafkaConfiguration;
+    this.kafkaProperties = kafkaProperties;
   }
 
   @Override
@@ -48,15 +48,15 @@ public class ConfluentSchemaRegistryCleanupPolicyStep implements UpgradeStep {
       log.info("Configuring Confluent Schema Registry cleanup policies...");
 
       // Check if Kafka setup is enabled
-      if (_kafkaConfiguration.getSetup() == null
-          || !_kafkaConfiguration.getSetup().isPreCreateTopics()) {
+      if (kafkaConfiguration.getSetup() == null
+          || !kafkaConfiguration.getSetup().isPreCreateTopics()) {
         log.info(
             "Skipping Confluent Schema Registry cleanup policy configuration - Kafka setup is disabled");
         return new DefaultUpgradeStepResult(this.id(), DataHubUpgradeState.SUCCEEDED);
       }
 
       // Check if Confluent Schema Registry is enabled
-      if (!_kafkaConfiguration.getSetup().isUseConfluentSchemaRegistry()) {
+      if (!kafkaConfiguration.getSetup().isUseConfluentSchemaRegistry()) {
         log.info(
             "Skipping Confluent Schema Registry cleanup policy configuration - schema registry is disabled");
         return new DefaultUpgradeStepResult(this.id(), DataHubUpgradeState.SUCCEEDED);
@@ -110,6 +110,6 @@ public class ConfluentSchemaRegistryCleanupPolicyStep implements UpgradeStep {
    */
   protected AdminClient createAdminClient() {
     return buildKafkaAdminClient(
-        _kafkaConfiguration, _kafkaProperties, "datahub-upgrade-kafka-setup");
+        kafkaConfiguration, kafkaProperties, "datahub-upgrade-kafka-setup");
   }
 }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/CreateKafkaTopicsStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/CreateKafkaTopicsStep.java
@@ -32,9 +32,9 @@ import org.springframework.kafka.config.TopicBuilder;
 @Slf4j
 public class CreateKafkaTopicsStep implements UpgradeStep {
 
-  private final OperationContext _opContext;
-  private final KafkaConfiguration _kafkaConfiguration;
-  private final KafkaProperties _kafkaProperties;
+  private final OperationContext opContext;
+  private final KafkaConfiguration kafkaConfiguration;
+  private final KafkaProperties kafkaProperties;
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -42,9 +42,9 @@ public class CreateKafkaTopicsStep implements UpgradeStep {
       OperationContext opContext,
       KafkaConfiguration kafkaConfiguration,
       KafkaProperties kafkaProperties) {
-    this._opContext = opContext;
-    this._kafkaConfiguration = kafkaConfiguration;
-    this._kafkaProperties = kafkaProperties;
+    this.opContext = opContext;
+    this.kafkaConfiguration = kafkaConfiguration;
+    this.kafkaProperties = kafkaProperties;
   }
 
   @Override
@@ -55,12 +55,12 @@ public class CreateKafkaTopicsStep implements UpgradeStep {
   @Override
   public Function<UpgradeContext, UpgradeStepResult> executable() {
     return (context) -> {
-      if (_kafkaConfiguration.getSetup() == null) {
+      if (kafkaConfiguration.getSetup() == null) {
         log.warn("Kafka setup configuration is null - skipping topic creation");
         return new DefaultUpgradeStepResult(this.id(), DataHubUpgradeState.SUCCEEDED);
       }
 
-      if (!_kafkaConfiguration.getSetup().isPreCreateTopics()) {
+      if (!kafkaConfiguration.getSetup().isPreCreateTopics()) {
         log.info("Skipping Kafka topic creation as preCreateTopics is false");
         return new DefaultUpgradeStepResult(this.id(), DataHubUpgradeState.SUCCEEDED);
       }
@@ -73,23 +73,23 @@ public class CreateKafkaTopicsStep implements UpgradeStep {
             "KafkaConfiguration setup: {}",
             OBJECT_MAPPER
                 .writerWithDefaultPrettyPrinter()
-                .writeValueAsString(_kafkaConfiguration.getSetup()));
+                .writeValueAsString(kafkaConfiguration.getSetup()));
         log.info(
             "KafkaConfiguration topics: {}",
             OBJECT_MAPPER
                 .writerWithDefaultPrettyPrinter()
-                .writeValueAsString(_kafkaConfiguration.getTopics()));
+                .writeValueAsString(kafkaConfiguration.getTopics()));
         log.info(
             "KafkaConfiguration topicDefaults: {}",
             OBJECT_MAPPER
                 .writerWithDefaultPrettyPrinter()
-                .writeValueAsString(_kafkaConfiguration.getTopicDefaults()));
+                .writeValueAsString(kafkaConfiguration.getTopicDefaults()));
 
         // Create AdminClient using AdminClientFactory
         AdminClient adminClient = createAdminClient();
 
         // Get topic configurations
-        TopicsConfiguration topicsConfig = _kafkaConfiguration.getTopics();
+        TopicsConfiguration topicsConfig = kafkaConfiguration.getTopics();
         if (topicsConfig == null) {
           log.warn("Topics configuration is null - skipping topic creation");
           return new DefaultUpgradeStepResult(this.id(), DataHubUpgradeState.SUCCEEDED);
@@ -133,7 +133,7 @@ public class CreateKafkaTopicsStep implements UpgradeStep {
           // Check if topic already exists
           if (existingTopics.contains(topicName)) {
             // Check if auto-increase is enabled before checking/increasing partitions
-            if (_kafkaConfiguration.getSetup().isAutoIncreasePartitions()) {
+            if (kafkaConfiguration.getSetup().isAutoIncreasePartitions()) {
               if (currentPartitionCounts.containsKey(topicName)) {
                 int currentPartitions = currentPartitionCounts.get(topicName);
                 int desiredPartitions = topicConfig.getPartitions();
@@ -271,7 +271,7 @@ public class CreateKafkaTopicsStep implements UpgradeStep {
     // Batch API call to get partition counts for all existing topics
     Map<String, Integer> currentPartitionCounts = new HashMap<>();
     if (!existingConfiguredTopics.isEmpty()
-        && _kafkaConfiguration.getSetup().isAutoIncreasePartitions()) {
+        && kafkaConfiguration.getSetup().isAutoIncreasePartitions()) {
       try {
         DescribeTopicsResult describeResult = adminClient.describeTopics(existingConfiguredTopics);
         Map<String, TopicDescription> topicDescriptions = describeResult.allTopicNames().get();
@@ -299,6 +299,6 @@ public class CreateKafkaTopicsStep implements UpgradeStep {
    */
   protected AdminClient createAdminClient() {
     return buildKafkaAdminClient(
-        _kafkaConfiguration, _kafkaProperties, "datahub-upgrade-kafka-setup");
+        kafkaConfiguration, kafkaProperties, "datahub-upgrade-kafka-setup");
   }
 }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/KafkaNonBlockingSetup.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/KafkaNonBlockingSetup.java
@@ -12,13 +12,13 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 @Slf4j
 public class KafkaNonBlockingSetup implements NonBlockingSystemUpgrade {
 
-  private final List<UpgradeStep> _steps;
+  private final List<UpgradeStep> steps;
 
   public KafkaNonBlockingSetup(
       OperationContext opContext,
       KafkaConfiguration kafkaConfiguration,
       KafkaProperties kafkaProperties) {
-    _steps =
+    this.steps =
         ImmutableList.of(
             new ConfluentSchemaRegistryCleanupPolicyStep(
                 opContext, kafkaConfiguration, kafkaProperties));
@@ -31,6 +31,6 @@ public class KafkaNonBlockingSetup implements NonBlockingSystemUpgrade {
 
   @Override
   public List<UpgradeStep> steps() {
-    return _steps;
+    return steps;
   }
 }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/KafkaSetup.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/KafkaSetup.java
@@ -12,13 +12,13 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 @Slf4j
 public class KafkaSetup implements BlockingSystemUpgrade {
 
-  private final List<UpgradeStep> _steps;
+  private final List<UpgradeStep> steps;
 
   public KafkaSetup(
       OperationContext opContext,
       KafkaConfiguration kafkaConfiguration,
       KafkaProperties kafkaProperties) {
-    _steps =
+    this.steps =
         ImmutableList.of(
             new WaitForKafkaReadyStep(opContext, kafkaConfiguration, kafkaProperties),
             new CreateKafkaTopicsStep(opContext, kafkaConfiguration, kafkaProperties));
@@ -31,6 +31,6 @@ public class KafkaSetup implements BlockingSystemUpgrade {
 
   @Override
   public List<UpgradeStep> steps() {
-    return _steps;
+    return steps;
   }
 }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/WaitForKafkaReadyStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/kafka/WaitForKafkaReadyStep.java
@@ -23,17 +23,17 @@ public class WaitForKafkaReadyStep implements UpgradeStep {
   private static final long RETRY_INTERVAL_SECONDS = 5;
   private static final long REQUEST_TIMEOUT_MS = 5000;
 
-  private final OperationContext _opContext;
-  private final KafkaConfiguration _kafkaConfiguration;
-  private final KafkaProperties _kafkaProperties;
+  private final OperationContext opContext;
+  private final KafkaConfiguration kafkaConfiguration;
+  private final KafkaProperties kafkaProperties;
 
   public WaitForKafkaReadyStep(
       OperationContext opContext,
       KafkaConfiguration kafkaConfiguration,
       KafkaProperties kafkaProperties) {
-    this._opContext = opContext;
-    this._kafkaConfiguration = kafkaConfiguration;
-    this._kafkaProperties = kafkaProperties;
+    this.opContext = opContext;
+    this.kafkaConfiguration = kafkaConfiguration;
+    this.kafkaProperties = kafkaProperties;
   }
 
   @Override
@@ -81,7 +81,7 @@ public class WaitForKafkaReadyStep implements UpgradeStep {
 
   protected AdminClient createAdminClient() {
     return buildKafkaAdminClient(
-        _kafkaConfiguration, _kafkaProperties, "datahub-upgrade-kafka-setup");
+        kafkaConfiguration, kafkaProperties, "datahub-upgrade-kafka-setup");
   }
 
   @Override


### PR DESCRIPTION
Remove underscore prefixes from private fields in kafka upgrade steps, following standard Java naming conventions.

- Remove '_' prefix from opContext, kafkaConfiguration, kafkaProperties
- Remove '_' prefix from steps field in setup classes

This addresses feedback from PR #15714 review.

- [X ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
