### PR TITLE
fix(ui): add dbt source config for docs link

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingest/source/builder/sources.json
@@ -80,6 +80,14 @@
         "recipe": "source:\n  type: dbt-cloud\n  config:\n    account_id: null\n    project_id: null\n    job_id: null\n    target_platform: null\n    stateful_ingestion:\n      enabled: true"
     },
     {
+        "urn": "urn:li:dataPlatform:dbt",
+        "name": "dbt",
+        "displayName": "dbt",
+        "description": "Import Sources, Seeds, Models, Snapshots, Tests, and lineage from dbt.",
+        "docsUrl": "https://docs.datahub.com/docs/generated/ingestion/sources/dbt/",
+        "recipe": "source:\n  type: dbt\n  config:\n    manifest_path: # path to manifest.json\n    catalog_path: # path to catalog.json\n    target_platform: # e.g. snowflake, bigquery\n    stateful_ingestion:\n      enabled: true"
+    },
+    {
         "urn": "urn:li:dataPlatform:mysql",
         "name": "mysql",
         "displayName": "MySQL",

--- a/datahub-web-react/src/app/ingestV2/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingestV2/source/builder/sources.json
@@ -100,6 +100,16 @@
         "isPopular": true
     },
     {
+        "urn": "urn:li:dataPlatform:dbt",
+        "name": "dbt",
+        "displayName": "dbt",
+        "description": "Import Sources, Seeds, Models, Snapshots, Tests, and lineage from dbt.",
+        "docsUrl": "https://docs.datahub.com/docs/generated/ingestion/sources/dbt/",
+        "recipe": "source:\n  type: dbt\n  config:\n    manifest_path: # path to manifest.json\n    catalog_path: # path to catalog.json\n    target_platform: # e.g. snowflake, bigquery\n    stateful_ingestion:\n      enabled: true",
+        "category": "ETL / ELT",
+        "isPopular": true
+    },
+    {
         "urn": "urn:li:dataPlatform:mysql",
         "name": "mysql",
         "displayName": "MySQL",


### PR DESCRIPTION
## Summary
- Added missing `dbt` entry to `sources.json` (only `dbt-cloud` existed previously)
- Fixes broken "source docs" link when editing ingestion sources with `type: dbt`
- The docs link now correctly points to https://docs.datahub.com/docs/generated/ingestion/sources/dbt/

## Test plan
- [x] Edit an existing ingestion source with `type: dbt` and verify the "source docs" link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)