### PR TITLE
feat(cli) support extra-pip & extra-env options in config file

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -295,7 +295,7 @@ For more information on setting up remote executors, see the [Remote Executor Se
 
 #### Using deployment section
 
-As an alternative to configuring settings from the CLI, all of these settings can also be set in the `deployment` field of the recipe.
+As an alternative to configuring settings from the CLI, they can also be set in the `deployment` field of the recipe.
 
 ```yml
 # deployment_recipe.yml
@@ -305,6 +305,8 @@ deployment:
   time_zone: "Europe/London"
   executor_id: "remote-executor-pool-1" # Optional: specify remote executor
   cli_version: "0.15.0.1" # Optional: specify CLI version
+  extra_pip: '["polars==1.35.2"]'
+  extra_env: "VAR1=value1,VAR2=value2"
 
 source: ...
 ```
@@ -317,7 +319,7 @@ CLI options will override corresponding values in the deployment section.
 
 #### Deployment Configuration Options
 
-All deployment options that can be specified via CLI flags can also be configured in the `deployment` section:
+These deployment options that can be specified via CLI flags can also be configured in the `deployment` section:
 
 | Field         | CLI Option      | Description                     | Default            |
 | ------------- | --------------- | ------------------------------- | ------------------ |
@@ -326,6 +328,8 @@ All deployment options that can be specified via CLI flags can also be configure
 | `time_zone`   | `--time-zone`   | Timezone for scheduled runs     | `"UTC"`            |
 | `executor_id` | `--executor-id` | Target executor for ingestion   | `"default"`        |
 | `cli_version` | `--cli-version` | CLI version for ingestion       | Server default     |
+| `extra_pip`.  | `--extra-pip`   | Extra pip packages              | None               |
+| `extra_env`   | `--extra-env`   | Extra environment variables     | None               |
 
 #### Batch Deployment
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -328,7 +328,7 @@ These deployment options that can be specified via CLI flags can also be configu
 | `time_zone`   | `--time-zone`   | Timezone for scheduled runs     | `"UTC"`            |
 | `executor_id` | `--executor-id` | Target executor for ingestion   | `"default"`        |
 | `cli_version` | `--cli-version` | CLI version for ingestion       | Server default     |
-| `extra_pip`.  | `--extra-pip`   | Extra pip packages              | None               |
+| `extra_pip`   | `--extra-pip`   | Extra pip packages              | None               |
 | `extra_env`   | `--extra-env`   | Extra environment variables     | None               |
 
 #### Batch Deployment

--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -195,6 +195,7 @@ def run(
     "--name",
     type=str,
     help="Recipe Name",
+    required=False,
 )
 @click.option(
     "-c",

--- a/metadata-ingestion/src/datahub/utilities/ingest_utils.py
+++ b/metadata-ingestion/src/datahub/utilities/ingest_utils.py
@@ -26,6 +26,8 @@ class DeployOptions(ConfigModel):
     time_zone: str = "UTC"
     cli_version: Optional[str] = None
     executor_id: str = "default"
+    extra_pip: Optional[str] = None
+    extra_env: Optional[str] = None
 
 
 def deploy_source_vars(
@@ -70,6 +72,10 @@ def deploy_source_vars(
         deploy_options.cli_version = cli_version
     if executor_id:
         deploy_options.executor_id = executor_id
+    if extra_pip:
+        deploy_options.extra_pip = extra_pip
+    if extra_env:
+        deploy_options.extra_env = extra_env
 
     logger.info(f"Using {repr(deploy_options)}")
 
@@ -97,20 +103,22 @@ def deploy_source_vars(
             "interval": deploy_options.schedule,
             "timezone": deploy_options.time_zone,
         }
-    if extra_pip is not None:
+    if deploy_options.extra_pip is not None:
         extra_args_list = (
             variables.get("input", {}).get("config", {}).get("extraArgs", [])
         )
-        extra_args_list.append({"key": "extra_pip_requirements", "value": extra_pip})
+        extra_args_list.append(
+            {"key": "extra_pip_requirements", "value": deploy_options.extra_pip}
+        )
         variables["input"]["config"]["extraArgs"] = extra_args_list
 
-    if extra_env is not None:
+    if deploy_options.extra_env is not None:
         extra_args_list = (
             variables.get("input", {}).get("config", {}).get("extraArgs", [])
         )
         # Parse comma-separated KEY=VALUE pairs into a JSON object
         env_dict = {}
-        for pair in extra_env.split(","):
+        for pair in deploy_options.extra_env.split(","):
             key, value = pair.split("=", 1)
             env_dict[key] = value
         extra_args_list.append({"key": "extra_env_vars", "value": json.dumps(env_dict)})

--- a/metadata-ingestion/tests/unit/utilities/sample_deploy_demo.dhub.yaml
+++ b/metadata-ingestion/tests/unit/utilities/sample_deploy_demo.dhub.yaml
@@ -4,6 +4,8 @@ deployment:
   schedule: '5 0 * * *'
   time_zone: 'Europe/London'
   cli_version: "1.3.1.1"
+  extra_pip: '["polars"]'
+  extra_env: 'VAR0=value0'
 
 source:
   type: demo-data

--- a/metadata-ingestion/tests/unit/utilities/sample_deploy_demo.dhub.yaml
+++ b/metadata-ingestion/tests/unit/utilities/sample_deploy_demo.dhub.yaml
@@ -1,0 +1,10 @@
+deployment:
+  name: test-deploy
+  executor_id: other-default
+  schedule: '5 0 * * *'
+  time_zone: 'Europe/London'
+  cli_version: "1.3.1.1"
+
+source:
+  type: demo-data
+  config: {}

--- a/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
+++ b/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
@@ -143,6 +143,10 @@ def test_deploy_source_vars_from_config_file():
                 "debugMode": False,
                 "executorId": "other-default",
                 "version": "1.3.1.1",
+                "extraArgs": [
+                    {"key": "extra_pip_requirements", "value": '["polars"]'},
+                    {"key": "extra_env_vars", "value": '{"VAR0": "value0"}'},
+                ],
             },
         },
     }
@@ -186,6 +190,10 @@ def test_deploy_source_name_precedence():
                 "debugMode": False,
                 "executorId": "other-default",
                 "version": "1.3.1.1",
+                "extraArgs": [
+                    {"key": "extra_pip_requirements", "value": '["polars"]'},
+                    {"key": "extra_env_vars", "value": '{"VAR0": "value0"}'},
+                ],
             },
         },
     }

--- a/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
+++ b/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
@@ -103,3 +103,139 @@ def test_deploy_source_vars_with_extra_env():
             },
         },
     }
+
+
+def test_deploy_source_vars_from_config_file():
+    name = None
+    config = pathlib.Path(__file__).parent / "sample_deploy_demo.dhub.yaml"
+    urn = None
+    executor_id = None
+    cli_version = None
+    schedule = None
+    time_zone = None
+    extra_pip = None
+    debug = False
+    extra_env = None
+
+    deploy_vars = deploy_source_vars(
+        name,
+        str(config),
+        urn,
+        executor_id,
+        cli_version,
+        schedule,
+        time_zone,
+        extra_pip,
+        debug,
+        extra_env,
+    )
+    assert deploy_vars == {
+        "urn": "urn:li:dataHubIngestionSource:deploy-9bb513c1b594da861f5a95a670938576",
+        "input": {
+            "name": "test-deploy",
+            "schedule": {
+                "interval": "5 0 * * *",
+                "timezone": "Europe/London",
+            },
+            "type": "demo-data",
+            "config": {
+                "recipe": '{"source": {"type": "demo-data", "config": {}}}',
+                "debugMode": False,
+                "executorId": "other-default",
+                "version": "1.3.1.1",
+            },
+        },
+    }
+
+
+def test_deploy_source_name_precedence():
+    name = "test"
+    config = pathlib.Path(__file__).parent / "sample_deploy_demo.dhub.yaml"
+    urn = None
+    executor_id = None
+    cli_version = None
+    schedule = None
+    time_zone = None
+    extra_pip = None
+    debug = False
+    extra_env = None
+
+    deploy_vars = deploy_source_vars(
+        name,
+        str(config),
+        urn,
+        executor_id,
+        cli_version,
+        schedule,
+        time_zone,
+        extra_pip,
+        debug,
+        extra_env,
+    )
+    assert deploy_vars == {
+        "urn": "urn:li:dataHubIngestionSource:deploy-2b895b6efaa28b818284e5c696a18799",
+        "input": {
+            "name": "test",
+            "schedule": {
+                "interval": "5 0 * * *",
+                "timezone": "Europe/London",
+            },
+            "type": "demo-data",
+            "config": {
+                "recipe": '{"source": {"type": "demo-data", "config": {}}}',
+                "debugMode": False,
+                "executorId": "other-default",
+                "version": "1.3.1.1",
+            },
+        },
+    }
+
+
+def test_deploy_source_vars_precedence():
+    name = None
+    config = pathlib.Path(__file__).parent / "sample_deploy_demo.dhub.yaml"
+    urn = None
+    executor_id = "default"
+    cli_version = "0.15.0.1"
+    schedule = "5 4 * * *"
+    time_zone = "UTC"
+    extra_pip = '["pandas"]'
+    debug = False
+    extra_env = "VAR1=value1,VAR2=value2"
+
+    deploy_vars = deploy_source_vars(
+        name,
+        str(config),
+        urn,
+        executor_id,
+        cli_version,
+        schedule,
+        time_zone,
+        extra_pip,
+        debug,
+        extra_env,
+    )
+    assert deploy_vars == {
+        "urn": "urn:li:dataHubIngestionSource:deploy-9bb513c1b594da861f5a95a670938576",
+        "input": {
+            "name": "test-deploy",
+            "schedule": {
+                "interval": "5 4 * * *",
+                "timezone": "UTC",
+            },
+            "type": "demo-data",
+            "config": {
+                "recipe": '{"source": {"type": "demo-data", "config": {}}}',
+                "debugMode": False,
+                "executorId": "default",
+                "version": "0.15.0.1",
+                "extraArgs": [
+                    {"key": "extra_pip_requirements", "value": '["pandas"]'},
+                    {
+                        "key": "extra_env_vars",
+                        "value": '{"VAR1": "value1", "VAR2": "value2"}',
+                    },
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
# Summary

- Support setting `--extra-pip` and `--extra-env` options of `datahub ingest deploy` command in `deployment` field of recipe.
- Added missing tests for setting config in `deployment` field of recipe.
- Extended tests to cover new config options
- Updated Docs to include new options
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
