### PR TITLE
fix(docker): Redundant volume mount fails on Mac Docker Desktop

### DIFF
--- a/docker/profiles/docker-compose.frontend.yml
+++ b/docker/profiles/docker-compose.frontend.yml
@@ -30,7 +30,10 @@ x-datahub-frontend-service-dev: &datahub-frontend-service-dev
     DATAHUB_ANALYTICS_ENABLED: ${DATAHUB_ANALYTICS_ENABLED:-true}
   volumes:
     - ../../datahub-frontend/build/stage/main:/datahub-frontend
-    - ./monitoring/client-prometheus-config.yaml:/datahub-frontend/client-prometheus-config.yaml
+    # Removed nested mount - causes virtiofs mountpoint error in Docker Desktop >= 4.42.0
+    # The file is already in the Docker image, so this mount isn't needed.
+    # If you need to override it for development, copy it to the build directory instead.
+    # - ./monitoring/client-prometheus-config.yaml:/datahub-frontend/client-prometheus-config.yaml
 
 services:
   frontend-quickstart:


### PR DESCRIPTION
Docker Desktop versions >= 4.44.0 fail to start docker containers 

The following error is seen when running via `./gradlew quickStartDebug`

```
Container datahub-opensearch-1  Healthy
 Container datahub-system-update-debug-1  Starting
 Container datahub-system-update-debug-1  Started
 Container datahub-system-update-debug-1  Waiting
 Container datahub-system-update-debug-1  Waiting
 Container datahub-system-update-debug-1  Exited
 Container datahub-system-update-debug-1  Exited
 Container datahub-frontend-debug-1  Starting
 Container datahub-datahub-gms-debug-1  Starting
 Container datahub-datahub-gms-debug-1  Started
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/host_mnt/Users/devashish.chandra/datahub/repos/datahub/docker/monitoring/client-prometheus-config.yaml" to rootfs at "/datahub-frontend/client-prometheus-config.yaml": create mountpoint for /datahub-frontend/client-prometheus-config.yaml mount: mountpoint "/run/host_virtiofs/Users/devashish.chandra/datahub/repos/datahub/datahub-frontend/build/stage/main/client-prometheus-config.yaml" is outside of rootfs "/var/lib/docker/rootfs/overlayfs/0c9ee4df4d9f38005fef1515f5de5f62fee2092fe5e6227267212b09c2cd1253"
```

The issue is probably attributed to the Change to Apple Virtualization by default for Docker Desktop starting v4.44.0 https://docs.docker.com/desktop/release-notes/#4440:~:text=Apple%20Virtualization%20is%20now%20the%20default%20VMM%20for%20better%20performance%20and%20QEMU%20Virtualization%20is%20removed.%20See%20blog%20post.

Removing this extra mount fixes the issue, and is redundant as the required file is already in the Docker image and is not needed. Added comment if the mount is needed locally for any reason.



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
