### PR TITLE
docs(local-dev): Added instructions on how to use mise for installing tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ out/
 # Mise
 **/mise.local.toml
 **/.mise.local.toml
+.mise/**
 
 #spark-lineage
 **/spark-lineage/metastore_db/

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -48,7 +48,7 @@ Fork and clone the repo if you haven't done so already. Refer: [Building the Pro
 > mise trust
 
 # Needed once if the required tools haven't been installed via mise before
-# or if there is a addition of new tools or change in tool versions since last use
+# or if a new tool is added or tool version changed since last use
 > mise install
 ```
 
@@ -60,10 +60,10 @@ You can verify the tools are activated correctly by running
 # Check tool versions installed
 ❯ mise ls --local
 Tool    Version  Source                             Requested
-java    17.0.2   ~/datahub/repos/datahub/mise.toml  17
-node    22.21.1  ~/datahub/repos/datahub/mise.toml  22
-python  3.11.14  ~/datahub/repos/datahub/mise.toml  3.11
-yarn    4.12.0   ~/datahub/repos/datahub/mise.toml  latest
+java    17.0.2   ~/path/to/datahub/mise.toml  17
+node    22.21.1  ~/path/to/datahub/mise.toml  22
+python  3.11.14  ~/path/to/datahub/mise.toml  3.11
+yarn    4.12.0   ~/path/to/datahub/mise.toml  latest
 ```
 
 ## Building the Project

--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,4 @@
 java = "17"
 node = "22"
 python = "3.11"
-yarn = "latest"
+yarn = "4.12.0"


### PR DESCRIPTION
- Added mise.toml to manage tool versions via mise
- Updated doc/developers.md to add instructions on how to use mise to manage tool versions

Updated docs to mention Python 3.11 instead of 3.10 for System python as Python 3.10 is nearly EOL.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
