### PR TITLE
fix(structured-properties): fix build indices mapping for structured …

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/models/StructuredPropertyUtils.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/StructuredPropertyUtils.java
@@ -87,6 +87,54 @@ public class StructuredPropertyUtils {
   }
 
   /**
+   * Extracts the entity type name from an entity type URN.
+   *
+   * <p>Entity type URNs may come in two formats:
+   *
+   * <ul>
+   *   <li>{@code urn:li:entityType:dataset} - legacy format without datahub prefix
+   *   <li>{@code urn:li:entityType:datahub.dataset} - current format with datahub prefix
+   * </ul>
+   *
+   * <p>This method normalizes both formats to return just the entity type name (e.g., "dataset").
+   *
+   * @param entityTypeUrn the entity type URN to extract the name from
+   * @return the entity type name (e.g., "dataset", "dataFlow"), or null if the URN is null
+   */
+  @Nullable
+  public static String getEntityTypeId(@Nullable final Urn entityTypeUrn) {
+    if (entityTypeUrn == null) {
+      return null;
+    }
+    String entityTypeId = entityTypeUrn.getId();
+    // Handle both "datahub.dataset" and "dataset" formats
+    if (entityTypeId.startsWith("datahub.")) {
+      entityTypeId = entityTypeId.substring("datahub.".length());
+    }
+    return entityTypeId;
+  }
+
+  /**
+   * Checks if the given entity type URN matches the specified entity type name.
+   *
+   * <p>This method handles both URN formats:
+   *
+   * <ul>
+   *   <li>{@code urn:li:entityType:dataset}
+   *   <li>{@code urn:li:entityType:datahub.dataset}
+   * </ul>
+   *
+   * @param entityTypeUrn the entity type URN to check
+   * @param entityTypeName the entity type name to match against (e.g., "dataset")
+   * @return true if the URN represents the specified entity type, false otherwise
+   */
+  public static boolean entityTypeMatches(
+      @Nullable final Urn entityTypeUrn, @Nonnull final String entityTypeName) {
+    String extractedType = getEntityTypeId(entityTypeUrn);
+    return entityTypeName.equals(extractedType);
+  }
+
+  /**
    * Given a structured property input field or facet name, return a valid structured property facet
    * name
    *

--- a/entity-registry/src/test/java/com/linkedin/metadata/models/StructuredPropertyUtilsTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/models/StructuredPropertyUtilsTest.java
@@ -1,0 +1,75 @@
+package com.linkedin.metadata.models;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import org.testng.annotations.Test;
+
+public class StructuredPropertyUtilsTest {
+
+  @Test
+  public void testGetEntityTypeIdWithDatahubPrefix() {
+    // URN with datahub. prefix (current format)
+    Urn entityTypeUrn = UrnUtils.getUrn("urn:li:entityType:datahub.dataset");
+    String entityTypeId = StructuredPropertyUtils.getEntityTypeId(entityTypeUrn);
+    assertEquals(entityTypeId, "dataset");
+  }
+
+  @Test
+  public void testGetEntityTypeIdWithoutDatahubPrefix() {
+    // URN without datahub. prefix (legacy format)
+    Urn entityTypeUrn = UrnUtils.getUrn("urn:li:entityType:dataset");
+    String entityTypeId = StructuredPropertyUtils.getEntityTypeId(entityTypeUrn);
+    assertEquals(entityTypeId, "dataset");
+  }
+
+  @Test
+  public void testGetEntityTypeIdWithNull() {
+    String entityTypeId = StructuredPropertyUtils.getEntityTypeId(null);
+    assertNull(entityTypeId);
+  }
+
+  @Test
+  public void testGetEntityTypeIdWithDataFlow() {
+    // Test another entity type with datahub. prefix
+    Urn entityTypeUrn = UrnUtils.getUrn("urn:li:entityType:datahub.dataFlow");
+    String entityTypeId = StructuredPropertyUtils.getEntityTypeId(entityTypeUrn);
+    assertEquals(entityTypeId, "dataFlow");
+  }
+
+  @Test
+  public void testGetEntityTypeIdWithSchemaField() {
+    // Test schema field entity type
+    Urn entityTypeUrn = UrnUtils.getUrn("urn:li:entityType:datahub.schemaField");
+    String entityTypeId = StructuredPropertyUtils.getEntityTypeId(entityTypeUrn);
+    assertEquals(entityTypeId, "schemaField");
+  }
+
+  @Test
+  public void testEntityTypeMatchesWithDatahubPrefix() {
+    Urn entityTypeUrn = UrnUtils.getUrn("urn:li:entityType:datahub.dataset");
+    assertTrue(StructuredPropertyUtils.entityTypeMatches(entityTypeUrn, "dataset"));
+    assertFalse(StructuredPropertyUtils.entityTypeMatches(entityTypeUrn, "dataFlow"));
+  }
+
+  @Test
+  public void testEntityTypeMatchesWithoutDatahubPrefix() {
+    Urn entityTypeUrn = UrnUtils.getUrn("urn:li:entityType:dataset");
+    assertTrue(StructuredPropertyUtils.entityTypeMatches(entityTypeUrn, "dataset"));
+    assertFalse(StructuredPropertyUtils.entityTypeMatches(entityTypeUrn, "dataFlow"));
+  }
+
+  @Test
+  public void testEntityTypeMatchesWithNull() {
+    assertFalse(StructuredPropertyUtils.entityTypeMatches(null, "dataset"));
+  }
+
+  @Test
+  public void testEntityTypeMatchesCaseSensitive() {
+    // Ensure matching is case-sensitive
+    Urn entityTypeUrn = UrnUtils.getUrn("urn:li:entityType:datahub.dataset");
+    assertFalse(StructuredPropertyUtils.entityTypeMatches(entityTypeUrn, "Dataset"));
+    assertFalse(StructuredPropertyUtils.entityTypeMatches(entityTypeUrn, "DATASET"));
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
@@ -1,7 +1,7 @@
 package com.linkedin.metadata.search.elasticsearch.index.entity.v2;
 
-import static com.linkedin.metadata.Constants.ENTITY_TYPE_URN_PREFIX;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_MAPPING_FIELD;
+import static com.linkedin.metadata.models.StructuredPropertyUtils.entityTypeMatches;
 import static com.linkedin.metadata.models.StructuredPropertyUtils.toElasticsearchFieldName;
 import static com.linkedin.metadata.models.annotation.SearchableAnnotation.OBJECT_FIELD_TYPES;
 import static com.linkedin.metadata.search.elasticsearch.index.entity.v2.V2LegacySettingsBuilder.*;
@@ -12,7 +12,6 @@ import static com.linkedin.metadata.search.utils.ESUtils.TYPE;
 
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.config.search.EntityIndexConfiguration;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.LogicalValueType;
@@ -147,12 +146,16 @@ public class V2MappingsBuilder implements MappingsBuilder {
     Map<String, Object> structuredPropertiesForEntity = Collections.emptyMap();
 
     if (!structuredProperties.isEmpty()) {
-      Urn matchUrn = UrnUtils.getUrn(ENTITY_TYPE_URN_PREFIX + entityName);
-
       structuredPropertiesForEntity =
           getIndexMappingsForStructuredProperty(
               structuredProperties.stream()
-                  .filter(urnProp -> urnProp.getSecond().getEntityTypes().contains(matchUrn))
+                  .filter(
+                      urnProp ->
+                          urnProp.getSecond().getEntityTypes() != null
+                              && urnProp.getSecond().getEntityTypes().stream()
+                                  .anyMatch(
+                                      entityTypeUrn ->
+                                          entityTypeMatches(entityTypeUrn, entityName)))
                   .collect(Collectors.toSet()));
     }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/StructuredPropertyMappingBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/StructuredPropertyMappingBuilder.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.search.elasticsearch.index.entity.v3;
 
+import static com.linkedin.metadata.models.StructuredPropertyUtils.entityTypeMatches;
 import static com.linkedin.metadata.models.StructuredPropertyUtils.toElasticsearchFieldName;
 import static com.linkedin.metadata.search.utils.ESUtils.TYPE;
 
@@ -45,13 +46,7 @@ public class StructuredPropertyMappingBuilder {
               StructuredPropertyDefinition definition = pair.getValue();
               return definition.getEntityTypes() != null
                   && definition.getEntityTypes().stream()
-                      .anyMatch(
-                          urn -> {
-                            // Extract entity type name from URN like "urn:li:entityType:dataset"
-                            String urnString = urn.toString();
-                            String[] parts = urnString.split(":");
-                            return parts.length > 3 && parts[3].equals(entityType);
-                          });
+                      .anyMatch(entityTypeUrn -> entityTypeMatches(entityTypeUrn, entityType));
             })
         .forEach(
             pair -> {

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/MultiEntityMappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/MultiEntityMappingsBuilderTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableMap;
+import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.config.search.EntityIndexConfiguration;
@@ -361,6 +362,10 @@ public class MultiEntityMappingsBuilderTest {
 
     // Mock the qualifiedName
     when(property.getQualifiedName()).thenReturn("test.property");
+
+    // Mock entity types - use production format with datahub. prefix
+    UrnArray entityTypes = new UrnArray(UrnUtils.getUrn("urn:li:entityType:datahub.testEntity"));
+    when(property.getEntityTypes()).thenReturn(entityTypes);
 
     return property;
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/StructuredPropertyMappingBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/StructuredPropertyMappingBuilderTest.java
@@ -1,0 +1,224 @@
+package com.linkedin.metadata.search.elasticsearch.index.entity.v3;
+
+import static com.linkedin.metadata.Constants.*;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.SetMode;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.annotation.EntityAnnotation;
+import com.linkedin.structured.StructuredPropertyDefinition;
+import com.linkedin.util.Pair;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/** Tests for StructuredPropertyMappingBuilder with focus on entity type URN format handling. */
+public class StructuredPropertyMappingBuilderTest {
+
+  private EntitySpec mockEntitySpec;
+  private EntityAnnotation mockEntityAnnotation;
+
+  @BeforeMethod
+  public void setUp() {
+    mockEntitySpec = mock(EntitySpec.class);
+    mockEntityAnnotation = mock(EntityAnnotation.class);
+    when(mockEntitySpec.getEntityAnnotation()).thenReturn(mockEntityAnnotation);
+    when(mockEntityAnnotation.getName()).thenReturn("dataset");
+  }
+
+  @Test
+  public void testCreateStructuredPropertyMappingsWithLegacyFormat() throws URISyntaxException {
+    // Test with legacy format (without datahub. prefix)
+    StructuredPropertyDefinition structProp =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("testProp")
+            .setDisplayName("testProp")
+            .setEntityTypes(
+                new UrnArray(
+                    // Legacy format: urn:li:entityType:dataset
+                    Urn.createFromString(ENTITY_TYPE_URN_PREFIX + "dataset")))
+            .setValueType(Urn.createFromString("urn:li:logicalType:STRING"));
+
+    Map<String, Object> mappings =
+        StructuredPropertyMappingBuilder.createStructuredPropertyMappings(
+            mockEntitySpec,
+            List.of(Pair.of(UrnUtils.getUrn("urn:li:structuredProperty:testProp"), structProp)));
+
+    assertNotNull(mappings, "Mappings should not be null");
+    assertEquals(mappings.size(), 1, "Should have one mapping for the structured property");
+    assertTrue(mappings.containsKey("testProp"), "Mapping should contain testProp key");
+  }
+
+  @Test
+  public void testCreateStructuredPropertyMappingsWithDatahubPrefix() throws URISyntaxException {
+    // Test with datahub. prefix format (production format)
+    StructuredPropertyDefinition structProp =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("testPropDatahub")
+            .setDisplayName("testPropDatahub")
+            .setEntityTypes(
+                new UrnArray(
+                    // Production format: urn:li:entityType:datahub.dataset
+                    Urn.createFromString("urn:li:entityType:datahub.dataset")))
+            .setValueType(Urn.createFromString("urn:li:logicalType:STRING"));
+
+    Map<String, Object> mappings =
+        StructuredPropertyMappingBuilder.createStructuredPropertyMappings(
+            mockEntitySpec,
+            List.of(
+                Pair.of(UrnUtils.getUrn("urn:li:structuredProperty:testPropDatahub"), structProp)));
+
+    assertNotNull(mappings, "Mappings should not be null");
+    assertEquals(
+        mappings.size(),
+        1,
+        "Should have one mapping for the structured property with datahub prefix");
+    assertTrue(
+        mappings.containsKey("testPropDatahub"), "Mapping should contain testPropDatahub key");
+  }
+
+  @Test
+  public void testCreateStructuredPropertyMappingsWithMixedFormats() throws URISyntaxException {
+    // Test with mixed formats in the same property
+    StructuredPropertyDefinition structProp =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("testPropMixed")
+            .setDisplayName("testPropMixed")
+            .setEntityTypes(
+                new UrnArray(
+                    // Both formats in the same property
+                    Urn.createFromString("urn:li:entityType:datahub.dataset"),
+                    Urn.createFromString(ENTITY_TYPE_URN_PREFIX + "dataFlow")))
+            .setValueType(Urn.createFromString("urn:li:logicalType:STRING"));
+
+    Map<String, Object> mappings =
+        StructuredPropertyMappingBuilder.createStructuredPropertyMappings(
+            mockEntitySpec,
+            List.of(
+                Pair.of(UrnUtils.getUrn("urn:li:structuredProperty:testPropMixed"), structProp)));
+
+    assertNotNull(mappings, "Mappings should not be null");
+    assertEquals(
+        mappings.size(), 1, "Should have one mapping since dataset matches (via datahub.dataset)");
+    assertTrue(mappings.containsKey("testPropMixed"), "Mapping should contain testPropMixed key");
+  }
+
+  @Test
+  public void testCreateStructuredPropertyMappingsNoMatch() throws URISyntaxException {
+    // Test that non-matching entity types are filtered out
+    StructuredPropertyDefinition structProp =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("testPropNoMatch")
+            .setDisplayName("testPropNoMatch")
+            .setEntityTypes(
+                new UrnArray(
+                    // Entity types that don't match "dataset"
+                    Urn.createFromString("urn:li:entityType:datahub.dataFlow"),
+                    Urn.createFromString(ENTITY_TYPE_URN_PREFIX + "chart")))
+            .setValueType(Urn.createFromString("urn:li:logicalType:STRING"));
+
+    Map<String, Object> mappings =
+        StructuredPropertyMappingBuilder.createStructuredPropertyMappings(
+            mockEntitySpec,
+            List.of(
+                Pair.of(UrnUtils.getUrn("urn:li:structuredProperty:testPropNoMatch"), structProp)));
+
+    assertNotNull(mappings, "Mappings should not be null");
+    assertTrue(mappings.isEmpty(), "Should have no mappings since entity types don't match");
+  }
+
+  @Test
+  public void testCreateStructuredPropertyMappingsWithEmptyEntityTypes() throws URISyntaxException {
+    // Test that empty entityTypes is handled gracefully
+    StructuredPropertyDefinition structProp =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("testPropEmptyTypes")
+            .setDisplayName("testPropEmptyTypes")
+            .setEntityTypes(new UrnArray()) // Empty array
+            .setValueType(Urn.createFromString("urn:li:logicalType:STRING"));
+
+    Map<String, Object> mappings =
+        StructuredPropertyMappingBuilder.createStructuredPropertyMappings(
+            mockEntitySpec,
+            List.of(
+                Pair.of(
+                    UrnUtils.getUrn("urn:li:structuredProperty:testPropEmptyTypes"), structProp)));
+
+    assertNotNull(mappings, "Mappings should not be null");
+    assertTrue(mappings.isEmpty(), "Should have no mappings when entityTypes is empty");
+  }
+
+  @Test
+  public void testCreateStructuredPropertyMappingsWithEmptyCollection() {
+    // Test with empty structured properties collection
+    Map<String, Object> mappings =
+        StructuredPropertyMappingBuilder.createStructuredPropertyMappings(
+            mockEntitySpec, List.of());
+
+    assertNotNull(mappings, "Mappings should not be null");
+    assertTrue(mappings.isEmpty(), "Should have no mappings for empty collection");
+  }
+
+  @Test
+  public void testCreateStructuredPropertyMappingsWithNullCollection() {
+    // Test with null structured properties collection
+    Map<String, Object> mappings =
+        StructuredPropertyMappingBuilder.createStructuredPropertyMappings(mockEntitySpec, null);
+
+    assertNotNull(mappings, "Mappings should not be null");
+    assertTrue(mappings.isEmpty(), "Should have no mappings for null collection");
+  }
+
+  @Test
+  public void testBothUrnFormatsProduceSameResult() throws URISyntaxException {
+    // Verify that both URN formats produce the same result for entity matching
+    StructuredPropertyDefinition structPropLegacy =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("propLegacy")
+            .setDisplayName("propLegacy")
+            .setEntityTypes(new UrnArray(Urn.createFromString(ENTITY_TYPE_URN_PREFIX + "dataset")))
+            .setValueType(Urn.createFromString("urn:li:logicalType:STRING"));
+
+    StructuredPropertyDefinition structPropDatahub =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("propDatahub")
+            .setDisplayName("propDatahub")
+            .setEntityTypes(new UrnArray(Urn.createFromString("urn:li:entityType:datahub.dataset")))
+            .setValueType(Urn.createFromString("urn:li:logicalType:STRING"));
+
+    Map<String, Object> mappingsLegacy =
+        StructuredPropertyMappingBuilder.createStructuredPropertyMappings(
+            mockEntitySpec,
+            List.of(
+                Pair.of(
+                    UrnUtils.getUrn("urn:li:structuredProperty:propLegacy"), structPropLegacy)));
+
+    Map<String, Object> mappingsDatahub =
+        StructuredPropertyMappingBuilder.createStructuredPropertyMappings(
+            mockEntitySpec,
+            List.of(
+                Pair.of(
+                    UrnUtils.getUrn("urn:li:structuredProperty:propDatahub"), structPropDatahub)));
+
+    // Both should produce exactly one mapping
+    assertEquals(
+        mappingsLegacy.size(),
+        mappingsDatahub.size(),
+        "Both URN formats should produce the same number of mappings");
+    assertEquals(mappingsLegacy.size(), 1, "Legacy format should produce one mapping");
+    assertEquals(mappingsDatahub.size(), 1, "Datahub prefix format should produce one mapping");
+  }
+}


### PR DESCRIPTION
…properties

Structured properties were not being correctly matched to entities when reindexing for breaking schema changes because the code expected entity type URNs in the format `urn:li:entityType:dataset` but we use the `datahub.` prefix format `urn:li:entityType:datahub.dataset`.
