### PR TITLE
chore: add aviraj-gour to pr-labeler team members

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -65,7 +65,8 @@ jobs:
           "alfiyas-datahub",
           "dinesh-verma-datahub",
           "rob-1019",
-          "kewats"
+          "kewats",
+          "aviraj-gour"
           ]'),
           github.actor
           )


### PR DESCRIPTION
This will stop the community-contribution label for my PRs.