### PR TITLE
feat(ci): add retry logic and PostHog metrics to nightly workflow

### DIFF
--- a/.github/workflows/docker-unified-nightly.yml
+++ b/.github/workflows/docker-unified-nightly.yml
@@ -130,41 +130,6 @@ jobs:
         run: |
           echo "${{ steps.collect-images.outputs.datahub_images }}"
 
-  smoke_test_lint:
-    name: Lint on smoke tests
-    runs-on: ${{ needs.setup.outputs.test_runner_type_small }}
-    needs: setup
-    steps:
-      - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v4
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-          cache: "pip"
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.cache/uv
-          key: ${{ needs.setup.outputs.uv_cache_key }}
-          restore-keys: |
-            ${{ needs.setup.outputs.uv_cache_key_prefix }}
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: |
-            ~/.cache/yarn
-          key: ${{ needs.setup.outputs.yarn_cache_key }}
-          restore-keys: |
-            ${{ needs.setup.outputs.yarn_cache_key_prefix }}
-
-      - name: Run lint on smoke test
-        run: |
-          python ./.github/scripts/check_python_package.py
-          ./gradlew :smoke-test:pythonLint
-          ./gradlew :smoke-test:cypressLint
-
   smoke_test:
     name: Run Smoke Tests (${{ matrix.profile }}, ${{ matrix.test_strategy }})
     runs-on: ${{ needs.setup.outputs.test_runner_type }}


### PR DESCRIPTION
Optimize CI efficiency by detecting workflow retries and running only failed tests instead of the full suite. Skip entire job when all tests passed in previous attempt. Add PostHog integration to track test failures for better observability. These are snippets that were present in docker-unified.yml already and now being pulled into docker-unified-nightly.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
