### PR TITLE
docs(structured-properties): clarify breaking schema changes behavior

### DIFF
--- a/docs/api/tutorials/structured-properties.md
+++ b/docs/api/tutorials/structured-properties.md
@@ -1563,7 +1563,7 @@ ENABLE_STRUCTURED_PROPERTIES_SYSTEM_UPDATE=true
 
 This section demonstrates how to make backwards incompatible schema changes to a Structured Property definition.
 
-Breaking schema changes require setting a `version` string in the Structured Property definition. 
+Breaking schema changes require setting a `version` string in the Structured Property definition.
 
 The format `yyyyMMddhhmmss` (for example, `20240614080000`) is a recommended convention, but not a strict requirement. Semantic versioning or other formats also work. Note that only the most recently created version is active.
 


### PR DESCRIPTION
Expands the documentation for breaking schema changes on Structured Properties to better explain what happens to existing values.

- Clarifies that existing values remain retrievable via GraphQL and the API
- Clarifies that existing values are excluded from search results, filters, and aggregations
- Adds guidance on when to use versioning vs creating a new property
- Adds a "When would you use this?" section with common scenarios