### PR TITLE
fix(docs): correct sql server odbc version

### DIFF
--- a/metadata-ingestion/docs/sources/mssql/mssql_recipe.yml
+++ b/metadata-ingestion/docs/sources/mssql/mssql_recipe.yml
@@ -43,7 +43,7 @@ source:
     # Options
     use_odbc: "True"
     uri_args:
-      driver: "ODBC Driver 17 for SQL Server"
+      driver: "ODBC Driver 18 for SQL Server"
       Encrypt: "yes"
       TrustServerCertificate: "Yes"
       ssl: "True"


### PR DESCRIPTION
The version of the driver that works currently is 18, not 17. Updating the sample documentation so as not to confuse customers.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
