### PR TITLE
fix(kafka): change auto-increase partitions to opt-in behavior

### DIFF
--- a/docs/how/kafka-config.md
+++ b/docs/how/kafka-config.md
@@ -90,7 +90,7 @@ the System Update container for topic setup:
 #### Topic Setup
 
 - `DATAHUB_PRECREATE_TOPICS`: Defaults to true, set this to false if you intend to create and configure the topics yourself and not have DataHub create them.
-- `DATAHUB_AUTO_INCREASE_PARTITIONS`: Defaults to true, controls whether DataHub automatically increases partition counts for existing topics when configured partition count exceeds current count. Only applies when `DATAHUB_PRECREATE_TOPICS` is enabled. Note that Kafka does not support decreasing partition counts.
+- `DATAHUB_AUTO_INCREASE_PARTITIONS`: Defaults to false, controls whether DataHub automatically increases partition counts for existing topics when configured partition count exceeds current count. Only applies when `DATAHUB_PRECREATE_TOPICS` is enabled. Note that Kafka does not support decreasing partition counts and attempting to do so is treated as an error when this setting is enabled.
 
 ### MCE Consumer (datahub-mce-consumer)
 

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -52,7 +52,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ### Other Notable Changes
 
-- #15714: Kafka topic partition counts are now automatically increased during upgrades if configured values exceed existing partitions. Set `DATAHUB_AUTO_INCREASE_PARTITIONS=false` to disable this behavior while still allowing DataHub to create new topics.
+- #15714: Kafka topic partition counts can now automatically be increased during upgrades if configured values exceed existing partition counts. Set `DATAHUB_AUTO_INCREASE_PARTITIONS=true` to enable.
 - (CLI) Added `--extra-env` option to `datahub ingest deploy` command to pass environment variables as comma-separated KEY=VALUE pairs (e.g., `--extra-env "VAR1=value1,VAR2=value2"`). These are stored in the ingestion source configuration and made available to the executor at runtime.
 
 ## 1.3.0

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kafka/SetupConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kafka/SetupConfiguration.java
@@ -6,5 +6,5 @@ import lombok.Data;
 public class SetupConfiguration {
   private boolean preCreateTopics = true;
   private boolean useConfluentSchemaRegistry = true;
-  private boolean autoIncreasePartitions = true;
+  private boolean autoIncreasePartitions = false;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -510,7 +510,7 @@ elasticsearch:
 kafka:
   setup:
     preCreateTopics: ${DATAHUB_PRECREATE_TOPICS:true}
-    autoIncreasePartitions: ${DATAHUB_AUTO_INCREASE_PARTITIONS:true}
+    autoIncreasePartitions: ${DATAHUB_AUTO_INCREASE_PARTITIONS:false}
     useConfluentSchemaRegistry: ${USE_CONFLUENT_SCHEMA_REGISTRY:false}
 
   # Topic defaults applied when individual topic configuration is missing


### PR DESCRIPTION
Changes the default value of DATAHUB_AUTO_INCREASE_PARTITIONS from true to false, making automatic partition count increases opt-in rather than automatic. This provides a safer default that prevents unexpected partition changes during upgrades.

Users who want automatic partition increases must explicitly set DATAHUB_AUTO_INCREASE_PARTITIONS=true.

Also clarifies that attempting to decrease partition counts is treated as an error when this setting is enabled.

- [X ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)