### PR TITLE
feat(api): sdk assertion privilege mapping

### DIFF
--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -1305,6 +1305,28 @@ public class PoliciesConfig {
                               VIEW_ENTITY_PAGE_PRIVILEGE,
                               SEARCH_PRIVILEGE))
                       .build())
+              .put(
+                  Constants.ASSERTION_ENTITY_NAME,
+                  ImmutableMap.<ApiOperation, Disjunctive<Conjunctive<Privilege>>>builder()
+                      .put(
+                          ApiOperation.CREATE,
+                          Disjunctive.disjoint(
+                              EDIT_ENTITY_ASSERTIONS_PRIVILEGE, EDIT_ENTITY_PRIVILEGE))
+                      .put(
+                          ApiOperation.READ,
+                          API_PRIVILEGE_MAP.get(ApiGroup.ENTITY).get(ApiOperation.READ))
+                      .put(
+                          ApiOperation.UPDATE,
+                          Disjunctive.disjoint(
+                              EDIT_ENTITY_ASSERTIONS_PRIVILEGE, EDIT_ENTITY_PRIVILEGE))
+                      .put(
+                          ApiOperation.DELETE,
+                          Disjunctive.disjoint(
+                              EDIT_ENTITY_ASSERTIONS_PRIVILEGE, DELETE_ENTITY_PRIVILEGE))
+                      .put(
+                          ApiOperation.EXISTS,
+                          API_PRIVILEGE_MAP.get(ApiGroup.ENTITY).get(ApiOperation.EXISTS))
+                      .build())
               .build();
 
   /**


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
**Fix(authorization): Align REST API assertion authorization with GraphQL**

This PR resolves an authorization mismatch for managing assertions via the REST API. Previously, the API incorrectly required the generic `EDIT_ENTITY_PRIVILEGE`, leading to 403 errors for users who possessed the more specific `EDIT_ENTITY_ASSERTIONS_PRIVILEGE` (which worked correctly in the UI via GraphQL).

The fix introduces a dedicated entry for `Assertion` entities in the `API_ENTITY_PRIVILEGE_MAP` within `PoliciesConfig.java`. This ensures that `EDIT_ENTITY_ASSERTIONS_PRIVILEGE` is correctly evaluated for assertion CREATE, UPDATE, and DELETE operations via the REST API, aligning its authorization behavior with GraphQL.

---
<a href="https://cursor.com/background-agent?bcId=bc-da868e17-268f-4c28-be15-28faee7e49cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da868e17-268f-4c28-be15-28faee7e49cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

