### PR TITLE
Add mTLS Support for Rest.li Clients in DataHub GMS Communication

### DIFF
--- a/datahub-frontend/app/utils/ConfigUtil.java
+++ b/datahub-frontend/app/utils/ConfigUtil.java
@@ -22,6 +22,10 @@ public class ConfigUtil {
       "metadataService.truststore.password";
   public static final String METADATA_SERVICE_SSL_TRUST_STORE_TYPE =
       "metadataService.truststore.type";
+  public static final String METADATA_SERVICE_SSL_KEY_STORE_PATH = "metadataService.keystore.path";
+  public static final String METADATA_SERVICE_SSL_KEY_STORE_PASSWORD =
+      "metadataService.keystore.password";
+  public static final String METADATA_SERVICE_SSL_KEY_STORE_TYPE = "metadataService.keystore.type";
 
   // Legacy env-var based config values, for backwards compatibility:
   public static final String GMS_HOST_ENV_VAR = "DATAHUB_GMS_HOST";

--- a/datahub-frontend/app/utils/KeyStoreConfig.java
+++ b/datahub-frontend/app/utils/KeyStoreConfig.java
@@ -1,0 +1,32 @@
+package utils;
+
+import com.typesafe.config.Config;
+
+public class KeyStoreConfig {
+  public final String path;
+  public final String password;
+  public final String type;
+  public final boolean metadataServiceUseSsl;
+
+  public KeyStoreConfig(String path, String password, String type, boolean metadataServiceUseSsl) {
+    this.path = path;
+    this.password = password;
+    this.type = type;
+    this.metadataServiceUseSsl = metadataServiceUseSsl;
+  }
+
+  public boolean isValid() {
+    return metadataServiceUseSsl && path != null && password != null;
+  }
+
+  public static KeyStoreConfig fromConfig(Config config) {
+    return new KeyStoreConfig(
+        ConfigUtil.getString(config, ConfigUtil.METADATA_SERVICE_SSL_KEY_STORE_PATH, null),
+        ConfigUtil.getString(config, ConfigUtil.METADATA_SERVICE_SSL_KEY_STORE_PASSWORD, null),
+        ConfigUtil.getString(config, ConfigUtil.METADATA_SERVICE_SSL_KEY_STORE_TYPE, "PKCS12"),
+        ConfigUtil.getBoolean(
+            config,
+            ConfigUtil.METADATA_SERVICE_USE_SSL_CONFIG_PATH,
+            ConfigUtil.DEFAULT_METADATA_SERVICE_USE_SSL));
+  }
+}

--- a/datahub-frontend/test/utils/CustomHttpClientFactoryTest.java
+++ b/datahub-frontend/test/utils/CustomHttpClientFactoryTest.java
@@ -63,8 +63,8 @@ class CustomHttpClientFactoryTest {
   void testCreateSslContextWithValidTruststore() throws Exception {
     Path truststorePath = generateTempTruststore();
     SSLContext context =
-        CustomHttpClientFactory.createSslContext(
-            truststorePath.toString(), TRUSTSTORE_PASSWORD, TRUSTSTORE_TYPE);
+        CustomHttpClientFactory.createSslContextWithKeyStore(
+            null, null, null, truststorePath.toString(), TRUSTSTORE_PASSWORD, TRUSTSTORE_TYPE);
     assertNotNull(context);
     assertEquals("TLS", context.getProtocol());
   }
@@ -74,8 +74,8 @@ class CustomHttpClientFactoryTest {
     assertThrows(
         Exception.class,
         () ->
-            CustomHttpClientFactory.createSslContext(
-                "doesnotexist.p12", "wrongpassword", TRUSTSTORE_TYPE));
+            CustomHttpClientFactory.createSslContextWithKeyStore(
+                null, null, null, "doesnotexist.p12", "wrongpassword", TRUSTSTORE_TYPE));
   }
 
   @Test
@@ -83,7 +83,7 @@ class CustomHttpClientFactoryTest {
     Path truststorePath = generateTempTruststore();
     HttpClient client =
         CustomHttpClientFactory.getJavaHttpClient(
-            truststorePath.toString(), TRUSTSTORE_PASSWORD, TRUSTSTORE_TYPE);
+            null, null, null, truststorePath.toString(), TRUSTSTORE_PASSWORD, TRUSTSTORE_TYPE);
     assertNotNull(client);
   }
 
@@ -91,7 +91,7 @@ class CustomHttpClientFactoryTest {
   void testGetJavaHttpClientWithInvalidTruststoreFallsBack() {
     HttpClient client =
         CustomHttpClientFactory.getJavaHttpClient(
-            "doesnotexist.p12", "wrongpassword", TRUSTSTORE_TYPE);
+            null, null, null, "doesnotexist.p12", "wrongpassword", TRUSTSTORE_TYPE);
     assertNotNull(client);
   }
 
@@ -100,7 +100,7 @@ class CustomHttpClientFactoryTest {
     Path truststorePath = generateTempTruststore();
     CloseableHttpClient client =
         CustomHttpClientFactory.getApacheHttpClient(
-            truststorePath.toString(), TRUSTSTORE_PASSWORD, TRUSTSTORE_TYPE);
+            null, null, null, truststorePath.toString(), TRUSTSTORE_PASSWORD, TRUSTSTORE_TYPE);
     assertNotNull(client);
   }
 
@@ -108,7 +108,7 @@ class CustomHttpClientFactoryTest {
   void testGetApacheHttpClientWithInvalidTruststoreFallsBack() {
     CloseableHttpClient client =
         CustomHttpClientFactory.getApacheHttpClient(
-            "doesnotexist.p12", "wrongpassword", TRUSTSTORE_TYPE);
+            null, null, null, "doesnotexist.p12", "wrongpassword", TRUSTSTORE_TYPE);
     assertNotNull(client);
   }
 }

--- a/metadata-jobs/mce-consumer-job/src/test/java/com/linkedin/metadata/kafka/MceConsumerApplicationTestConfiguration.java
+++ b/metadata-jobs/mce-consumer-job/src/test/java/com/linkedin/metadata/kafka/MceConsumerApplicationTestConfiguration.java
@@ -56,7 +56,8 @@ public class MceConsumerApplicationTestConfiguration {
       final EntityClientConfig entityClientConfig,
       final MetricUtils metricUtils) {
     String selfUri = restTemplate.getRootUri();
-    final Client restClient = DefaultRestliClientFactory.getRestLiClient(URI.create(selfUri), null);
+     final Client restClient = DefaultRestliClientFactory.getRestLiClient(
+            URI.create(selfUri), null, null, null, null, null, null, null);
     return new SystemRestliEntityClient(
         restClient,
         entityClientConfig,

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -117,7 +117,11 @@ datahub:
   basePath: ${DATAHUB_BASE_PATH:}
   # For special deployment modes intended to point at read replicas. WARNING: THIS WILL DROP WRITE OPERATIONS WITHOUT ERRORS, intended for analytics based deploys to offload work from user serving deploys
   readOnly: ${DATAHUB_READ_ONLY:false}
-
+  server:
+    keystore:
+      path: ${SERVER_SSL_KEY_STORE:#{null}} # Required if useSSL is true
+      password: ${SERVER_SSL_KEY_STORE_PASSWORD:#{null}} # Required if useSSL is true
+      type: ${SERVER_SSL_KEY_STORE_TYPE:PKCS12}
   gms:
     host: ${DATAHUB_GMS_HOST:localhost}
     port: ${DATAHUB_GMS_PORT:8080}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityclient/RestliEntityClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityclient/RestliEntityClientFactory.java
@@ -7,7 +7,6 @@ import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.entity.client.SystemRestliEntityClient;
 import com.linkedin.metadata.config.cache.client.EntityClientCacheConfig;
 import com.linkedin.metadata.restli.DefaultRestliClientFactory;
-import com.linkedin.metadata.utils.BasePathUtils;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.restli.client.Client;
 import java.net.URI;
@@ -32,18 +31,40 @@ public class RestliEntityClientFactory {
       @Value("${datahub.gms.useSSL}") boolean gmsUseSSL,
       @Value("${datahub.gms.uri}") String gmsUri,
       @Value("${datahub.gms.sslContext.protocol}") String gmsSslProtocol,
+      @Value("${datahub.gms.truststore.path}") String gmsSslTrustStorePath,
+      @Value("${datahub.gms.truststore.password}") String gmsSslTrustStorePass,
+      @Value("${datahub.gms.truststore.type}") String gmsSslTrustStoreType,
+      @Value("${datahub.server.keystore.path}") String serverSslKeyStorePath,
+      @Value("${datahub.server.keystore.password}") String serverSslKeyStorePass,
+      @Value("${datahub.server.keystore.type}") String serverSslKeyStoreType,
       final EntityClientConfig entityClientConfig,
       final MetricUtils metricUtils) {
     final Client restClient;
-    if (gmsUri != null) {
-      restClient = DefaultRestliClientFactory.getRestLiClient(URI.create(gmsUri), gmsSslProtocol);
-    } else {
-      // Use the same logic as GMSConfiguration.getResolvedBasePath()
-      String resolvedBasePath = BasePathUtils.resolveBasePath(gmsBasePathEnabled, gmsBasePath);
-      restClient =
-          DefaultRestliClientFactory.getRestLiClient(
-              gmsHost, gmsPort, resolvedBasePath, gmsUseSSL, gmsSslProtocol);
-    }
+      if (gmsUri != null) {
+          restClient =
+                  DefaultRestliClientFactory.getRestLiClient(
+                          URI.create(gmsUri),
+                          gmsSslProtocol,
+                          gmsSslTrustStorePath,
+                          gmsSslTrustStorePass,
+                          gmsSslTrustStoreType,
+                          serverSslKeyStorePath,
+                          serverSslKeyStorePass,
+                          serverSslKeyStoreType);
+      } else {
+          restClient =
+                  DefaultRestliClientFactory.getRestLiClient(
+                          gmsHost,
+                          gmsPort,
+                          gmsUseSSL,
+                          gmsSslProtocol,
+                          gmsSslTrustStorePath,
+                          gmsSslTrustStorePass,
+                          gmsSslTrustStoreType,
+                          serverSslKeyStorePath,
+                          serverSslKeyStorePass,
+                          serverSslKeyStoreType);
+      }
     return new RestliEntityClient(restClient, entityClientConfig, metricUtils);
   }
 
@@ -57,20 +78,42 @@ public class RestliEntityClientFactory {
       @Value("${datahub.gms.useSSL}") boolean gmsUseSSL,
       @Value("${datahub.gms.uri}") String gmsUri,
       @Value("${datahub.gms.sslContext.protocol}") String gmsSslProtocol,
+      @Value("${datahub.gms.truststore.path}") String gmsSslTrustStorePath,
+      @Value("${datahub.gms.truststore.password}") String gmsSslTrustStorePass,
+      @Value("${datahub.gms.truststore.type}") String gmsSslTrustStoreType,
+      @Value("${datahub.server.keystore.path}") String serverSslKeyStorePath,
+      @Value("${datahub.server.keystore.password}") String serverSslKeyStorePass,
+      @Value("${datahub.server.keystore.type}") String serverSslKeyStoreType,
       final EntityClientCacheConfig entityClientCacheConfig,
       final EntityClientConfig entityClientConfig,
       final MetricUtils metricUtils) {
 
     final Client restClient;
-    if (gmsUri != null) {
-      restClient = DefaultRestliClientFactory.getRestLiClient(URI.create(gmsUri), gmsSslProtocol);
-    } else {
-      // Use the same logic as GMSConfiguration.getResolvedBasePath()
-      String resolvedBasePath = BasePathUtils.resolveBasePath(gmsBasePathEnabled, gmsBasePath);
-      restClient =
-          DefaultRestliClientFactory.getRestLiClient(
-              gmsHost, gmsPort, resolvedBasePath, gmsUseSSL, gmsSslProtocol);
-    }
+      if (gmsUri != null) {
+          restClient =
+                  DefaultRestliClientFactory.getRestLiClient(
+                          URI.create(gmsUri),
+                          gmsSslProtocol,
+                          gmsSslTrustStorePath,
+                          gmsSslTrustStorePass,
+                          gmsSslTrustStoreType,
+                          serverSslKeyStorePath,
+                          serverSslKeyStorePass,
+                          serverSslKeyStoreType);
+      } else {
+          restClient =
+                  DefaultRestliClientFactory.getRestLiClient(
+                          gmsHost,
+                          gmsPort,
+                          gmsUseSSL,
+                          gmsSslProtocol,
+                          gmsSslTrustStorePath,
+                          gmsSslTrustStorePass,
+                          gmsSslTrustStoreType,
+                          serverSslKeyStorePath,
+                          serverSslKeyStorePass,
+                          serverSslKeyStoreType);
+      }
     return new SystemRestliEntityClient(
         restClient, entityClientConfig, entityClientCacheConfig, metricUtils);
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/usage/UsageClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/usage/UsageClientFactory.java
@@ -30,6 +30,24 @@ public class UsageClientFactory {
   @Value("${DATAHUB_GMS_SSL_PROTOCOL:#{null}}")
   private String gmsSslProtocol;
 
+    @Value("${DATAHUB_GMS_SSL_TRUSTSTORE_PATH:#{null}}")
+    private String gmsSslTrustStorePath;
+
+    @Value("${DATAHUB_GMS_SSL_TRUSTSTORE_PASSWORD:#{null}}")
+    private String gmsSslTrustStorePass;
+
+    @Value("${DATAHUB_GMS_SSL_TRUSTSTORE_TYPE:#{null}}")
+    private String gmsSslTrustStoreType;
+
+    @Value("${SERVER_SSL_KEY_STORE:#{null}}")
+    private String serverSslTrustStorePath;
+
+    @Value("${SERVER_SSL_KEY_STORE_PASSWORD:#{null}}")
+    private String serverSslTrustStorePass;
+
+    @Value("${SERVER_SSL_KEY_STORE_TYPE:#{null}}")
+    private String serverSslTrustStoreType;
+
   @Value("${usageClient.retryInterval:2}")
   private int retryInterval;
 
@@ -48,9 +66,19 @@ public class UsageClientFactory {
     Map<String, String> params = new HashMap<>();
     params.put(HttpClientFactory.HTTP_REQUEST_TIMEOUT, String.valueOf(timeoutMs));
 
-    Client restClient =
-        DefaultRestliClientFactory.getRestLiClient(
-            gmsHost, gmsPort, gmsUseSSL, gmsSslProtocol, params);
+      Client restClient =
+              DefaultRestliClientFactory.getRestLiClient(
+                      gmsHost,
+                      gmsPort,
+                      gmsUseSSL,
+                      gmsSslProtocol,
+                      params,
+                      gmsSslTrustStorePath,
+                      gmsSslTrustStorePass,
+                      gmsSslTrustStoreType,
+                      serverSslTrustStorePath,
+                      serverSslTrustStorePass,
+                      serverSslTrustStoreType);
     return new RestliUsageClient(
         restClient,
         new ExponentialBackoff(retryInterval),

--- a/metadata-utils/src/main/java/com/linkedin/metadata/restli/SslContextUtil.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/restli/SslContextUtil.java
@@ -1,0 +1,62 @@
+package com.linkedin.metadata.restli;
+
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import javax.annotation.Nullable;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+public final class SslContextUtil {
+
+  public static SSLContext buildSslContext(
+      @Nullable String keystorePath,
+      @Nullable String keystorePassword,
+      @Nullable String keystoreType,
+      @Nullable String truststorePath,
+      @Nullable String truststorePassword,
+      @Nullable String truststoreType)
+      throws Exception {
+
+    KeyManagerFactory keyManagerFactory = null;
+
+    // --- Load keystore (client certificate) ---
+    if (keystorePath != null && !keystorePath.isBlank()) {
+      KeyStore keyStore =
+          KeyStore.getInstance(keystoreType != null ? keystoreType : KeyStore.getDefaultType());
+      try (FileInputStream fis = new FileInputStream(keystorePath)) {
+        keyStore.load(fis, keystorePassword != null ? keystorePassword.toCharArray() : null);
+      }
+
+      keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+      keyManagerFactory.init(
+          keyStore, keystorePassword != null ? keystorePassword.toCharArray() : null);
+    }
+
+    // --- Load truststore ---
+    TrustManagerFactory trustManagerFactory =
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+
+    if (truststorePath != null && !truststorePath.isBlank()) {
+      KeyStore trustStore =
+          KeyStore.getInstance(truststoreType != null ? truststoreType : KeyStore.getDefaultType());
+      try (FileInputStream fis = new FileInputStream(truststorePath)) {
+        trustStore.load(fis, truststorePassword != null ? truststorePassword.toCharArray() : null);
+      }
+      trustManagerFactory.init(trustStore);
+    } else {
+      trustManagerFactory.init((KeyStore) null); // default JRE trusted CAs
+    }
+
+    // --- Build SSLContext ---
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(
+        keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null,
+        trustManagerFactory.getTrustManagers(),
+        null);
+
+    return sslContext;
+  }
+
+  private SslContextUtil() {}
+}


### PR DESCRIPTION
This PR introduces full mutual TLS (mTLS) support for all Rest.li-based clients communicating with the DataHub GMS service. The update ensures that GMS clients—including the Entity Client, System Entity Client, and Usage Client—can authenticate using both client certificates (keystores) and trusted server certificates (truststores).

**Benefits**
1. Enables secure bidirectional authentication between DataHub components.
2. Allows deployments in zero-trust, service mesh, or regulated environments requiring mTLS.
3. Improves flexibility through environment-configurable SSL settings.
4. Maintains compatibility for non-mTLS users by making all new settings optional.

**Additional Notes**
1. The PR introduces no behavioral changes for non-SSL or one-way TLS setups.
2. All new configuration entries use Spring @Value injection and support defaults.
3. Fully compatible with existing Rest.li transport and GMS client timeout configuration.