### PR TITLE
feat(sql-parsing): resolve TSQL UPDATE/DELETE alias to real table at parser level

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -380,14 +380,122 @@ def _extract_table_names(
     )
 
 
+def _build_tsql_update_alias_map(
+    statement: sqlglot.Expression,
+) -> Dict[str, sqlglot.exp.Table]:
+    """Build alias → table mapping for TSQL UPDATE/DELETE statements.
+
+    TSQL allows "UPDATE alias FROM table alias" and "DELETE alias FROM table alias"
+    syntax where the target is just the alias, not the real table name. This function
+    builds a mapping from alias names to their corresponding real tables.
+
+    Only looks at immediate tables, not tables inside subqueries (which have their
+    own scope for alias resolution).
+
+    Note: We only track aliases that differ from table names. sqlglot's qualify()
+    normalizes "FROM orders" to "FROM orders AS orders", so filtering same-name
+    aliases preserves legitimate table references in subqueries.
+
+    Example:
+        UPDATE dst SET col1 = 1 FROM dbo.target_table dst
+        → alias_map = {"dst": Table(dbo.target_table)}
+
+        DELETE dst FROM dbo.target_table dst WHERE ...
+        → alias_map = {"dst": Table(dbo.target_table)}
+
+    Args:
+        statement: The UPDATE or DELETE statement to analyze
+
+    Returns:
+        Dict mapping lowercase alias names to their Table expressions
+    """
+    alias_map: Dict[str, sqlglot.exp.Table] = {}
+
+    def _add_table_if_aliased(table: sqlglot.exp.Table) -> None:
+        # Track aliases that differ from table names (e.g., "target_table AS dst").
+        # sqlglot's qualify() normalizes "FROM orders" to "FROM orders AS orders",
+        # so we skip same-name aliases to preserve legitimate table references.
+        if table.alias and table.alias.lower() != table.name.lower():
+            alias_map[table.alias.lower()] = table
+
+    # For DELETE, the aliased table is in statement.this directly
+    # (e.g., DELETE dst FROM target_table dst → statement.this = target_table AS dst)
+    if isinstance(statement, sqlglot.exp.Delete):
+        if isinstance(statement.this, sqlglot.exp.Table):
+            _add_table_if_aliased(statement.this)
+        return alias_map
+
+    # For UPDATE, check the FROM clause and JOINs
+    # 1. Check the FROM clause (immediate table only, not subqueries)
+    from_clause = statement.find(sqlglot.exp.From)
+    if from_clause and isinstance(from_clause.this, sqlglot.exp.Table):
+        _add_table_if_aliased(from_clause.this)
+
+    # 2. Check JOINs (immediate tables only, skip subqueries)
+    for join in statement.args.get("joins", []):
+        if isinstance(join.this, sqlglot.exp.Table):
+            _add_table_if_aliased(join.this)
+
+    return alias_map
+
+
+def _resolve_tsql_update_alias(
+    table: sqlglot.exp.Table,
+    alias_map: Dict[str, sqlglot.exp.Table],
+) -> sqlglot.exp.Table:
+    """Resolve TSQL UPDATE target alias to the real table.
+
+    If the table name matches a known alias from the FROM clause,
+    return the real table instead.
+
+    Alias matching is case-insensitive, which aligns with TSQL's default
+    behavior where identifiers are case-insensitive.
+
+    Args:
+        table: The table expression from UPDATE clause (might be an alias)
+        alias_map: Mapping from alias names to real tables
+
+    Returns:
+        The resolved real table, or the original table if no resolution needed
+    """
+    # Check if the table name matches a known alias
+    real_table = alias_map.get(table.name.lower())
+    if real_table is not None:
+        return real_table
+    return table
+
+
 def _table_level_lineage(
     statement: sqlglot.Expression, dialect: sqlglot.Dialect
 ) -> Tuple[AbstractSet[_TableName], AbstractSet[_TableName]]:
+    # TSQL-specific: Build alias → table mapping for UPDATE/DELETE statements.
+    # TSQL syntax "UPDATE dst FROM target_table dst" places only the alias in the
+    # UPDATE clause. Without resolution, lineage would show "dst" as the output
+    # table instead of "target_table", breaking downstream lineage tracking.
+    tsql_alias_map: Dict[str, sqlglot.exp.Table] = {}
+    if is_dialect_instance(dialect, "tsql") and isinstance(
+        statement, (sqlglot.exp.Update, sqlglot.exp.Delete)
+    ):
+        tsql_alias_map = _build_tsql_update_alias_map(statement)
+
+    def _maybe_resolve_tsql_alias(
+        expr: sqlglot.Expression,
+    ) -> sqlglot.exp.Table:
+        """Resolve TSQL UPDATE/DELETE alias if applicable."""
+        table = expr.this
+        if (
+            tsql_alias_map
+            and isinstance(expr, sqlglot.exp.Update)
+            and isinstance(table, sqlglot.exp.Table)
+        ):
+            return _resolve_tsql_update_alias(table, tsql_alias_map)
+        return table
+
     # Generate table-level lineage.
     modified = (
         _extract_table_names(
             (
-                expr.this
+                _maybe_resolve_tsql_alias(expr)
                 for expr in statement.find_all(
                     sqlglot.exp.Create,
                     sqlglot.exp.Insert,
@@ -451,6 +559,12 @@ def _table_level_lineage(
         }
     )
     # TODO: If a CTAS has "LIMIT 0", it's not really lineage, just copying the schema.
+
+    # TSQL-specific: Remove aliases from input tables to avoid phantom dependencies.
+    # In "UPDATE dst FROM target_table dst", sqlglot creates a Table node for "dst"
+    # that would otherwise appear as a separate input dataset (e.g., "mydb.dbo.dst").
+    if tsql_alias_map:
+        tables = {t for t in tables if t.table.lower() not in tsql_alias_map}
 
     # Update statements implicitly read from the table being updated, so add those back in.
     if isinstance(statement, sqlglot.exp.Update):

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_tsql_update_with_alias_basic.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_tsql_update_with_alias_basic.json
@@ -1,0 +1,62 @@
+{
+    "query_type": "UPDATE",
+    "query_type_props": {},
+    "query_fingerprint": "d4101967aa0695083a97b645340ee9cc166a4301031cff167886f0289774695e",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.source_table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)"
+    ],
+    "out_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)"
+    ],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)",
+                "column": "col1",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.source_table,PROD)",
+                    "column": "col1"
+                }
+            ],
+            "logic": {
+                "is_direct_copy": true,
+                "column_logic": "[src].[col1] AS [col1]"
+            }
+        }
+    ],
+    "joins": [
+        {
+            "join_type": "JOIN",
+            "left_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)"
+            ],
+            "right_tables": [
+                "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.source_table,PROD)"
+            ],
+            "on_clause": "[dst].[id] = [src].[id]",
+            "columns_involved": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.source_table,PROD)",
+                    "column": "id"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)",
+                    "column": "id"
+                }
+            ]
+        }
+    ],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "UPDATE dst SET dst.col1 = src.col1 FROM mydb.dbo.target_table AS dst JOIN mydb.dbo.source_table AS src ON dst.id = src.id"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_tsql_update_with_subquery.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_tsql_update_with_subquery.json
@@ -1,0 +1,18 @@
+{
+    "query_type": "UPDATE",
+    "query_type_props": {},
+    "query_fingerprint": "0a1886daa57731074954e342496756697132cb3a1648f1e48e421dba5af1cb33",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.source_table,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)"
+    ],
+    "out_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)"
+    ],
+    "column_lineage": null,
+    "joins": null,
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "UPDATE dst SET dst.col1 = sub.max_val FROM mydb.dbo.target_table AS dst JOIN (SELECT id AS id, MAX(value) AS max_val FROM mydb.dbo.source_table GROUP BY id) AS sub ON dst.id = sub.id"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_tsql_update_without_alias.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_tsql_update_without_alias.json
@@ -1,0 +1,35 @@
+{
+    "query_type": "UPDATE",
+    "query_type_props": {},
+    "query_fingerprint": "d8218d2b4dca6025b8abcd8a901c44acb2d8a2833a58131d5befe520899f68ad",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)"
+    ],
+    "out_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)"
+    ],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)",
+                "column": "col1",
+                "column_type": {
+                    "type": {
+                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                },
+                "native_column_type": "VARCHAR"
+            },
+            "upstreams": [],
+            "logic": {
+                "is_direct_copy": true,
+                "column_logic": "'value' AS [col1]"
+            }
+        }
+    ],
+    "joins": [],
+    "debug_info": {
+        "confidence": 0.9,
+        "generalized_statement": "UPDATE mydb.dbo.target_table SET col1 = ? WHERE id = ?"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/test_tsql_update_alias_resolution.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_tsql_update_alias_resolution.py
@@ -1,0 +1,224 @@
+"""Tests for TSQL UPDATE alias resolution.
+
+TSQL (SQL Server) uses a unique syntax where UPDATE target can be an alias:
+    UPDATE dst SET ... FROM dbo.target_table dst JOIN ...
+
+This is different from other databases where the table name is required.
+These tests verify that the alias is correctly resolved to the real table.
+"""
+
+import pathlib
+
+import pytest
+
+from datahub.sql_parsing.sqlglot_lineage import sqlglot_lineage
+from datahub.testing.check_sql_parser_result import assert_sql_result
+
+RESOURCE_DIR = pathlib.Path(__file__).parent / "goldens"
+
+
+@pytest.fixture(scope="function", autouse=True)
+def _disable_cooperative_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "datahub.sql_parsing.sqlglot_lineage.SQL_LINEAGE_TIMEOUT_ENABLED", False
+    )
+
+
+def test_tsql_update_with_alias_basic() -> None:
+    """TSQL UPDATE with alias should resolve to real table."""
+    assert_sql_result(
+        """
+UPDATE dst
+SET dst.col1 = src.col1
+FROM mydb.dbo.target_table dst
+JOIN mydb.dbo.source_table src ON dst.id = src.id
+""",
+        dialect="tsql",
+        default_db="mydb",
+        default_schema="dbo",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)": {
+                "id": "int",
+                "col1": "varchar",
+            },
+            "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.source_table,PROD)": {
+                "id": "int",
+                "col1": "varchar",
+            },
+        },
+        expected_file=RESOURCE_DIR / "test_tsql_update_with_alias_basic.json",
+    )
+
+
+def test_tsql_update_without_alias() -> None:
+    """TSQL UPDATE without alias should work unchanged."""
+    assert_sql_result(
+        """
+UPDATE mydb.dbo.target_table
+SET col1 = 'value'
+WHERE id = 1
+""",
+        dialect="tsql",
+        default_db="mydb",
+        default_schema="dbo",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)": {
+                "id": "int",
+                "col1": "varchar",
+            },
+        },
+        expected_file=RESOURCE_DIR / "test_tsql_update_without_alias.json",
+    )
+
+
+def test_tsql_update_with_subquery() -> None:
+    """TSQL UPDATE with alias and subquery - verifies same-name alias bug fix.
+
+    After qualify(), sqlglot may add 'FROM table AS table'. This test ensures
+    tables inside subqueries are NOT incorrectly filtered when alias equals
+    table name.
+    """
+    assert_sql_result(
+        """
+UPDATE dst
+SET dst.col1 = sub.max_val
+FROM mydb.dbo.target_table dst
+JOIN (SELECT id, MAX(value) as max_val FROM mydb.dbo.source_table GROUP BY id) sub
+    ON dst.id = sub.id
+""",
+        dialect="tsql",
+        default_db="mydb",
+        default_schema="dbo",
+        schemas={
+            "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.target_table,PROD)": {
+                "id": "int",
+                "col1": "int",
+            },
+            "urn:li:dataset:(urn:li:dataPlatform:tsql,mydb.dbo.source_table,PROD)": {
+                "id": "int",
+                "value": "int",
+            },
+        },
+        expected_file=RESOURCE_DIR / "test_tsql_update_with_subquery.json",
+    )
+
+
+# Additional tests using inline assertions (no golden files needed)
+
+
+def test_tsql_update_cross_db_resolves_alias() -> None:
+    """TSQL UPDATE with alias across databases resolves correctly."""
+    from datahub.sql_parsing.schema_resolver import SchemaResolver
+
+    schema_resolver = SchemaResolver(
+        platform="mssql",
+        env="PROD",
+    )
+    result = sqlglot_lineage(
+        """
+UPDATE dst
+SET dst.col1 = src.col1
+FROM TimeSeries.dbo.target_table dst
+JOIN Staging.dbo.source_table src ON dst.id = src.id
+""",
+        schema_resolver=schema_resolver,
+        default_db="TimeSeries",
+        default_schema="dbo",
+    )
+    # Alias 'dst' should resolve to real table, not appear as separate table
+    out_tables = [str(t) for t in result.out_tables]
+    assert any("target_table" in t for t in out_tables)
+    assert len(out_tables) == 1
+
+
+def test_tsql_update_mixed_case_alias_resolves() -> None:
+    """TSQL UPDATE with mixed-case alias uses case-insensitive matching."""
+    from datahub.sql_parsing.schema_resolver import SchemaResolver
+
+    schema_resolver = SchemaResolver(
+        platform="mssql",
+        env="PROD",
+    )
+    result = sqlglot_lineage(
+        """
+UPDATE Dst
+SET Dst.col1 = src.col1
+FROM mydb.dbo.target_table DST
+JOIN mydb.dbo.source_table src ON DST.id = src.id
+""",
+        schema_resolver=schema_resolver,
+        default_db="mydb",
+        default_schema="dbo",
+    )
+    # Mixed case 'Dst'/'DST' should resolve to target_table
+    out_tables = [str(t) for t in result.out_tables]
+    assert any("target_table" in t for t in out_tables)
+    assert len(out_tables) == 1
+
+
+def test_tsql_update_same_alias_in_subquery_scope() -> None:
+    """Same alias in subquery should not conflict with outer scope.
+
+    This tests a potential bug where 'dst' alias is used both in the outer
+    FROM clause and inside a subquery. The outer 'dst' should be resolved
+    correctly without being confused with the inner scoped 'dst'.
+    """
+    from datahub.sql_parsing.schema_resolver import SchemaResolver
+
+    schema_resolver = SchemaResolver(
+        platform="mssql",
+        env="PROD",
+    )
+    result = sqlglot_lineage(
+        """
+UPDATE dst
+SET dst.col1 = sub.val
+FROM target_table dst
+JOIN (SELECT id, val FROM source_table dst GROUP BY id, val) sub
+    ON dst.id = sub.id
+""",
+        schema_resolver=schema_resolver,
+        default_db="mydb",
+        default_schema="dbo",
+    )
+    # 'dst' should resolve to outer target_table, not inner source_table
+    out_tables = [str(t) for t in result.out_tables]
+    assert any("target_table" in t for t in out_tables)
+    assert len(out_tables) == 1
+    # source_table should be in in_tables (from subquery)
+    in_tables = [str(t) for t in result.in_tables]
+    assert any("source_table" in t for t in in_tables)
+
+
+def test_tsql_delete_with_alias_filters_correctly() -> None:
+    """TSQL DELETE with alias should not have spurious alias in in_tables.
+
+    DELETE dst FROM target_table dst WHERE ... should:
+    - Have target_table in out_tables
+    - NOT have 'dst' as a spurious entry in in_tables
+    """
+    from datahub.sql_parsing.schema_resolver import SchemaResolver
+
+    schema_resolver = SchemaResolver(
+        platform="mssql",
+        env="PROD",
+    )
+    result = sqlglot_lineage(
+        """
+DELETE dst
+FROM target_table dst
+WHERE dst.id IN (SELECT id FROM to_delete)
+""",
+        schema_resolver=schema_resolver,
+        default_db="mydb",
+        default_schema="dbo",
+    )
+    # out_tables should have target_table
+    out_tables = [str(t) for t in result.out_tables]
+    assert any("target_table" in t for t in out_tables)
+    assert len(out_tables) == 1
+    # in_tables should have to_delete but NOT 'dst' as a spurious table
+    in_tables = [str(t) for t in result.in_tables]
+    assert any("to_delete" in t for t in in_tables)
+    # Verify no spurious 'dst' table (would appear as mydb.dbo.dst)
+    assert not any("dbo.dst" in t.lower() for t in in_tables)


### PR DESCRIPTION
TSQL (SQL Server) uses unique syntax where UPDATE/DELETE target can be an alias:
  UPDATE dst SET ... FROM dbo.target_table dst JOIN ...
  DELETE dst FROM dbo.target_table dst WHERE ...

  Before this fix, the parser extracted dst (the alias) as the output table instead of dbo.target_table (the real table), breaking downstream lineage tracking.

  Changes:
  - Add _build_tsql_update_alias_map() to build alias → table mapping from FROM clause
  - Add _resolve_tsql_update_alias() to resolve UPDATE alias to real table
  - Filter aliases from in_tables to prevent phantom upstream dependencies (e.g., mydb.dbo.dst)
  - Handle scope correctly: aliases in subqueries don't conflict with outer scope