### PR TITLE
fix(ingestion): expand sources sections while searching (#7869)

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/SelectSourceStep.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/SelectSourceStep.tsx
@@ -151,7 +151,7 @@ export function SelectSourceStep() {
                                 cardsPerRow,
                             );
 
-                            const isOpen = expanded[category] ?? true;
+                            const isOpen = !!searchQuery || (expanded[category] ?? true);
                             const showAll = showAllByCategory[category] ?? false;
 
                             const visible = showAll || searchQuery ? [...popular, ...nonPopular] : computedVisible;


### PR DESCRIPTION
Linear - https://linear.app/acryl-data/issue/CAT-1227/bug-filtering-sources-when-section-is-closed

This PR expands collapsed sources sections while searching

Before

<img width="961" height="292" alt="image" src="https://github.com/user-attachments/assets/14d9a999-1b1f-48db-94ac-44b99265f609" />


After

<img width="1212" height="369" alt="image" src="https://github.com/user-attachments/assets/11b78bf1-6f4b-46fa-b809-bcd403c274ab" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
