### PR TITLE
refactor: Update Google Analytics tracking ID

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -377,7 +377,7 @@ module.exports = {
           containerId: 'GTM-5M8T9HNN',
         },
         gtag: {
-          trackingID: "G-PKGVLETT4C",
+          trackingID: "G-H5QDNJNMHY",
         },
       },
     ],


### PR DESCRIPTION
We're currently losing the data when users are switching sites, and converting to a single tracking ID will give us more context as to a users full journey no matter whether they are on the marketing or docs site.

Per Tyler Barry's request since the current tracking ID has been outdated for a while. 