### PR TITLE
(fix: datahub-web-react) fixed query for EntitySearchDropdown to remove unnecessary fields and improve performance

### DIFF
--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -1538,6 +1538,17 @@ query getSearchResultsForMultipleTrimmed($input: SearchAcrossEntitiesInput!) {
     }
 }
 
+# Lightweight search query
+query getEntitySearchResultsAutoCompleteFields($input: SearchAcrossEntitiesInput!) {
+    searchAcrossEntities(input: $input) {
+        searchResults {
+            entity {
+                ...autoCompleteFields
+            }
+        }
+    }
+}
+
 query getSearchCount($input: SearchAcrossEntitiesInput!) {
     searchAcrossEntities(input: $input) {
         total


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
EntitySearchDropdown currently fetches everything about the entity in order to just render the entity names in the dropdown. Even though it's paginated to 10, the properties in it could lead to really long responses causing the UI to crash as experienced by some of the users. 

- This PR fixes the query to just include the fields that are necessary to function the EntitySelector/EntitySearchDropdown.
- Also added debounce to the filter in the dropdown.

<img width="662" height="192" alt="Screenshot 2026-01-15 at 6 51 23 PM" src="https://github.com/user-attachments/assets/3fd2874d-7bd9-4238-970e-11389588e83a" />


