### PR TITLE
feat(smoke-test): add skip support for concurrent openapi tests

### DIFF
--- a/smoke-test/tests/utilities/concurrent_openapi.py
+++ b/smoke-test/tests/utilities/concurrent_openapi.py
@@ -52,6 +52,12 @@ def evaluate_test(auth_session, test_name, test_data):
                 description = req_resp["request"].pop("description")
             else:
                 description = None
+            if "skip" in req_resp["request"]:
+                skip_reason = req_resp["request"].pop("skip")
+                logger.info(
+                    f"Skipping step {idx}: {description or 'no description'} - {skip_reason}"
+                )
+                continue
             if "wait" in req_resp["request"]:
                 time.sleep(req_resp["request"]["wait"])
                 continue


### PR DESCRIPTION
Add ability to skip test steps with a reason by including a 'skip' field in the request. Skipped steps are logged with their description and reason.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
