### PR TITLE
fix(ui) Fix ingestion cache bug when creating new source

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
@@ -22,6 +22,7 @@ import {
     SubmitOptions,
 } from '@app/ingestV2/source/multiStepBuilder/types';
 import {
+    DEFAULT_SOURCE_SORT_CRITERION,
     getIngestionSourceMutationInput,
     getIngestionSourceSystemFilter,
     getNewIngestionSourcePlaceholder,
@@ -92,7 +93,7 @@ export function IngestionSourceCreatePage() {
                     count: DEFAULT_PAGE_SIZE,
                     query: undefined,
                     filters: [getIngestionSourceSystemFilter(true)],
-                    sort: undefined,
+                    sort: DEFAULT_SOURCE_SORT_CRITERION,
                 });
 
                 analytics.event({


### PR DESCRIPTION
Fixes a caching bug where after creating a new source with the new ingestion experience it doesn't get added to the list of sources right away and requires a refresh.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
