### PR TITLE
fix(ui) Add ingestion links and executor pools dropdown to ingestion 

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/ConnectionDetailsStep.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/ConnectionDetailsStep.tsx
@@ -10,7 +10,7 @@ import { getRecipeJson } from '@app/ingestV2/source/builder/RecipeForm/TestConne
 import { CSV, LOOKER, LOOK_ML } from '@app/ingestV2/source/builder/constants';
 import { useIngestionSources } from '@app/ingestV2/source/builder/useIngestionSources';
 import { INGESTION_TYPE_ERROR } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/constants';
-import { AdvancedSection } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/AdvansedSection';
+import { AdvancedSection } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/AdvancedSection';
 import { NameAndOwnersSection } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/NameAndOwnersSection';
 import { RecipeSection } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/RecipeSection';
 import { IngestionSourceFormStep, MultiStepSourceBuilderState } from '@app/ingestV2/source/multiStepBuilder/types';
@@ -165,7 +165,7 @@ export function ConnectionDetailsStep() {
                     setIsRecipeValid={setIsRecipeValid}
                 />
 
-                <AdvancedSection state={state} updateState={updateState} />
+                <AdvancedSection state={state} updateState={updateState} isEditing={isEditing} />
             </Container>
         </>
     );

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/ConnectionDetailsSubTitle.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/ConnectionDetailsSubTitle.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@components';
 import React from 'react';
 
 import { useIngestionSources } from '@app/ingestV2/source/builder/useIngestionSources';
@@ -11,8 +12,21 @@ export function ConnectionDetailsSubTitle() {
     const { ingestionSources } = useIngestionSources();
     const sourceConfigs = getSourceConfigs(ingestionSources, type as string);
     const sourceDisplayName = sourceConfigs?.displayName;
+    const docsUrl = sourceConfigs?.docsUrl;
 
-    const displayName = sourceDisplayName === CUSTOM_SOURCE_DISPLAY_NAME ? 'this source' : sourceDisplayName;
+    const isCustomSource = sourceDisplayName === CUSTOM_SOURCE_DISPLAY_NAME;
+    const displayName = isCustomSource ? 'this source' : sourceDisplayName;
+    const linkDisplayName = isCustomSource ? 'Metadata Ingestion' : displayName;
 
-    return <>Provide credentials and define what metadata to collect from {displayName}.</>;
+    return (
+        <>
+            Provide credentials and define what metadata to collect from {displayName}.
+            {docsUrl && (
+                <>
+                    {' '}
+                    Check out the <Link href={docsUrl}>{linkDisplayName} Guide</Link> for more information.
+                </>
+            )}
+        </>
+    );
 }

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/AdvancedSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/AdvancedSection.tsx
@@ -1,9 +1,11 @@
-import { Input, spacing, transition } from '@components';
+import { Input, colors, spacing, transition } from '@components';
 import { Form } from 'antd';
 import useFormInstance from 'antd/lib/form/hooks/useFormInstance';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
+import RemoteExecutorPoolSelector from '@app/ingest/source/builder/RemoteExecutorPoolSelector.saas';
+import { useExecutorPoolSelection } from '@app/ingest/source/builder/useExecutorPoolSelection';
 import { AntdFormCompatibleCheckbox } from '@app/ingestV2/source/multiStepBuilder/components/AntdCompatibleCheckbox';
 import { ExpandCollapseButton } from '@app/ingestV2/source/multiStepBuilder/components/ExpandCollapseButton';
 import { SectionName } from '@app/ingestV2/source/multiStepBuilder/components/SectionName';
@@ -28,16 +30,31 @@ const FormContainer = styled(Container)<{ $expanded?: boolean }>`
         opacity ${transition.duration.normal} ${transition.easing['ease-in-out']};
 `;
 
+const RemoteExecutorSelectWrapper = styled.div`
+    &&& .ant-select-selector {
+        border: 1px solid ${colors.gray[100]};
+        border-radius: 8px;
+        height: 40px;
+        padding-top: 4px;
+        padding-right: 4px;
+        color: ${colors.gray[700]};
+
+        font-size: 14px;
+    }
+`;
+
 interface Props {
     state: MultiStepSourceBuilderState;
     updateState: (newState: Partial<MultiStepSourceBuilderState>) => void;
+    isEditing: boolean;
 }
 
 const ExtraEnvKey = 'extra_env_vars';
 const ExtraReqKey = 'extra_pip_requirements';
 const ExtraPluginKey = 'extra_pip_plugins';
 
-export function AdvancedSection({ state, updateState }: Props) {
+export function AdvancedSection({ state, updateState, isEditing }: Props) {
+    const [searchPoolQuery, setSearchPoolQuery] = useState('');
     const [isExpanded, setIsExpanded] = useState<boolean>(false);
     const sectionRef = useRef<HTMLDivElement | null>(null);
 
@@ -82,6 +99,17 @@ export function AdvancedSection({ state, updateState }: Props) {
         [updateState, state],
     );
 
+    const setExecutorId = (execId: string) => {
+        const newState = {
+            ...state,
+            config: {
+                ...state.config,
+                executorId: execId,
+            },
+        };
+        updateState(newState);
+    };
+
     useEffect(() => {
         if (isExpanded) {
             sectionRef.current?.scrollIntoView({
@@ -90,6 +118,13 @@ export function AdvancedSection({ state, updateState }: Props) {
             });
         }
     }, [isExpanded]);
+
+    const { pools, loading, total } = useExecutorPoolSelection({
+        searchQuery: searchPoolQuery,
+        currentExecutorId: state?.config?.executorId || '',
+        isEditing,
+        onSetExecutorId: setExecutorId,
+    });
 
     return (
         <Form form={form} layout="vertical" initialValues={initialState} onValuesChange={onValuesChange}>
@@ -100,16 +135,23 @@ export function AdvancedSection({ state, updateState }: Props) {
                 />
 
                 <FormContainer $expanded={isExpanded}>
-                    {/* NOTE: Executor ID is OSS-only, used by actions pod */}
+                    {/* NOTE: Executor Pool is SaaS-only, different than Executor ID in OSS */}
                     <CustomLabelFormItem
-                        label="Executor ID"
-                        help="Provide the ID of the executor that should execute this ingestion recipe. This ID is used to route
-                    execution requests of the recipe to the executor of the same ID. The built-in DataHub executor ID is
-                    'default'. Do not change this unless you have configured a custom executor via actions
-                    framework."
+                        label="Executor Pool"
+                        help="Choose an Executor Pool to execute this ingestion recipe."
                         name="executor_id"
                     >
-                        <Input placeholder="default" value={state.config?.executorId || ''} />
+                        <RemoteExecutorSelectWrapper>
+                            <RemoteExecutorPoolSelector
+                                value={state.config?.executorId || (isEditing ? '' : undefined)}
+                                onChange={(newPoolId) => setExecutorId(newPoolId)}
+                                onBlur={(newPoolId) => setExecutorId(newPoolId)}
+                                pools={pools || []}
+                                total={total}
+                                loading={loading}
+                                handleSearch={setSearchPoolQuery}
+                            />
+                        </RemoteExecutorSelectWrapper>
                     </CustomLabelFormItem>
 
                     <CustomLabelFormItem


### PR DESCRIPTION
This solves two problems that came out of a recent round of review:
1. Adds a link to ingestion source specific guides to the page for editing connection details
2. Replaces the executor ID in advanced settings with the existing dropdown for executor pools (mildly hacked to get our styles in there)

<img width="1725" height="906" alt="Screenshot 2026-01-13 at 4 12 19 PM" src="https://github.com/user-attachments/assets/065bbe5d-b774-4eab-b7e6-ca7148e80170" />

<img width="653" height="214" alt="Screenshot 2026-01-13 at 4 12 37 PM" src="https://github.com/user-attachments/assets/65b5ac74-0630-4795-b433-65b10d1c48eb" />

<img width="674" height="348" alt="Screenshot 2026-01-13 at 4 12 49 PM" src="https://github.com/user-attachments/assets/b2324394-19c4-4148-8e3d-16bee5dda668" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
