### PR TITLE
fix(ui) Remove form validation except for name for ingestion sources

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceBottomPanel.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceBottomPanel.tsx
@@ -58,5 +58,10 @@ export function IngestionSourceBottomPanel() {
         [isFinalStep, isCurrentStepCompleted, onSave, onSaveAndRun, isSaveAndRunInProgress],
     );
 
-    return <MultiStepFormBottomPanel renderRightButtons={renderRightButtons} />;
+    return (
+        <MultiStepFormBottomPanel
+            renderRightButtons={renderRightButtons}
+            disabledNextTooltip="Enter a name to continue"
+        />
+    );
 }

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/ConnectionDetailsStep.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/ConnectionDetailsStep.tsx
@@ -37,7 +37,6 @@ export function ConnectionDetailsStep() {
     const isEditing = !!state.isEditing;
     const sourceConfigs = getSourceConfigs(ingestionSources, type as string);
     const placeholderRecipe = getPlaceholderRecipe(ingestionSources, type);
-    const [isRecipeValid, setIsRecipeValid] = useState<boolean>(isEditing || !!state.isConnectionDetailsValid);
     const [initialRecipeYml] = useState(existingRecipeFromStateYaml || existingRecipeYaml);
     const [stagedRecipeYml, setStagedRecipeYml] = useState(initialRecipeYml || placeholderRecipe);
 
@@ -91,14 +90,14 @@ export function ConnectionDetailsStep() {
     const displayRecipe = stagedRecipeYml || placeholderRecipe;
 
     useEffect(() => {
-        if (isRecipeValid && state.name && stagedRecipeYml && stagedRecipeYml.length > 0) {
+        if (state.name) {
             setCurrentStepCompleted();
             updateState({ isConnectionDetailsValid: true });
         } else {
             setCurrentStepUncompleted();
             updateState({ isConnectionDetailsValid: false });
         }
-    }, [isRecipeValid, updateState, stagedRecipeYml, setCurrentStepCompleted, setCurrentStepUncompleted, state.name]);
+    }, [updateState, setCurrentStepCompleted, setCurrentStepUncompleted, state.name]);
 
     useEffect(() => {
         if (analyticsRef.current) return;
@@ -162,7 +161,6 @@ export function ConnectionDetailsStep() {
                     displayRecipe={displayRecipe}
                     sourceConfigs={sourceConfigs}
                     setStagedRecipe={updateStagedRecipeAndState}
-                    setIsRecipeValid={setIsRecipeValid}
                 />
 
                 <AdvancedSection state={state} updateState={updateState} />

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/RecipeSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/RecipeSection.tsx
@@ -1,5 +1,5 @@
 import { Form, message } from 'antd';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import YAML from 'yamljs';
 
 import { Tab, Tabs } from '@components/components/Tabs/Tabs';
@@ -15,37 +15,22 @@ interface Props {
     displayRecipe: string;
     sourceConfigs?: SourceConfig;
     setStagedRecipe: (recipe: string) => void;
-    setIsRecipeValid?: (isValid: boolean) => void;
 }
 
-export function RecipeSection({ state, displayRecipe, sourceConfigs, setStagedRecipe, setIsRecipeValid }: Props) {
+export function RecipeSection({ state, displayRecipe, sourceConfigs, setStagedRecipe }: Props) {
     const { type } = state;
-    const isEditing = !!state.isEditing;
     const hasForm = useMemo(() => type && CONNECTORS_WITH_FORM_INCLUDING_DYNAMIC_FIELDS.has(type), [type]);
     const [selectedTabKey, setSelectedTabKey] = useState<string>('form');
-    // FYI: We don't have form validation for sources without a form
-    useEffect(() => {
-        setIsRecipeValid?.(!hasForm || isEditing || !!state.isConnectionDetailsValid);
-    }, [hasForm, isEditing, setIsRecipeValid, state.isConnectionDetailsValid]);
 
     const [form] = Form.useForm();
     const runFormValidation = useCallback(() => {
-        form.validateFields()
-            .then(() => {
-                setIsRecipeValid?.(true);
-            })
-            .catch((error) => {
-                // FYI: `error` could be triggered with empty list of `errorFields` when form is valid
-                const hasErrors = (error.errorFields?.length ?? 0) > 0;
-                setIsRecipeValid?.(!hasErrors);
-            });
-    }, [form, setIsRecipeValid]);
+        form.validateFields();
+    }, [form]);
 
     const onTabClick = useCallback(
         (activeKey) => {
             if (activeKey !== 'form') {
                 setSelectedTabKey(activeKey);
-                setIsRecipeValid?.(true); // no field validation when in yaml editor
                 return;
             }
 
@@ -62,7 +47,7 @@ export function RecipeSection({ state, displayRecipe, sourceConfigs, setStagedRe
                 message.warn(`Found invalid YAML. ${messageText} in order to switch views.`);
             }
         },
-        [displayRecipe, setIsRecipeValid, runFormValidation],
+        [displayRecipe, runFormValidation],
     );
 
     const tabs: Tab[] = useMemo(

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/FiltersSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/FiltersSection.tsx
@@ -55,39 +55,12 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
     const ruleSelectOptions = useMemo(() => getOptionsForTypeSelect(), []);
     // FYI: assuming that each filter has both allow and deny version
     const subtypeSelectOptions = useMemo(() => getSubtypeOptions(supportedFields), [supportedFields]);
-    const defaultRule = useMemo(() => {
-        return 'exclude';
-    }, []);
 
-    const defaultSubtype = useMemo(() => {
-        if (subtypeSelectOptions.length > 0) {
-            return subtypeSelectOptions[0].value;
-        }
-        return undefined;
-    }, [subtypeSelectOptions]);
-
-    const defaultSubtypeSelectValues = useMemo(() => {
-        if (defaultSubtype) {
-            return [defaultSubtype];
-        }
-        return [];
-    }, [defaultSubtype]);
-
-    const defaultsForEmptyFilter = useMemo(
-        () => ({
-            rule: defaultRule,
-            subtype: defaultSubtype,
-        }),
-        [defaultRule, defaultSubtype],
-    );
-
-    const [filters, setFilters] = useState<Filter[]>(() =>
-        getInitialFilters(supportedFields, recipe, defaultsForEmptyFilter),
-    );
+    const [filters, setFilters] = useState<Filter[]>(() => getInitialFilters(supportedFields, recipe));
 
     const addFilter = useCallback(() => {
-        setFilters((prev) => [...prev, getEmptyFilter(defaultsForEmptyFilter)]);
-    }, [defaultsForEmptyFilter]);
+        setFilters((prev) => [...prev, getEmptyFilter()]);
+    }, []);
 
     const onAddFilterClick = useCallback(
         (e: React.MouseEvent) => {
@@ -110,13 +83,13 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
         (key: string) => {
             const updatedFilters = filters.filter((filter) => filter.key !== key);
             if (updatedFilters.length === 0) {
-                setFilters([getEmptyFilter(defaultsForEmptyFilter)]);
+                setFilters([getEmptyFilter()]);
             } else {
                 setFilters(updatedFilters);
             }
             updateRecipeByFilters(updatedFilters);
         },
-        [filters, updateRecipeByFilters, defaultsForEmptyFilter],
+        [filters, updateRecipeByFilters],
     );
 
     const updateFilters = useCallback(
@@ -157,6 +130,8 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
 
     if (fields.length === 0) return null;
 
+    const showDeleteButton = filters.length > 1 || filters[0]?.rule || filters[0]?.subtype || filters[0]?.value;
+
     return (
         <>
             <SectionName
@@ -189,24 +164,24 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
                         <FilterCell>
                             <SimpleSelect
                                 options={ruleSelectOptions}
-                                values={filter.rule ? [filter.rule] : [defaultRule]}
+                                values={filter.rule ? [filter.rule] : []}
                                 onUpdate={(values) => updateFilterRule(filter.key, values?.[0])}
                                 showClear={false}
                                 width="full"
                                 minWidth="fit-content"
-                                placeholder="Rule"
+                                placeholder="Filter Type"
                                 size="lg"
                             />
                         </FilterCell>
                         <FilterCell>
                             <SimpleSelect
                                 options={subtypeSelectOptions}
-                                values={filter.subtype ? [filter.subtype] : defaultSubtypeSelectValues}
+                                values={filter.subtype ? [filter.subtype] : []}
                                 onUpdate={(values) => updateFilterSubtype(filter.key, values?.[0])}
                                 showClear={false}
                                 width="full"
                                 minWidth="fit-content"
-                                placeholder={filter.subtype ? `[${filter.subtype}]` : '[Table]'}
+                                placeholder={filter.subtype ? `[${filter.subtype}]` : 'Asset Type'}
                                 size="lg"
                             />
                         </FilterCell>
@@ -217,9 +192,11 @@ export function FiltersSection({ fields, recipe, updateRecipe }: Props) {
                                 placeholder="^my_db$"
                             />
                         </FilterCell>
-                        <RemoveIconCell>
-                            <RemoveIcon onClick={() => removeFilter(filter.key)} />
-                        </RemoveIconCell>
+                        {showDeleteButton && (
+                            <RemoveIconCell>
+                                <RemoveIcon onClick={() => removeFilter(filter.key)} />
+                            </RemoveIconCell>
+                        )}
                     </React.Fragment>
                 ))}
             </FiltersGridContainer>

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/__tests__/utils.test.ts
@@ -36,38 +36,6 @@ describe('Filters utils', () => {
                 value: '',
             });
         });
-
-        it('should apply defaults when provided', () => {
-            const defaults: Partial<Filter> = {
-                rule: 'include',
-                subtype: 'database',
-                value: 'test-value',
-            };
-
-            const result = getEmptyFilter(defaults);
-
-            expect(result).toEqual({
-                key: 'mocked-uuid',
-                rule: 'include',
-                subtype: 'database',
-                value: 'test-value',
-            });
-        });
-
-        it('should merge defaults with existing properties', () => {
-            const defaults: Partial<Filter> = {
-                rule: 'exclude',
-            };
-
-            const result = getEmptyFilter(defaults);
-
-            expect(result).toEqual({
-                key: 'mocked-uuid',
-                rule: 'exclude',
-                subtype: undefined,
-                value: '',
-            });
-        });
     });
 
     describe('getInitialFilters', () => {
@@ -148,29 +116,6 @@ source:
                 key: 'mocked-uuid',
                 rule: undefined,
                 subtype: undefined,
-                value: '',
-            });
-        });
-
-        it('should return a single empty filter with defaults when no values are found in recipe and defaults are provided', () => {
-            const recipe = `
-source:
-  config:
-    other_config: true
-            `.trim();
-
-            const defaults = {
-                rule: FilterRule.INCLUDE,
-                subtype: 'Databases',
-            };
-
-            const result = getInitialFilters(mockFields, recipe, defaults);
-
-            expect(result).toHaveLength(1);
-            expect(result[0]).toEqual({
-                key: 'mocked-uuid',
-                rule: FilterRule.INCLUDE,
-                subtype: 'Databases',
                 value: '',
             });
         });

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/utils.ts
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/utils.ts
@@ -5,21 +5,16 @@ import { FieldType, FilterRecipeField } from '@app/ingestV2/source/builder/Recip
 import { getValuesFromRecipe } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/recipeForm/utils';
 import { Filter } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/filtersSection/types';
 
-export function getEmptyFilter(defaults?: Partial<Filter>): Filter {
+export function getEmptyFilter(): Filter {
     return {
         key: uuidv4(),
         rule: undefined,
         subtype: undefined,
         value: '',
-        ...(defaults || {}),
     };
 }
 
-export function getInitialFilters(
-    fields: FilterRecipeField[],
-    recipe: string,
-    defaultsForEmptyFilter?: Partial<Filter>,
-) {
+export function getInitialFilters(fields: FilterRecipeField[], recipe: string) {
     const filters: Filter[] = [];
 
     let valuesFromRecipe = {};
@@ -43,7 +38,7 @@ export function getInitialFilters(
     });
 
     if (filters.length === 0) {
-        filters.push(getEmptyFilter(defaultsForEmptyFilter));
+        filters.push(getEmptyFilter());
     }
 
     return filters;

--- a/datahub-web-react/src/app/sharedV2/forms/multiStepForm/MultiStepFormBottomPanel.tsx
+++ b/datahub-web-react/src/app/sharedV2/forms/multiStepForm/MultiStepFormBottomPanel.tsx
@@ -35,12 +35,14 @@ interface Props {
     showSubmitButton?: boolean;
     renderLeftButtons?: (buttons: React.ReactNode[]) => React.ReactNode;
     renderRightButtons?: (buttons: React.ReactNode[]) => React.ReactNode;
+    disabledNextTooltip?: string;
 }
 
 export function MultiStepFormBottomPanel<TState, TStep extends Step>({
     showSubmitButton,
     renderLeftButtons,
     renderRightButtons,
+    disabledNextTooltip,
 }: Props) {
     const {
         goToNext,
@@ -99,7 +101,12 @@ export function MultiStepFormBottomPanel<TState, TStep extends Step>({
 
             buttons.push(
                 isDisabled ? (
-                    <Tooltip key="next" title="Please complete all required fields before moving to the next step">
+                    <Tooltip
+                        key="next"
+                        title={
+                            disabledNextTooltip || 'Please complete all required fields before moving to the next step'
+                        }
+                    >
                         <span>{nextButton}</span>
                     </Tooltip>
                 ) : (
@@ -124,6 +131,7 @@ export function MultiStepFormBottomPanel<TState, TStep extends Step>({
 
         return buttons;
     }, [
+        disabledNextTooltip,
         canGoToNext,
         isFinalStep,
         cancel,


### PR DESCRIPTION
i think the risks of getting something wrong and barring a user from going to the next step when they want to, causing frustration for the them, are greater than the benefits of holding the users hand to make sure they fill out all the fields of their recipe that they need to.

So this PR removes validation on whether the form is completely filled out in order to go to the next step, but still requires the source name to be there since that is truly a required field.

Additionally this makes an update to the filters section to have the fields be blank by default removing some confusion we heard about from feedback where it looked like we default applied a filter for the user and they couldn't remove it.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
