### PR TITLE
fix(ui) Fix error page when switching to executors tab

### DIFF
--- a/datahub-web-react/src/app/ingestV2/ManageIngestionPage.tsx
+++ b/datahub-web-react/src/app/ingestV2/ManageIngestionPage.tsx
@@ -95,6 +95,17 @@ export const ManageIngestionPage = () => {
     const { value: sourceFilter, setValue: setSourceFilter } = useUrlQueryParam('sourceFilter');
     const { value: searchQuery, setValue: setSearchQuery } = useUrlQueryParam('query');
 
+    // Stable callbacks to prevent infinite re-render loops in child components
+    const handleSetSourceFilter = useCallback(
+        (value: number | undefined) => setSourceFilter(value?.toString() || ''),
+        [setSourceFilter],
+    );
+
+    const handleSetHideSystemSources = useCallback(
+        (value: boolean) => setHideSystemSources(value.toString()),
+        [setHideSystemSources],
+    );
+
     // defaultTab might not be calculated correctly on mount, if `config` or `me` haven't been loaded yet
     useEffect(() => {
         if (loadedAppConfig && loadedPlatformPrivileges && selectedTab === undefined) {
@@ -141,11 +152,11 @@ export const ManageIngestionPage = () => {
                     setShowCreateModal={setShowCreateSourceModal}
                     shouldPreserveParams={shouldPreserveParams}
                     hideSystemSources={hideSystemSources === 'true'}
-                    setHideSystemSources={(value: boolean) => setHideSystemSources(value.toString())}
+                    setHideSystemSources={handleSetHideSystemSources}
                     selectedTab={selectedTab}
                     setSelectedTab={setSelectedTab}
                     sourceFilter={sourceFilter ? Number(sourceFilter) : undefined}
-                    setSourceFilter={(value: number | undefined) => setSourceFilter(value?.toString() || '')}
+                    setSourceFilter={handleSetSourceFilter}
                     searchQuery={searchQuery}
                     setSearchQuery={setSearchQuery}
                 />
@@ -158,7 +169,7 @@ export const ManageIngestionPage = () => {
                 <ExecutionsTab
                     shouldPreserveParams={shouldPreserveParams}
                     hideSystemSources={hideSystemSources === 'true'}
-                    setHideSystemSources={(value: boolean) => setHideSystemSources(value.toString())}
+                    setHideSystemSources={handleSetHideSystemSources}
                     selectedTab={selectedTab}
                     setSelectedTab={setSelectedTab}
                 />


### PR DESCRIPTION
**Problem:**
  Infinite render loop occurring on the Executors tab (and potentially other tabs) causing "Maximum update depth exceeded" error.

  **Root Cause:**
  Inline arrow functions in `ManageIngestionPage.tsx` (lines 173, 178, 190) were being recreated on every render. These functions were passed to child components (`IngestionSourceList`, `ExecutionsTab`)
  where they were included in `useEffect` dependency arrays, creating an infinite loop:
  1. Parent renders → creates new inline function
  2. Child's useEffect sees new function reference → runs effect
  3. Effect updates URL params via `useUrlQueryParam`
  4. URL change triggers parent re-render → back to step 1

  **Resolution:**
  Wrapped inline functions in `useCallback` to create stable references:
  - `handleSetSourceFilter`
  - `handleSetHideSystemSources`

  This prevents unnecessary re-renders and breaks the infinite loop cycle.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
