### PR TITLE
fix(ingest/sql): Fix test connection with stateful_ingestion enabled

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -396,6 +396,15 @@ class SQLAlchemySource(StatefulIngestionSourceBase, TestableSource):
     def test_connection(cls, config_dict: dict) -> TestConnectionReport:
         test_report = TestConnectionReport()
         try:
+            if config_dict.get("stateful_ingestion", {}).get("enabled", False):
+                # Connection test should only care about config for connecting to the source
+                # Ingestion-only details like whether stateful_ingestion is enabled are irrelevant
+                # And specifically, stateful_ingestion requires a connection to DataHub
+                # which should not be required to test a connection
+                config_dict = {
+                    **config_dict,
+                    "stateful_ingestion": {"enabled": False},
+                }
             source = cast(
                 SQLAlchemySource,
                 cls.create(config_dict, PipelineContext(run_id="test_connection")),

--- a/metadata-ingestion/tests/integration/mysql/test_mysql.py
+++ b/metadata-ingestion/tests/integration/mysql/test_mysql.py
@@ -88,6 +88,7 @@ def test_mysql_ingest_no_db(
                 "database": "northwind",
                 "username": "root",
                 "password": "example",
+                "stateful_ingestion": {"enabled": "true"},
             },
             True,
         ),

--- a/metadata-ingestion/tests/integration/postgres/postgres_test_connection.yml
+++ b/metadata-ingestion/tests/integration/postgres/postgres_test_connection.yml
@@ -1,0 +1,16 @@
+source:
+  type: postgres
+  config:
+    host_port: 'localhost:5432'
+    initial_database: 'postgrestest'
+    username: 'postgres'
+    password: 'example'
+    include_tables: true
+    database: postgres
+    profiling:
+      enabled: true
+      profile_table_level_only: true
+    include_views: true
+    stateful_ingestion:
+      enabled: true
+pipeline_name: 'urn:li:dataHubExecutionRequest:test'


### PR DESCRIPTION
This previously failed because (i) `pipeline_name` was not set in the `PipelineContext` created for the source and (ii) the pipeline context didn't have a graph. We could make a fake pipeline name but not sure that would solve the graph issue. This seemed like the easiest option.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
