### PR TITLE
fix(catalog): unapplied filter for data product csv download

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -206,10 +206,11 @@ export const EmbeddedListSearch = ({
         variables: {
             input: {
                 types: entityTypes || [],
-                query,
+                query: finalQuery,
                 count: SearchCfg.RESULTS_PER_PAGE,
-                orFilters: generateOrFilters(unionType, filters),
+                orFilters: finalFilters,
                 scrollId: null,
+                viewUrn: applyView ? selectedViewUrn : undefined, 
                 searchFlags,
             },
         },


### PR DESCRIPTION
Currently when you try to download results from a data product like this one
<img width="314" height="154" alt="image" src="https://github.com/user-attachments/assets/707dd56c-e905-486c-ac03-d95d39ac90af" />
it downloads all assets!
<img width="384" height="79" alt="image" src="https://github.com/user-attachments/assets/8c9beb84-9c99-4d5d-95d1-c83878e69527" />
because there is no filter applied.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
