### PR TITLE
feat(ingestion): implement batch processing for SQL aggregator with parallel parsing

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/env_vars.py
+++ b/metadata-ingestion/src/datahub/configuration/env_vars.py
@@ -347,3 +347,13 @@ def get_update_entity_registry() -> str:
 def get_ci() -> Optional[str]:
     """Indicates running in CI environment."""
     return os.getenv("CI")
+
+
+def get_sql_aggregator_parsing_workers() -> int:
+    """Number of worker threads for parallel SQL query parsing."""
+    return int(os.getenv("SQL_AGGREGATOR_PARSING_WORKERS", "1"))
+
+
+def get_bigquery_observe_queries_batch_size() -> int:
+    """Batch size for BigQuery queries when using the new queries extractor."""
+    return int(os.getenv("BIGQUERY_OBSERVE_QUERIES_BATCH_SIZE", "500"))

--- a/metadata-ingestion/tests/performance/test_sql_aggregator.py
+++ b/metadata-ingestion/tests/performance/test_sql_aggregator.py
@@ -1,0 +1,177 @@
+"""Performance tests for SQL aggregator batch processing.
+
+This module provides performance benchmarking for the SQL aggregator's batch processing
+capabilities, including parallel parsing with configurable worker counts.
+
+Usage:
+    # Run the benchmark test (runs matrix of configurations)
+    pytest tests/performance/test_sql_aggregator.py::test_benchmark -s --log-cli-level=INFO
+"""
+
+import logging
+import os
+import time
+from typing import Iterable, List
+
+import pytest
+
+from datahub.sql_parsing.sql_parsing_aggregator import (
+    ObservedQuery,
+    SqlParsingAggregator,
+)
+from tests.unit.sql_parsing.test_sql_aggregator import (  # type: ignore[import-untyped]
+    generate_queries_at_scale,
+)
+
+logger = logging.getLogger(__name__)
+
+# Matrix parameters for performance testing
+WORKERS_OPTIONS = [1, 2, 8]
+QUERY_COUNT_OPTIONS = [10000]
+BATCH_SIZE_OPTIONS = [500]
+
+
+def run_configuration(
+    workers: int,
+    batch_size: int,
+    queries: Iterable[ObservedQuery],
+) -> float:
+    """Run a given configuration and compute elapsed time.
+
+    Args:
+        workers: Number of worker threads for parallel parsing
+        batch_size: Size of each batch
+        queries: Iterable of ObservedQuery objects to process
+
+    Returns:
+        Elapsed time in seconds
+    """
+    # Set environment variable for worker count
+    os.environ["SQL_AGGREGATOR_PARSING_WORKERS"] = str(workers)
+    try:
+        aggregator = SqlParsingAggregator(
+            platform="redshift",
+            generate_lineage=True,
+            generate_usage_statistics=False,
+            generate_operations=False,
+        )
+    finally:
+        # Clean up environment variable
+        os.environ.pop("SQL_AGGREGATOR_PARSING_WORKERS", None)
+
+    # Convert queries to list and split into batches
+    queries_list = list(queries)
+    query_batches = [
+        queries_list[i : i + batch_size]
+        for i in range(0, len(queries_list), batch_size)
+    ]
+
+    # Measure processing time
+    start_time = time.perf_counter()
+    for batch in query_batches:
+        aggregator.add_batch(batch)
+    elapsed_time = time.perf_counter() - start_time
+
+    aggregator.close()
+
+    return elapsed_time
+
+
+def test_benchmark(pytestconfig: pytest.Config) -> None:
+    """Run benchmark test across a matrix of configurations.
+
+    Tests with:
+    - Workers: [1, 2, 4, 8, 10]
+    - Query counts: [10000, 100000]
+    - Batch sizes: [200, 400]
+
+    Results are logged for each configuration.
+    """
+    seed = int(
+        os.getenv("SQL_AGGREGATOR_TEST_SEED", "42")
+    )  # Fixed seed for reproducibility
+
+    results: List[dict] = []
+    total_combinations = (
+        len(WORKERS_OPTIONS) * len(QUERY_COUNT_OPTIONS) * len(BATCH_SIZE_OPTIONS)
+    )
+
+    print("=" * 100)
+    print(f"Running performance benchmark across {total_combinations} configurations")
+    print("=" * 100)
+
+    combination_num = 0
+
+    for query_count in QUERY_COUNT_OPTIONS:
+        # Generate queries once per query_count (all configurations with same count use same queries)
+        print(f"Generating {query_count} queries...")
+        all_queries = generate_queries_at_scale(query_count, seed=seed)
+
+        for workers in WORKERS_OPTIONS:
+            for batch_size in BATCH_SIZE_OPTIONS:
+                combination_num += 1
+                print(
+                    f"[{combination_num}/{total_combinations}] "
+                    f"Workers={workers}, Queries={query_count}, Batch={batch_size}"
+                )
+
+                # Run configuration and measure time
+                elapsed_time = run_configuration(workers, batch_size, all_queries)
+
+                avg_time_per_query = (
+                    elapsed_time / query_count if query_count > 0 else 0.0
+                )
+                throughput = query_count / elapsed_time if elapsed_time > 0 else 0.0
+
+                print(
+                    f"  Elapsed: {elapsed_time:.2f}s, "
+                    f"Avg: {avg_time_per_query * 1000:.2f}ms/query, "
+                    f"Throughput: {throughput:.2f} queries/sec"
+                )
+
+                results.append(
+                    {
+                        "workers": workers,
+                        "query_count": query_count,
+                        "batch_size": batch_size,
+                        "elapsed_time": elapsed_time,
+                        "avg_time_per_query": avg_time_per_query,
+                        "throughput": throughput,
+                    }
+                )
+
+    # Print results table
+    print("")
+    print("=" * 100)
+    print("Performance Benchmark Results")
+    print("=" * 100)
+    print("")
+
+    headers = [
+        "Workers",
+        "Query Count",
+        "Batch Size",
+        "Elapsed Time (s)",
+        "Avg Time/Query (ms)",
+        "Throughput (q/s)",
+    ]
+    print("| " + " | ".join(headers) + " |")
+    print("|" + "---|" * len(headers))
+
+    for res in results:
+        print(
+            f"| {res['workers']} | {res['query_count']} | {res['batch_size']} | "
+            f"{res['elapsed_time']:.2f} | {res['avg_time_per_query'] * 1000:.2f} | "
+            f"{res['throughput']:.2f} |"
+        )
+
+    print("")
+    print("=" * 100)
+
+    # Basic assertions to ensure tests ran
+    assert len(results) == total_combinations, (
+        f"Expected {total_combinations} results, got {len(results)}"
+    )
+    assert all(r["elapsed_time"] > 0 for r in results), (
+        "All configurations should have positive elapsed time"
+    )


### PR DESCRIPTION
- Added support for configurable worker threads for SQL query parsing via environment variable `SQL_AGGREGATOR_PARSING_WORKERS`.
- Introduced batch processing in `SqlParsingAggregator` to improve performance by processing queries in parallel.
- Added new environment variable functions to retrieve batch size and worker count.
- Using environment variables to not expose this to users yet.
- Created performance tests to benchmark the new batch processing capabilities.
- Ensured that query order is maintained during parallel processing.
- Updated existing tests to validate batch processing behavior and error handling.

So far:

The benchmark results are pretty disappointing. Overall, more concurrency leads to worse performance.

```
===================================================================================================
Running performance benchmark across 3 configurations
====================================================================================================
Generating 10000 queries...
[1/3] Workers=1, Queries=10000, Batch=500
  Elapsed: 146.95s, Avg: 14.69ms/query, Throughput: 68.05 queries/sec
[2/3] Workers=2, Queries=10000, Batch=500
  Elapsed: 150.47s, Avg: 15.05ms/query, Throughput: 66.46 queries/sec
[3/3] Workers=8, Queries=10000, Batch=500
  Elapsed: 200.60s, Avg: 20.06ms/query, Throughput: 49.85 queries/sec

====================================================================================================
Performance Benchmark Results
====================================================================================================

| Workers | Query Count | Batch Size | Elapsed Time (s) | Avg Time/Query (ms) | Throughput (q/s) |
|---|---|---|---|---|---|
| 1 | 10000 | 500 | 146.95 | 14.69 | 68.05 |
| 2 | 10000 | 500 | 150.47 | 15.05 | 66.46 |
| 8 | 10000 | 500 | 200.60 | 20.06 | 49.85 |

====================================================================================================
```

A likely cause is thread pool contention around the GIL, since this is a CPU-bound workload.
Just wondering whether real-world scenarios involve more I/O that could drastically change this behavior — though I think that’s very unlikely.




