### PR TITLE
fix(frontend): prevent open redirect in redirectTrailingSlash

### DIFF
--- a/datahub-frontend/app/controllers/Application.java
+++ b/datahub-frontend/app/controllers/Application.java
@@ -130,8 +130,16 @@ public class Application extends Controller {
    */
   @Nonnull
   public Result redirectTrailingSlash(@Nullable String path) {
+    String redirectBase = basePath.equals("/") ? "" : basePath;
 
-    return movedPermanently("/" + path);
+    if (path == null || path.isEmpty()) {
+      return movedPermanently(redirectBase + "/");
+    }
+    String sanitizedPath = path.replaceFirst("^/+", "");
+    if (sanitizedPath.isEmpty()) {
+      return movedPermanently(redirectBase + "/");
+    }
+    return movedPermanently(redirectBase + "/" + sanitizedPath);
   }
 
   /**

--- a/datahub-frontend/test/app/ApplicationTest.java
+++ b/datahub-frontend/test/app/ApplicationTest.java
@@ -622,6 +622,64 @@ public class ApplicationTest extends WithBrowser {
   }
 
   @Test
+  public void testRedirectTrailingSlashNestedPath() {
+    Http.RequestBuilder request =
+        fakeRequest(routes.Application.redirectTrailingSlash("foo/bar/baz"));
+
+    Result result = route(app, request);
+    assertEquals(MOVED_PERMANENTLY, result.status());
+    assertEquals("/foo/bar/baz", result.redirectLocation().orElse(""));
+  }
+
+  @Test
+  public void testRedirectTrailingSlashDirectWithLeadingSlash() {
+    controllers.Application controller = app.injector().instanceOf(controllers.Application.class);
+    Result result = controller.redirectTrailingSlash("/evil.com");
+    assertEquals(MOVED_PERMANENTLY, result.status());
+    assertEquals("/evil.com", result.redirectLocation().orElse(""));
+  }
+
+  @Test
+  public void testRedirectTrailingSlashDirectWithMultipleLeadingSlashes() {
+    controllers.Application controller = app.injector().instanceOf(controllers.Application.class);
+    Result result = controller.redirectTrailingSlash("///evil.com/path");
+    assertEquals(MOVED_PERMANENTLY, result.status());
+    assertEquals("/evil.com/path", result.redirectLocation().orElse(""));
+  }
+
+  @Test
+  public void testRedirectTrailingSlashDirectWithNull() {
+    controllers.Application controller = app.injector().instanceOf(controllers.Application.class);
+    Result result = controller.redirectTrailingSlash(null);
+    assertEquals(MOVED_PERMANENTLY, result.status());
+    assertEquals("/", result.redirectLocation().orElse(""));
+  }
+
+  @Test
+  public void testRedirectTrailingSlashDirectWithEmpty() {
+    controllers.Application controller = app.injector().instanceOf(controllers.Application.class);
+    Result result = controller.redirectTrailingSlash("");
+    assertEquals(MOVED_PERMANENTLY, result.status());
+    assertEquals("/", result.redirectLocation().orElse(""));
+  }
+
+  @Test
+  public void testRedirectTrailingSlashDirectWithOnlySlashes() {
+    controllers.Application controller = app.injector().instanceOf(controllers.Application.class);
+    Result result = controller.redirectTrailingSlash("////");
+    assertEquals(MOVED_PERMANENTLY, result.status());
+    assertEquals("/", result.redirectLocation().orElse(""));
+  }
+
+  @Test
+  public void testRedirectTrailingSlashDirectWithNormalPath() {
+    controllers.Application controller = app.injector().instanceOf(controllers.Application.class);
+    Result result = controller.redirectTrailingSlash("dataset/urn:li:dataset:1");
+    assertEquals(MOVED_PERMANENTLY, result.status());
+    assertEquals("/dataset/urn:li:dataset:1", result.redirectLocation().orElse(""));
+  }
+
+  @Test
   public void testAppConfigWithEmptyBasePath() {
     // Create a new application with empty basePath
     Application customApp =


### PR DESCRIPTION
# Fix: Open Redirect in redirectTrailingSlash

## Issue

The `redirectTrailingSlash()` method in `Application.java` did not sanitize the `path` parameter before constructing the redirect URL. This allowed URLs with leading slashes (e.g., `//external.com/`) to produce protocol-relative redirects.

## Changes

**File:** `datahub-frontend/app/controllers/Application.java`

- Strip leading slashes from path parameter
- Normalize `basePath="/"` to empty string to prevent double-slash in redirect URL
- Handle null/empty path cases

## Before & After

| Input | Before | After |
|-------|--------|-------|
| `//example.com/` | `//example.com` | `/example.com` |
| `///path/` | `///path` | `/path` |
| `test/` | `/test` | `/test` |
