### PR TITLE
feat(graphql): add semantic search configuration API

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -328,6 +328,7 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.client.UsageStatsJavaClient;
 import com.linkedin.metadata.config.*;
+import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
 import com.linkedin.metadata.config.telemetry.TelemetryConfiguration;
 import com.linkedin.metadata.connection.ConnectionService;
 import com.linkedin.metadata.entity.EntityService;
@@ -450,6 +451,7 @@ public class GmsGraphQLEngine {
   private final SearchFlagsConfiguration searchFlagsConfiguration;
   private final HomePageConfiguration homePageConfiguration;
   private final ChromeExtensionConfiguration chromeExtensionConfiguration;
+  private final SemanticSearchConfiguration semanticSearchConfiguration;
 
   private final DatasetType datasetType;
 
@@ -593,6 +595,7 @@ public class GmsGraphQLEngine {
     this.homePageConfiguration = args.homePageConfiguration;
     this.featureFlags = args.featureFlags;
     this.chromeExtensionConfiguration = args.chromeExtensionConfiguration;
+    this.semanticSearchConfiguration = args.semanticSearchConfiguration;
 
     this.datasetType = new DatasetType(entityClient);
     this.roleType = new RoleType(entityClient);
@@ -1018,7 +1021,8 @@ public class GmsGraphQLEngine {
                         this.featureFlags,
                         this.chromeExtensionConfiguration,
                         this.settingsService,
-                        this.s3Util != null))
+                        this.s3Util != null,
+                        this.semanticSearchConfiguration))
                 .dataFetcher(
                     "latestProductUpdate",
                     new ProductUpdateResolver(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngineArgs.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngineArgs.java
@@ -14,6 +14,7 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.client.UsageStatsJavaClient;
 import com.linkedin.metadata.config.*;
+import com.linkedin.metadata.config.search.SemanticSearchConfiguration;
 import com.linkedin.metadata.config.telemetry.TelemetryConfiguration;
 import com.linkedin.metadata.connection.ConnectionService;
 import com.linkedin.metadata.entity.EntityService;
@@ -107,5 +108,6 @@ public class GmsGraphQLEngineArgs {
   MetricUtils metricUtils;
   S3Util s3Util;
   SemanticSearchService semanticSearchService;
+  SemanticSearchConfiguration semanticSearchConfiguration;
   // any fork specific args should go below this line
 }

--- a/datahub-graphql-core/src/main/resources/app.semantic.graphql
+++ b/datahub-graphql-core/src/main/resources/app.semantic.graphql
@@ -1,0 +1,67 @@
+# Semantic Search Configuration Extensions
+
+"""
+Configuration for semantic search including embedding generation settings
+"""
+type SemanticSearchConfig {
+  """
+  Whether semantic search is enabled on the server
+  """
+  enabled: Boolean!
+
+  """
+  Entity types that support semantic search (e.g., ["document"])
+  """
+  enabledEntities: [String!]!
+
+  """
+  Embedding generation configuration (nullable when semantic search is disabled)
+  """
+  embeddingConfig: EmbeddingConfig
+}
+
+"""
+Embedding model configuration for generating semantic search vectors.
+Only includes minimal settings required for clients to match server embedding behavior.
+"""
+type EmbeddingConfig {
+  """
+  Embedding provider type (e.g., "aws-bedrock")
+  """
+  provider: String!
+
+  """
+  Model identifier (e.g., "cohere.embed-english-v3")
+  """
+  modelId: String!
+
+  """
+  Embedding storage key for SemanticContent aspects (e.g., "cohere_embed_v3").
+  This is the canonical key used in the embeddings map when storing SemanticContent aspects.
+  Server-provided to ensure exact match between client (writing) and server (querying).
+  """
+  modelEmbeddingKey: String!
+
+  """
+  AWS Bedrock-specific configuration (only populated when provider is "aws-bedrock")
+  """
+  awsProviderConfig: AwsProviderConfig
+}
+
+"""
+AWS Bedrock provider-specific configuration
+"""
+type AwsProviderConfig {
+  """
+  AWS region where Bedrock is accessed (e.g., "us-west-2")
+  """
+  region: String!
+}
+
+# Extend AppConfig with semantic search configuration
+extend type AppConfig {
+  """
+  Semantic search and embedding configuration
+  """
+  semanticSearchConfig: SemanticSearchConfig
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
@@ -310,6 +310,8 @@ public class GraphQLEngineFactory {
     args.setMetricUtils(metricUtils);
     args.setS3Util(s3Util);
     args.setSemanticSearchService(semanticSearchService);
+    args.setSemanticSearchConfiguration(
+        configProvider.getElasticSearch().getEntityIndex().getSemanticSearch());
 
     return new GmsGraphQLEngine(args).builder().build();
   }


### PR DESCRIPTION
## Summary

Adds GraphQL API to expose server semantic search configuration, enabling ingestion clients to auto-discover and match server embedding settings for consistent vector generation between document ingestion (client-side) and query processing (server-side).

## Problem

For semantic search to work correctly, document embeddings generated during ingestion must be compatible with query embeddings generated during search. This requires:
1. Using the same embedding provider (e.g., AWS Bedrock)
2. Using the same model (e.g., `cohere.embed-english-v3`)
3. Using the same provider-specific settings (e.g., AWS region)
4. Storing embeddings with the correct key that the server expects when querying

Previously, clients had no way to discover the server's configuration, leading to potential mismatches.

## Solution

New GraphQL API that exposes minimal, client-required embedding configuration:

```graphql
type SemanticSearchConfig {
  enabled: Boolean!
  enabledEntities: [String!]!
  embeddingConfig: EmbeddingConfig
}

type EmbeddingConfig {
  provider: String!
  modelId: String!
  modelEmbeddingKey: String!
  awsProviderConfig: AwsProviderConfig
}

type AwsProviderConfig {
  region: String!
}
```

### Key Design Decisions

**1. Two Identifiers: `modelId` vs `modelEmbeddingKey`**

- **`modelId`**: The actual API identifier used when calling embedding providers
- **`modelEmbeddingKey`**: The sanitized storage key used in SemanticContent aspects and Elasticsearch fields

We need both because:
- Embedding APIs require specific model identifiers (e.g., `cohere.embed-english-v3`)
- Elasticsearch field names cannot contain dots (they denote nested paths)
- Server provides canonical `modelEmbeddingKey` to ensure exact match between client writes and server queries

**2. Provider-Specific Configuration Pattern**

Enables clean extensibility without breaking changes by using nested provider-specific configs instead of top-level fields.

**3. Nullable `embeddingConfig`**

Allows semantic search to be enabled but not fully configured yet, avoiding all-or-nothing API behavior.

## Client Usage

```python
# 1. Discover configuration
config = datahub_graph.get_app_config().semantic_search_config.embedding_config

# 2. Generate embeddings using modelId
embeddings = bedrock.invoke_model(
    modelId=config.model_id,
    region=config.aws_provider_config.region,
    body={"texts": [...]}
)

# 3. Store using modelEmbeddingKey
aspect = SemanticContentClass(
    embeddings={
        config.model_embedding_key: embedding_data
    }
)
datahub_graph.emit(aspect)
```

## Implementation Details

- **Schema**: `datahub-graphql-core/src/main/resources/app.semantic.graphql`
- **Resolver**: `AppConfigResolver` populates config from `SemanticSearchConfiguration`
- **Key Derivation**: `deriveModelEmbeddingKey()` provides single source of truth
- **Tests**: Full coverage including key derivation validation

## Testing

**Test Results:**
- ✅ 1,327 tests passing in datahub-graphql-core
- ✅ 20 tests in AppConfigResolverTest (including 3 new semantic search tests)
- ✅ All integration tests passing

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [x] Code follows existing patterns
- [x] All tests passing