### PR TITLE
fix(ui/search/filters): Fix tooltip on more filters dropdown

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/MoreFilterOption.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/MoreFilterOption.tsx
@@ -1,5 +1,4 @@
 import { RightOutlined } from '@ant-design/icons';
-import { Tooltip } from '@components';
 import { Typography } from 'antd';
 import React, { useRef } from 'react';
 import styled from 'styled-components';


### PR DESCRIPTION
Outer tooltip wrapper was redundant and breaking styling. Uses inner tooltip only, but with appropriate styling

Before:
<img width="403" height="824" alt="Screenshot 2026-01-23 at 12 45 21 PM" src="https://github.com/user-attachments/assets/5f138177-8bfa-42d9-a24b-e9bd7be8d4bf" />

After:
<img width="648" height="571" alt="Screenshot 2026-01-23 at 1 12 29 PM" src="https://github.com/user-attachments/assets/992020e3-3ae2-4b19-9b5d-9ed7c4f46f2f" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
