### PR TITLE
feat(ingestion): make SQL parse cache size configurable via env var

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/env_vars.py
+++ b/metadata-ingestion/src/datahub/configuration/env_vars.py
@@ -179,6 +179,11 @@ def get_sql_agg_query_log() -> str:
     return os.getenv("DATAHUB_SQL_AGG_QUERY_LOG", "DISABLED")
 
 
+def get_sql_parse_cache_size() -> int:
+    """SQL parse result cache size (number of entries)."""
+    return int(os.getenv("DATAHUB_SQL_PARSE_CACHE_SIZE", "1000"))
+
+
 def get_dataset_urn_to_lower() -> str:
     """Convert dataset URNs to lowercase."""
     return os.getenv("DATAHUB_DATASET_URN_TO_LOWER", "false")

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_lineage.py
@@ -31,6 +31,7 @@ import sqlglot.optimizer.unnest_subqueries
 from pydantic import field_serializer, field_validator
 
 from datahub.cli.env_utils import get_boolean_env_variable
+from datahub.configuration.env_vars import get_sql_parse_cache_size
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import (
     ArrayTypeClass,
@@ -176,7 +177,7 @@ def _table_name_from_sqlglot_table(
 
 Urn = str
 
-SQL_PARSE_RESULT_CACHE_SIZE = 1000
+SQL_PARSE_RESULT_CACHE_SIZE = get_sql_parse_cache_size()
 SQL_LINEAGE_TIMEOUT_ENABLED = get_boolean_env_variable(
     "SQL_LINEAGE_TIMEOUT_ENABLED", True
 )

--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_utils.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_utils.py
@@ -9,15 +9,15 @@ import sqlglot
 import sqlglot.errors
 import sqlglot.optimizer.eliminate_ctes
 
+from datahub.configuration.env_vars import get_sql_parse_cache_size
 from datahub.sql_parsing.fingerprint_utils import generate_hash
 
 assert SQLGLOT_PATCHED
 
 logger = logging.getLogger(__name__)
 DialectOrStr = Union[sqlglot.Dialect, str]
-SQL_PARSE_CACHE_SIZE = 1000
-
-FORMAT_QUERY_CACHE_SIZE = 1000
+SQL_PARSE_CACHE_SIZE = get_sql_parse_cache_size()
+FORMAT_QUERY_CACHE_SIZE = get_sql_parse_cache_size()
 
 
 def _get_dialect_str(platform: str) -> str:


### PR DESCRIPTION
Add DATAHUB_SQL_PARSE_CACHE_SIZE environment variable to allow tuning cache size based on environment constraints and workload characteristics.

- Default: 1,000 entries (as per current behaviour)
- Applied to both SQL_PARSE_CACHE_SIZE and FORMAT_QUERY_CACHE_SIZE
- Applied to both sqlglot_utils and sqlglot_lineage for consistency

Usage:
  DATAHUB_SQL_PARSE_CACHE_SIZE=50000 datahub ingest -c recipe.yml

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
