### PR TITLE
fix(ingestion): enforce boto3>=1.35.0 for S3 ListBuckets Prefix support

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -188,7 +188,8 @@ sql_common = (
 
 aws_common = {
     # AWS Python SDK
-    "boto3<2.0.0",
+    # Minimum 1.35.0 required for S3 ListBuckets Prefix parameter support (added October 2024)
+    "boto3>=1.35.0,<2.0.0",
     # Deal with a version incompatibility between botocore (used by boto3) and urllib3.
     # See https://github.com/boto/botocore/pull/2563.
     "botocore!=1.23.0",
@@ -442,7 +443,7 @@ embedding_common = {
     # LiteLLM for unified embedding API (Bedrock, Cohere, OpenAI)
     "litellm==1.80.5",
     # AWS SDK for Bedrock embedding support
-    "boto3==1.34.0",
+    *aws_common,
 }
 
 unstructured_lib = {


### PR DESCRIPTION
## Summary

This PR fixes boto3 dependency versioning issues that were breaking S3 functionality requiring the ListBuckets `Prefix` parameter (added in boto3 1.35.0, October 2024).

### Changes:
- Replace hardcoded `boto3==1.34.0` pin in `embedding_common` with `*aws_common` extension
- Add `boto3>=1.35.0` minimum version constraint to `aws_common` dependency set
- Ensures consistent boto3 versioning across all AWS-related functionality

### Fixes:
- `test_resolve_templated_buckets_wildcard_at_end`
- `test_resolve_templated_buckets_single_wildcard`

The old `boto3==1.34.0` pin (December 2023) was too old and broke S3 functionality that depends on the ListBuckets Prefix parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)