### PR TITLE
fix(fivetran): adds missing databricks-sdk dependency via databricks_common

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -406,6 +406,9 @@ slack = {
 }
 
 databricks_common = {
+    # 0.1.11 appears to have authentication issues with azure databricks
+    # 0.22.0 has support for `include_browse` in metadata list apis
+    "databricks-sdk>=0.30.0,<1.0.0",
     # Version 2.4.0 includes sqlalchemy dialect, 2.8.0 includes some bug fixes
     # Version 3.0.0 required SQLAlchemy > 2.0.21
     # TODO: When upgrading to >=3.0.0, remove proxy authentication monkey patching
@@ -415,9 +418,6 @@ databricks_common = {
 }
 
 databricks = {
-    # 0.1.11 appears to have authentication issues with azure databricks
-    # 0.22.0 has support for `include_browse` in metadata list apis
-    "databricks-sdk>=0.30.0,<1.0.0",
     "pyspark~=3.5.6,<4.0.0",
     "requests<3.0.0",
     # Due to https://github.com/databricks/databricks-sql-python/issues/326


### PR DESCRIPTION
Fixes

```
{'fivetran': 'Testing connector fivetran\n'
             'testing version [https://datahub-wheels.pages.dev/\n](https://datahub-wheels.pages.dev//n)'
             'Using CPython 3.10.19 interpreter at: '
             '/opt/hostedtoolcache/Python/3.10.19/x64/bin/python\n'
             'Creating virtual environment at: venv-fivetran\n'
             'Activate with: source venv-fivetran/bin/activate\n'
             'No cache entries found\n'
             "+ uv pip install -q 'acryl-datahub[testing-utils] @ "
             "https://datahub-wheels.pages.dev//artifacts/wheels/acryl_datahub-0.0.0.dev1-py3-none-any.whl'\n"
             'Removed 1230 files (12.4MiB)\n'
             "+ uv pip install -q 'acryl-datahub[testing-utils,fivetran] @ "
             "https://datahub-wheels.pages.dev//artifacts/wheels/acryl_datahub-0.0.0.dev1-py3-none-any.whl'\n"
             '+ venv-fivetran/bin/datahub check plugins --source fivetran\n'
             '/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/google/api_core/_python_version_support.py:275: '
             'FutureWarning: You are using a Python version (3.10.19) which '
             'Google will stop supporting in new releases of google.api_core '
             'once it reaches its end of life (2026-10-04). Please upgrade to '
             '  File "<frozen importlib._bootstrap>", line 688, in '
             '_load_unlocked\n'
             '  File "<frozen importlib._bootstrap_external>", line 883, in '
             'exec_module\n'
             '  File "<frozen importlib._bootstrap>", line 241, in '
             '_call_with_frames_removed\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/datahub/ingestion/source/fivetran/fivetran.py", '
             'line 27, in <module>\n'
             '    from datahub.ingestion.source.fivetran.config import (\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/datahub/ingestion/source/fivetran/config.py", '
             'line 32, in <module>\n'
             '    from datahub.ingestion.source.unity.connection import '
             'UnityCatalogConnectionConfig\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/datahub/ingestion/source/unity/connection.py", '
             'line 7, in <module>\n'
             '    from databricks.sdk import WorkspaceClient\n'
             "ModuleNotFoundError: No module named 'databricks.sdk'\n"
             '\n'
             'The above exception was the direct cause of the following '
             'exception:\n'
             '\n'
             'Traceback (most recent call last):\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/datahub/entrypoints.py", '
             'line 238, in main\n'
             '    sys.exit(datahub(standalone_mode=False, **kwargs))\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/click/core.py", '
             'line 1485, in __call__\n'
             '    return self.main(*args, **kwargs)\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/click/core.py", '
             'line 1406, in main\n'
             '    rv = self.invoke(ctx)\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/click/core.py", '
             'line 1873, in invoke\n'
             '    return _process_result(sub_ctx.command.invoke(sub_ctx))\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/click/core.py", '
             'line 1873, in invoke\n'
             '    return _process_result(sub_ctx.command.invoke(sub_ctx))\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/click/core.py", '
             'line 1269, in invoke\n'
             '    return ctx.invoke(self.callback, **ctx.params)\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/click/core.py", '
             'line 824, in invoke\n'
             '    return callback(*args, **kwargs)\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/datahub/telemetry/telemetry.py", '
             'line 490, in wrapper\n'
             '    raise e\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/datahub/telemetry/telemetry.py", '
             'line 438, in wrapper\n'
             '    res = func(*args, **kwargs)\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/datahub/cli/check_cli.py", '
             'line 149, in plugins\n'
             '    source_registry.get(source)\n'
             '  File '
             '"/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/datahub/ingestion/api/registry.py", '
             'line 178, in get\n'
             '    raise ConfigurationError(\n'
             'datahub.configuration.common.ConfigurationError: fivetran is '
             'disabled due to a missing dependency: databricks.sdk; try '
             "running `pip install 'acryl-datahub[fivetran]'`\n"
             'Failed-fivetran-[https://datahub-wheels.pages.dev/\n](https://datahub-wheels.pages.dev//n)'}
```

Evidence

```
Starting test for connector fivetran
Testing connector fivetran
testing version https://8981a42e.datahub-wheels.pages.dev/
Using CPython 3.10.19 interpreter at: /opt/hostedtoolcache/Python/3.10.19/x64/bin/python
Creating virtual environment at: venv-fivetran
Activate with: source venv-fivetran/bin/activate
No cache entries found
+ uv pip install -q 'acryl-datahub[testing-utils] @ https://8981a42e.datahub-wheels.pages.dev//artifacts/wheels/acryl_datahub-0.0.0.dev1-py3-none-any.whl'
Removed 1230 files (12.4MiB)
+ uv pip install -q 'acryl-datahub[testing-utils,fivetran] @ https://8981a42e.datahub-wheels.pages.dev//artifacts/wheels/acryl_datahub-0.0.0.dev1-py3-none-any.whl'
+ venv-fivetran/bin/datahub check plugins --source fivetran
/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/google/api_core/_python_version_support.py:275: FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.api_core once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.api_core past that date.
  warnings.warn(message, FutureWarning)
/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/google/api_core/_python_version_support.py:275: FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.cloud.datacatalog_v1 once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.cloud.datacatalog_v1 past that date.
  warnings.warn(message, FutureWarning)
/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/google/api_core/_python_version_support.py:275: FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.cloud.resourcemanager_v3 once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.cloud.resourcemanager_v3 past that date.
  warnings.warn(message, FutureWarning)
/home/runner/work/connector-tests/connector-tests/harness/venv-fivetran/lib/python3.10/site-packages/google/api_core/_python_version_support.py:275: FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.cloud.appengine_logging_v1 once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.cloud.appengine_logging_v1 past that date.
  warnings.warn(message, FutureWarning)
Source fivetran is enabled.
+ exit 0
Success-fivetran-https://8981a42e.datahub-wheels.pages.dev/
```