### PR TITLE
fix(cli): preserve /api/gms URL for Acryl Cloud deployments

### DIFF
--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -339,8 +339,8 @@ def _ensure_valid_gms_url_acryl_cloud(url: str) -> str:
         url = f"{url}/gms"
     elif url.endswith("acryl.io/"):
         url = f"{url}gms"
-    if url.endswith("acryl.io/api/gms"):
-        url = url.replace("acryl.io/api/gms", "acryl.io/gms")
+    # Note: Do not convert /api/gms to /gms - some Acryl Cloud deployments
+    # expose GMS at /api/gms and this conversion breaks those setups
 
     return url
 


### PR DESCRIPTION
## Summary
- Remove incorrect URL conversion that changes `/api/gms` to `/gms` for acryl.io URLs
- Some Acryl Cloud deployments expose GMS at `/api/gms` and this conversion breaks CLI connectivity
- Noticed when authenticating to carta.acryl.io

## The Problem
The `_ensure_valid_gms_url_acryl_cloud` function in `cli_utils.py` has logic that converts URLs ending with `acryl.io/api/gms` to `acryl.io/gms`:

```python
if url.endswith("acryl.io/api/gms"):
    url = url.replace("acryl.io/api/gms", "acryl.io/gms")
```

This breaks CLI connectivity for Acryl Cloud deployments where the GMS API is exposed at `/api/gms` rather than `/gms`.

## The Fix
Remove this conversion and preserve the user's configured URL. If a user explicitly configures `/api/gms`, that should be respected.

## Test plan
- Tested locally with an Acryl Cloud deployment using `/api/gms` endpoint
- Verified `datahub graphql --list-queries` works after the fix
- Verified `datahub dataset get --urn "..."` works after the fix

🤖 Generated with [Claude Code](https://claude.ai/code)