### PR TITLE
fix(ingest): hide empty Settings section in recipe form

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/RecipeForm.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/RecipeForm.tsx
@@ -214,30 +214,34 @@ function RecipeForm(props: Props) {
                         </Collapse.Panel>
                     </StyledCollapse>
                 )}
-                <StyledCollapse defaultActiveKey={defaultOpenSections?.includes(RecipeSections.Advanced) ? '2' : ''}>
-                    <Collapse.Panel
-                        forceRender
-                        header={
-                            <SectionHeader
-                                icon={<SettingOutlined />}
-                                text="Settings"
-                                sectionTooltip={advancedSectionTooltip}
-                            />
-                        }
-                        key="2"
+                {advancedFields.length > 0 && (
+                    <StyledCollapse
+                        defaultActiveKey={defaultOpenSections?.includes(RecipeSections.Advanced) ? '2' : ''}
                     >
-                        {advancedFields.map((field, i) => (
-                            <FormField
-                                key={field.name}
-                                field={field}
-                                secrets={secrets}
-                                refetchSecrets={refetchSecrets}
-                                removeMargin={i === advancedFields.length - 1}
-                                updateFormValue={updateFormValue}
-                            />
-                        ))}
-                    </Collapse.Panel>
-                </StyledCollapse>
+                        <Collapse.Panel
+                            forceRender
+                            header={
+                                <SectionHeader
+                                    icon={<SettingOutlined />}
+                                    text="Settings"
+                                    sectionTooltip={advancedSectionTooltip}
+                                />
+                            }
+                            key="2"
+                        >
+                            {advancedFields.map((field, i) => (
+                                <FormField
+                                    key={field.name}
+                                    field={field}
+                                    secrets={secrets}
+                                    refetchSecrets={refetchSecrets}
+                                    removeMargin={i === advancedFields.length - 1}
+                                    updateFormValue={updateFormValue}
+                                />
+                            ))}
+                        </Collapse.Panel>
+                    </StyledCollapse>
+                )}
             </RequiredFieldForm>
             <ControlsContainer>
                 <Button variant="outline" color="gray" disabled={isEditing} onClick={goToPrevious}>

--- a/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/RecipeForm.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/RecipeForm/RecipeForm.tsx
@@ -221,30 +221,32 @@ function RecipeForm({
                     </Collapse.Panel>
                 </StyledCollapse>
             )}
-            <StyledCollapse defaultActiveKey={defaultOpenSections?.includes(RecipeSections.Advanced) ? '2' : ''}>
-                <Collapse.Panel
-                    forceRender
-                    header={
-                        <SectionHeader
-                            icon={<SettingOutlined />}
-                            text="Settings"
-                            sectionTooltip={advancedSectionTooltip}
-                        />
-                    }
-                    key="2"
-                >
-                    {advancedFields.map((field, i) => (
-                        <FormField
-                            key={field.name}
-                            field={field}
-                            secrets={secrets}
-                            refetchSecrets={refetchSecrets}
-                            removeMargin={i === advancedFields.length - 1}
-                            updateFormValue={updateFormValue}
-                        />
-                    ))}
-                </Collapse.Panel>
-            </StyledCollapse>
+            {advancedFields.length > 0 && (
+                <StyledCollapse defaultActiveKey={defaultOpenSections?.includes(RecipeSections.Advanced) ? '2' : ''}>
+                    <Collapse.Panel
+                        forceRender
+                        header={
+                            <SectionHeader
+                                icon={<SettingOutlined />}
+                                text="Settings"
+                                sectionTooltip={advancedSectionTooltip}
+                            />
+                        }
+                        key="2"
+                    >
+                        {advancedFields.map((field, i) => (
+                            <FormField
+                                key={field.name}
+                                field={field}
+                                secrets={secrets}
+                                refetchSecrets={refetchSecrets}
+                                removeMargin={i === advancedFields.length - 1}
+                                updateFormValue={updateFormValue}
+                            />
+                        ))}
+                    </Collapse.Panel>
+                </StyledCollapse>
+            )}
             <ControlsContainer>
                 <Button variant="outline" color="gray" disabled={isEditing} onClick={goToPrevious}>
                     Previous


### PR DESCRIPTION
Sources like Notion that have no advanced fields were showing a blank Settings section in the OLD ingestion UI. This wraps the Settings collapse panel with a conditional check so it only renders when advancedFields is non-empty.


Before:
<img width="1840" height="1196" alt="Screenshot 2026-01-27 at 11 49 43 AM" src="https://github.com/user-attachments/assets/42c0a105-ba3f-4fdb-9316-830b8a23f945" />
After: 
<img width="1796" height="1152" alt="Screenshot 2026-01-27 at 11 49 38 AM" src="https://github.com/user-attachments/assets/8e852e8f-eea0-45c6-a57a-15bbbdc18868" />

[

](url)
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
