### PR TITLE
CAT-1292: allow configuration of reset password expiration

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -176,6 +176,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "authentication.enforceExistenceEnabled",
           "authentication.excludedPaths",
           "authentication.logAuthenticatorExceptions",
+          "authentication.passwordResetTokenExpirationMs",
           "authentication.sessionTokenDurationMs",
           "authentication.tokenService.issuer",
           "authentication.tokenService.signingAlgorithm",

--- a/metadata-service/auth-config/src/main/java/com/datahub/authentication/AuthenticationConfiguration.java
+++ b/metadata-service/auth-config/src/main/java/com/datahub/authentication/AuthenticationConfiguration.java
@@ -30,5 +30,8 @@ public class AuthenticationConfiguration {
   /** The lifespan of a UI session token. */
   private long sessionTokenDurationMs;
 
+  /** The lifespan of a password reset token in milliseconds. Defaults to 24 hours. */
+  private long passwordResetTokenExpirationMs;
+
   private TokenServiceConfiguration tokenService;
 }

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/user/NativeUserService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/user/NativeUserService.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class NativeUserService {
-  private static final long ONE_DAY_MILLIS = TimeUnit.DAYS.toMillis(1);
+  private static final long DEFAULT_PASSWORD_RESET_TOKEN_EXPIRATION_MS = TimeUnit.DAYS.toMillis(1);
 
   private final EntityService<?> _entityService;
   private final EntityClient _entityClient;
@@ -151,7 +151,11 @@ public class NativeUserService {
     String passwordResetToken = _secretService.generateUrlSafeToken(PASSWORD_RESET_TOKEN_LENGTH);
     corpUserCredentials.setPasswordResetToken(_secretService.encrypt(passwordResetToken));
 
-    long expirationTime = Instant.now().plusMillis(ONE_DAY_MILLIS).toEpochMilli();
+    long tokenExpirationMs = _authConfig.getPasswordResetTokenExpirationMs();
+    if (tokenExpirationMs <= 0) {
+      tokenExpirationMs = DEFAULT_PASSWORD_RESET_TOKEN_EXPIRATION_MS;
+    }
+    long expirationTime = Instant.now().plusMillis(tokenExpirationMs).toEpochMilli();
     corpUserCredentials.setPasswordResetTokenExpirationTimeMillis(expirationTime);
 
     // Ingest CorpUserCredentials MCP

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -75,6 +75,9 @@ authentication:
   # The max duration of a UI session in milliseconds. Defaults to 1 day.
   sessionTokenDurationMs: ${SESSION_TOKEN_DURATION_MS:86400000}
 
+  # The max duration of a password reset token in milliseconds. Defaults to 1 day.
+  passwordResetTokenExpirationMs: ${PASSWORD_RESET_TOKEN_EXPIRATION_MS:86400000}
+
 # Authorization-related configurations.
 authorization:
   # Configurations for the default DataHub policies-based authorizer.


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
In absence of "Forgot password" flows, we would like to be able to configure expiration of reset password tokens.