### PR TITLE
fix(read_documents): use correct graphql operation

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/read_documents.gql
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/read_documents.gql
@@ -1,7 +1,7 @@
 # GraphQL query for fetching document content by URNs
 # Used by grep_documents to search within document content
 
-query readDocuments($urns: [String!]!) {
+query documentContent($urns: [String!]!) {
   entities(urns: $urns) {
     urn
     ... on Document {


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

use correct gql for read documents tool. Graphql requires the correct operation from the query i order to work. 