### PR TITLE
tests(cypress): add lineage filtering tests

### DIFF
--- a/datahub-web-react/src/app/lineageV2/LineageFilterNode/LineageFilterNodeBasic.tsx
+++ b/datahub-web-react/src/app/lineageV2/LineageFilterNode/LineageFilterNodeBasic.tsx
@@ -104,7 +104,7 @@ export default function LineageFilterNode(props: NodeProps<LineageFilter>) {
             <CustomHandle type="target" position={Position.Left} isConnectable={false} />
             <CustomHandle type="source" position={Position.Right} isConnectable={false} />
             <TitleWrapper>
-                <Title>
+                <Title data-testid="title">
                     <TitleCount>{Math.min(numerator, denominator)}</TitleCount> of{' '}
                     <TitleCount>
                         {denominator}
@@ -135,11 +135,11 @@ interface EntryProps<T> {
 }
 
 function PlatformEntry({ agg, index }: EntryProps<PlatformAggregate>) {
-    return LineageFilterEntry(PLATFORM_FILTER_NAME, agg, index);
+    return LineageFilterEntry(PLATFORM_FILTER_NAME, agg, index, 'platform');
 }
 
 function SubtypeEntry({ agg, index }: EntryProps<SubtypeAggregate>) {
-    return LineageFilterEntry(ENTITY_SUB_TYPE_FILTER_NAME, agg, index);
+    return LineageFilterEntry(ENTITY_SUB_TYPE_FILTER_NAME, agg, index, 'subtype');
 }
 
 const EntryWrapper = styled.span<{ includeBefore: boolean }>`
@@ -162,6 +162,7 @@ function LineageFilterEntry(
     filterName: string,
     [filterValue, count, entity]: PlatformAggregate | SubtypeAggregate,
     index: number,
+    dataTestIdPrefix: string,
 ) {
     const entityRegistry = useEntityRegistryV2();
     const { icon, label } = getFilterIconAndLabel(filterName, filterValue, entityRegistry, entity || null, 12);
@@ -169,7 +170,7 @@ function LineageFilterEntry(
     return (
         <EntryWrapper title={label} includeBefore={index > 0}>
             {icon}
-            <CountWrapper>{count}</CountWrapper>
+            <CountWrapper data-testid={`filter-counter-${dataTestIdPrefix}-${label}`}>{count}</CountWrapper>
         </EntryWrapper>
     );
 }

--- a/datahub-web-react/src/app/lineageV2/LineageFilterNode/LineageFilterSearch.tsx
+++ b/datahub-web-react/src/app/lineageV2/LineageFilterNode/LineageFilterSearch.tsx
@@ -109,10 +109,11 @@ export default function LineageFilterSearch({ data, numMatches, setNumMatches }:
                     errorOnHover
                     value={inputValue}
                     setValue={setInputValue}
+                    inputTestId="search-input"
                 />
                 <LoadingWrapper>{loading && <Spin indicator={<LoadingOutlined />} />}</LoadingWrapper>
             </SearchLine>
-            <SearchMatchesText type="div" size="xs" color="gray">
+            <SearchMatchesText type="div" size="xs" color="gray" data-testid="matches">
                 {searchQuery.length >= 3 && (!loading || !!numMatches) && `${numMatches} matches`}
             </SearchMatchesText>
         </>

--- a/datahub-web-react/src/app/lineageV2/LineageFilterNode/ShowMoreButton.tsx
+++ b/datahub-web-react/src/app/lineageV2/LineageFilterNode/ShowMoreButton.tsx
@@ -99,6 +99,7 @@ export function ShowMoreButton({ data, numMatches }: Props) {
                 <Button
                     key="show-more"
                     onClick={() => setPagination(Math.min(limit + LINEAGE_FILTER_PAGINATION, maximum))}
+                    data-testid="show-more"
                 >
                     <Text>{limit + LINEAGE_FILTER_PAGINATION >= maximum ? 'Show All' : 'Show More'}</Text>
                     <KeyboardDoubleArrowDownIcon fontSize="inherit" />
@@ -110,6 +111,7 @@ export function ShowMoreButton({ data, numMatches }: Props) {
                 <Button
                     key="show-less"
                     onClick={() => setPagination(Math.min(maximum, limit) - LINEAGE_FILTER_PAGINATION)}
+                    data-testid="show-less"
                 >
                     <Text>Show Less</Text>
                     <KeyboardDoubleArrowDownIcon fontSize="inherit" />
@@ -118,7 +120,7 @@ export function ShowMoreButton({ data, numMatches }: Props) {
         }
         if (limit + LINEAGE_FILTER_PAGINATION < maximum && limit + MAX_INCREASE >= maximum) {
             list.push(
-                <Button key="show-all" onClick={() => setPagination(maximum)}>
+                <Button key="show-all" onClick={() => setPagination(maximum)} data-testid="show-all">
                     <Text>Show All</Text>
                     <KeyboardDoubleArrowDownIcon fontSize="inherit" />
                 </Button>,
@@ -126,7 +128,7 @@ export function ShowMoreButton({ data, numMatches }: Props) {
         }
         if (limit + MAX_INCREASE < maximum) {
             list.push(
-                <Button key="show-max" onClick={() => setPagination(limit + MAX_INCREASE)}>
+                <Button key="show-max" onClick={() => setPagination(limit + MAX_INCREASE)} data-testid="show-max">
                     <Text>Show +{MAX_INCREASE}</Text>
                     <KeyboardDoubleArrowDownIcon fontSize="inherit" />
                 </Button>,
@@ -137,7 +139,7 @@ export function ShowMoreButton({ data, numMatches }: Props) {
 
     if (!buttons.length) return null;
     return (
-        <Wrapper className="show-more">
+        <Wrapper className="show-more" data-testid="show-max-wrapper">
             {buttons[0]}
             {buttons.length > 1 && <ExtraButtons>{buttons.slice(1)}</ExtraButtons>}
         </Wrapper>

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/utils.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/utils.js
@@ -75,3 +75,71 @@ export function checkIfEdgeBetweenColumnsNotExist(
     `rf__edge-${node1Urn}::${column1Name}-${node2Urn}::${column2Name}`,
   ).should("not.exist");
 }
+
+function getFilteringNode(nodeUrn, direction) {
+  const directionSign = direction === "up" ? "u" : "d";
+  return cy.getWithTestId(`rf__node-lf:${directionSign}:${nodeUrn}`);
+}
+
+export function checkFilteringNodeExist(nodeUrn, direction) {
+  getFilteringNode(nodeUrn, direction).should("exist");
+}
+
+export function showMore(nodeUrn, direction) {
+  getFilteringNode(nodeUrn, direction).within(() => {
+    cy.clickOptionWithTestId("show-more");
+  });
+}
+
+export function showAll(nodeUrn, direction) {
+  getFilteringNode(nodeUrn, direction).within(() => {
+    cy.clickOptionWithTestId("show-all");
+  });
+}
+
+export function showLess(nodeUrn, direction) {
+  getFilteringNode(nodeUrn, direction).within(() => {
+    cy.clickOptionWithTestId("show-less");
+  });
+}
+
+export function filter(nodeUrn, direction, query) {
+  getFilteringNode(nodeUrn, direction).within(() => {
+    cy.getWithTestId("search-input")
+      .clear({ force: true })
+      .type(query, { force: true });
+  });
+}
+
+export function clearFilter(nodeUrn, direction) {
+  getFilteringNode(nodeUrn, direction).within(() => {
+    cy.getWithTestId("search-input").clear({ force: true });
+  });
+}
+
+export function ensureTitleHasText(nodeUrn, direction, text) {
+  getFilteringNode(nodeUrn, direction).within(() => {
+    cy.getWithTestId("title").should("have.text", text);
+  });
+}
+
+export function checkMatches(nodeUrn, direction, matchesNumber) {
+  getFilteringNode(nodeUrn, direction).within(() => {
+    cy.getWithTestId("matches").should("have.text", `${matchesNumber} matches`);
+  });
+}
+
+export function checkCounter(
+  nodeUrn,
+  direction,
+  couterSection,
+  counterType,
+  value,
+) {
+  getFilteringNode(nodeUrn, direction).within(() => {
+    cy.getWithTestId(`filter-counter-${couterSection}-${counterType}`).should(
+      "have.text",
+      `${value}`,
+    );
+  });
+}

--- a/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_graph.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineageV2/v2_lineage_graph.js
@@ -1,16 +1,25 @@
 import { getTimestampMillisNumDaysAgo } from "../../support/commands";
 import {
+  checkCounter,
+  checkFilteringNodeExist,
   checkIfEdgeBetweenColumnsExist,
   checkIfEdgeBetweenColumnsNotExist,
   checkIfEdgeExist,
   checkIfNodeExist,
   checkIfNodeNotExist,
+  checkMatches,
+  clearFilter,
   contract,
+  ensureTitleHasText,
   expandAll,
   expandColumns,
   expandOne,
+  filter,
   hoverColumn,
   selectColumn,
+  showAll,
+  showLess,
+  showMore,
   unhoverColumn,
 } from "./utils";
 
@@ -53,6 +62,46 @@ const NODE11_DBT_URN =
   "urn:li:dataset:(urn:li:dataPlatform:dbt,cypress_lineage.node11_dbt,PROD)";
 const NODE12_DATASET_URN =
   "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage.node12_dataset,PROD)";
+const FILTERING_NODE1_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node1,PROD)";
+const FILTERING_NODE2_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node2,PROD)";
+const FILTERING_NODE3_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node3,PROD)";
+const FILTERING_NODE4_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node4,PROD)";
+const FILTERING_NODE5_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node5,PROD)";
+const FILTERING_NODE6_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node6,PROD)";
+const FILTERING_NODE7_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)";
+const FILTERING_NODE8_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node8,PROD)";
+const FILTERING_NODE9_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node9,PROD)";
+const FILTERING_NODE10_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node10,PROD)";
+const FILTERING_NODE11_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node11,PROD)";
+const FILTERING_NODE12_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node12,PROD)";
+const FILTERING_NODE13_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node13,PROD)";
+const FILTERING_NODE14_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node14,PROD)";
+const FILTERING_NODE15_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node15,PROD)";
+const FILTERING_NODE16_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node16,PROD)";
+const FILTERING_NODE17_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node17,PROD)";
+const FILTERING_NODE18_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node18,PROD)";
+const FILTERING_NODE19_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node19,PROD)";
+const FILTERING_NODE20_URN =
+  "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node20,PROD)";
 
 describe("lineage_graph", () => {
   beforeEach(() => {
@@ -342,5 +391,319 @@ describe("lineage_graph", () => {
     checkIfEdgeExist(NODE6_DATASET_URN, NODE4_DATASET_URN);
     checkIfEdgeExist(NODE4_DATASET_URN, NODE7_DATAJOB_URN);
     checkIfEdgeExist(NODE7_DATAJOB_URN, NODE8_DATASET_URN);
+  });
+
+  it("should allow to expand and filter children", () => {
+    cy.login();
+    cy.goToEntityLineageGraphV2(DATASET_ENTITY_TYPE, FILTERING_NODE7_URN);
+
+    checkIfNodeExist(FILTERING_NODE7_URN);
+
+    // Check upstream filtering node
+
+    // Initial state
+    checkFilteringNodeExist(FILTERING_NODE7_URN, "up");
+    ensureTitleHasText(FILTERING_NODE7_URN, "up", "4 of 6 shown");
+    checkCounter(FILTERING_NODE7_URN, "up", "platform", "PostgreSQL", "3");
+    checkCounter(FILTERING_NODE7_URN, "up", "platform", "Snowflake", "3");
+    checkCounter(FILTERING_NODE7_URN, "up", "subtype", "Datasets", "6");
+    checkIfNodeNotExist(FILTERING_NODE1_URN);
+    checkIfNodeNotExist(FILTERING_NODE2_URN);
+    checkIfNodeExist(FILTERING_NODE3_URN);
+    checkIfNodeExist(FILTERING_NODE4_URN);
+    checkIfNodeExist(FILTERING_NODE5_URN);
+    checkIfNodeExist(FILTERING_NODE6_URN);
+    // Show more
+    showMore(FILTERING_NODE7_URN, "up");
+    checkIfNodeExist(FILTERING_NODE1_URN);
+    checkIfNodeExist(FILTERING_NODE2_URN);
+    checkIfNodeExist(FILTERING_NODE3_URN);
+    checkIfNodeExist(FILTERING_NODE4_URN);
+    checkIfNodeExist(FILTERING_NODE5_URN);
+    checkIfNodeExist(FILTERING_NODE6_URN);
+    // Filtering (less than 3 characters)
+    filter(FILTERING_NODE7_URN, "up", "xx");
+    checkIfNodeExist(FILTERING_NODE1_URN);
+    checkIfNodeExist(FILTERING_NODE2_URN);
+    checkIfNodeExist(FILTERING_NODE3_URN);
+    checkIfNodeExist(FILTERING_NODE4_URN);
+    checkIfNodeExist(FILTERING_NODE5_URN);
+    checkIfNodeExist(FILTERING_NODE6_URN);
+    // Filtering (single node)
+    filter(FILTERING_NODE7_URN, "up", "node6");
+    ensureTitleHasText(FILTERING_NODE7_URN, "up", "1 of 6 shown");
+    checkMatches(FILTERING_NODE7_URN, "up", "1");
+    checkIfNodeNotExist(FILTERING_NODE1_URN);
+    checkIfNodeNotExist(FILTERING_NODE2_URN);
+    checkIfNodeNotExist(FILTERING_NODE3_URN);
+    checkIfNodeNotExist(FILTERING_NODE4_URN);
+    checkIfNodeNotExist(FILTERING_NODE5_URN);
+    checkIfNodeExist(FILTERING_NODE6_URN);
+    // Filtering (multiple nodes)
+    filter(FILTERING_NODE7_URN, "up", "node");
+    ensureTitleHasText(FILTERING_NODE7_URN, "up", "6 of 6 shown");
+    checkMatches(FILTERING_NODE7_URN, "up", "6");
+    checkIfNodeExist(FILTERING_NODE1_URN);
+    checkIfNodeExist(FILTERING_NODE2_URN);
+    checkIfNodeExist(FILTERING_NODE3_URN);
+    checkIfNodeExist(FILTERING_NODE4_URN);
+    checkIfNodeExist(FILTERING_NODE5_URN);
+    checkIfNodeExist(FILTERING_NODE6_URN);
+    // Filtering (no any nodes)
+    filter(FILTERING_NODE7_URN, "up", "unknown");
+    ensureTitleHasText(FILTERING_NODE7_URN, "up", "0 of 6 shown");
+    checkMatches(FILTERING_NODE7_URN, "up", "0");
+    checkIfNodeNotExist(FILTERING_NODE1_URN);
+    checkIfNodeNotExist(FILTERING_NODE2_URN);
+    checkIfNodeNotExist(FILTERING_NODE3_URN);
+    checkIfNodeNotExist(FILTERING_NODE4_URN);
+    checkIfNodeNotExist(FILTERING_NODE5_URN);
+    checkIfNodeNotExist(FILTERING_NODE6_URN);
+    // Filtering (platform)
+    filter(FILTERING_NODE7_URN, "up", "postgres");
+    ensureTitleHasText(FILTERING_NODE7_URN, "up", "3 of 6 shown");
+    checkMatches(FILTERING_NODE7_URN, "up", "3");
+    checkIfNodeExist(FILTERING_NODE1_URN);
+    checkIfNodeExist(FILTERING_NODE2_URN);
+    checkIfNodeExist(FILTERING_NODE3_URN);
+    checkIfNodeNotExist(FILTERING_NODE4_URN);
+    checkIfNodeNotExist(FILTERING_NODE5_URN);
+    checkIfNodeNotExist(FILTERING_NODE6_URN);
+    filter(FILTERING_NODE7_URN, "up", "snowflake");
+    ensureTitleHasText(FILTERING_NODE7_URN, "up", "3 of 6 shown");
+    checkMatches(FILTERING_NODE7_URN, "up", "3");
+    checkIfNodeNotExist(FILTERING_NODE1_URN);
+    checkIfNodeNotExist(FILTERING_NODE2_URN);
+    checkIfNodeNotExist(FILTERING_NODE3_URN);
+    checkIfNodeExist(FILTERING_NODE4_URN);
+    checkIfNodeExist(FILTERING_NODE5_URN);
+    checkIfNodeExist(FILTERING_NODE6_URN);
+
+    // Check donwsteam filtering node
+
+    // Initial state
+    checkFilteringNodeExist(FILTERING_NODE7_URN, "down");
+    ensureTitleHasText(FILTERING_NODE7_URN, "down", "4 of 13 shown");
+    checkCounter(FILTERING_NODE7_URN, "down", "platform", "PostgreSQL", "3");
+    checkCounter(FILTERING_NODE7_URN, "down", "platform", "Snowflake", "10");
+    checkCounter(FILTERING_NODE7_URN, "down", "subtype", "Datasets", "13");
+    checkIfNodeNotExist(FILTERING_NODE8_URN);
+    checkIfNodeNotExist(FILTERING_NODE9_URN);
+    checkIfNodeNotExist(FILTERING_NODE10_URN);
+    checkIfNodeNotExist(FILTERING_NODE11_URN);
+    checkIfNodeNotExist(FILTERING_NODE12_URN);
+    checkIfNodeNotExist(FILTERING_NODE13_URN);
+    checkIfNodeNotExist(FILTERING_NODE14_URN);
+    checkIfNodeNotExist(FILTERING_NODE15_URN);
+    checkIfNodeNotExist(FILTERING_NODE16_URN);
+    checkIfNodeExist(FILTERING_NODE17_URN);
+    checkIfNodeExist(FILTERING_NODE18_URN);
+    checkIfNodeExist(FILTERING_NODE19_URN);
+    checkIfNodeExist(FILTERING_NODE20_URN);
+    // Show more
+    showMore(FILTERING_NODE7_URN, "down");
+    checkIfNodeNotExist(FILTERING_NODE8_URN);
+    checkIfNodeNotExist(FILTERING_NODE9_URN);
+    checkIfNodeNotExist(FILTERING_NODE10_URN);
+    checkIfNodeNotExist(FILTERING_NODE11_URN);
+    checkIfNodeNotExist(FILTERING_NODE12_URN);
+    checkIfNodeExist(FILTERING_NODE13_URN);
+    checkIfNodeExist(FILTERING_NODE14_URN);
+    checkIfNodeExist(FILTERING_NODE15_URN);
+    checkIfNodeExist(FILTERING_NODE16_URN);
+    checkIfNodeExist(FILTERING_NODE17_URN);
+    checkIfNodeExist(FILTERING_NODE18_URN);
+    checkIfNodeExist(FILTERING_NODE19_URN);
+    checkIfNodeExist(FILTERING_NODE20_URN);
+    // Show less
+    showLess(FILTERING_NODE7_URN, "down");
+    checkIfNodeNotExist(FILTERING_NODE8_URN);
+    checkIfNodeNotExist(FILTERING_NODE9_URN);
+    checkIfNodeNotExist(FILTERING_NODE10_URN);
+    checkIfNodeNotExist(FILTERING_NODE11_URN);
+    checkIfNodeNotExist(FILTERING_NODE12_URN);
+    checkIfNodeNotExist(FILTERING_NODE13_URN);
+    checkIfNodeNotExist(FILTERING_NODE14_URN);
+    checkIfNodeNotExist(FILTERING_NODE15_URN);
+    checkIfNodeNotExist(FILTERING_NODE16_URN);
+    checkIfNodeExist(FILTERING_NODE17_URN);
+    checkIfNodeExist(FILTERING_NODE18_URN);
+    checkIfNodeExist(FILTERING_NODE19_URN);
+    checkIfNodeExist(FILTERING_NODE20_URN);
+    // Show all
+    showAll(FILTERING_NODE7_URN, "down");
+    checkIfNodeExist(FILTERING_NODE8_URN);
+    checkIfNodeExist(FILTERING_NODE9_URN);
+    checkIfNodeExist(FILTERING_NODE10_URN);
+    checkIfNodeExist(FILTERING_NODE11_URN);
+    checkIfNodeExist(FILTERING_NODE12_URN);
+    checkIfNodeExist(FILTERING_NODE13_URN);
+    checkIfNodeExist(FILTERING_NODE14_URN);
+    checkIfNodeExist(FILTERING_NODE15_URN);
+    checkIfNodeExist(FILTERING_NODE16_URN);
+    checkIfNodeExist(FILTERING_NODE17_URN);
+    checkIfNodeExist(FILTERING_NODE18_URN);
+    checkIfNodeExist(FILTERING_NODE19_URN);
+    checkIfNodeExist(FILTERING_NODE20_URN);
+    // Filtering (less than 3 characters)
+    filter(FILTERING_NODE7_URN, "up", "xx");
+    checkIfNodeExist(FILTERING_NODE8_URN);
+    checkIfNodeExist(FILTERING_NODE9_URN);
+    checkIfNodeExist(FILTERING_NODE10_URN);
+    checkIfNodeExist(FILTERING_NODE11_URN);
+    checkIfNodeExist(FILTERING_NODE12_URN);
+    checkIfNodeExist(FILTERING_NODE13_URN);
+    checkIfNodeExist(FILTERING_NODE14_URN);
+    checkIfNodeExist(FILTERING_NODE15_URN);
+    checkIfNodeExist(FILTERING_NODE16_URN);
+    checkIfNodeExist(FILTERING_NODE17_URN);
+    checkIfNodeExist(FILTERING_NODE18_URN);
+    checkIfNodeExist(FILTERING_NODE19_URN);
+    checkIfNodeExist(FILTERING_NODE20_URN);
+    // Filtering (single node)
+    filter(FILTERING_NODE7_URN, "down", "node13");
+    ensureTitleHasText(FILTERING_NODE7_URN, "down", "1 of 13 shown");
+    checkMatches(FILTERING_NODE7_URN, "down", "1");
+    checkIfNodeNotExist(FILTERING_NODE8_URN);
+    checkIfNodeNotExist(FILTERING_NODE9_URN);
+    checkIfNodeNotExist(FILTERING_NODE10_URN);
+    checkIfNodeNotExist(FILTERING_NODE11_URN);
+    checkIfNodeNotExist(FILTERING_NODE12_URN);
+    checkIfNodeExist(FILTERING_NODE13_URN);
+    checkIfNodeNotExist(FILTERING_NODE14_URN);
+    checkIfNodeNotExist(FILTERING_NODE15_URN);
+    checkIfNodeNotExist(FILTERING_NODE16_URN);
+    checkIfNodeNotExist(FILTERING_NODE17_URN);
+    checkIfNodeNotExist(FILTERING_NODE18_URN);
+    checkIfNodeNotExist(FILTERING_NODE19_URN);
+    checkIfNodeNotExist(FILTERING_NODE20_URN);
+    // Filtering (multiple nodes)
+    filter(FILTERING_NODE7_URN, "down", "node");
+    ensureTitleHasText(FILTERING_NODE7_URN, "down", "13 of 13 shown");
+    checkMatches(FILTERING_NODE7_URN, "downup", "13");
+    checkIfNodeExist(FILTERING_NODE8_URN);
+    checkIfNodeExist(FILTERING_NODE9_URN);
+    checkIfNodeExist(FILTERING_NODE10_URN);
+    checkIfNodeExist(FILTERING_NODE11_URN);
+    checkIfNodeExist(FILTERING_NODE12_URN);
+    checkIfNodeExist(FILTERING_NODE13_URN);
+    checkIfNodeExist(FILTERING_NODE14_URN);
+    checkIfNodeExist(FILTERING_NODE15_URN);
+    checkIfNodeExist(FILTERING_NODE16_URN);
+    checkIfNodeExist(FILTERING_NODE17_URN);
+    checkIfNodeExist(FILTERING_NODE18_URN);
+    checkIfNodeExist(FILTERING_NODE19_URN);
+    checkIfNodeExist(FILTERING_NODE20_URN);
+    // Filtering (no any nodes)
+    filter(FILTERING_NODE7_URN, "down", "unknown");
+    ensureTitleHasText(FILTERING_NODE7_URN, "down", "0 of 13 shown");
+    checkMatches(FILTERING_NODE7_URN, "down", "0");
+    checkIfNodeNotExist(FILTERING_NODE8_URN);
+    checkIfNodeNotExist(FILTERING_NODE9_URN);
+    checkIfNodeNotExist(FILTERING_NODE10_URN);
+    checkIfNodeNotExist(FILTERING_NODE11_URN);
+    checkIfNodeNotExist(FILTERING_NODE12_URN);
+    checkIfNodeNotExist(FILTERING_NODE13_URN);
+    checkIfNodeNotExist(FILTERING_NODE14_URN);
+    checkIfNodeNotExist(FILTERING_NODE15_URN);
+    checkIfNodeNotExist(FILTERING_NODE16_URN);
+    checkIfNodeNotExist(FILTERING_NODE17_URN);
+    checkIfNodeNotExist(FILTERING_NODE18_URN);
+    checkIfNodeNotExist(FILTERING_NODE19_URN);
+    checkIfNodeNotExist(FILTERING_NODE20_URN);
+    // Filtering (platform)
+    filter(FILTERING_NODE7_URN, "down", "postgres");
+    ensureTitleHasText(FILTERING_NODE7_URN, "down", "3 of 13 shown");
+    checkMatches(FILTERING_NODE7_URN, "down", "3");
+    checkIfNodeExist(FILTERING_NODE8_URN);
+    checkIfNodeExist(FILTERING_NODE9_URN);
+    checkIfNodeExist(FILTERING_NODE10_URN);
+    checkIfNodeNotExist(FILTERING_NODE11_URN);
+    checkIfNodeNotExist(FILTERING_NODE12_URN);
+    checkIfNodeNotExist(FILTERING_NODE13_URN);
+    checkIfNodeNotExist(FILTERING_NODE14_URN);
+    checkIfNodeNotExist(FILTERING_NODE15_URN);
+    checkIfNodeNotExist(FILTERING_NODE16_URN);
+    checkIfNodeNotExist(FILTERING_NODE17_URN);
+    checkIfNodeNotExist(FILTERING_NODE18_URN);
+    checkIfNodeNotExist(FILTERING_NODE19_URN);
+    checkIfNodeNotExist(FILTERING_NODE20_URN);
+    filter(FILTERING_NODE7_URN, "down", "snowflake");
+    ensureTitleHasText(FILTERING_NODE7_URN, "down", "10 of 13 shown");
+    checkMatches(FILTERING_NODE7_URN, "down", "10");
+    checkIfNodeNotExist(FILTERING_NODE8_URN);
+    checkIfNodeNotExist(FILTERING_NODE9_URN);
+    checkIfNodeNotExist(FILTERING_NODE10_URN);
+    checkIfNodeExist(FILTERING_NODE11_URN);
+    checkIfNodeExist(FILTERING_NODE12_URN);
+    checkIfNodeExist(FILTERING_NODE13_URN);
+    checkIfNodeExist(FILTERING_NODE14_URN);
+    checkIfNodeExist(FILTERING_NODE15_URN);
+    checkIfNodeExist(FILTERING_NODE16_URN);
+    checkIfNodeExist(FILTERING_NODE17_URN);
+    checkIfNodeExist(FILTERING_NODE18_URN);
+    checkIfNodeExist(FILTERING_NODE19_URN);
+    checkIfNodeExist(FILTERING_NODE20_URN);
+
+    cy.goToEntityLineageGraphV2(DATASET_ENTITY_TYPE, FILTERING_NODE1_URN);
+    checkIfNodeExist(FILTERING_NODE1_URN);
+    checkIfNodeExist(FILTERING_NODE7_URN);
+    checkIfEdgeExist(FILTERING_NODE1_URN, FILTERING_NODE7_URN);
+    expandOne(FILTERING_NODE7_URN);
+    checkFilteringNodeExist(FILTERING_NODE7_URN, "down");
+    ensureTitleHasText(FILTERING_NODE7_URN, "down", "4 of 13 shown");
+    checkCounter(FILTERING_NODE7_URN, "down", "platform", "PostgreSQL", "3");
+    checkCounter(FILTERING_NODE7_URN, "down", "platform", "Snowflake", "10");
+    checkCounter(FILTERING_NODE7_URN, "down", "subtype", "Datasets", "13");
+    checkIfNodeNotExist(FILTERING_NODE8_URN);
+    checkIfNodeNotExist(FILTERING_NODE9_URN);
+    checkIfNodeNotExist(FILTERING_NODE10_URN);
+    checkIfNodeNotExist(FILTERING_NODE11_URN);
+    checkIfNodeNotExist(FILTERING_NODE12_URN);
+    checkIfNodeNotExist(FILTERING_NODE13_URN);
+    checkIfNodeNotExist(FILTERING_NODE14_URN);
+    checkIfNodeNotExist(FILTERING_NODE15_URN);
+    checkIfNodeNotExist(FILTERING_NODE16_URN);
+    checkIfNodeExist(FILTERING_NODE17_URN);
+    checkIfNodeExist(FILTERING_NODE18_URN);
+    checkIfNodeExist(FILTERING_NODE19_URN);
+    checkIfNodeExist(FILTERING_NODE20_URN);
+    // Filtering (no any nodes but filtering node should exist)
+    filter(FILTERING_NODE7_URN, "down", "unknown");
+    ensureTitleHasText(FILTERING_NODE7_URN, "down", "0 of 13 shown");
+    checkMatches(FILTERING_NODE7_URN, "down", "0");
+    checkIfNodeNotExist(FILTERING_NODE8_URN);
+    checkIfNodeNotExist(FILTERING_NODE9_URN);
+    checkIfNodeNotExist(FILTERING_NODE10_URN);
+    checkIfNodeNotExist(FILTERING_NODE11_URN);
+    checkIfNodeNotExist(FILTERING_NODE12_URN);
+    checkIfNodeNotExist(FILTERING_NODE13_URN);
+    checkIfNodeNotExist(FILTERING_NODE14_URN);
+    checkIfNodeNotExist(FILTERING_NODE15_URN);
+    checkIfNodeNotExist(FILTERING_NODE16_URN);
+    checkIfNodeNotExist(FILTERING_NODE17_URN);
+    checkIfNodeNotExist(FILTERING_NODE18_URN);
+    checkIfNodeNotExist(FILTERING_NODE19_URN);
+    checkIfNodeNotExist(FILTERING_NODE20_URN);
+    // Clear filters (nodes should still be expanded)
+    clearFilter(FILTERING_NODE7_URN, "down");
+    checkFilteringNodeExist(FILTERING_NODE7_URN, "down");
+    ensureTitleHasText(FILTERING_NODE7_URN, "down", "4 of 13 shown");
+    checkCounter(FILTERING_NODE7_URN, "down", "platform", "PostgreSQL", "3");
+    checkCounter(FILTERING_NODE7_URN, "down", "platform", "Snowflake", "10");
+    checkCounter(FILTERING_NODE7_URN, "down", "subtype", "Datasets", "13");
+    checkIfNodeNotExist(FILTERING_NODE8_URN);
+    checkIfNodeNotExist(FILTERING_NODE9_URN);
+    checkIfNodeNotExist(FILTERING_NODE10_URN);
+    checkIfNodeNotExist(FILTERING_NODE11_URN);
+    checkIfNodeNotExist(FILTERING_NODE12_URN);
+    checkIfNodeNotExist(FILTERING_NODE13_URN);
+    checkIfNodeNotExist(FILTERING_NODE14_URN);
+    checkIfNodeNotExist(FILTERING_NODE15_URN);
+    checkIfNodeNotExist(FILTERING_NODE16_URN);
+    checkIfNodeExist(FILTERING_NODE17_URN);
+    checkIfNodeExist(FILTERING_NODE18_URN);
+    checkIfNodeExist(FILTERING_NODE19_URN);
+    checkIfNodeExist(FILTERING_NODE20_URN);
   });
 });

--- a/smoke-test/tests/cypress/data.json
+++ b/smoke-test/tests/cypress/data.json
@@ -3480,5 +3480,491 @@
       }
     },
     "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node1,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "cypress_lineage_filtering.node1"
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node2,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "cypress_lineage_filtering.node2"
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node3,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "cypress_lineage_filtering.node3"
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node4,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "cypress_lineage_filtering.node4"
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node5,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "cypress_lineage_filtering.node5"
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node6,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "cypress_lineage_filtering.node6"
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node1,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                },
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node2,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                },
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node3,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                },
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node4,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                },
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node5,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                },
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node6,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node8,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node9,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,cypress_lineage_filtering.node10,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node11,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node12,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node13,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node14,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node15,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node16,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node17,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node18,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node19,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node20,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.UpstreamLineage": {
+              "upstreams": [
+                {
+                  "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,cypress_lineage_filtering.node7,PROD)",
+                  "type": "TRANSFORMED",
+                  "auditStamp": {
+                    "time": 1704067400000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
   }
 ]


### PR DESCRIPTION
Linear: https://linear.app/acryl-data/issue/CAT-1315/lineage-filter-node-tests

This PR adds filtering lineage cypress tests

Depends on: https://github.com/datahub-project/datahub/pull/15998
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
