### PR TITLE
fix(ci): restore Java 8 compatibility check and fix code for Java 8

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -139,6 +139,10 @@ jobs:
           ./gradlew :datahub-frontend:build :datahub-web-react:build
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Gradle compile (jdk8) for legacy Spark
+        if: ${{  matrix.command == 'except_metadata_ingestion' && needs.setup.outputs.backend_change == 'true' }}
+        run: |
+          ./gradlew -PjavaClassVersionDefault=8 :metadata-integration:java:spark-lineage:compileJava
       - name: Gather coverage files
         run: |
           {

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/utils/AssertionUtils.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/utils/AssertionUtils.java
@@ -12,6 +12,7 @@ import com.linkedin.assertion.VolumeAssertionInfo;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -36,29 +37,34 @@ public class AssertionUtils {
    * validators and consistency checks to verify that the correct sub-property is populated.
    */
   public static final Map<AssertionType, Function<AssertionInfo, Boolean>>
-      ASSERTION_TYPE_SUB_PROPERTY_CHECKS =
-          Collections.unmodifiableMap(
-              Map.of(
-                  AssertionType.DATASET,
-                      info ->
-                          isValidSubProperty(info.hasDatasetAssertion(), info::getDatasetAssertion),
-                  AssertionType.FRESHNESS,
-                      info ->
-                          isValidSubProperty(
-                              info.hasFreshnessAssertion(), info::getFreshnessAssertion),
-                  AssertionType.VOLUME,
-                      info ->
-                          isValidSubProperty(info.hasVolumeAssertion(), info::getVolumeAssertion),
-                  AssertionType.SQL,
-                      info -> isValidSubProperty(info.hasSqlAssertion(), info::getSqlAssertion),
-                  AssertionType.FIELD,
-                      info -> isValidSubProperty(info.hasFieldAssertion(), info::getFieldAssertion),
-                  AssertionType.DATA_SCHEMA,
-                      info ->
-                          isValidSubProperty(info.hasSchemaAssertion(), info::getSchemaAssertion),
-                  AssertionType.CUSTOM,
-                      info ->
-                          isValidSubProperty(info.hasCustomAssertion(), info::getCustomAssertion)));
+      ASSERTION_TYPE_SUB_PROPERTY_CHECKS = createAssertionTypeSubPropertyChecks();
+
+  private static Map<AssertionType, Function<AssertionInfo, Boolean>>
+      createAssertionTypeSubPropertyChecks() {
+    Map<AssertionType, Function<AssertionInfo, Boolean>> map = new HashMap<>();
+    map.put(
+        AssertionType.DATASET,
+        info -> isValidSubProperty(info.hasDatasetAssertion(), info::getDatasetAssertion));
+    map.put(
+        AssertionType.FRESHNESS,
+        info -> isValidSubProperty(info.hasFreshnessAssertion(), info::getFreshnessAssertion));
+    map.put(
+        AssertionType.VOLUME,
+        info -> isValidSubProperty(info.hasVolumeAssertion(), info::getVolumeAssertion));
+    map.put(
+        AssertionType.SQL,
+        info -> isValidSubProperty(info.hasSqlAssertion(), info::getSqlAssertion));
+    map.put(
+        AssertionType.FIELD,
+        info -> isValidSubProperty(info.hasFieldAssertion(), info::getFieldAssertion));
+    map.put(
+        AssertionType.DATA_SCHEMA,
+        info -> isValidSubProperty(info.hasSchemaAssertion(), info::getSchemaAssertion));
+    map.put(
+        AssertionType.CUSTOM,
+        info -> isValidSubProperty(info.hasCustomAssertion(), info::getCustomAssertion));
+    return Collections.unmodifiableMap(map);
+  }
 
   /**
    * Check if a sub-property is valid (present and non-empty).

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/Chart.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/Chart.java
@@ -11,6 +11,8 @@ import com.linkedin.metadata.aspect.patch.builder.ChartInfoPatchBuilder;
 import datahub.client.v2.annotations.RequiresMutable;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -134,15 +136,16 @@ public class Chart extends Entity
   @Override
   @Nonnull
   public List<Class<? extends com.linkedin.data.template.RecordTemplate>> getDefaultAspects() {
-    return List.of(
-        com.linkedin.common.Ownership.class,
-        com.linkedin.common.GlobalTags.class,
-        com.linkedin.common.GlossaryTerms.class,
-        com.linkedin.domain.Domains.class,
-        com.linkedin.common.Status.class,
-        com.linkedin.common.InstitutionalMemory.class,
-        ChartInfo.class,
-        com.linkedin.chart.EditableChartProperties.class);
+    return Collections.unmodifiableList(
+        Arrays.asList(
+            com.linkedin.common.Ownership.class,
+            com.linkedin.common.GlobalTags.class,
+            com.linkedin.common.GlossaryTerms.class,
+            com.linkedin.domain.Domains.class,
+            com.linkedin.common.Status.class,
+            com.linkedin.common.InstitutionalMemory.class,
+            ChartInfo.class,
+            com.linkedin.chart.EditableChartProperties.class));
   }
 
   /**

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/Container.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/Container.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -144,15 +146,16 @@ public class Container extends Entity
   @Nonnull
   public java.util.List<Class<? extends com.linkedin.data.template.RecordTemplate>>
       getDefaultAspects() {
-    return java.util.List.of(
-        com.linkedin.common.Ownership.class,
-        com.linkedin.common.GlobalTags.class,
-        com.linkedin.common.GlossaryTerms.class,
-        com.linkedin.domain.Domains.class,
-        com.linkedin.common.Status.class,
-        com.linkedin.common.InstitutionalMemory.class,
-        ContainerProperties.class,
-        com.linkedin.container.EditableContainerProperties.class);
+    return Collections.unmodifiableList(
+        Arrays.asList(
+            com.linkedin.common.Ownership.class,
+            com.linkedin.common.GlobalTags.class,
+            com.linkedin.common.GlossaryTerms.class,
+            com.linkedin.domain.Domains.class,
+            com.linkedin.common.Status.class,
+            com.linkedin.common.InstitutionalMemory.class,
+            ContainerProperties.class,
+            com.linkedin.container.EditableContainerProperties.class));
   }
 
   /**

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/Dashboard.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/Dashboard.java
@@ -13,6 +13,8 @@ import com.linkedin.metadata.aspect.patch.builder.DashboardInfoPatchBuilder;
 import datahub.client.v2.annotations.RequiresMutable;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -132,15 +134,16 @@ public class Dashboard extends Entity
   @Override
   @Nonnull
   public List<Class<? extends com.linkedin.data.template.RecordTemplate>> getDefaultAspects() {
-    return List.of(
-        com.linkedin.common.Ownership.class,
-        com.linkedin.common.GlobalTags.class,
-        com.linkedin.common.GlossaryTerms.class,
-        com.linkedin.domain.Domains.class,
-        com.linkedin.common.Status.class,
-        com.linkedin.common.InstitutionalMemory.class,
-        DashboardInfo.class,
-        com.linkedin.dashboard.EditableDashboardProperties.class);
+    return Collections.unmodifiableList(
+        Arrays.asList(
+            com.linkedin.common.Ownership.class,
+            com.linkedin.common.GlobalTags.class,
+            com.linkedin.common.GlossaryTerms.class,
+            com.linkedin.domain.Domains.class,
+            com.linkedin.common.Status.class,
+            com.linkedin.common.InstitutionalMemory.class,
+            DashboardInfo.class,
+            com.linkedin.dashboard.EditableDashboardProperties.class));
   }
 
   @Override

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/DataFlow.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/DataFlow.java
@@ -7,6 +7,8 @@ import com.linkedin.datajob.DataFlowInfo;
 import com.linkedin.metadata.aspect.patch.builder.DataFlowInfoPatchBuilder;
 import datahub.client.v2.annotations.RequiresMutable;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
@@ -130,15 +132,16 @@ public class DataFlow extends Entity
   @Nonnull
   public java.util.List<Class<? extends com.linkedin.data.template.RecordTemplate>>
       getDefaultAspects() {
-    return java.util.List.of(
-        com.linkedin.common.Ownership.class,
-        com.linkedin.common.GlobalTags.class,
-        com.linkedin.common.GlossaryTerms.class,
-        com.linkedin.domain.Domains.class,
-        com.linkedin.common.Status.class,
-        com.linkedin.common.InstitutionalMemory.class,
-        DataFlowInfo.class,
-        com.linkedin.datajob.EditableDataFlowProperties.class);
+    return Collections.unmodifiableList(
+        Arrays.asList(
+            com.linkedin.common.Ownership.class,
+            com.linkedin.common.GlobalTags.class,
+            com.linkedin.common.GlossaryTerms.class,
+            com.linkedin.domain.Domains.class,
+            com.linkedin.common.Status.class,
+            com.linkedin.common.InstitutionalMemory.class,
+            DataFlowInfo.class,
+            com.linkedin.datajob.EditableDataFlowProperties.class));
   }
 
   /**

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/DataJob.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/DataJob.java
@@ -11,6 +11,7 @@ import com.linkedin.metadata.aspect.patch.builder.DataJobInputOutputPatchBuilder
 import datahub.client.v2.annotations.RequiresMutable;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -133,15 +134,16 @@ public class DataJob extends Entity
   @Override
   @Nonnull
   public List<Class<? extends com.linkedin.data.template.RecordTemplate>> getDefaultAspects() {
-    return List.of(
-        com.linkedin.common.Ownership.class,
-        com.linkedin.common.GlobalTags.class,
-        com.linkedin.common.GlossaryTerms.class,
-        com.linkedin.domain.Domains.class,
-        com.linkedin.common.Status.class,
-        com.linkedin.common.InstitutionalMemory.class,
-        DataJobInfo.class,
-        com.linkedin.datajob.EditableDataJobProperties.class);
+    return Collections.unmodifiableList(
+        Arrays.asList(
+            com.linkedin.common.Ownership.class,
+            com.linkedin.common.GlobalTags.class,
+            com.linkedin.common.GlossaryTerms.class,
+            com.linkedin.domain.Domains.class,
+            com.linkedin.common.Status.class,
+            com.linkedin.common.InstitutionalMemory.class,
+            DataJobInfo.class,
+            com.linkedin.datajob.EditableDataJobProperties.class));
   }
 
   @Override

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/Dataset.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/Dataset.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -154,15 +156,16 @@ public class Dataset extends Entity
   @Override
   @Nonnull
   public List<Class<? extends com.linkedin.data.template.RecordTemplate>> getDefaultAspects() {
-    return List.of(
-        com.linkedin.common.Ownership.class,
-        com.linkedin.common.GlobalTags.class,
-        com.linkedin.common.GlossaryTerms.class,
-        com.linkedin.domain.Domains.class,
-        com.linkedin.common.Status.class,
-        com.linkedin.common.InstitutionalMemory.class,
-        DatasetProperties.class,
-        EditableDatasetProperties.class);
+    return Collections.unmodifiableList(
+        Arrays.asList(
+            com.linkedin.common.Ownership.class,
+            com.linkedin.common.GlobalTags.class,
+            com.linkedin.common.GlossaryTerms.class,
+            com.linkedin.domain.Domains.class,
+            com.linkedin.common.Status.class,
+            com.linkedin.common.InstitutionalMemory.class,
+            DatasetProperties.class,
+            EditableDatasetProperties.class));
   }
 
   /**

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/HasStructuredProperties.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/HasStructuredProperties.java
@@ -2,7 +2,6 @@ package datahub.client.v2.entity;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.aspect.patch.builder.StructuredPropertiesPatchBuilder;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -73,7 +72,7 @@ public interface HasStructuredProperties<T extends Entity & HasStructuredPropert
    */
   @Nonnull
   default T setStructuredProperty(@Nonnull String propertyUrn, @Nonnull List<String> values) {
-    Urn urn = makeStructuredPropertyUrn(propertyUrn);
+    Urn urn = StructuredPropertyUrns.makeStructuredPropertyUrn(propertyUrn);
     Entity entity = (Entity) this;
 
     StructuredPropertiesPatchBuilder builder =
@@ -101,7 +100,7 @@ public interface HasStructuredProperties<T extends Entity & HasStructuredPropert
    */
   @Nonnull
   default T setStructuredProperty(@Nonnull String propertyUrn, @Nonnull Number value) {
-    Urn urn = makeStructuredPropertyUrn(propertyUrn);
+    Urn urn = StructuredPropertyUrns.makeStructuredPropertyUrn(propertyUrn);
     Entity entity = (Entity) this;
 
     StructuredPropertiesPatchBuilder builder =
@@ -138,7 +137,7 @@ public interface HasStructuredProperties<T extends Entity & HasStructuredPropert
       @Nonnull Number value1,
       @Nonnull Number value2,
       @Nonnull Number... additionalValues) {
-    Urn urn = makeStructuredPropertyUrn(propertyUrn);
+    Urn urn = StructuredPropertyUrns.makeStructuredPropertyUrn(propertyUrn);
     Entity entity = (Entity) this;
 
     StructuredPropertiesPatchBuilder builder =
@@ -173,7 +172,7 @@ public interface HasStructuredProperties<T extends Entity & HasStructuredPropert
    */
   @Nonnull
   default T removeStructuredProperty(@Nonnull String propertyUrn) {
-    Urn urn = makeStructuredPropertyUrn(propertyUrn);
+    Urn urn = StructuredPropertyUrns.makeStructuredPropertyUrn(propertyUrn);
     Entity entity = (Entity) this;
 
     StructuredPropertiesPatchBuilder builder =
@@ -185,33 +184,5 @@ public interface HasStructuredProperties<T extends Entity & HasStructuredPropert
 
     builder.removeProperty(urn);
     return (T) this;
-  }
-
-  /**
-   * Converts a property identifier (qualified name or full URN) to a proper Urn object.
-   *
-   * <p>This helper accepts flexible input formats:
-   *
-   * <ul>
-   *   <li>Qualified property name: {@code "io.acryl.dataQuality.score"} → {@code
-   *       "urn:li:structuredProperty:io.acryl.dataQuality.score"}
-   *   <li>Full URN: {@code "urn:li:structuredProperty:io.acryl.dataQuality.score"} → unchanged
-   * </ul>
-   *
-   * @param propertyUrn the property identifier (qualified name or full URN)
-   * @return the Urn object
-   * @throws IllegalArgumentException if the URN format is invalid
-   */
-  @Nonnull
-  private static Urn makeStructuredPropertyUrn(@Nonnull String propertyUrn) {
-    String fullUrn =
-        propertyUrn.startsWith("urn:li:structuredProperty:")
-            ? propertyUrn
-            : "urn:li:structuredProperty:" + propertyUrn;
-    try {
-      return Urn.createFromString(fullUrn);
-    } catch (URISyntaxException e) {
-      throw new datahub.client.v2.exceptions.InvalidUrnException(fullUrn, e);
-    }
   }
 }

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/HasTags.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/HasTags.java
@@ -315,7 +315,8 @@ public interface HasTags<T extends Entity & HasTags<T>> {
           // Extract tag URN from path (encoded in path after /tags/)
           String encodedTagUrn = path.substring("/tags/".length());
           // The tag URN is URL-encoded in the path, decode it
-          String tagUrnString = java.net.URLDecoder.decode(encodedTagUrn, StandardCharsets.UTF_8);
+          String tagUrnString =
+              java.net.URLDecoder.decode(encodedTagUrn, StandardCharsets.UTF_8.name());
 
           try {
             TagUrn tagUrn = TagUrn.createFromString(tagUrnString);

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/MLModel.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/MLModel.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,15 +158,16 @@ public class MLModel extends Entity
   @Override
   @Nonnull
   public List<Class<? extends com.linkedin.data.template.RecordTemplate>> getDefaultAspects() {
-    return List.of(
-        com.linkedin.common.Ownership.class,
-        com.linkedin.common.GlobalTags.class,
-        com.linkedin.common.GlossaryTerms.class,
-        com.linkedin.domain.Domains.class,
-        com.linkedin.common.Status.class,
-        com.linkedin.common.InstitutionalMemory.class,
-        MLModelProperties.class,
-        com.linkedin.ml.metadata.EditableMLModelProperties.class);
+    return Collections.unmodifiableList(
+        Arrays.asList(
+            com.linkedin.common.Ownership.class,
+            com.linkedin.common.GlobalTags.class,
+            com.linkedin.common.GlossaryTerms.class,
+            com.linkedin.domain.Domains.class,
+            com.linkedin.common.Status.class,
+            com.linkedin.common.InstitutionalMemory.class,
+            MLModelProperties.class,
+            com.linkedin.ml.metadata.EditableMLModelProperties.class));
   }
 
   /**

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/MLModelGroup.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/MLModelGroup.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -148,15 +150,16 @@ public class MLModelGroup extends Entity
   @Override
   @Nonnull
   public List<Class<? extends com.linkedin.data.template.RecordTemplate>> getDefaultAspects() {
-    return List.of(
-        com.linkedin.common.Ownership.class,
-        com.linkedin.common.GlobalTags.class,
-        com.linkedin.common.GlossaryTerms.class,
-        com.linkedin.domain.Domains.class,
-        com.linkedin.common.Status.class,
-        com.linkedin.common.InstitutionalMemory.class,
-        MLModelGroupProperties.class,
-        com.linkedin.ml.metadata.EditableMLModelGroupProperties.class);
+    return Collections.unmodifiableList(
+        Arrays.asList(
+            com.linkedin.common.Ownership.class,
+            com.linkedin.common.GlobalTags.class,
+            com.linkedin.common.GlossaryTerms.class,
+            com.linkedin.domain.Domains.class,
+            com.linkedin.common.Status.class,
+            com.linkedin.common.InstitutionalMemory.class,
+            MLModelGroupProperties.class,
+            com.linkedin.ml.metadata.EditableMLModelGroupProperties.class));
   }
 
   @Override

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/StructuredPropertyUrns.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/v2/entity/StructuredPropertyUrns.java
@@ -1,0 +1,27 @@
+package datahub.client.v2.entity;
+
+import com.linkedin.common.urn.Urn;
+import java.net.URISyntaxException;
+import javax.annotation.Nonnull;
+
+/**
+ * Helper for structured property URN conversion. Package-private for use by HasStructuredProperties
+ * (avoids private interface methods for Java 8 compatibility).
+ */
+final class StructuredPropertyUrns {
+
+  private StructuredPropertyUrns() {}
+
+  @Nonnull
+  static Urn makeStructuredPropertyUrn(@Nonnull String propertyUrn) {
+    String fullUrn =
+        propertyUrn.startsWith("urn:li:structuredProperty:")
+            ? propertyUrn
+            : "urn:li:structuredProperty:" + propertyUrn;
+    try {
+      return Urn.createFromString(fullUrn);
+    } catch (URISyntaxException e) {
+      throw new datahub.client.v2.exceptions.InvalidUrnException(fullUrn, e);
+    }
+  }
+}

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/ChartTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/ChartTest.java
@@ -678,4 +678,21 @@ public class ChartTest {
       assertEquals("chartInfo", patch.getAspectName());
     }
   }
+
+  @Test
+  public void testChartGetDefaultAspects() throws Exception {
+    Chart chart = Chart.builder().tool("looker").id("my_chart").build();
+
+    List<?> aspects = chart.getDefaultAspects();
+    assertNotNull(aspects);
+    assertFalse("Default aspects should not be empty", aspects.isEmpty());
+    assertTrue("Should include ChartInfo", aspects.contains(com.linkedin.chart.ChartInfo.class));
+    assertTrue("Should include Ownership", aspects.contains(com.linkedin.common.Ownership.class));
+    try {
+      ((List) aspects).add(com.linkedin.common.GlobalTags.class);
+      fail("getDefaultAspects() should return an immutable list");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
 }

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/ContainerTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/ContainerTest.java
@@ -706,4 +706,24 @@ public class ContainerTest {
     assertNotNull(container.getCustomProperties());
     assertTrue(container.getCustomProperties().size() >= 3);
   }
+
+  @Test
+  public void testContainerGetDefaultAspects() {
+    Container container =
+        Container.builder().platform("snowflake").displayName("My Database").build();
+
+    List<?> aspects = container.getDefaultAspects();
+    assertNotNull(aspects);
+    assertFalse("Default aspects should not be empty", aspects.isEmpty());
+    assertTrue(
+        "Should include ContainerProperties",
+        aspects.contains(com.linkedin.container.ContainerProperties.class));
+    assertTrue("Should include Ownership", aspects.contains(com.linkedin.common.Ownership.class));
+    try {
+      ((List) aspects).clear();
+      fail("getDefaultAspects() should return an immutable list");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
 }

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/DashboardTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/DashboardTest.java
@@ -785,4 +785,23 @@ public class DashboardTest {
     List<MetadataChangeProposal> patches = dashboard.getPendingPatches();
     assertFalse("Should have multiple patches", patches.isEmpty());
   }
+
+  @Test
+  public void testDashboardGetDefaultAspects() throws Exception {
+    Dashboard dashboard = Dashboard.builder().tool("tableau").id("my_dashboard").build();
+
+    List<?> aspects = dashboard.getDefaultAspects();
+    assertNotNull(aspects);
+    assertFalse("Default aspects should not be empty", aspects.isEmpty());
+    assertTrue(
+        "Should include DashboardInfo",
+        aspects.contains(com.linkedin.dashboard.DashboardInfo.class));
+    assertTrue("Should include Ownership", aspects.contains(com.linkedin.common.Ownership.class));
+    try {
+      ((List) aspects).clear();
+      fail("getDefaultAspects() should return an immutable list");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
 }

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/DataFlowTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/DataFlowTest.java
@@ -490,6 +490,25 @@ public class DataFlowTest {
     assertTrue(str.contains("urn"));
   }
 
+  @Test
+  public void testDataFlowGetDefaultAspects() {
+    DataFlow dataflow =
+        DataFlow.builder().orchestrator("airflow").flowId("my_dag").cluster("prod").build();
+
+    List<?> aspects = dataflow.getDefaultAspects();
+    assertNotNull(aspects);
+    assertFalse("Default aspects should not be empty", aspects.isEmpty());
+    assertTrue(
+        "Should include DataFlowInfo", aspects.contains(com.linkedin.datajob.DataFlowInfo.class));
+    assertTrue("Should include Ownership", aspects.contains(com.linkedin.common.Ownership.class));
+    try {
+      ((List) aspects).clear();
+      fail("getDefaultAspects() should return an immutable list");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
+
   // ==================== URN Structure Tests ====================
 
   @Test

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/DataJobTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/DataJobTest.java
@@ -708,6 +708,29 @@ public class DataJobTest {
   }
 
   @Test
+  public void testDataJobGetDefaultAspects() throws Exception {
+    DataJob dataJob =
+        DataJob.builder()
+            .orchestrator("airflow")
+            .flowId("etl_pipeline")
+            .jobId("extract_task")
+            .build();
+
+    List<?> aspects = dataJob.getDefaultAspects();
+    assertNotNull(aspects);
+    assertFalse("Default aspects should not be empty", aspects.isEmpty());
+    assertTrue(
+        "Should include DataJobInfo", aspects.contains(com.linkedin.datajob.DataJobInfo.class));
+    assertTrue("Should include Ownership", aspects.contains(com.linkedin.common.Ownership.class));
+    try {
+      ((List) aspects).clear();
+      fail("getDefaultAspects() should return an immutable list");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
+
+  @Test
   public void testDataJobRemoveOwner() throws Exception {
     DataJob dataJob =
         DataJob.builder()

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/DatasetTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/DatasetTest.java
@@ -326,6 +326,25 @@ public class DatasetTest {
   }
 
   @Test
+  public void testDatasetGetDefaultAspects() {
+    Dataset dataset = Dataset.builder().platform("postgres").name("my_table").build();
+
+    List<?> aspects = dataset.getDefaultAspects();
+    assertNotNull(aspects);
+    assertFalse("Default aspects should not be empty", aspects.isEmpty());
+    assertTrue(
+        "Should include DatasetProperties",
+        aspects.contains(com.linkedin.dataset.DatasetProperties.class));
+    assertTrue("Should include Ownership", aspects.contains(com.linkedin.common.Ownership.class));
+    try {
+      ((List) aspects).add(com.linkedin.common.GlobalTags.class);
+      fail("getDefaultAspects() should return an immutable list");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
+
+  @Test
   public void testDatasetPatchVsFullAspect() {
     Dataset dataset1 =
         Dataset.builder()

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/HasTagsPatchTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/HasTagsPatchTest.java
@@ -103,6 +103,43 @@ public class HasTagsPatchTest {
   }
 
   @Test
+  public void testApplyPatchOperations_RemoveTagWithUrlEncodedPath()
+      throws IOException, URISyntaxException {
+    // Create initial GlobalTags with a tag whose URN contains characters that may be encoded
+    GlobalTags current = new GlobalTags();
+    TagAssociationArray tags = new TagAssociationArray();
+    TagAssociation tag1 = new TagAssociation();
+    tag1.setTag(TagUrn.createFromString("urn:li:tag:tag1"));
+    tags.add(tag1);
+    current.setTags(tags);
+
+    // Create patch with URL-encoded URN in path (e.g. urn:li:tag:tag1 -> urn%3Ali%3Atag%3Atag1)
+    String encodedPath = "/tags/urn%3Ali%3Atag%3Atag1";
+    String patchJson =
+        "{"
+            + "\"patch\": ["
+            + "  {"
+            + "    \"op\": \"remove\","
+            + "    \"path\": \""
+            + encodedPath
+            + "\""
+            + "  }"
+            + "]"
+            + "}";
+
+    MetadataChangeProposal patch = new MetadataChangeProposal();
+    GenericAspect aspect = new GenericAspect();
+    aspect.setValue(ByteString.copyString(patchJson, StandardCharsets.UTF_8));
+    aspect.setContentType("application/json");
+    patch.setAspect(aspect);
+
+    GlobalTags result = HasTags.applyPatchOperations(current, patch);
+
+    // Verify tag was removed after decoding path
+    assertEquals(0, result.getTags().size());
+  }
+
+  @Test
   public void testApplyPatchOperations_RemoveNonExistentTag()
       throws IOException, URISyntaxException {
     // Create initial GlobalTags with one tag

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/MLModelGroupTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/MLModelGroupTest.java
@@ -617,4 +617,24 @@ public class MLModelGroupTest {
     modelGroup.setMode(datahub.client.v2.config.DataHubClientConfigV2.OperationMode.INGESTION);
     assertTrue("Should be in ingestion mode", modelGroup.isIngestionMode());
   }
+
+  @Test
+  public void testMLModelGroupGetDefaultAspects() {
+    MLModelGroup modelGroup =
+        MLModelGroup.builder().platform("mlflow").groupId("model-group").build();
+
+    List<?> aspects = modelGroup.getDefaultAspects();
+    assertNotNull(aspects);
+    assertFalse("Default aspects should not be empty", aspects.isEmpty());
+    assertTrue(
+        "Should include MLModelGroupProperties",
+        aspects.contains(com.linkedin.ml.metadata.MLModelGroupProperties.class));
+    assertTrue("Should include Ownership", aspects.contains(com.linkedin.common.Ownership.class));
+    try {
+      ((List) aspects).clear();
+      fail("getDefaultAspects() should return an immutable list");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
 }

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/MLModelTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/v2/entity/MLModelTest.java
@@ -593,4 +593,23 @@ public class MLModelTest {
     assertTrue(prodModel.getUrn().toString().contains("PROD"));
     assertTrue(devModel.getUrn().toString().contains("DEV"));
   }
+
+  @Test
+  public void testMLModelGetDefaultAspects() {
+    MLModel model = MLModel.builder().platform("tensorflow").name("my_model").build();
+
+    List<?> aspects = model.getDefaultAspects();
+    assertNotNull(aspects);
+    assertFalse("Default aspects should not be empty", aspects.isEmpty());
+    assertTrue(
+        "Should include MLModelProperties",
+        aspects.contains(com.linkedin.ml.metadata.MLModelProperties.class));
+    assertTrue("Should include Ownership", aspects.contains(com.linkedin.common.Ownership.class));
+    try {
+      ((List) aspects).clear();
+      fail("getDefaultAspects() should return an immutable list");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
+  }
 }


### PR DESCRIPTION
- Restore 'Gradle compile (jdk8) for legacy Spark' step in build-and-test.yml
- entity-registry: replace Map.of() with Collections.unmodifiableMap(HashMap) in AssertionUtils
- datahub-client: move HasStructuredProperties private interface method to StructuredPropertyUrns helper (Java 8 has no private interface methods)
- datahub-client: use URLDecoder.decode(encodedTagUrn, charset.name()) in HasTags for Java 8
- datahub-client: replace List.of() with Collections.unmodifiableList(Arrays.asList()) in Dataset, DataFlow, Chart, Dashboard, Container, DataJob, MLModel, MLModelGroup

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
