### PR TITLE
fix(applications): add proper permissions check for application creation

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/application/ApplicationAuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/application/ApplicationAuthorizationUtils.java
@@ -33,6 +33,20 @@ public class ApplicationAuthorizationUtils {
   }
 
   /**
+   * Returns true if the current user is authorized to create any application entity. This is true
+   * if the user has the EDIT_ENTITY privilege for applications.
+   */
+  public static boolean canCreateApplications(@Nonnull QueryContext context) {
+    final DisjunctivePrivilegeGroup orPrivilegeGroups =
+        new DisjunctivePrivilegeGroup(
+            ImmutableList.of(
+                new ConjunctivePrivilegeGroup(
+                    ImmutableList.of(PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType()))));
+
+    return AuthorizationUtils.isAuthorized(context, APPLICATION_ENTITY_NAME, "", orPrivilegeGroups);
+  }
+
+  /**
    * Verifies that the current user is authorized to edit applications on a specific resource
    * entity.
    *

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/application/CreateApplicationResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/application/CreateApplicationResolver.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.application;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 
-import com.datahub.authorization.AuthUtil;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -14,7 +13,6 @@ import com.linkedin.datahub.graphql.generated.OwnerEntityType;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.datahub.graphql.types.application.mappers.ApplicationMapper;
 import com.linkedin.entity.EntityResponse;
-import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.service.ApplicationService;
 import graphql.schema.DataFetcher;
@@ -40,8 +38,7 @@ public class CreateApplicationResolver implements DataFetcher<CompletableFuture<
 
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
-          if (!AuthUtil.isAuthorized(
-              context.getOperationContext(), PoliciesConfig.EDIT_ENTITY_PRIVILEGE)) {
+          if (!ApplicationAuthorizationUtils.canCreateApplications(context)) {
             throw new AuthorizationException(
                 "Unauthorized to perform this action. Please contact your DataHub administrator.");
           }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/CreateApplicationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/CreateApplicationResolverTest.java
@@ -121,4 +121,32 @@ public class CreateApplicationResolverTest {
     Mockito.verify(mockApplicationService, Mockito.never())
         .createApplication(any(), any(), any(), any());
   }
+
+  @Test
+  public void testCanCreateApplicationWhenAuthorized() throws Exception {
+    CreateApplicationPropertiesInput propertiesInput =
+        CreateApplicationPropertiesInput.builder()
+            .setName(TEST_APP_NAME)
+            .setDescription(TEST_APP_DESCRIPTION)
+            .build();
+    CreateApplicationInput input =
+        CreateApplicationInput.builder().setId(TEST_APP_ID).setProperties(propertiesInput).build();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+
+    // Mock the ApplicationService call
+    Mockito.when(
+            mockApplicationService.createApplication(
+                any(), eq(TEST_APP_ID), eq(TEST_APP_NAME), eq(TEST_APP_DESCRIPTION)))
+        .thenReturn(TEST_APP_URN);
+
+    Mockito.when(mockApplicationService.getApplicationEntityResponse(any(), eq(TEST_APP_URN)))
+        .thenReturn(null);
+
+    // Execute - should succeed because setupTest() uses getMockAllowContext
+    resolver.get(mockEnv).get();
+
+    // Verify the application was created
+    Mockito.verify(mockApplicationService, Mockito.times(1))
+        .createApplication(any(), eq(TEST_APP_ID), eq(TEST_APP_NAME), eq(TEST_APP_DESCRIPTION));
+  }
 }


### PR DESCRIPTION
There is a bug where we look at a generic `EDIT_ENTITY` privilege in order to create Application entities. This doesn't work as it needs to look at Applications specifically.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
