### PR TITLE
fix: Add retry logic when constructing kafka producer (#86)

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfig.java
@@ -1,5 +1,7 @@
 package com.linkedin.datahub.upgrade.config;
 
+import static com.linkedin.gms.factory.kafka.DataHubKafkaProducerFactory.createProducerWithRetry;
+
 import com.linkedin.datahub.graphql.featureflags.FeatureFlags;
 import com.linkedin.datahub.upgrade.conditions.SystemUpdateCondition;
 import com.linkedin.datahub.upgrade.system.BlockingSystemUpgrade;
@@ -45,7 +47,6 @@ import javax.annotation.Nonnull;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.IndexedRecord;
-import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -164,9 +165,10 @@ public class SystemUpdateConfig {
       MetricUtils metricUtils) {
     KafkaConfiguration kafkaConfiguration = provider.getKafka();
     Producer<String, IndexedRecord> producer =
-        new KafkaProducer<>(
+        createProducerWithRetry(
             DataHubKafkaProducerFactory.buildProducerProperties(
-                duheSchemaRegistryConfig, kafkaConfiguration, properties));
+                duheSchemaRegistryConfig, kafkaConfiguration, properties),
+            kafkaConfiguration.getProducer());
     return new KafkaEventProducer(producer, topicConvention, kafkaHealthChecker, metricUtils);
   }
 

--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -137,6 +137,23 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN --mount=type=bind,source=./docker/snippets/oracle_instantclient.sh,target=/oracle_instantclient.sh \
     /oracle_instantclient.sh
 
+FROM ingestion-base-full AS wheel-builder
+
+WORKDIR /wheelhouse
+
+# 1. Install 'pip' (mandatory!) and the legacy build tools
+# uv creates bare venvs, so we must explicitly ask for pip.
+RUN --mount=type=cache,target=/home/datahub/.cache/uv,uid=1000,gid=1000,sharing=private \
+    uv pip install pip "setuptools<58" wheel
+
+# 2. Use the pip we just installed to build the wheel
+# We use python3 -m pip to ensure we use the one in the venv
+RUN --mount=type=cache,target=/home/datahub/.cache/uv,uid=1000,gid=1000,sharing=private \
+    python3 -m pip wheel \
+        --no-build-isolation \
+        --wheel-dir /wheelhouse \
+        flatdict==4.0.1
+
 USER datahub
 
 # Locked variant uses the same base as slim (no JRE/Oracle needed)
@@ -188,8 +205,12 @@ FROM add-code-full AS final-full
 
 ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
 
+# Copy the pre-built binary from the builder stage
+COPY --from=wheel-builder --chown=datahub:datahub /wheelhouse /tmp/wheelhouse
+
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \
     UV_LINK_MODE=copy uv pip install \
+        --find-links /tmp/wheelhouse \
         -e "/metadata-ingestion/[all]" \
     && datahub --version
 

--- a/docker/quickstart/docker-compose.quickstart-profile.yml
+++ b/docker/quickstart/docker-compose.quickstart-profile.yml
@@ -35,11 +35,13 @@ services:
       source: ${HOME}/.aws
       target: /home/datahub/.aws
       read_only: true
-      bind: {}
+      bind:
+        create_host_path: true
     - type: bind
       source: ${HOME}/.aws/sso/cache
       target: /home/datahub/.aws/sso/cache
-      bind: {}
+      bind:
+        create_host_path: true
   datahub-gms-quickstart:
     profiles:
     - quickstart
@@ -121,11 +123,13 @@ services:
     - type: bind
       source: ${HOME}/.datahub/plugins
       target: /etc/datahub/plugins
-      bind: {}
+      bind:
+        create_host_path: true
     - type: bind
       source: ${HOME}/.datahub/search
       target: /etc/datahub/search
-      bind: {}
+      bind:
+        create_host_path: true
   frontend-quickstart:
     profiles:
     - quickstart
@@ -163,7 +167,8 @@ services:
     - type: bind
       source: ${HOME}/.datahub/plugins
       target: /etc/datahub/plugins
-      bind: {}
+      bind:
+        create_host_path: true
   kafka-broker:
     command:
     - /bin/bash
@@ -462,7 +467,8 @@ services:
     - type: bind
       source: ${HOME}/.datahub/plugins
       target: /etc/datahub/plugins
-      bind: {}
+      bind:
+        create_host_path: true
 networks:
   default:
     name: datahub_network

--- a/docker/quickstart/docker-compose.quickstart-profile.yml
+++ b/docker/quickstart/docker-compose.quickstart-profile.yml
@@ -35,13 +35,11 @@ services:
       source: ${HOME}/.aws
       target: /home/datahub/.aws
       read_only: true
-      bind:
-        create_host_path: true
+      bind: {}
     - type: bind
       source: ${HOME}/.aws/sso/cache
       target: /home/datahub/.aws/sso/cache
-      bind:
-        create_host_path: true
+      bind: {}
   datahub-gms-quickstart:
     profiles:
     - quickstart
@@ -123,13 +121,11 @@ services:
     - type: bind
       source: ${HOME}/.datahub/plugins
       target: /etc/datahub/plugins
-      bind:
-        create_host_path: true
+      bind: {}
     - type: bind
       source: ${HOME}/.datahub/search
       target: /etc/datahub/search
-      bind:
-        create_host_path: true
+      bind: {}
   frontend-quickstart:
     profiles:
     - quickstart
@@ -167,8 +163,7 @@ services:
     - type: bind
       source: ${HOME}/.datahub/plugins
       target: /etc/datahub/plugins
-      bind:
-        create_host_path: true
+      bind: {}
   kafka-broker:
     command:
     - /bin/bash
@@ -467,8 +462,7 @@ services:
     - type: bind
       source: ${HOME}/.datahub/plugins
       target: /etc/datahub/plugins
-      bind:
-        create_host_path: true
+      bind: {}
 networks:
   default:
     name: datahub_network

--- a/metadata-dao-impl/kafka-producer/src/test/java/com/datahub/metadata/dao/throttle/KafkaThrottleSensorTest.java
+++ b/metadata-dao-impl/kafka-producer/src/test/java/com/datahub/metadata/dao/throttle/KafkaThrottleSensorTest.java
@@ -267,13 +267,19 @@ public class KafkaThrottleSensorTest {
 
     try {
       test.start();
-      Thread.sleep(50);
-      assertEquals(
-          test.getLag(),
+
+      Map<ThrottleType, Long> expectedLag =
           Map.of(
               ThrottleType.MCL_VERSIONED_LAG, 1L,
-              ThrottleType.MCL_TIMESERIES_LAG, 1L),
-          "Expected lag updated");
+              ThrottleType.MCL_TIMESERIES_LAG, 1L);
+
+      // Poll until the scheduler has executed refresh(), with a generous timeout for slow CI
+      long deadline = System.currentTimeMillis() + 200;
+      while (!expectedLag.equals(test.getLag()) && System.currentTimeMillis() < deadline) {
+        Thread.sleep(10);
+      }
+
+      assertEquals(test.getLag(), expectedLag, "Expected lag updated");
     } finally {
       test.stop();
     }

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -278,6 +278,8 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "kafka.producer.schemaRegistryUrl",
           "kafka.producer.compressionType",
           "kafka.producer.deliveryTimeout",
+          "kafka.producer.initializationRetryBackoffMs",
+          "kafka.producer.initializationRetryCount",
           "kafka.producer.maxRequestSize",
           "kafka.producer.requestTimeout",
           "kafka.producer.retryCount",

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kafka/ProducerConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kafka/ProducerConfiguration.java
@@ -20,4 +20,10 @@ public class ProducerConfiguration {
   private String bootstrapServers;
   private String securityProtocol;
   private String schemaRegistryUrl;
+
+  /** Number of retries for producer initialization */
+  private int initializationRetryCount = 5;
+
+  /** Initial backoff delay in milliseconds for producer initialization retries */
+  private long initializationRetryBackoffMs = 500;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -648,6 +648,8 @@ kafka:
     backoffTimeout: ${KAFKA_PRODUCER_BACKOFF_TIMEOUT:500}
     compressionType: ${KAFKA_PRODUCER_COMPRESSION_TYPE:snappy} # producer's compression algorithm
     maxRequestSize: ${KAFKA_PRODUCER_MAX_REQUEST_SIZE:5242880} # the max bytes sent by the producer, also see kafka-setup MAX_MESSAGE_BYTES for matching value
+    initializationRetryCount: ${KAFKA_PRODUCER_INITIALIZATION_RETRY_COUNT:5} # retries for producer initialization
+    initializationRetryBackoffMs: ${KAFKA_PRODUCER_INITIALIZATION_RETRY_BACKOFF_MS:500} # initial backoff delay in ms for initialization retries
   consumer:
     bootstrapServers: ${KAFKA_CONSUMER_BOOTSTRAP_SERVER:} # Used as an override for the base setting for when split producer/consumer is desired
     securityProtocol: ${KAFKA_CONSUMER_SECURITY_PROTOCOL:} # Used as an override for the base security protocol setting for when split producer/consumer is desired

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
@@ -6,11 +6,13 @@ import com.linkedin.metadata.config.kafka.ProducerConfiguration;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import java.util.Arrays;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -18,6 +20,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 
+@Slf4j
 @Configuration
 @DependsOn("configurationProvider")
 public class DataHubKafkaProducerFactory {
@@ -29,8 +32,9 @@ public class DataHubKafkaProducerFactory {
       @Qualifier("schemaRegistryConfig")
           final KafkaConfiguration.SerDeKeyValueConfig schemaRegistryConfig) {
     KafkaConfiguration kafkaConfiguration = provider.getKafka();
-    return new KafkaProducer<>(
-        buildProducerProperties(schemaRegistryConfig, kafkaConfiguration, properties));
+    Map<String, Object> props =
+        buildProducerProperties(schemaRegistryConfig, kafkaConfiguration, properties);
+    return createProducerWithRetry(props, kafkaConfiguration.getProducer());
   }
 
   /**
@@ -68,7 +72,48 @@ public class DataHubKafkaProducerFactory {
     props.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, producerConfiguration.getMaxRequestSize());
     props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, producerConfiguration.getCompressionType());
 
-    return new KafkaProducer<>(props);
+    return createProducerWithRetry(props, producerConfiguration);
+  }
+
+  /**
+   * Creates a KafkaProducer with retry logic for initialization failures. This handles transient
+   * issues like DNS resolution failures that can occur during container startup in Kubernetes
+   * environments.
+   *
+   * @param props the producer configuration properties
+   * @param producerConfiguration the producer configuration containing retry settings
+   * @return the created KafkaProducer
+   */
+  public static <K, V> Producer<K, V> createProducerWithRetry(
+      Map<String, Object> props, ProducerConfiguration producerConfiguration) {
+    int maxRetries = producerConfiguration.getInitializationRetryCount();
+    long retryDelayMs = producerConfiguration.getInitializationRetryBackoffMs();
+    KafkaException lastException = null;
+
+    for (int attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        return new KafkaProducer<>(props);
+      } catch (KafkaException e) {
+        lastException = e;
+        if (attempt < maxRetries) {
+          log.warn(
+              "Failed to construct Kafka producer, retrying in {}ms (attempt {}/{}): {}",
+              retryDelayMs,
+              attempt,
+              maxRetries,
+              e.getMessage());
+          try {
+            Thread.sleep(retryDelayMs);
+            retryDelayMs *= 2; // Exponential backoff
+          } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw e;
+          }
+        }
+      }
+    }
+    log.error("Failed to construct Kafka producer after {} attempts", maxRetries);
+    throw lastException;
   }
 
   public static Map<String, Object> buildProducerProperties(

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
@@ -6,6 +6,7 @@ import com.linkedin.metadata.config.kafka.ProducerConfiguration;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.commons.lang3.StringUtils;
@@ -86,13 +87,29 @@ public class DataHubKafkaProducerFactory {
    */
   public static <K, V> Producer<K, V> createProducerWithRetry(
       Map<String, Object> props, ProducerConfiguration producerConfiguration) {
+    return createProducerWithRetry(props, producerConfiguration, KafkaProducer::new);
+  }
+
+  /**
+   * Creates a KafkaProducer with retry logic, using the provided factory function to construct the
+   * producer. This overload exists to support testing without requiring a real Kafka broker.
+   *
+   * @param props the producer configuration properties
+   * @param producerConfiguration the producer configuration containing retry settings
+   * @param producerFactory function that creates a Producer from config properties
+   * @return the created Producer
+   */
+  static <K, V> Producer<K, V> createProducerWithRetry(
+      Map<String, Object> props,
+      ProducerConfiguration producerConfiguration,
+      Function<Map<String, Object>, Producer<K, V>> producerFactory) {
     int maxRetries = producerConfiguration.getInitializationRetryCount();
     long retryDelayMs = producerConfiguration.getInitializationRetryBackoffMs();
     KafkaException lastException = null;
 
     for (int attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        return new KafkaProducer<>(props);
+        return producerFactory.apply(props);
       } catch (KafkaException e) {
         lastException = e;
         if (attempt < maxRetries) {

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactoryRetryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactoryRetryTest.java
@@ -1,0 +1,237 @@
+package com.linkedin.gms.factory.kafka;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.metadata.config.kafka.ProducerConfiguration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.KafkaException;
+import org.testng.annotations.Test;
+
+public class DataHubKafkaProducerFactoryRetryTest {
+
+  @Test
+  public void testCreateProducerWithRetry_SuccessOnFirstAttempt() {
+    ProducerConfiguration config = new ProducerConfiguration();
+    config.setInitializationRetryCount(3);
+    config.setInitializationRetryBackoffMs(100);
+
+    Map<String, Object> props = createMinimalProducerProps();
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    // Mock producer factory that succeeds on first attempt
+    Function<Map<String, Object>, Producer<String, String>> mockFactory =
+        p -> {
+          attemptCount.incrementAndGet();
+          return createMockProducer();
+        };
+
+    Producer<String, String> producer = createProducerWithRetryTestable(props, config, mockFactory);
+
+    assertNotNull(producer);
+    assertEquals(attemptCount.get(), 1, "Producer should be created on first attempt");
+  }
+
+  @Test
+  public void testCreateProducerWithRetry_SuccessAfterRetries() {
+    ProducerConfiguration config = new ProducerConfiguration();
+    config.setInitializationRetryCount(3);
+    config.setInitializationRetryBackoffMs(10); // Short delay for test
+
+    Map<String, Object> props = createMinimalProducerProps();
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    // Mock producer factory that fails twice then succeeds
+    Function<Map<String, Object>, Producer<String, String>> mockFactory =
+        p -> {
+          int attempt = attemptCount.incrementAndGet();
+          if (attempt < 3) {
+            throw new KafkaException("Failed to construct kafka producer");
+          }
+          return createMockProducer();
+        };
+
+    Producer<String, String> producer = createProducerWithRetryTestable(props, config, mockFactory);
+
+    assertNotNull(producer);
+    assertEquals(attemptCount.get(), 3, "Should have taken 3 attempts to succeed");
+  }
+
+  @Test(expectedExceptions = KafkaException.class)
+  public void testCreateProducerWithRetry_FailsAfterAllRetries() {
+    ProducerConfiguration config = new ProducerConfiguration();
+    config.setInitializationRetryCount(3);
+    config.setInitializationRetryBackoffMs(10); // Short delay for test
+
+    Map<String, Object> props = createMinimalProducerProps();
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    // Mock producer factory that always fails
+    Function<Map<String, Object>, Producer<String, String>> mockFactory =
+        p -> {
+          attemptCount.incrementAndGet();
+          throw new KafkaException("Failed to construct kafka producer");
+        };
+
+    try {
+      createProducerWithRetryTestable(props, config, mockFactory);
+      fail("Should have thrown KafkaException");
+    } catch (KafkaException e) {
+      assertEquals(attemptCount.get(), 3, "Should have attempted 3 times before giving up");
+      throw e;
+    }
+  }
+
+  @Test
+  public void testCreateProducerWithRetry_ExponentialBackoff() {
+    ProducerConfiguration config = new ProducerConfiguration();
+    config.setInitializationRetryCount(4);
+    config.setInitializationRetryBackoffMs(50);
+
+    Map<String, Object> props = createMinimalProducerProps();
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    long startTime = System.currentTimeMillis();
+
+    // Mock producer factory that fails 3 times then succeeds
+    Function<Map<String, Object>, Producer<String, String>> mockFactory =
+        p -> {
+          int attempt = attemptCount.incrementAndGet();
+          if (attempt < 4) {
+            throw new KafkaException("Failed to construct kafka producer");
+          }
+          return createMockProducer();
+        };
+
+    Producer<String, String> producer = createProducerWithRetryTestable(props, config, mockFactory);
+
+    long elapsed = System.currentTimeMillis() - startTime;
+
+    assertNotNull(producer);
+    assertEquals(attemptCount.get(), 4, "Should have taken 4 attempts");
+    // Expected delays: 50 + 100 + 200 = 350ms minimum
+    assertTrue(elapsed >= 300, "Should have waited at least 300ms due to exponential backoff");
+  }
+
+  @Test
+  public void testCreateProducerWithRetry_SingleRetryConfig() {
+    ProducerConfiguration config = new ProducerConfiguration();
+    config.setInitializationRetryCount(1);
+    config.setInitializationRetryBackoffMs(10);
+
+    Map<String, Object> props = createMinimalProducerProps();
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    // Mock producer factory that always fails
+    Function<Map<String, Object>, Producer<String, String>> mockFactory =
+        p -> {
+          attemptCount.incrementAndGet();
+          throw new KafkaException("Failed to construct kafka producer");
+        };
+
+    try {
+      createProducerWithRetryTestable(props, config, mockFactory);
+      fail("Should have thrown KafkaException");
+    } catch (KafkaException e) {
+      assertEquals(attemptCount.get(), 1, "With retryCount=1, should only attempt once");
+    }
+  }
+
+  @Test
+  public void testCreateProducerWithRetry_PreservesOriginalException() {
+    ProducerConfiguration config = new ProducerConfiguration();
+    config.setInitializationRetryCount(2);
+    config.setInitializationRetryBackoffMs(10);
+
+    Map<String, Object> props = createMinimalProducerProps();
+    String expectedMessage = "No resolvable bootstrap urls given in bootstrap.servers";
+
+    // Mock producer factory that always fails with specific message
+    Function<Map<String, Object>, Producer<String, String>> mockFactory =
+        p -> {
+          throw new KafkaException(expectedMessage);
+        };
+
+    try {
+      createProducerWithRetryTestable(props, config, mockFactory);
+      fail("Should have thrown KafkaException");
+    } catch (KafkaException e) {
+      assertEquals(e.getMessage(), expectedMessage, "Should preserve original exception message");
+    }
+  }
+
+  @Test
+  public void testCreateProducerWithRetry_ZeroRetryCount() {
+    ProducerConfiguration config = new ProducerConfiguration();
+    config.setInitializationRetryCount(0);
+    config.setInitializationRetryBackoffMs(10);
+
+    Map<String, Object> props = createMinimalProducerProps();
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
+    // Mock producer factory that always fails
+    Function<Map<String, Object>, Producer<String, String>> mockFactory =
+        p -> {
+          attemptCount.incrementAndGet();
+          throw new KafkaException("Failed to construct kafka producer");
+        };
+
+    try {
+      createProducerWithRetryTestable(props, config, mockFactory);
+      fail("Should have thrown KafkaException");
+    } catch (KafkaException e) {
+      assertEquals(attemptCount.get(), 0, "With retryCount=0, should not attempt at all");
+    } catch (NullPointerException e) {
+      // Expected when lastException is null due to 0 retries
+      assertEquals(attemptCount.get(), 0, "With retryCount=0, should not attempt at all");
+    }
+  }
+
+  /**
+   * Testable version of createProducerWithRetry that accepts a factory function. This mirrors the
+   * logic in DataHubKafkaProducerFactory.createProducerWithRetry but allows injecting a mock
+   * producer factory.
+   */
+  private <K, V> Producer<K, V> createProducerWithRetryTestable(
+      Map<String, Object> props,
+      ProducerConfiguration producerConfiguration,
+      Function<Map<String, Object>, Producer<K, V>> producerFactory) {
+    int maxRetries = producerConfiguration.getInitializationRetryCount();
+    long retryDelayMs = producerConfiguration.getInitializationRetryBackoffMs();
+    KafkaException lastException = null;
+
+    for (int attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        return producerFactory.apply(props);
+      } catch (KafkaException e) {
+        lastException = e;
+        if (attempt < maxRetries) {
+          try {
+            Thread.sleep(retryDelayMs);
+            retryDelayMs *= 2; // Exponential backoff
+          } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw e;
+          }
+        }
+      }
+    }
+    throw lastException;
+  }
+
+  private Map<String, Object> createMinimalProducerProps() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    return props;
+  }
+
+  @SuppressWarnings("unchecked")
+  private <K, V> Producer<K, V> createMockProducer() {
+    return (Producer<K, V>) org.mockito.Mockito.mock(Producer.class);
+  }
+}

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactoryRetryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactoryRetryTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 public class DataHubKafkaProducerFactoryRetryTest {
 
   @Test
-  public void testCreateProducerWithRetry_SuccessOnFirstAttempt() {
+  public void testSuccessOnFirstAttempt() {
     ProducerConfiguration config = new ProducerConfiguration();
     config.setInitializationRetryCount(3);
     config.setInitializationRetryBackoffMs(100);
@@ -22,29 +22,28 @@ public class DataHubKafkaProducerFactoryRetryTest {
     Map<String, Object> props = createMinimalProducerProps();
     AtomicInteger attemptCount = new AtomicInteger(0);
 
-    // Mock producer factory that succeeds on first attempt
     Function<Map<String, Object>, Producer<String, String>> mockFactory =
         p -> {
           attemptCount.incrementAndGet();
           return createMockProducer();
         };
 
-    Producer<String, String> producer = createProducerWithRetryTestable(props, config, mockFactory);
+    Producer<String, String> producer =
+        DataHubKafkaProducerFactory.createProducerWithRetry(props, config, mockFactory);
 
     assertNotNull(producer);
     assertEquals(attemptCount.get(), 1, "Producer should be created on first attempt");
   }
 
   @Test
-  public void testCreateProducerWithRetry_SuccessAfterRetries() {
+  public void testSuccessAfterRetries() {
     ProducerConfiguration config = new ProducerConfiguration();
     config.setInitializationRetryCount(3);
-    config.setInitializationRetryBackoffMs(10); // Short delay for test
+    config.setInitializationRetryBackoffMs(1);
 
     Map<String, Object> props = createMinimalProducerProps();
     AtomicInteger attemptCount = new AtomicInteger(0);
 
-    // Mock producer factory that fails twice then succeeds
     Function<Map<String, Object>, Producer<String, String>> mockFactory =
         p -> {
           int attempt = attemptCount.incrementAndGet();
@@ -54,22 +53,22 @@ public class DataHubKafkaProducerFactoryRetryTest {
           return createMockProducer();
         };
 
-    Producer<String, String> producer = createProducerWithRetryTestable(props, config, mockFactory);
+    Producer<String, String> producer =
+        DataHubKafkaProducerFactory.createProducerWithRetry(props, config, mockFactory);
 
     assertNotNull(producer);
     assertEquals(attemptCount.get(), 3, "Should have taken 3 attempts to succeed");
   }
 
   @Test(expectedExceptions = KafkaException.class)
-  public void testCreateProducerWithRetry_FailsAfterAllRetries() {
+  public void testFailsAfterAllRetries() {
     ProducerConfiguration config = new ProducerConfiguration();
     config.setInitializationRetryCount(3);
-    config.setInitializationRetryBackoffMs(10); // Short delay for test
+    config.setInitializationRetryBackoffMs(1);
 
     Map<String, Object> props = createMinimalProducerProps();
     AtomicInteger attemptCount = new AtomicInteger(0);
 
-    // Mock producer factory that always fails
     Function<Map<String, Object>, Producer<String, String>> mockFactory =
         p -> {
           attemptCount.incrementAndGet();
@@ -77,7 +76,7 @@ public class DataHubKafkaProducerFactoryRetryTest {
         };
 
     try {
-      createProducerWithRetryTestable(props, config, mockFactory);
+      DataHubKafkaProducerFactory.createProducerWithRetry(props, config, mockFactory);
       fail("Should have thrown KafkaException");
     } catch (KafkaException e) {
       assertEquals(attemptCount.get(), 3, "Should have attempted 3 times before giving up");
@@ -86,46 +85,14 @@ public class DataHubKafkaProducerFactoryRetryTest {
   }
 
   @Test
-  public void testCreateProducerWithRetry_ExponentialBackoff() {
-    ProducerConfiguration config = new ProducerConfiguration();
-    config.setInitializationRetryCount(4);
-    config.setInitializationRetryBackoffMs(50);
-
-    Map<String, Object> props = createMinimalProducerProps();
-    AtomicInteger attemptCount = new AtomicInteger(0);
-
-    long startTime = System.currentTimeMillis();
-
-    // Mock producer factory that fails 3 times then succeeds
-    Function<Map<String, Object>, Producer<String, String>> mockFactory =
-        p -> {
-          int attempt = attemptCount.incrementAndGet();
-          if (attempt < 4) {
-            throw new KafkaException("Failed to construct kafka producer");
-          }
-          return createMockProducer();
-        };
-
-    Producer<String, String> producer = createProducerWithRetryTestable(props, config, mockFactory);
-
-    long elapsed = System.currentTimeMillis() - startTime;
-
-    assertNotNull(producer);
-    assertEquals(attemptCount.get(), 4, "Should have taken 4 attempts");
-    // Expected delays: 50 + 100 + 200 = 350ms minimum
-    assertTrue(elapsed >= 300, "Should have waited at least 300ms due to exponential backoff");
-  }
-
-  @Test
-  public void testCreateProducerWithRetry_SingleRetryConfig() {
+  public void testSingleRetryConfig() {
     ProducerConfiguration config = new ProducerConfiguration();
     config.setInitializationRetryCount(1);
-    config.setInitializationRetryBackoffMs(10);
+    config.setInitializationRetryBackoffMs(1);
 
     Map<String, Object> props = createMinimalProducerProps();
     AtomicInteger attemptCount = new AtomicInteger(0);
 
-    // Mock producer factory that always fails
     Function<Map<String, Object>, Producer<String, String>> mockFactory =
         p -> {
           attemptCount.incrementAndGet();
@@ -133,7 +100,7 @@ public class DataHubKafkaProducerFactoryRetryTest {
         };
 
     try {
-      createProducerWithRetryTestable(props, config, mockFactory);
+      DataHubKafkaProducerFactory.createProducerWithRetry(props, config, mockFactory);
       fail("Should have thrown KafkaException");
     } catch (KafkaException e) {
       assertEquals(attemptCount.get(), 1, "With retryCount=1, should only attempt once");
@@ -141,38 +108,41 @@ public class DataHubKafkaProducerFactoryRetryTest {
   }
 
   @Test
-  public void testCreateProducerWithRetry_PreservesOriginalException() {
+  public void testPreservesLastException() {
     ProducerConfiguration config = new ProducerConfiguration();
     config.setInitializationRetryCount(2);
-    config.setInitializationRetryBackoffMs(10);
-
-    Map<String, Object> props = createMinimalProducerProps();
-    String expectedMessage = "No resolvable bootstrap urls given in bootstrap.servers";
-
-    // Mock producer factory that always fails with specific message
-    Function<Map<String, Object>, Producer<String, String>> mockFactory =
-        p -> {
-          throw new KafkaException(expectedMessage);
-        };
-
-    try {
-      createProducerWithRetryTestable(props, config, mockFactory);
-      fail("Should have thrown KafkaException");
-    } catch (KafkaException e) {
-      assertEquals(e.getMessage(), expectedMessage, "Should preserve original exception message");
-    }
-  }
-
-  @Test
-  public void testCreateProducerWithRetry_ZeroRetryCount() {
-    ProducerConfiguration config = new ProducerConfiguration();
-    config.setInitializationRetryCount(0);
-    config.setInitializationRetryBackoffMs(10);
+    config.setInitializationRetryBackoffMs(1);
 
     Map<String, Object> props = createMinimalProducerProps();
     AtomicInteger attemptCount = new AtomicInteger(0);
 
-    // Mock producer factory that always fails
+    Function<Map<String, Object>, Producer<String, String>> mockFactory =
+        p -> {
+          int attempt = attemptCount.incrementAndGet();
+          if (attempt == 1) {
+            throw new KafkaException("First failure");
+          }
+          throw new KafkaException("Second failure");
+        };
+
+    try {
+      DataHubKafkaProducerFactory.createProducerWithRetry(props, config, mockFactory);
+      fail("Should have thrown KafkaException");
+    } catch (KafkaException e) {
+      assertEquals(attemptCount.get(), 2);
+      assertEquals(e.getMessage(), "Second failure", "Should throw the last exception encountered");
+    }
+  }
+
+  @Test
+  public void testZeroRetryCount() {
+    ProducerConfiguration config = new ProducerConfiguration();
+    config.setInitializationRetryCount(0);
+    config.setInitializationRetryBackoffMs(1);
+
+    Map<String, Object> props = createMinimalProducerProps();
+    AtomicInteger attemptCount = new AtomicInteger(0);
+
     Function<Map<String, Object>, Producer<String, String>> mockFactory =
         p -> {
           attemptCount.incrementAndGet();
@@ -180,175 +150,53 @@ public class DataHubKafkaProducerFactoryRetryTest {
         };
 
     try {
-      createProducerWithRetryTestable(props, config, mockFactory);
-      fail("Should have thrown KafkaException");
-    } catch (KafkaException e) {
-      assertEquals(attemptCount.get(), 0, "With retryCount=0, should not attempt at all");
-    } catch (NullPointerException e) {
-      // Expected when lastException is null due to 0 retries
+      DataHubKafkaProducerFactory.createProducerWithRetry(props, config, mockFactory);
+      fail("Should have thrown");
+    } catch (KafkaException | NullPointerException e) {
       assertEquals(attemptCount.get(), 0, "With retryCount=0, should not attempt at all");
     }
   }
 
   @Test(expectedExceptions = KafkaException.class)
-  public void testCreateProducerWithRetry_InterruptedDuringSleep() {
+  public void testInterruptedDuringSleep() {
     ProducerConfiguration config = new ProducerConfiguration();
     config.setInitializationRetryCount(3);
-    config.setInitializationRetryBackoffMs(1000); // Long delay to ensure interrupt happens
+    config.setInitializationRetryBackoffMs(5000);
 
     Map<String, Object> props = createMinimalProducerProps();
     AtomicInteger attemptCount = new AtomicInteger(0);
     Thread testThread = Thread.currentThread();
 
-    // Mock producer factory that fails, then interrupts the thread
     Function<Map<String, Object>, Producer<String, String>> mockFactory =
         p -> {
           int attempt = attemptCount.incrementAndGet();
           if (attempt == 1) {
-            // First attempt fails and triggers sleep
+            // Schedule interrupt before throwing so it fires during the subsequent sleep
+            new Thread(
+                    () -> {
+                      try {
+                        Thread.sleep(100);
+                        testThread.interrupt();
+                      } catch (InterruptedException ignored) {
+                      }
+                    })
+                .start();
             throw new KafkaException("Failed to construct kafka producer");
-          } else if (attempt == 2) {
-            // Second attempt should not happen because thread should be interrupted
-            fail("Should not reach second attempt after interrupt");
           }
+          fail("Should not reach second attempt after interrupt");
           return createMockProducer();
         };
 
-    // Create a thread that will interrupt the test thread after a short delay
-    Thread interrupter =
-        new Thread(
-            () -> {
-              try {
-                Thread.sleep(100); // Wait for the retry logic to start sleeping
-                testThread.interrupt();
-              } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-              }
-            });
-    interrupter.start();
-
     try {
-      createProducerWithRetryTestable(props, config, mockFactory);
+      DataHubKafkaProducerFactory.createProducerWithRetry(props, config, mockFactory);
       fail("Should have thrown KafkaException due to interrupt");
     } catch (KafkaException e) {
-      // Expected - should throw the original KafkaException
       assertEquals(attemptCount.get(), 1, "Should only attempt once before being interrupted");
       assertTrue(
           Thread.interrupted(),
           "Thread interrupt flag should be set after InterruptedException handling");
       throw e;
-    } finally {
-      try {
-        interrupter.join();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
     }
-  }
-
-  @Test
-  public void testCreateProducerWithRetry_VerifyBackoffMultiplication() {
-    ProducerConfiguration config = new ProducerConfiguration();
-    config.setInitializationRetryCount(3);
-    config.setInitializationRetryBackoffMs(100);
-
-    Map<String, Object> props = createMinimalProducerProps();
-    AtomicInteger attemptCount = new AtomicInteger(0);
-    long[] sleepTimestamps = new long[3];
-
-    // Mock producer factory that fails twice then succeeds
-    Function<Map<String, Object>, Producer<String, String>> mockFactory =
-        p -> {
-          int attempt = attemptCount.incrementAndGet();
-          sleepTimestamps[attempt - 1] = System.currentTimeMillis();
-          if (attempt < 3) {
-            throw new KafkaException("Failed to construct kafka producer");
-          }
-          return createMockProducer();
-        };
-
-    Producer<String, String> producer = createProducerWithRetryTestable(props, config, mockFactory);
-
-    assertNotNull(producer);
-    assertEquals(attemptCount.get(), 3);
-
-    // Verify exponential backoff: delay between attempts should roughly double each time
-    // First delay: ~100ms, Second delay: ~200ms
-    long firstDelay = sleepTimestamps[1] - sleepTimestamps[0];
-    long secondDelay = sleepTimestamps[2] - sleepTimestamps[1];
-
-    assertTrue(firstDelay >= 90, "First delay should be at least 90ms");
-    assertTrue(
-        secondDelay >= 180,
-        "Second delay should be at least 180ms (approximately double the first)");
-    assertTrue(
-        secondDelay > firstDelay * 1.5,
-        "Second delay should be significantly longer than first delay");
-  }
-
-  @Test(expectedExceptions = KafkaException.class)
-  public void testCreateProducerWithRetry_DifferentKafkaExceptionTypes() {
-    ProducerConfiguration config = new ProducerConfiguration();
-    config.setInitializationRetryCount(2);
-    config.setInitializationRetryBackoffMs(10);
-
-    Map<String, Object> props = createMinimalProducerProps();
-    AtomicInteger attemptCount = new AtomicInteger(0);
-
-    // Mock producer factory that throws different exceptions on each attempt
-    Function<Map<String, Object>, Producer<String, String>> mockFactory =
-        p -> {
-          int attempt = attemptCount.incrementAndGet();
-          if (attempt == 1) {
-            throw new KafkaException("No resolvable bootstrap urls given in bootstrap.servers");
-          } else {
-            throw new KafkaException("Failed to create new KafkaAdminClient");
-          }
-        };
-
-    try {
-      createProducerWithRetryTestable(props, config, mockFactory);
-      fail("Should have thrown KafkaException");
-    } catch (KafkaException e) {
-      assertEquals(attemptCount.get(), 2);
-      // Should preserve the last exception
-      assertTrue(
-          e.getMessage().contains("Failed to create new KafkaAdminClient"),
-          "Should throw the last exception encountered");
-      throw e;
-    }
-  }
-
-  /**
-   * Testable version of createProducerWithRetry that accepts a factory function. This mirrors the
-   * logic in DataHubKafkaProducerFactory.createProducerWithRetry but allows injecting a mock
-   * producer factory.
-   */
-  private <K, V> Producer<K, V> createProducerWithRetryTestable(
-      Map<String, Object> props,
-      ProducerConfiguration producerConfiguration,
-      Function<Map<String, Object>, Producer<K, V>> producerFactory) {
-    int maxRetries = producerConfiguration.getInitializationRetryCount();
-    long retryDelayMs = producerConfiguration.getInitializationRetryBackoffMs();
-    KafkaException lastException = null;
-
-    for (int attempt = 1; attempt <= maxRetries; attempt++) {
-      try {
-        return producerFactory.apply(props);
-      } catch (KafkaException e) {
-        lastException = e;
-        if (attempt < maxRetries) {
-          try {
-            Thread.sleep(retryDelayMs);
-            retryDelayMs *= 2; // Exponential backoff
-          } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            throw e;
-          }
-        }
-      }
-    }
-    throw lastException;
   }
 
   private Map<String, Object> createMinimalProducerProps() {


### PR DESCRIPTION
Intermittent network issue could cause datahub-gms (and other services) to fail to startup successfully while trying to configure kafka producer.

This change allows for retry logic to go past such intermittent errors.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
