### PR TITLE
docs(lineage): updating docs to show example with time filtering

### DIFF
--- a/docs/api/tutorials/lineage.md
+++ b/docs/api/tutorials/lineage.md
@@ -384,6 +384,38 @@ query scrollAcrossLineage {
 }
 ```
 
+#### Get Time-Filtered Lineage with GraphQL
+
+Filter lineage edges by their last update time using `lineageFlags`:
+
+```graphql
+query searchAcrossLineage {
+  searchAcrossLineage(
+    input: {
+      query: "*"
+      urn: "urn:li:dataset:(urn:li:dataPlatform:snowflake,analytics.orders,PROD)"
+      count: 10
+      direction: UPSTREAM
+      orFilters: [{ and: [{ field: "degree", values: ["1"] }] }]
+      lineageFlags: {
+        startTimeMillis: 1625097600000
+        endTimeMillis: 1627776000000
+      }
+    }
+  ) {
+    searchResults {
+      entity {
+        urn
+        type
+      }
+      degree
+    }
+  }
+}
+```
+
+This returns only upstream lineage edges that were last updated between July 1 and August 1, 2021.
+
 ## FAQ
 
 **Can I get lineage at the column level?**


### PR DESCRIPTION
When making lineage API calls, start and end time can be factored in.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
