### PR TITLE
fix(ci): use dynamic base branch in check-python-deps workflow

### DIFF
--- a/.github/workflows/check-python-deps.yml
+++ b/.github/workflows/check-python-deps.yml
@@ -80,14 +80,16 @@ jobs:
             fi
           done < /tmp/projects_to_check.txt
 
-      - name: Checkout master branch
+      # Use github.base_ref to automatically detect the PR's target branch.
+      # Fork repositories no longer need to override the base branch name.
+      - name: Checkout base branch
         run: |
-          git fetch origin master
-          git checkout origin/master
+          git fetch origin ${{ github.base_ref }}
+          git checkout origin/${{ github.base_ref }}
 
-      - name: Analyze dependencies on master branch
+      - name: Analyze dependencies on base branch
         run: |
-          echo "Analyzing Python dependencies on master branch..."
+          echo "Analyzing Python dependencies on base branch (${{ github.base_ref }})..."
           mkdir -p /tmp/master-results
 
           while IFS= read -r project; do
@@ -97,7 +99,7 @@ jobs:
               echo "  Analyzing: $project -> /tmp/master-${safe_name}.json"
 
               python .github/scripts/dep-analyzer.py --exec --json "$project" > "/tmp/master-${safe_name}.json" 2>&1 || {
-                echo "Warning: Failed to analyze $project on master branch"
+                echo "Warning: Failed to analyze $project on base branch"
                 echo '{"by_level": {}, "errors": ["Analysis failed"]}' > "/tmp/master-${safe_name}.json"
               }
             fi


### PR DESCRIPTION
## Summary

Replace hardcoded `master` branch reference with `github.base_ref` to make the `check-python-deps` workflow work automatically across all repository configurations.

## Changes

- Use `${{ github.base_ref }}` instead of hardcoded `master` in git fetch/checkout commands
- Update step names and messages to refer to "base branch" instead of "master branch"
- Add helpful comment explaining that fork repositories no longer need to override the base branch name

## Why This Change?

The current workflow hardcodes `origin/master` which:
- Fails on fork repositories that use different default branch names
- Doesn't respect the actual PR target branch
- Requires manual configuration overrides in forks

Using `github.base_ref`:
- Automatically uses the PR's actual target branch (master, main, etc.)
- Works universally across all repositories without configuration
- Semantically correct - compares against what the PR will merge into
- No maintenance needed when repos rename default branches

## Testing

The workflow is PR-triggered only, so `github.base_ref` is always available. This change will be tested when CI runs on this PR itself.

## Affected Files

- `.github/workflows/check-python-deps.yml`