### PR TITLE
improvement(ui/ingestion): implement feedback on ingestion run details page

### DIFF
--- a/datahub-web-react/src/app/ingestV2/executions/components/BaseTab.tsx
+++ b/datahub-web-react/src/app/ingestV2/executions/components/BaseTab.tsx
@@ -31,7 +31,22 @@ export const DetailsContainer = styled.div`
 export const ScrollableDetailsContainer = styled(DetailsContainer)`
     pre {
         max-height: 300px;
-        overflow-y: scroll;
+        overflow-y: auto;
+
+        scrollbar-width: none;
+    }
+
+    pre::-webkit-scrollbar {
+        width: 0;
+    }
+
+    pre:hover {
+        scrollbar-width: thin;
+        scrollbar-color: rgba(193, 196, 208, 0.8) transparent;
+    }
+
+    pre:hover::-webkit-scrollbar {
+        width: 8px;
     }
 
     pre::-webkit-scrollbar-track {


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-1243/uiux-feedback-on-ingestion-run-llm-page

**Description:**

Bringing [this](https://github.com/acryldata/datahub-fork/pull/8084) PR back to OSS

- Only show scrollbars on ingestion logs and ingestion recipe when hovered

**Screenshots:**

Scrollbar on hover:
<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/5bcf8e2f-2bb0-450b-9c82-b9dfbbc455fd" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
