### PR TITLE
fix(ui): fix mentions dropdown bugs and keyboard shortcut conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,10 @@ smoke-test/rollback-reports
 coverage*.xml
 .vercel
 .envrc
+
+# Local dev environment overrides (user-specific GMS/Kafka settings)
+docker/profiles/my-settings.env
+
 **/.claude/settings.local.json
 **/.claude/*.md
 

--- a/datahub-web-react/src/alchemy-components/components/Editor/extensions/mentions/DataHubMentionsExtension.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Editor/extensions/mentions/DataHubMentionsExtension.tsx
@@ -126,6 +126,11 @@ class DataHubMentionsExtension extends NodeExtension<DataHubMentionsOptions> {
                     const acState: ActiveAutocompleteState = acPluginKey.getState(state);
                     const { from = 0, to = 0 } = range ?? acState.range ?? {};
                     tr.replaceRangeWith(from, to, this.type.create(attrs));
+                    // Append a space after the mention to fix Safari cursor positioning bug.
+                    // Safari has a known issue where the cursor jumps to the start of the line
+                    // when an atom node is the last element. Appending text gives the cursor
+                    // a text node to position after. See: https://github.com/ProseMirror/prosemirror/issues/1165
+                    tr.insertText(' ');
                     dispatch?.(tr);
 
                     return true;
@@ -135,5 +140,10 @@ class DataHubMentionsExtension extends NodeExtension<DataHubMentionsOptions> {
     }
 }
 
-const decoratedExt = extension<DataHubMentionsOptions>({ handlerKeys: ['handleEvents'] })(DataHubMentionsExtension);
+const decoratedExt = extension<DataHubMentionsOptions>({
+    defaultOptions: {},
+    staticKeys: [],
+    handlerKeys: ['handleEvents'],
+    customHandlerKeys: [],
+})(DataHubMentionsExtension);
 export { decoratedExt as DataHubMentionsExtension };

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/editor/extensions/mentions/DataHubMentionsExtension.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/editor/extensions/mentions/DataHubMentionsExtension.tsx
@@ -126,6 +126,11 @@ class DataHubMentionsExtension extends NodeExtension<DataHubMentionsOptions> {
                     const acState: ActiveAutocompleteState = acPluginKey.getState(state);
                     const { from = 0, to = 0 } = range ?? acState.range ?? {};
                     tr.replaceRangeWith(from, to, this.type.create(attrs));
+                    // Append a space after the mention to fix Safari cursor positioning bug.
+                    // Safari has a known issue where the cursor jumps to the start of the line
+                    // when an atom node is the last element. Appending text gives the cursor
+                    // a text node to position after. See: https://github.com/ProseMirror/prosemirror/issues/1165
+                    tr.insertText(' ');
                     dispatch?.(tr);
 
                     return true;
@@ -135,5 +140,10 @@ class DataHubMentionsExtension extends NodeExtension<DataHubMentionsOptions> {
     }
 }
 
-const decoratedExt = extension<DataHubMentionsOptions>({ handlerKeys: ['handleEvents'] })(DataHubMentionsExtension);
+const decoratedExt = extension<DataHubMentionsOptions>({
+    defaultOptions: {},
+    staticKeys: [],
+    handlerKeys: ['handleEvents'],
+    customHandlerKeys: [],
+})(DataHubMentionsExtension);
 export { decoratedExt as DataHubMentionsExtension };

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/useKeyboardControls.ts
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/useKeyboardControls.ts
@@ -60,6 +60,21 @@ export default function useKeyboardControls(
     }, [index, rows, expandedRows, setExpandedRows, selectedRow]);
 
     function handleArrowKeys(event: KeyboardEvent) {
+        // Skip if user is in any editable element (input, textarea, editor, etc.)
+        // This prevents the schema navigation keyboard shortcuts from blocking
+        // normal cursor movement in text inputs, chat inputs, document editors,
+        // and other interactive elements on the page.
+        const target = event.target as HTMLElement;
+        if (
+            target.closest('.ProseMirror') ||
+            target.tagName === 'INPUT' ||
+            target.tagName === 'TEXTAREA' ||
+            target.tagName === 'SELECT' ||
+            target.isContentEditable
+        ) {
+            return;
+        }
+
         if (event.code === 'ArrowUp') {
             event.preventDefault();
             selectPreviousField();

--- a/datahub-web-react/src/app/searchV2/SearchResultList.tsx
+++ b/datahub-web-react/src/app/searchV2/SearchResultList.tsx
@@ -106,7 +106,17 @@ function useSearchKeyboardControls(
 ) {
     return useCallback(
         (event: KeyboardEvent) => {
-            if ((event.target as HTMLElement).closest(`.${SEARCH_BAR_CLASS_NAME}`)) return null;
+            // Skip if user is in any editable element (search bar, editor, input, etc.)
+            const target = event.target as HTMLElement;
+            if (
+                target.closest(`.${SEARCH_BAR_CLASS_NAME}`) ||
+                target.closest('.ProseMirror') ||
+                target.tagName === 'INPUT' ||
+                target.tagName === 'TEXTAREA' ||
+                target.isContentEditable
+            ) {
+                return null;
+            }
 
             const prevIndex = highlightedIndex;
             let newIndex: number | null | undefined;

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -16,6 +16,7 @@ from typing import (
     Union,
 )
 
+import dateutil.parser
 import more_itertools
 import pydantic
 from pydantic import field_validator, model_validator
@@ -58,9 +59,12 @@ from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.ingestion.source.dbt.dbt_tests import (
+    DBTFreshnessInfo,
     DBTTest,
     DBTTestResult,
+    make_assertion_from_freshness,
     make_assertion_from_test,
+    make_assertion_result_from_freshness,
     make_assertion_result_from_test,
 )
 from datahub.ingestion.source.sql.sql_types import resolve_sql_type
@@ -176,6 +180,10 @@ _SV_DERIVED_METRIC_RE = re.compile(
 _SV_TABLE_METRIC_REF_RE = re.compile(
     rf"{_SV_IDENTIFIER}\.{_SV_IDENTIFIER}", re.IGNORECASE
 )
+
+
+def parse_dbt_timestamp(timestamp: str) -> datetime:
+    return dateutil.parser.parse(timestamp)
 
 
 def _add_cll_entry(
@@ -792,6 +800,9 @@ class DBTNode:
 
     test_info: Optional["DBTTest"] = None  # only populated if node_type == 'test'
     test_results: List["DBTTestResult"] = field(default_factory=list)
+    freshness_info: Optional["DBTFreshnessInfo"] = (
+        None  # only populated for sources with freshness
+    )
 
     model_performances: List["DBTModelPerformance"] = field(default_factory=list)
 
@@ -1182,6 +1193,77 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                             f"Skipping test result {node.name} ({test_result.invocation_id}) emission since it is turned off."
                         )
 
+    def create_freshness_assertion_mcps(
+        self,
+        source_nodes: List[DBTNode],
+        extra_custom_props: Dict[str, str],
+    ) -> Iterable[MetadataChangeProposalWrapper]:
+        """Create assertions for dbt freshness tests on source nodes."""
+        for node in sorted(source_nodes, key=lambda n: n.dbt_name):
+            # Only process source nodes that have freshness info
+            if node.node_type != "source" or not node.freshness_info:
+                continue
+
+            upstream_urn = node.get_urn(
+                target_platform=self.config.target_platform,
+                data_platform_instance=self.config.platform_instance,
+                env=self.config.env,
+            )
+
+            assertion_urn = mce_builder.make_assertion_urn(
+                mce_builder.datahub_guid(
+                    {
+                        k: v
+                        for k, v in {
+                            "platform": DBT_PLATFORM,
+                            "name": f"{node.dbt_name}_freshness",
+                            "instance": self.config.platform_instance,
+                            # Ideally we'd include the env unconditionally. However, we started out
+                            # not including env in the guid, so we need to maintain backwards compatibility
+                            # with existing PROD assertions.
+                            **(
+                                {"env": self.config.env}
+                                if self.config.env != mce_builder.DEFAULT_ENV
+                                and self.config.include_env_in_assertion_guid
+                                else {}
+                            ),
+                        }.items()
+                        if v is not None
+                    }
+                )
+            )
+
+            custom_props = {
+                "dbt_unique_id": node.dbt_name,
+                **extra_custom_props,
+            }
+
+            if self.config.entities_enabled.can_emit_test_definitions:
+                assertion_mcp = make_assertion_from_freshness(
+                    custom_props,
+                    node,
+                    assertion_urn,
+                    upstream_urn,
+                )
+
+                yield MetadataChangeProposalWrapper(
+                    entityUrn=assertion_urn,
+                    aspect=self._make_data_platform_instance_aspect(),
+                )
+                yield assertion_mcp
+
+            if self.config.entities_enabled.can_emit_test_results:
+                yield make_assertion_result_from_freshness(
+                    node,
+                    assertion_urn,
+                    upstream_urn,
+                    test_warnings_are_errors=self.config.test_warnings_are_errors,
+                )
+            else:
+                logger.debug(
+                    f"Skipping freshness result for {node.name} emission since it is turned off."
+                )
+
     @abstractmethod
     def load_nodes(self) -> Tuple[List[DBTNode], Dict[str, Optional[str]]]:
         # return dbt nodes (including semantic models) + global custom properties
@@ -1251,6 +1333,11 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             test_nodes,
             additional_custom_props_filtered,
             all_nodes_map,
+        )
+
+        yield from self.create_freshness_assertion_mcps(
+            non_test_nodes,
+            additional_custom_props_filtered,
         )
 
     def _is_allowed_node(self, node: DBTNode) -> bool:

--- a/metadata-ingestion/tests/integration/dbt/dbt_enabled_with_schemas_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_enabled_with_schemas_mces_golden.json
@@ -1433,7 +1433,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759930000,
+                            "time": 1623751200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -1729,7 +1729,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759987000,
+                            "time": 1623319200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2135,7 +2135,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759840000,
+                            "time": 1624033800000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2316,7 +2316,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581760640000,
+                            "time": 1624032000000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -4271,6 +4271,1178 @@
                 }
             }
         ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "warn",
+                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "259200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "nativeResults": {
+                    "status": "error",
+                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "691200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "error_after_count": "1",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "30",
+                "warn_after_period": "minute"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "2335.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "1",
+                "warn_after_period": "day",
+                "error_after_count": "2",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "4085.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "3",
+                "warn_after_period": "day",
+                "error_after_count": "7",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-schemas-dbt-enabled",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,

--- a/metadata-ingestion/tests/integration/dbt/dbt_sources.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_sources.json
@@ -12,13 +12,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "max_loaded_at": "2020-02-15T09:34:33+00:00",
@@ -31,52 +31,49 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
-      "max_loaded_at": "2020-02-15T09:45:30+00:00",
-      "max_loaded_at_time_ago_in_s": 42276862.910052,
+      "max_loaded_at": "2021-06-15T10:00:00+00:00",
+      "max_loaded_at_time_ago_in_s": 259200.0,
       "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-      "status": "pass",
+      "status": "warn",
       "unique_id": "source.sample_dbt.pagila.address"
     },
     {
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
-      "max_loaded_at": "2020-02-15T09:46:27+00:00",
-      "max_loaded_at_time_ago_in_s": 42276862.910052,
+      "max_loaded_at": "2021-06-10T10:00:00+00:00",
+      "max_loaded_at_time_ago_in_s": 691200.0,
       "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
-      "status": "pass",
+      "status": "error",
       "unique_id": "source.sample_dbt.pagila.category"
     },
     {
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
+          "count": 1,
           "period": "day"
         },
         "filter": null,
-        "warn_after": {
-          "count": 123456789,
-          "period": "day"
-        }
+        "warn_after": null
       },
       "max_loaded_at": "2020-02-15T09:45:25+00:00",
       "max_loaded_at_time_ago_in_s": 42276862.910052,
@@ -87,18 +84,15 @@
     {
       "adapter_response": {},
       "criteria": {
-        "error_after": {
-          "count": 999999999,
-          "period": "day"
-        },
+        "error_after": null,
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 30,
+          "period": "minute"
         }
       },
-      "max_loaded_at": "2020-02-15T09:44:00+00:00",
-      "max_loaded_at_time_ago_in_s": 42276862.910052,
+      "max_loaded_at": "2021-06-18T16:30:00+00:00",
+      "max_loaded_at_time_ago_in_s": 2335.925443,
       "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
       "status": "pass",
       "unique_id": "source.sample_dbt.pagila.country"
@@ -107,17 +101,17 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
+          "count": 2,
           "period": "day"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
+          "count": 1,
           "period": "day"
         }
       },
-      "max_loaded_at": "2020-02-15T09:57:20+00:00",
-      "max_loaded_at_time_ago_in_s": 42276862.910052,
+      "max_loaded_at": "2021-06-18T16:00:00+00:00",
+      "max_loaded_at_time_ago_in_s": 4085.925443,
       "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
       "status": "pass",
       "unique_id": "source.sample_dbt.pagila.customer"
@@ -126,12 +120,12 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
+          "count": 7,
           "period": "day"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
+          "count": 3,
           "period": "day"
         }
       },
@@ -145,13 +139,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
@@ -164,13 +158,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
@@ -183,13 +177,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
@@ -202,13 +196,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
@@ -221,13 +215,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "max_loaded_at": "0001-01-01T00:00:00+00:00",

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_prefer_sql_parser_lineage_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_prefer_sql_parser_lineage_golden.json
@@ -5160,6 +5160,1006 @@
 },
 {
     "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:30+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:46:27+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:44:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:57:20+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
     "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
     "changeType": "UPSERT",
     "aspectName": "status",
@@ -5192,7 +6192,119 @@
 },
 {
     "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
     "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -5224,7 +6336,71 @@
 },
 {
     "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_target_platform_primary_siblings_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_target_platform_primary_siblings_golden.json
@@ -365,31 +365,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -615,31 +590,6 @@
         "json": {
             "platform": "urn:li:dataPlatform:dbt"
         }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -1005,31 +955,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -1230,31 +1155,6 @@
         "json": {
             "platform": "urn:li:dataPlatform:dbt"
         }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -1515,31 +1415,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -1597,7 +1472,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759930000,
+                            "time": 1623751200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -1855,31 +1730,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -1937,7 +1787,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759987000,
+                            "time": 1623319200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2071,31 +1921,6 @@
         "json": {
             "platform": "urn:li:dataPlatform:dbt"
         }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -2328,31 +2153,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -2428,7 +2228,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759840000,
+                            "time": 1624033800000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2571,31 +2371,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -2653,7 +2428,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581760640000,
+                            "time": 1624032000000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2957,31 +2732,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -3242,31 +2992,6 @@
         "json": {
             "platform": "urn:li:dataPlatform:dbt"
         }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -3564,31 +3289,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -3849,31 +3549,6 @@
         "json": {
             "platform": "urn:li:dataPlatform:dbt"
         }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -4152,31 +3827,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -4446,31 +4096,6 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
-    "changeType": "PATCH",
-    "aspectName": "siblings",
-    "aspect": {
-        "json": [
-            {
-                "op": "add",
-                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
-                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)"
-            },
-            {
-                "op": "add",
-                "path": "/primary",
-                "value": true
-            }
-        ]
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-test-target-platform-primary-siblings",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
     "changeType": "UPSERT",
     "aspectName": "siblings",
@@ -4708,6 +4333,31 @@
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
     "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-monthly-billing,PROD)",
+    "changeType": "PATCH",
     "aspectName": "upstreamLineage",
     "aspect": {
         "json": [
@@ -4750,6 +4400,31 @@
                 "value": {
                     "confidenceScore": 1.0
                 }
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.an-aliased-view-for-payments,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
             }
         ]
     },
@@ -4832,6 +4507,31 @@
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
     "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
+    "changeType": "PATCH",
     "aspectName": "upstreamLineage",
     "aspect": {
         "json": [
@@ -4869,6 +4569,1478 @@
                 }
             }
         ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.actor,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.category,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.country,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "siblings",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/siblings/urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
+                "value": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)"
+            },
+            {
+                "op": "add",
+                "path": "/primary",
+                "value": true
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "warn",
+                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "259200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "nativeResults": {
+                    "status": "error",
+                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "691200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "error_after_count": "1",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "30",
+                "warn_after_period": "minute"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "2335.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "1",
+                "warn_after_period": "day",
+                "error_after_count": "2",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "4085.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "3",
+                "warn_after_period": "day",
+                "error_after_count": "7",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-target-platform-primary-siblings",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_test_model_performance_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_test_model_performance_golden.json
@@ -5932,6 +5932,1006 @@
 },
 {
     "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:30+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:46:27+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:44:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:57:20+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
     "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
     "changeType": "UPSERT",
     "aspectName": "status",
@@ -5964,7 +6964,119 @@
 },
 {
     "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
     "entityUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -5996,7 +7108,71 @@
 },
 {
     "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_complex_owner_patterns_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_complex_owner_patterns_mces_golden.json
@@ -1376,7 +1376,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759930000,
+                            "time": 1623751200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -1672,7 +1672,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759987000,
+                            "time": 1623319200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2075,7 +2075,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759840000,
+                            "time": 1624033800000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2256,7 +2256,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581760640000,
+                            "time": 1624032000000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -3958,6 +3958,1080 @@
                 }
             }
         ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "warn",
+                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "259200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "nativeResults": {
+                    "status": "error",
+                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "691200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "error_after_count": "1",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "30",
+                "warn_after_period": "minute"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "2335.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "1",
+                "warn_after_period": "day",
+                "error_after_count": "2",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "4085.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "3",
+                "warn_after_period": "day",
+                "error_after_count": "7",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-complex-owner-patterns",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_data_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_data_platform_instance_mces_golden.json
@@ -1383,7 +1383,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759930000,
+                            "time": 1623751200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -1680,7 +1680,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759987000,
+                            "time": 1623319200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2085,7 +2085,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759840000,
+                            "time": 1624033800000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2267,7 +2267,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581760640000,
+                            "time": 1624032000000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -4225,6 +4225,1190 @@
                 }
             }
         ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.actor,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.address,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "warn",
+                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "259200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.category,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "nativeResults": {
+                    "status": "error",
+                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "691200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "error_after_count": "1",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.city,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "30",
+                "warn_after_period": "minute"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.country,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "2335.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "1",
+                "warn_after_period": "day",
+                "error_after_count": "2",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.customer,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "4085.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "3",
+                "warn_after_period": "day",
+                "error_after_count": "7",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_01,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_02,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_03,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_04,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_05,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:dbt,dbt-instance-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_06,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,dbt-instance-1.pagila.public.payment_p2020_06,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:08eec22f4bafbf8bc076998b83a4d06e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:114b26676391b0d4bc7143f090aa2092",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:26edbe8ed47e1675145a09ec0867207c",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:31628ac3818b105279e9063edbaccc05",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:6caf326d9f2e14e2b05e487a61da0282",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:6dafa476c7e3f886e89c0448bf6b3756",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:7dc3c97ede9287646994b3b955afecd7",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8161adb9a5a93baa4f9ce0396812db1b",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:d1c318d2d5b710066a75f0451adc9d00",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:d607430fab76cb43e7b2c5e0106849d1",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:deb7bd9eb9d2806806bb5496853ea01d",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-data-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f33d16bca24e0a4b25f05fc2a93c9124",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_non_incremental_lineage_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_non_incremental_lineage_mces_golden.json
@@ -1377,7 +1377,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759930000,
+                            "time": 1623751200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -1673,7 +1673,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759987000,
+                            "time": 1623319200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2076,7 +2076,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759840000,
+                            "time": 1624033800000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2257,7 +2257,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581760640000,
+                            "time": 1624032000000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -4260,6 +4260,1178 @@
                     "confidenceScore": 1.0
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "warn",
+                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "259200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "nativeResults": {
+                    "status": "error",
+                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "691200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "error_after_count": "1",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "30",
+                "warn_after_period": "minute"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "2335.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "1",
+                "warn_after_period": "day",
+                "error_after_count": "2",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "4085.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "3",
+                "warn_after_period": "day",
+                "error_after_count": "7",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-non-incremental-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_source_database_pattern_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_source_database_pattern_mces_golden.json
@@ -1376,7 +1376,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759930000,
+                            "time": 1623751200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -1672,7 +1672,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759987000,
+                            "time": 1623319200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2075,7 +2075,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759840000,
+                            "time": 1624033800000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2256,7 +2256,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581760640000,
+                            "time": 1624032000000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -4208,6 +4208,1178 @@
                 }
             }
         ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "warn",
+                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "259200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "nativeResults": {
+                    "status": "error",
+                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "691200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "error_after_count": "1",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "30",
+                "warn_after_period": "minute"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "2335.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "1",
+                "warn_after_period": "day",
+                "error_after_count": "2",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "4085.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "3",
+                "warn_after_period": "day",
+                "error_after_count": "7",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-source-database-pattern",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_with_target_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_with_target_platform_instance_mces_golden.json
@@ -1377,7 +1377,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759930000,
+                            "time": 1623751200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -1673,7 +1673,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759987000,
+                            "time": 1623319200000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2076,7 +2076,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581759840000,
+                            "time": 1624033800000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -2257,7 +2257,7 @@
                             "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
-                            "time": 1581760640000,
+                            "time": 1624032000000,
                             "actor": "urn:li:corpuser:dbt_executor"
                         },
                         "hash": "",
@@ -4209,6 +4209,1178 @@
                 }
             }
         ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.actor",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.actor,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:34:33+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.address",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.address,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "warn",
+                    "max_loaded_at": "2021-06-15T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "259200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.category",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.category,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "nativeResults": {
+                    "status": "error",
+                    "max_loaded_at": "2021-06-10T10:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "691200.0"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.city",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "error_after_count": "1",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.city,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-15T09:45:25+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.country",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "30",
+                "warn_after_period": "minute"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.country,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:30:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "2335.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.customer",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "1",
+                "warn_after_period": "day",
+                "error_after_count": "2",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.customer,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2021-06-18T16:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "4085.925443"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_01",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "3",
+                "warn_after_period": "day",
+                "error_after_count": "7",
+                "error_after_period": "day"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_01,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-01-31T21:16:11.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_02",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_02,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-02-21T21:17:25.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_03",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_03,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-03-23T21:18:38.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_04",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_04,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-04-30T22:53:48.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_05",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_05,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "2020-05-14T12:44:29.996577+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "source.sample_dbt.pagila.payment_p2020_06",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v1.json",
+                "manifest_version": "0.19.1",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "0.19.1",
+                "dbt_freshness_test": "true",
+                "warn_after_count": "12",
+                "warn_after_period": "hour",
+                "error_after_count": "24",
+                "error_after_period": "hour"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Freshness",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1624036135925,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,pagila.public.payment_p2020_06,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {
+                    "status": "pass",
+                    "max_loaded_at": "0001-01-01T00:00:00+00:00",
+                    "snapshotted_at": "2021-06-18T17:08:55.925443+00:00",
+                    "max_loaded_at_time_ago_in_s": "42276862.910052"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0e897847a1cf3f322dd0774acf483399",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:491ada896ecb9230502025d51a12872a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:651e6c588fd0e337ea96b16361b8f8cb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:8f608f7b939427c2e497cc3b4a54a916",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9483a77996aca6855668b76f3ff37c69",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:94b5cdcd00175242b32bb1edf826b173",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:9b755da945f53077e504038135bb69bd",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:b58a6548515bc0fa0309129856118759",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:bc178c606c9d627638da55fffd49c273",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ce9dd15d0bd20b99be69a94aeaf55088",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:eb0aa22f582225797d3792545b691833",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-test-with-target-platform-instance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:ef37eda03c06a3968d18d24f4ca2d29e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,

--- a/metadata-ingestion/tests/integration/dbt/sample_dbt_sources_1.json
+++ b/metadata-ingestion/tests/integration/dbt/sample_dbt_sources_1.json
@@ -12,13 +12,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -45,13 +45,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -78,13 +78,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -111,13 +111,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -144,13 +144,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -177,13 +177,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -210,13 +210,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -243,13 +243,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -276,13 +276,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -309,13 +309,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -342,13 +342,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -375,13 +375,13 @@
       "adapter_response": {},
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,

--- a/metadata-ingestion/tests/integration/dbt/sample_dbt_sources_2.json
+++ b/metadata-ingestion/tests/integration/dbt/sample_dbt_sources_2.json
@@ -16,13 +16,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -53,13 +53,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -90,13 +90,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -127,13 +127,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -164,13 +164,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -201,13 +201,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -238,13 +238,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -275,13 +275,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -312,13 +312,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -349,13 +349,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -386,13 +386,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,
@@ -423,13 +423,13 @@
       },
       "criteria": {
         "error_after": {
-          "count": 999999999,
-          "period": "day"
+          "count": 24,
+          "period": "hour"
         },
         "filter": null,
         "warn_after": {
-          "count": 123456789,
-          "period": "day"
+          "count": 12,
+          "period": "hour"
         }
       },
       "execution_time": 0.023441791534423828,


### PR DESCRIPTION
Fixes several issues in the editor mentions functionality:
- Fix Safari cursor positioning bug by inserting trailing space after mention atoms
- Fix useState destructuring bug in useDataHubMentions (index/setter were swapped)
- Add guard for empty items when pressing Enter during debounce window
- Reset selectedIndex when items change to prevent out-of-bounds access
- Add scroll-into-view for keyboard navigation in mentions dropdown

Also prevents global keyboard shortcuts from interfering with text editing:
- Schema table arrow key navigation now skips editable elements
- Search result list navigation now skips editable elements

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
