### PR TITLE
Databricks ML model ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -321,6 +321,11 @@ class UnityCatalogSourceConfig(
         description="Details about the delta lake, incase to emit siblings",
     )
 
+    include_ml_models: bool = pydantic.Field(
+        default=True,
+        description="Whether to ingest ML models and MLflow experiments. Requires View permissions on ML model objects.",
+    )
+
     include_ml_model_aliases: bool = pydantic.Field(
         default=False,
         description="Whether to include ML model aliases in the ingestion.",

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -537,7 +537,8 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 yield from self.gen_schema_containers(schema)
                 try:
                     yield from self.process_tables(schema)
-                    yield from self.process_ml_models(schema)
+                    if self.config.include_ml_models:
+                        yield from self.process_ml_models(schema)
                 except Exception as e:
                     logger.exception(f"Error parsing schema {schema}")
                     self.report.report_warning(

--- a/metadata-ingestion/tests/unit/test_unity_catalog_config.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_config.py
@@ -495,3 +495,30 @@ def test_usage_data_source_can_be_set_with_warehouse():
 
     assert config.usage_data_source == UsageDataSource.SYSTEM_TABLES
     assert config.warehouse_id == "test_warehouse"
+
+
+def test_include_ml_models_default():
+    """Test that include_ml_models defaults to True."""
+    config = UnityCatalogSourceConfig.model_validate(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "include_tags": False,
+        }
+    )
+    assert config.include_ml_models is True
+
+
+def test_include_ml_models_can_be_disabled():
+    """Test that include_ml_models can be set to False."""
+    config = UnityCatalogSourceConfig.model_validate(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "include_tags": False,
+            "include_ml_models": False,
+        }
+    )
+    assert config.include_ml_models is False


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
This PR introduces a new configuration option, `include_ml_models`, for the Databricks Unity Catalog connector.

The primary motivation is to allow users to explicitly disable the ingestion of ML models and MLflow experiments. This is particularly useful for environments where the DataHub ingestion service lacks the necessary "View permissions on ML model objects" in Databricks, preventing ingestion failures due to permission errors.

By default, `include_ml_models` is set to `True` to maintain existing behavior and ensure no breaking changes.

---
[Slack Thread](https://datahub.slack.com/archives/C09UY1S8K55/p1770105474507589?thread_ts=1770105474.507589&cid=C09UY1S8K55)

<a href="https://cursor.com/background-agent?bcId=bc-1abebcde-c001-5945-929d-9c08eff330fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1abebcde-c001-5945-929d-9c08eff330fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

