### PR TITLE
feat(save_document tool): add save_document tool to datahub-agent-con…

### DIFF
--- a/datahub-agent-context/README.md
+++ b/datahub-agent-context/README.md
@@ -43,7 +43,7 @@ from datahub_agent_context.mcp_tools.entities import get_entities
 client = DataHubClient.from_env()
 
 # Search for datasets
-with client.graph as graph:
+with client as client:
     results = search(
         query="user_data",
         filters={"entity_type": ["dataset"]},
@@ -51,7 +51,7 @@ with client.graph as graph:
     )
 
 # Get detailed entity information
-with client.graph as graph:
+with client as client:
     entities = get_entities(
         urns=[result["entity"]["urn"] for result in results["searchResults"]]
     )
@@ -113,6 +113,7 @@ agent = create_agent(model, tools=tools, system_prompt="...")
 - `add_owners()`, `remove_owners()` - Manage owners
 - `add_glossary_terms()`, `remove_glossary_terms()` - Manage glossary terms
 - `add_structured_properties()`, `remove_structured_properties()` - Manage structured properties
+- `save_document()` - Save or update a Document.
 
 #### User Tools
 

--- a/datahub-agent-context/src/datahub_agent_context/__init__.py
+++ b/datahub-agent-context/src/datahub_agent_context/__init__.py
@@ -17,9 +17,17 @@
 from datahub_agent_context._version import __version__
 from datahub_agent_context.context import (
     DataHubContext,
+    get_datahub_client,
     get_graph,
-    reset_graph,
-    set_graph,
+    reset_client,
+    set_client,
 )
 
-__all__ = ["__version__", "DataHubContext", "get_graph", "set_graph", "reset_graph"]
+__all__ = [
+    "__version__",
+    "DataHubContext",
+    "get_datahub_client",
+    "get_graph",
+    "set_client",
+    "reset_client",
+]

--- a/datahub-agent-context/src/datahub_agent_context/langchain_tools/builder.py
+++ b/datahub-agent-context/src/datahub_agent_context/langchain_tools/builder.py
@@ -3,7 +3,7 @@
 import functools
 from typing import TYPE_CHECKING, Callable
 
-from datahub_agent_context.context import set_graph
+from datahub_agent_context.context import set_client
 from datahub_agent_context.mcp_tools import get_me
 from datahub_agent_context.mcp_tools.documents import grep_documents, search_documents
 from datahub_agent_context.mcp_tools.domains import remove_domains, set_domains
@@ -32,6 +32,7 @@ from datahub_agent_context.mcp_tools.lineage import (
 )
 from datahub_agent_context.mcp_tools.owners import add_owners, remove_owners
 from datahub_agent_context.mcp_tools.queries import get_dataset_queries
+from datahub_agent_context.mcp_tools.save_document import save_document
 from datahub_agent_context.mcp_tools.search import search
 from datahub_agent_context.mcp_tools.tags import add_tags, remove_tags
 from datahub_agent_context.mcp_tools.terms import (
@@ -57,14 +58,14 @@ def create_context_wrapper(func: Callable, client: "DataHubClient") -> Callable:
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # Set graph in context for this function call
-        token = set_graph(client._graph)
+        token = set_client(client)
         try:
             return func(*args, **kwargs)
         finally:
             # Always reset context, even if function raises
-            from datahub_agent_context.context import reset_graph
+            from datahub_agent_context.context import reset_client
 
-            reset_graph(token)
+            reset_client(token)
 
     return wrapper
 
@@ -123,5 +124,6 @@ def build_langchain_tools(
         tools.append(tool(create_context_wrapper(remove_tags, client)))
         tools.append(tool(create_context_wrapper(add_glossary_terms, client)))
         tools.append(tool(create_context_wrapper(remove_glossary_terms, client)))
+        tools.append(tool(create_context_wrapper(save_document, client)))
 
     return tools

--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/save_document.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/save_document.py
@@ -1,0 +1,634 @@
+"""Document saving tool for DataHub MCP server.
+
+This tool enables AI agents to save documents to DataHub's knowledge base.
+Documents are organized under a configurable parent folder (default: "Shared"),
+optionally with per-user subfolders for organization.
+
+Configuration via environment variables:
+- SAVE_DOCUMENT_TOOL_ENABLED: Set to "false" to disable this tool (default: enabled). Also requires TOOLS_IS_MUTATION_ENABLED enabled.
+- SAVE_DOCUMENT_PARENT_TITLE: Custom title for the parent folder (default: "Shared")
+- SAVE_DOCUMENT_ORGANIZE_BY_USER: Set to "true" to enable per-user organization (default: false)
+- SAVE_DOCUMENT_RESTRICT_UPDATES: Set to "false" to allow updating any document (default: true - only agent-created docs can be updated)
+"""
+
+import logging
+import os
+import re
+import uuid
+from datetime import datetime
+from typing import Dict, List, Literal, Optional, Tuple
+
+from datahub.metadata import schema_classes as models
+from datahub.sdk import Document
+from datahub_agent_context.context import get_datahub_client
+from datahub_agent_context.mcp_tools.base import execute_graphql
+
+logger = logging.getLogger(__name__)
+
+# Fixed root parent document ID - independent of title for future flexibility
+ROOT_PARENT_DOC_ID = "__system_shared_documents"
+
+
+def _get_parent_title() -> str:
+    """Get the configurable parent document title from environment."""
+    return os.environ.get("SAVE_DOCUMENT_PARENT_TITLE", "Shared")
+
+
+def _is_organize_by_user_enabled() -> bool:
+    """Check if per-user organization is enabled (default: False)."""
+    value = os.environ.get("SAVE_DOCUMENT_ORGANIZE_BY_USER", "false")
+    return value.lower() in ("true", "1", "yes")
+
+
+def _restrict_updates_to_shared_folder() -> bool:
+    """Check if updates should be restricted to the shared folder (default: True).
+
+    When enabled, only documents inside the shared folder can be updated.
+    This prevents accidental modification of user-created or imported documents.
+    """
+    value = os.environ.get("SAVE_DOCUMENT_RESTRICT_UPDATES", "true")
+    return value.lower() in ("true", "1", "yes")
+
+
+def _make_safe_id(text: str, max_length: int = 30) -> str:
+    """Convert text to a safe ID string."""
+    safe_id = "".join(c if c.isalnum() else "-" for c in text.lower())[:max_length]
+    safe_id = re.sub(r"-+", "-", safe_id)  # Collapse multiple dashes
+    return safe_id.strip("-")
+
+
+def _get_root_parent_id() -> str:
+    """Get the root parent document ID.
+
+    Uses a fixed ID independent of the display title to allow changing
+    the title without requiring data migration.
+    """
+    return ROOT_PARENT_DOC_ID
+
+
+def _get_root_parent_urn() -> str:
+    """Get the root parent document URN."""
+    return f"urn:li:document:{_get_root_parent_id()}"
+
+
+# Supported document types (subtypes)
+DocumentType = Literal[
+    "Insight",
+    "Decision",
+    "FAQ",
+    "Analysis",
+    "Summary",
+    "Recommendation",
+    "Note",
+    "Context",
+]
+
+
+def _get_current_user_info() -> Optional[Dict]:
+    """Fetch the current authenticated user's information."""
+
+    client = get_datahub_client()
+
+    query = """
+        query getMe {
+            me {
+                corpUser {
+                    urn
+                    username
+                    info {
+                        displayName
+                        fullName
+                        firstName
+                        lastName
+                    }
+                    editableProperties {
+                        displayName
+                    }
+                }
+            }
+        }
+    """
+
+    try:
+        result = execute_graphql(
+            client._graph,
+            query=query,
+            variables={},
+            operation_name="getMe",
+        )
+        me_data = result.get("me", {})
+        return me_data.get("corpUser") if me_data else None
+    except Exception as e:
+        logger.warning(f"Failed to get current user info: {e}")
+        return None
+
+
+def _get_user_display_name(user_info: Optional[Dict]) -> str:
+    """Extract the best display name from user info."""
+    if not user_info:
+        return "Unknown User"
+
+    # Try editable displayName first, then info fields
+    editable = user_info.get("editableProperties") or {}
+    info = user_info.get("info") or {}
+
+    return (
+        editable.get("displayName")
+        or info.get("displayName")
+        or info.get("fullName")
+        or f"{info.get('firstName', '')} {info.get('lastName', '')}".strip()
+        or user_info.get("username")
+        or "Unknown User"
+    )
+
+
+def _generate_document_id() -> str:
+    """Generate a unique document ID using UUID.
+
+    Each save creates a new document with a unique ID.
+    Format: shared-<uuid>
+    """
+    unique_id = str(uuid.uuid4())
+    return f"shared-{unique_id}"
+
+
+def _is_document_in_shared_folder(document_urn: str) -> Tuple[bool, Optional[str]]:
+    """Check if a document is within the shared documents folder.
+
+    Simple validation: document must have the shared folder as a parent/ancestor.
+
+    Returns:
+        Tuple of (is_valid, error_message)
+        - (True, None) if document is in the shared folder
+        - (False, error_message) if document is outside the folder
+    """
+
+    client = get_datahub_client()
+    root_parent_urn = _get_root_parent_urn()
+
+    # Can't update the root folder itself
+    if document_urn == root_parent_urn:
+        return False, (
+            "Cannot update the root shared documents folder. "
+            "Only documents within this folder can be updated."
+        )
+
+    try:
+        # Fetch the document
+        doc = client.entities.get(document_urn)
+        logger.debug(
+            f"Validating document {document_urn} for update, fetched: {doc is not None}"
+        )
+        if doc is None:
+            # Document doesn't exist yet - allow (will be created)
+            logger.debug(f"Document {document_urn} does not exist, allowing update")
+            return True, None
+
+        # Get documentInfo aspect
+        aspects = getattr(doc, "aspects", None) or getattr(doc, "_aspects", {})
+        logger.debug(
+            f"Document aspects type: {type(aspects)}, keys: {list(aspects.keys()) if isinstance(aspects, dict) else 'N/A'}"
+        )
+        doc_info = aspects.get("documentInfo") if isinstance(aspects, dict) else None
+
+        if doc_info is None:
+            logger.debug(f"Document {document_urn} has no documentInfo aspect")
+            return False, (
+                f"Document '{document_urn}' has no document info. "
+                "Cannot verify it's in the shared folder."
+            )
+
+        # Walk up the parent chain looking for the shared folder
+        # parentDocument is a ParentDocumentClass with a .document field containing the URN
+        parent_doc_obj = getattr(doc_info, "parentDocument", None)
+        logger.debug(f"Document parentDocument object: {parent_doc_obj}")
+        current_parent_urn = (
+            getattr(parent_doc_obj, "document", None) if parent_doc_obj else None
+        )
+        logger.debug(
+            f"Document parent URN: {current_parent_urn}, looking for root: {root_parent_urn}"
+        )
+        visited = set()
+
+        while current_parent_urn:
+            if current_parent_urn in visited:
+                break
+            visited.add(current_parent_urn)
+
+            # Found the shared folder - document is valid
+            if current_parent_urn == root_parent_urn:
+                return True, None
+
+            # Fetch parent and continue walking up
+            try:
+                parent_doc = client.entities.get(current_parent_urn)
+                if parent_doc is None:
+                    break
+                parent_aspects = getattr(parent_doc, "aspects", None) or getattr(
+                    parent_doc, "_aspects", {}
+                )
+                parent_info = (
+                    parent_aspects.get("documentInfo")
+                    if isinstance(parent_aspects, dict)
+                    else None
+                )
+                if parent_info is None:
+                    break
+                # Get next parent - again, it's a ParentDocumentClass object
+                next_parent_obj = getattr(parent_info, "parentDocument", None)
+                current_parent_urn = (
+                    getattr(next_parent_obj, "document", None)
+                    if next_parent_obj
+                    else None
+                )
+            except Exception:
+                break
+
+        return False, (
+            f"Document '{document_urn}' is not in the shared documents folder. "
+            "Only documents in this folder can be updated."
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to validate document hierarchy: {e}", exc_info=True)
+        # Fail closed - if we can't validate, don't allow the update
+        return False, (
+            f"Failed to validate document hierarchy for '{document_urn}': {str(e)}. "
+            "Cannot update document without verifying it's in the shared folder."
+        )
+
+
+def _ensure_document_exists(
+    doc_id: str,
+    title: str,
+    description: str,
+    parent_urn: Optional[str] = None,
+) -> str:
+    """Ensure a document exists, creating it if necessary. Returns the URN."""
+
+    client = get_datahub_client()
+    doc_urn = f"urn:li:document:{doc_id}"
+
+    try:
+        existing = client.entities.get(doc_urn)
+        if existing is not None:
+            return doc_urn
+    except Exception:
+        pass
+
+    # Create the document
+    doc = Document.create_document(
+        id=doc_id,
+        title=title,
+        text=description,
+        subtype="Folder",
+        parent_document=parent_urn,
+        show_in_global_context=True,
+    )
+
+    try:
+        client.entities.upsert(doc)
+        logger.info(f"Created folder document: {doc_urn}")
+    except Exception as e:
+        logger.warning(f"Failed to create folder document (may already exist): {e}")
+
+    return doc_urn
+
+
+def _ensure_parent_hierarchy(user_info: Optional[Dict]) -> Tuple[str, Optional[str]]:
+    """Ensure the parent document hierarchy exists.
+
+    Returns:
+        Tuple of (parent_urn_for_document, user_urn_if_available)
+    """
+    root_title = _get_parent_title()
+    root_id = _get_root_parent_id()
+
+    # Always create the root parent
+    root_urn = _ensure_document_exists(
+        doc_id=root_id,
+        title=root_title,
+        description="Contains shared documents authored through AI agents like Ask DataHub.",
+        parent_urn=None,
+    )
+
+    # If per-user organization is disabled, return root as parent
+    if not _is_organize_by_user_enabled():
+        return root_urn, user_info.get("urn") if user_info else None
+
+    # Create user-specific folder if we have user info
+    if user_info:
+        user_urn = user_info.get("urn")
+        username = user_info.get("username", "unknown")
+        display_name = _get_user_display_name(user_info)
+
+        # Create user folder under root
+        user_folder_id = f"agent-docs-user-{_make_safe_id(username, max_length=30)}"
+        user_folder_urn = _ensure_document_exists(
+            doc_id=user_folder_id,
+            title=display_name,
+            description=f"Contains documents authored in sessions for {display_name}.",
+            parent_urn=root_urn,
+        )
+        return user_folder_urn, user_urn
+
+    # No user info available, use root
+    return root_urn, None
+
+
+def save_document(
+    document_type: DocumentType,
+    title: str,
+    content: str,
+    urn: Optional[str] = None,
+    topics: Optional[List[str]] = None,
+    related_documents: Optional[List[str]] = None,
+    related_assets: Optional[List[str]] = None,
+) -> dict:
+    """Save or update a STANDALONE document in DataHub's knowledge base. Once saved,
+    a document will be visible to all users of DataHub and to Ask DataHub AI assistant.
+
+    NOTE: This tool is for creating standalone documents (insights, FAQs, notes, etc.),
+    NOT for updating descriptions on data assets like datasets or dashboards.
+    Use update_description for asset descriptions.
+
+    WHEN TO USE THIS TOOL:
+
+    Use this tool when the user explicitly requests to save information:
+    - "Save this for later..."
+    - "Bookmark this.."
+    - "Document this insight.."
+    - "Remember this.."
+    - "Add this to our knowledge base.."
+    - "Create a document about this.."
+
+    Also SUGGEST using this tool when the user provides valuable information such as:
+    - Useful SQL queries they want to reuse
+    - Decisions about data modeling or architecture
+    - FAQs or common questions about data
+    - Analysis results worth sharing with the team
+    - Corrections or clarifications about data, service, business definitions, etc.
+
+    ⚠️  IMPORTANT: Before calling this tool, you SHOULD confirm with the user that
+    they want to save this document. Present the title, content summary,
+    and any related assets, and ask for their approval before proceeding. Do not attempt to save
+    information that would be private or user-specific.
+
+    This tool persists insights, decisions, FAQs, and other contextual information
+    as documents in DataHub. Documents are organized hierarchically:
+    - Under a configurable parent folder (default: "Shared" for global context)
+    - Optionally grouped by the user who authored them
+
+    UPSERT BEHAVIOR:
+    - If `urn` is NOT provided: Creates a NEW document with a unique URN
+    - If `urn` IS provided: Updates the EXISTING document with that URN
+
+    IMPORTANT USAGE GUIDELINES:
+    - Always confirm with the user before saving
+    - Provide a clear summary of what will be saved
+    - Ask if the user wants to proceed with creating/updating the document
+
+    REQUIRED PARAMETERS:
+
+    document_type: The type of document being saved. For example:
+        - "Insight": Data insights or discoveries
+        - "Decision": Documented decisions with rationale
+        - "FAQ": Frequently asked questions and answers
+        - "Analysis": Data analysis findings
+        - "Summary": Summaries of complex information
+        - "Recommendation": Suggested actions or improvements
+        - "Note": General notes or observations
+
+    title: A descriptive title for the document.
+        - Example: "Sales Data Quality Issues - Q4 2024"
+        - Example: "Decision: Deprecating Legacy Customer Table"
+
+    content: The full content of the document (supports markdown formatting).
+        - Can include headers, lists, code blocks, tables, etc.
+        - Example: "## Summary\\n\\nThe orders table shows 15% null values..."
+
+    OPTIONAL PARAMETERS:
+
+    urn: The URN of an existing document to update.
+        - ONLY use after a search_documents or get_entity call returns a document URN
+        - Example: "urn:li:document:agent-insight-abc123"
+        - If not provided, a new document is created with a unique URN
+        - If provided, the existing document is updated (upsert operation)
+
+    topics: List of topic tags for categorization and discovery (like a word cloud).
+        - These become searchable tags in DataHub that users can click to find related documents
+        - Example: ["data-quality", "customer-data", "Q4-2024"]
+        - Example: ["high-priority", "sales", "email", "null-values"]
+
+    related_documents: URNs of related documents.
+        - Example: ["urn:li:document:agent-insight-sales-abc123"]
+        - Creates links between related knowledge
+
+    related_assets: URNs of related data assets (tables, dashboards, etc).
+        - Example: ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.orders,PROD)"]
+        - Links the document to specific data assets in the catalog
+        - Users can then see this document when viewing those assets
+
+    Returns:
+        Dictionary with:
+        - success: Boolean indicating if the operation succeeded
+        - urn: The URN of the created/updated document
+        - message: Success or error message
+        - author: The user who authored the document (if available)
+
+    RECOMMENDED WORKFLOW:
+
+    1. Gather information you want to save publicly
+    2. Present a summary to the user:
+       "I'd like to save the following insight to DataHub:
+        - Title: High Null Rate in Customer Emails
+        - Type: Insight
+        - Related to: customers table
+        Would you like me to save this?"
+    3. Only call save_document after user confirms
+
+    EXAMPLE USAGE:
+
+    1. Create a new insight (after user confirmation):
+        save_document(
+            document_type="Insight",
+            title="High Null Rate in Customer Emails",
+            content="## Finding\\n\\n23% of customer records have null email...",
+            topics=["data-quality", "customer-data", "email", "high-severity"],
+            related_assets=["urn:li:dataset:(urn:li:dataPlatform:snowflake,customers,PROD)"]
+        )
+
+    2. Update an existing document (after finding it via search_documents):
+        save_document(
+            urn="urn:li:document:agent-insight-abc123",  # From search_documents result
+            document_type="Insight",
+            title="High Null Rate in Customer Emails (Updated)",
+            content="## Finding\\n\\nUpdated: Now 18% of customer records have null email...",
+            topics=["data-quality", "customer-data", "email", "resolved"]
+        )
+
+    3. Document a decision:
+        save_document(
+            document_type="Decision",
+            title="Migrating to New Production Database",
+            content="## Decision\\n\\nWe will migrate to v2 schema...\\n\\n## Rationale\\n...",
+            topics=["architecture", "data-model", "migration", "approved"]
+        )
+    """
+
+    client = get_datahub_client()
+
+    # Validate inputs
+    if not title or not title.strip():
+        return {
+            "success": False,
+            "urn": None,
+            "message": "title cannot be empty",
+            "author": None,
+        }
+
+    if not content or not content.strip():
+        return {
+            "success": False,
+            "urn": None,
+            "message": "content cannot be empty",
+            "author": None,
+        }
+
+    valid_document_types = [
+        "Insight",
+        "Decision",
+        "FAQ",
+        "Analysis",
+        "Summary",
+        "Recommendation",
+        "Note",
+        "Context",
+    ]
+    if document_type not in valid_document_types:
+        return {
+            "success": False,
+            "urn": None,
+            "message": f"Invalid document_type '{document_type}'. Must be one of: {', '.join(valid_document_types)}",
+            "author": None,
+        }
+
+    # Validate URN format if provided
+    if urn is not None:
+        if not urn.startswith("urn:li:document:"):
+            return {
+                "success": False,
+                "urn": None,
+                "message": f"Invalid urn format '{urn}'. Must start with 'urn:li:document:'",
+                "author": None,
+            }
+
+        # Validate that the document is within the agent-authored hierarchy
+        # This prevents accidental modification of user-created or imported documents
+        if _restrict_updates_to_shared_folder():
+            is_valid, error_message = _is_document_in_shared_folder(urn)
+            if not is_valid:
+                return {
+                    "success": False,
+                    "urn": None,
+                    "message": error_message,
+                    "author": None,
+                }
+
+        is_update = True
+        document_urn = urn
+        # Extract document ID from URN
+        document_id = urn.replace("urn:li:document:", "")
+    else:
+        is_update = False
+        # Generate new document ID
+        document_id = _generate_document_id()
+        document_urn = f"urn:li:document:{document_id}"
+
+    try:
+        # Get current user info for attribution and organization
+        user_info = _get_current_user_info()
+        user_display_name = _get_user_display_name(user_info) if user_info else None
+        user_urn = user_info.get("urn") if user_info else None
+
+        # Ensure parent hierarchy exists and get the parent URN for our document
+        # For updates, we still want to maintain proper parent hierarchy
+        parent_urn, _ = _ensure_parent_hierarchy(user_info)
+
+        # Set current user as owner only for NEW documents (captures authorship)
+        # For updates, preserve existing ownership by not setting owners
+        # The SDK expects owner URNs as strings in a list
+        if is_update:
+            owners = None  # Don't overwrite existing ownership on updates
+            logger.info("Updating existing document - preserving existing ownership")
+        else:
+            owners = [user_urn] if user_urn else None
+            logger.info(f"Creating new document - setting owners: {owners}")
+
+        # Convert topics to tag URNs (DataHub expects full URNs)
+        # TODO: Decide whether tags are the right abstraction here.
+        # Alternative: Use Structured Properties, custom properties, or custom label.
+        # Just needs to be searchable later on.
+        tag_urns = None
+        if topics:
+            tag_urns = [f"urn:li:tag:{topic}" for topic in topics]
+
+        # Create the document
+        doc = Document.create_document(
+            id=document_id,
+            title=title,
+            text=content,
+            subtype=document_type,
+            parent_document=parent_urn,
+            related_documents=related_documents,
+            related_assets=related_assets,
+            owners=owners,
+            tags=tag_urns,  # Use topics as tags for searchability
+            show_in_global_context=True,
+        )
+
+        # Manually add DocumentSettings to ensure showInGlobalContext=True is set
+        # This is a workaround until the SDK is updated to always emit this aspect
+        # TODO: Remove this once SDK properly emits DocumentSettings for show_in_global_context=True
+        actor_urn = user_urn or "urn:li:corpuser:datahub"
+        settings_audit = models.AuditStampClass(
+            time=int(datetime.now().timestamp() * 1000),
+            actor=actor_urn,
+        )
+        document_settings = models.DocumentSettingsClass(
+            showInGlobalContext=True,
+            lastModified=settings_audit,
+        )
+        doc._set_aspect(document_settings)
+
+        # Log document details before upsert
+        logger.info(
+            f"Document to upsert: URN={document_urn}, owners={owners}, parent={parent_urn}"
+        )
+
+        # Upsert the document
+        try:
+            client.entities.upsert(doc)
+            logger.info("Upsert completed successfully")
+        except Exception as upsert_error:
+            logger.error(f"Failed to upsert document: {upsert_error}", exc_info=True)
+            raise
+
+        action = "updated" if is_update else "created"
+        logger.info(f"Successfully {action} document: {document_urn}")
+
+        return {
+            "success": True,
+            "urn": document_urn,
+            "message": f"Successfully {action} document: {title}",
+            "author": user_display_name,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to save document: {e}")
+        return {
+            "success": False,
+            "urn": None,
+            "message": f"Error saving document: {str(e)}",
+            "author": None,
+        }

--- a/datahub-agent-context/tests/unit/mcp_tools/test_base.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_base.py
@@ -9,61 +9,64 @@ from datahub_agent_context.mcp_tools.base import _is_datahub_cloud
 
 
 @pytest.fixture
-def mock_graph_with_frontend_url():
-    """Create a mock DataHubGraph with frontend_base_url set."""
+def mock_client_with_frontend_url():
+    """Create a mock DataHubClient with frontend_base_url set."""
     mock = Mock()
-    mock.frontend_base_url = "https://mycompany.acryl.io"
+    mock._graph = Mock()
+    mock.graph.frontend_base_url = "https://mycompany.acryl.io"
     return mock
 
 
 @pytest.fixture
-def mock_graph_without_frontend_url():
-    """Create a mock DataHubGraph without frontend_base_url."""
+def mock_client_without_frontend_url():
+    """Create a mock DataHubClient without frontend_base_url."""
     mock = Mock()
+    mock._graph = Mock()
     # Explicitly make hasattr return False for frontend_base_url
-    del mock.frontend_base_url
+    del mock.graph.frontend_base_url
     return mock
 
 
 @pytest.fixture
-def mock_graph_with_empty_frontend_url():
-    """Create a mock DataHubGraph with empty frontend_base_url."""
+def mock_client_with_empty_frontend_url():
+    """Create a mock DataHubClient with empty frontend_base_url."""
     mock = Mock()
-    mock.frontend_base_url = None
+    mock._graph = Mock()
+    mock.graph.frontend_base_url = None
     return mock
 
 
-def test_is_datahub_cloud_with_frontend_url(mock_graph_with_frontend_url):
+def test_is_datahub_cloud_with_frontend_url(mock_client_with_frontend_url):
     """Test cloud detection returns True when frontend_base_url is set."""
-    result = _is_datahub_cloud(mock_graph_with_frontend_url)
+    result = _is_datahub_cloud(mock_client_with_frontend_url.graph)
     assert result is True
 
 
-def test_is_datahub_cloud_without_frontend_url(mock_graph_without_frontend_url):
+def test_is_datahub_cloud_without_frontend_url(mock_client_without_frontend_url):
     """Test cloud detection returns False when frontend_base_url is not present."""
-    result = _is_datahub_cloud(mock_graph_without_frontend_url)
+    result = _is_datahub_cloud(mock_client_without_frontend_url.graph)
     assert result is False
 
 
-def test_is_datahub_cloud_with_empty_frontend_url(mock_graph_with_empty_frontend_url):
+def test_is_datahub_cloud_with_empty_frontend_url(mock_client_with_empty_frontend_url):
     """Test cloud detection returns False when frontend_base_url is None."""
-    result = _is_datahub_cloud(mock_graph_with_empty_frontend_url)
+    result = _is_datahub_cloud(mock_client_with_empty_frontend_url.graph)
     assert result is False
 
 
-def test_is_datahub_cloud_with_env_var_disabled(mock_graph_with_frontend_url):
+def test_is_datahub_cloud_with_env_var_disabled(mock_client_with_frontend_url):
     """Test cloud detection returns False when DISABLE_NEWER_GMS_FIELD_DETECTION is set."""
     with patch.dict(os.environ, {"DISABLE_NEWER_GMS_FIELD_DETECTION": "true"}):
-        result = _is_datahub_cloud(mock_graph_with_frontend_url)
+        result = _is_datahub_cloud(mock_client_with_frontend_url.graph)
         assert result is False
 
 
-def test_is_datahub_cloud_with_value_error(mock_graph_with_frontend_url):
+def test_is_datahub_cloud_with_value_error(mock_client_with_frontend_url):
     """Test cloud detection returns False when ValueError is raised."""
     # Configure the mock to raise ValueError when accessing frontend_base_url
-    type(mock_graph_with_frontend_url).frontend_base_url = property(
+    type(mock_client_with_frontend_url.graph).frontend_base_url = property(
         lambda self: (_ for _ in ()).throw(ValueError("test error"))
     )
 
-    result = _is_datahub_cloud(mock_graph_with_frontend_url)
+    result = _is_datahub_cloud(mock_client_with_frontend_url.graph)
     assert result is False

--- a/datahub-agent-context/tests/unit/mcp_tools/test_domains.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_domains.py
@@ -9,17 +9,18 @@ from datahub_agent_context.mcp_tools.domains import remove_domains, set_domains
 
 
 @pytest.fixture
-def mock_graph():
-    """Create a mock DataHubGraph."""
+def mock_client():
+    """Create a mock DataHubClient."""
     mock = Mock()
-    mock.execute_graphql = Mock()
+    mock._graph = Mock()
+    mock.graph.execute_graphql = Mock()
     return mock
 
 
 # Set domain tests
 
 
-def test_set_domains_single_entity(mock_graph):
+def test_set_domains_single_entity(mock_client):
     """Test setting domain for a single entity."""
     domain_urn = "urn:li:domain:marketing"
     entity_urns = [
@@ -27,7 +28,7 @@ def test_set_domains_single_entity(mock_graph):
     ]
 
     # Mock domain validation response
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         # First call: domain validation
         {
             "entity": {
@@ -40,16 +41,16 @@ def test_set_domains_single_entity(mock_graph):
         {"batchSetDomain": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = set_domains(domain_urn=domain_urn, entity_urns=entity_urns)
     assert result["success"] is True
     assert "1 entit(ies)" in result["message"]
 
     # Verify GraphQL was called twice (validation + mutation)
-    assert mock_graph.execute_graphql.call_count == 2
+    assert mock_client._graph.execute_graphql.call_count == 2
 
     # Verify mutation was called with correct parameters
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     assert mutation_call.kwargs["operation_name"] == "batchSetDomain"
     assert mutation_call.kwargs["variables"]["input"]["domainUrn"] == domain_urn
     assert (
@@ -58,7 +59,7 @@ def test_set_domains_single_entity(mock_graph):
     )
 
 
-def test_set_domains_multiple_entities(mock_graph):
+def test_set_domains_multiple_entities(mock_client):
     """Test setting domain for multiple entities."""
     domain_urn = "urn:li:domain:finance"
     entity_urns = [
@@ -67,7 +68,7 @@ def test_set_domains_multiple_entities(mock_graph):
         "urn:li:dashboard:(urn:li:dataPlatform:looker,revenue,PROD)",
     ]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entity": {
                 "urn": domain_urn,
@@ -78,12 +79,12 @@ def test_set_domains_multiple_entities(mock_graph):
         {"batchSetDomain": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = set_domains(domain_urn=domain_urn, entity_urns=entity_urns)
     assert result["success"] is True
     assert "3 entit(ies)" in result["message"]
 
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     resources = mutation_call.kwargs["variables"]["input"]["resources"]
     assert len(resources) == 3
     assert resources[0]["resourceUrn"] == entity_urns[0]
@@ -91,7 +92,7 @@ def test_set_domains_multiple_entities(mock_graph):
     assert resources[2]["resourceUrn"] == entity_urns[2]
 
 
-def test_set_domains_mixed_entity_types(mock_graph):
+def test_set_domains_mixed_entity_types(mock_client):
     """Test setting domain for mixed entity types (datasets, dashboards, dataflows)."""
     domain_urn = "urn:li:domain:engineering"
     entity_urns = [
@@ -100,7 +101,7 @@ def test_set_domains_mixed_entity_types(mock_graph):
         "urn:li:dashboard:(urn:li:dataPlatform:superset,metrics,PROD)",
     ]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entity": {
                 "urn": domain_urn,
@@ -111,7 +112,7 @@ def test_set_domains_mixed_entity_types(mock_graph):
         {"batchSetDomain": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = set_domains(domain_urn=domain_urn, entity_urns=entity_urns)
     assert result["success"] is True
     assert "3 entit(ies)" in result["message"]
@@ -120,19 +121,19 @@ def test_set_domains_mixed_entity_types(mock_graph):
 # Remove domain tests
 
 
-def test_remove_domains_single_entity(mock_graph):
+def test_remove_domains_single_entity(mock_client):
     """Test removing domain from a single entity."""
     entity_urns = ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.old,PROD)"]
 
-    mock_graph.execute_graphql.return_value = {"batchSetDomain": True}
+    mock_client._graph.execute_graphql.return_value = {"batchSetDomain": True}
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = remove_domains(entity_urns=entity_urns)
     assert result["success"] is True
     assert "removed domain from 1 entit(ies)" in result["message"]
 
     # Verify mutation was called with domainUrn set to None
-    call_args = mock_graph.execute_graphql.call_args
+    call_args = mock_client._graph.execute_graphql.call_args
     assert call_args.kwargs["variables"]["input"]["domainUrn"] is None
     assert (
         call_args.kwargs["variables"]["input"]["resources"][0]["resourceUrn"]
@@ -140,7 +141,7 @@ def test_remove_domains_single_entity(mock_graph):
     )
 
 
-def test_remove_domains_multiple_entities(mock_graph):
+def test_remove_domains_multiple_entities(mock_client):
     """Test removing domain from multiple entities."""
     entity_urns = [
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.temp1,PROD)",
@@ -148,14 +149,14 @@ def test_remove_domains_multiple_entities(mock_graph):
         "urn:li:dashboard:(urn:li:dataPlatform:looker,old_dashboard,PROD)",
     ]
 
-    mock_graph.execute_graphql.return_value = {"batchSetDomain": True}
+    mock_client._graph.execute_graphql.return_value = {"batchSetDomain": True}
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = remove_domains(entity_urns=entity_urns)
     assert result["success"] is True
     assert "removed domain from 3 entit(ies)" in result["message"]
 
-    call_args = mock_graph.execute_graphql.call_args
+    call_args = mock_client._graph.execute_graphql.call_args
     resources = call_args.kwargs["variables"]["input"]["resources"]
     assert len(resources) == 3
     assert call_args.kwargs["variables"]["input"]["domainUrn"] is None
@@ -164,121 +165,121 @@ def test_remove_domains_multiple_entities(mock_graph):
 # Validation tests
 
 
-def test_set_domains_empty_domain_urn(mock_graph):
+def test_set_domains_empty_domain_urn(mock_client):
     """Test that empty domain_urn raises ValueError."""
     entity_urns = ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.test,PROD)"]
 
     with pytest.raises(ValueError, match="domain_urn cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             set_domains(domain_urn="", entity_urns=entity_urns)
 
 
-def test_set_domains_empty_entity_urns(mock_graph):
+def test_set_domains_empty_entity_urns(mock_client):
     """Test that empty entity_urns raises ValueError."""
     domain_urn = "urn:li:domain:test"
 
     with pytest.raises(ValueError, match="entity_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             set_domains(domain_urn=domain_urn, entity_urns=[])
 
 
-def test_remove_domains_empty_entity_urns(mock_graph):
+def test_remove_domains_empty_entity_urns(mock_client):
     """Test that empty entity_urns raises ValueError."""
     with pytest.raises(ValueError, match="entity_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_domains(entity_urns=[])
 
 
-def test_set_domains_nonexistent_domain(mock_graph):
+def test_set_domains_nonexistent_domain(mock_client):
     """Test that nonexistent domain URN returns error."""
     domain_urn = "urn:li:domain:nonexistent"
     entity_urns = ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.test,PROD)"]
 
     # Mock validation returning None (domain doesn't exist)
-    mock_graph.execute_graphql.return_value = {"entity": None}
+    mock_client._graph.execute_graphql.return_value = {"entity": None}
 
     with pytest.raises(ValueError, match="Domain URN does not exist"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             set_domains(domain_urn=domain_urn, entity_urns=entity_urns)
 
 
-def test_set_domains_invalid_domain_type(mock_graph):
+def test_set_domains_invalid_domain_type(mock_client):
     """Test that URN with wrong entity type returns error."""
     domain_urn = "urn:li:tag:not-a-domain"
     entity_urns = ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.test,PROD)"]
 
     # Mock validation returning wrong type
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "entity": {"urn": domain_urn, "type": "TAG"}
     }
 
     with pytest.raises(ValueError, match="not a domain entity"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             set_domains(domain_urn=domain_urn, entity_urns=entity_urns)
 
 
 # Error handling tests
 
 
-def test_set_domains_mutation_returns_false(mock_graph):
+def test_set_domains_mutation_returns_false(mock_client):
     """Test handling when mutation returns false."""
     domain_urn = "urn:li:domain:test"
     entity_urns = ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.test,PROD)"]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {"entity": {"urn": domain_urn, "type": "DOMAIN"}},
         {"batchSetDomain": False},
     ]
 
     with pytest.raises(RuntimeError, match="Failed to set domain"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             set_domains(domain_urn=domain_urn, entity_urns=entity_urns)
 
 
-def test_remove_domains_mutation_returns_false(mock_graph):
+def test_remove_domains_mutation_returns_false(mock_client):
     """Test handling when remove mutation returns false."""
     entity_urns = ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.test,PROD)"]
 
-    mock_graph.execute_graphql.return_value = {"batchSetDomain": False}
+    mock_client._graph.execute_graphql.return_value = {"batchSetDomain": False}
 
     with pytest.raises(RuntimeError, match="Failed to remove domain"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_domains(entity_urns=entity_urns)
 
 
-def test_set_domains_graphql_exception(mock_graph):
+def test_set_domains_graphql_exception(mock_client):
     """Test handling of GraphQL execution errors."""
     domain_urn = "urn:li:domain:test"
     entity_urns = ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.test,PROD)"]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {"entity": {"urn": domain_urn, "type": "DOMAIN"}},
         Exception("GraphQL error"),
     ]
 
     with pytest.raises(RuntimeError, match="Error setting domain"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             set_domains(domain_urn=domain_urn, entity_urns=entity_urns)
 
 
-def test_remove_domains_graphql_exception(mock_graph):
+def test_remove_domains_graphql_exception(mock_client):
     """Test handling of GraphQL execution errors during removal."""
     entity_urns = ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.test,PROD)"]
 
-    mock_graph.execute_graphql.side_effect = Exception("Network error")
+    mock_client._graph.execute_graphql.side_effect = Exception("Network error")
 
     with pytest.raises(RuntimeError, match="Error removing domain"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_domains(entity_urns=entity_urns)
 
 
-def test_set_domains_validation_exception(mock_graph):
+def test_set_domains_validation_exception(mock_client):
     """Test handling of validation errors."""
     domain_urn = "urn:li:domain:test"
     entity_urns = ["urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.test,PROD)"]
 
-    mock_graph.execute_graphql.side_effect = Exception("Connection timeout")
+    mock_client._graph.execute_graphql.side_effect = Exception("Connection timeout")
 
     with pytest.raises(ValueError, match="Failed to validate domain URN"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             set_domains(domain_urn=domain_urn, entity_urns=entity_urns)

--- a/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_save_document.py
@@ -1,0 +1,727 @@
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from datahub_agent_context.context import DataHubContext
+from datahub_agent_context.mcp_tools.save_document import (
+    ROOT_PARENT_DOC_ID,
+    _generate_document_id,
+    _get_parent_title,
+    _get_root_parent_id,
+    _get_root_parent_urn,
+    _get_user_display_name,
+    _is_document_in_shared_folder,
+    _is_organize_by_user_enabled,
+    _make_safe_id,
+    _restrict_updates_to_shared_folder,
+    save_document,
+)
+
+
+@pytest.fixture
+def mock_client():
+    """Fixture for mocking DataHubClient."""
+    mock = Mock()
+    mock_entities = Mock()
+    mock.entities = mock_entities
+    mock._graph = Mock()
+    return mock
+
+
+@pytest.fixture
+def mock_user_info():
+    """Fixture for mock user info."""
+    return {
+        "urn": "urn:li:corpuser:john.doe",
+        "username": "john.doe",
+        "info": {
+            "displayName": "John Doe",
+            "fullName": "John Doe",
+            "firstName": "John",
+            "lastName": "Doe",
+        },
+        "editableProperties": {
+            "displayName": "John Doe",
+        },
+    }
+
+
+class TestDocumentIdGeneration:
+    """Tests for document ID generation."""
+
+    def test_generate_document_id_is_unique(self):
+        """Test that document ID generation creates unique IDs."""
+        doc_id_1 = _generate_document_id()
+        doc_id_2 = _generate_document_id()
+        # Each call should generate a unique UUID
+        assert doc_id_1 != doc_id_2
+
+    def test_generate_document_id_format(self):
+        """Test that document ID has expected format (shared-<uuid>)."""
+        doc_id = _generate_document_id()
+        assert doc_id.startswith("shared-")
+        # Should have UUID format after the prefix
+        parts = doc_id.split("-", 1)
+        assert len(parts) == 2
+        assert parts[0] == "shared"
+        # The second part should be a valid UUID
+        assert len(parts[1]) == 36  # UUID length with dashes
+
+
+class TestUserInfoHelpers:
+    """Tests for user info helper functions."""
+
+    def test_get_user_display_name_with_editable_display_name(self, mock_user_info):
+        """Test display name extraction with editable displayName."""
+        assert _get_user_display_name(mock_user_info) == "John Doe"
+
+    def test_get_user_display_name_with_full_name(self):
+        """Test display name extraction with fullName."""
+        user_info = {
+            "info": {"fullName": "Jane Smith"},
+            "editableProperties": {},
+        }
+        assert _get_user_display_name(user_info) == "Jane Smith"
+
+    def test_get_user_display_name_with_first_last(self):
+        """Test display name extraction with first/last name."""
+        user_info = {
+            "info": {"firstName": "Bob", "lastName": "Jones"},
+            "editableProperties": {},
+        }
+        assert _get_user_display_name(user_info) == "Bob Jones"
+
+    def test_get_user_display_name_with_username(self):
+        """Test display name extraction fallback to username."""
+        user_info = {
+            "username": "bob.jones",
+            "info": {},
+            "editableProperties": {},
+        }
+        assert _get_user_display_name(user_info) == "bob.jones"
+
+    def test_get_user_display_name_unknown(self):
+        """Test display name extraction with no info."""
+        assert _get_user_display_name(None) == "Unknown User"
+        assert _get_user_display_name({}) == "Unknown User"
+
+
+class TestConfigHelpers:
+    """Tests for configuration helper functions."""
+
+    def test_make_safe_id(self):
+        """Test safe ID generation."""
+        assert _make_safe_id("Hello World") == "hello-world"
+        assert _make_safe_id("Test   Multiple   Spaces") == "test-multiple-spaces"
+        assert _make_safe_id("Special!@#$%Characters") == "special-characters"
+
+    def test_get_parent_title_default(self):
+        """Test default parent title."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove env var if set
+            os.environ.pop("SAVE_DOCUMENT_PARENT_TITLE", None)
+            assert _get_parent_title() == "Shared"
+
+    def test_get_parent_title_custom(self):
+        """Test custom parent title from env var."""
+        with patch.dict(os.environ, {"SAVE_DOCUMENT_PARENT_TITLE": "Custom Title"}):
+            assert _get_parent_title() == "Custom Title"
+
+    def test_is_organize_by_user_enabled_default(self):
+        """Test default organize by user setting."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("SAVE_DOCUMENT_ORGANIZE_BY_USER", None)
+            assert _is_organize_by_user_enabled() is False
+
+    def test_is_organize_by_user_disabled(self):
+        """Test disabled organize by user setting."""
+        with patch.dict(os.environ, {"SAVE_DOCUMENT_ORGANIZE_BY_USER": "false"}):
+            assert _is_organize_by_user_enabled() is False
+
+    def test_restrict_updates_to_shared_folder_default(self):
+        """Test default update restriction setting (should be True)."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("SAVE_DOCUMENT_RESTRICT_UPDATES", None)
+            assert _restrict_updates_to_shared_folder() is True
+
+    def test_restrict_updates_to_shared_folder_disabled(self):
+        """Test update restriction disabled setting."""
+        with patch.dict(os.environ, {"SAVE_DOCUMENT_RESTRICT_UPDATES": "false"}):
+            assert _restrict_updates_to_shared_folder() is False
+
+    def test_root_parent_doc_id_constant(self):
+        """Test that ROOT_PARENT_DOC_ID is a fixed constant."""
+        assert ROOT_PARENT_DOC_ID == "__system_shared_documents"
+
+
+class TestSaveDocument:
+    """Tests for the save_document function."""
+
+    def test_save_document_creates_document(self, mock_client, mock_user_info):
+        """Test saving a new document."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="High Null Rate in Customer Emails",
+                content="## Finding\n\n23% of customer records have null email...",
+                topics=["data-quality", "customer-data", "high-severity"],
+                related_assets=[
+                    "urn:li:dataset:(urn:li:dataPlatform:snowflake,customers,PROD)"
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["urn"] is not None
+        assert "urn:li:document:" in result["urn"]
+        assert result["author"] == "John Doe"
+        assert "created" in result["message"].lower()
+
+    def test_save_document_empty_title_fails(self, mock_client):
+        """Test that empty title returns error."""
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="",
+                content="Some content",
+            )
+
+        assert result["success"] is False
+        assert "title cannot be empty" in result["message"]
+
+    def test_save_document_empty_content_fails(self, mock_client):
+        """Test that empty content returns error."""
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="Some title",
+                content="",
+            )
+
+        assert result["success"] is False
+        assert "content cannot be empty" in result["message"]
+
+    def test_save_document_invalid_document_type_fails(self, mock_client):
+        """Test that invalid document type returns error."""
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="InvalidType",  # type: ignore
+                title="Some title",
+                content="Some content",
+            )
+
+        assert result["success"] is False
+        assert "Invalid document_type" in result["message"]
+
+    def test_save_document_with_all_options(self, mock_client, mock_user_info):
+        """Test saving a document with all optional parameters."""
+        mock_client.entities.get.return_value = Mock()
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Decision",
+                title="Migrating to New Data Model",
+                content="## Decision\n\nWe will migrate to v2 schema...",
+                topics=["architecture", "migration", "approved"],
+                related_documents=["urn:li:document:agent-insight-related-abc123"],
+                related_assets=[
+                    "urn:li:dataset:(urn:li:dataPlatform:snowflake,old_schema,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:snowflake,new_schema,PROD)",
+                ],
+            )
+
+        assert result["success"] is True
+        assert result["urn"] is not None
+
+    def test_save_document_update_existing_document(self, mock_client, mock_user_info):
+        """Test updating an existing document by providing URN."""
+        mock_client.entities.get.return_value = Mock()
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        existing_urn = "urn:li:document:agent-insight-existing-abc123"
+
+        # Disable update restrictions for this test
+        with (
+            patch.dict(os.environ, {"SAVE_DOCUMENT_RESTRICT_UPDATES": "false"}),
+            DataHubContext(mock_client),
+        ):
+            result = save_document(
+                document_type="Insight",
+                title="Updated Title",
+                content="Updated content...",
+                urn=existing_urn,
+            )
+
+        assert result["success"] is True
+        assert result["urn"] == existing_urn
+        assert "updated" in result["message"].lower()
+
+    def test_save_document_invalid_urn_format(self, mock_client):
+        """Test that invalid URN format returns error."""
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="Test",
+                content="Some content",
+                urn="invalid-urn-format",
+            )
+
+        assert result["success"] is False
+        assert "Invalid urn format" in result["message"]
+
+    def test_save_document_update_restriction_blocks_external_doc(
+        self, mock_client, mock_user_info
+    ):
+        """Test that update restrictions block updating non-agent documents."""
+        # Create a mock document that is NOT in the agent hierarchy
+        mock_doc = Mock()
+        mock_doc.aspects = {
+            "documentInfo": Mock(parentDocument=None)  # No parent = not in hierarchy
+        }
+        mock_client.entities.get.return_value = mock_doc
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        external_urn = "urn:li:document:user-created-doc-123"
+
+        # Enable update restrictions (default)
+        with (
+            patch.dict(os.environ, {"SAVE_DOCUMENT_RESTRICT_UPDATES": "true"}),
+            DataHubContext(mock_client),
+        ):
+            result = save_document(
+                document_type="Insight",
+                title="Trying to Update External Doc",
+                content="This should fail...",
+                urn=external_urn,
+            )
+
+        assert result["success"] is False
+        assert "not in the shared documents folder" in result["message"]
+
+    def test_save_document_create_without_urn(self, mock_client, mock_user_info):
+        """Test that not providing URN creates a new document."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="New Document",
+                content="New content...",
+            )
+
+        assert result["success"] is True
+        assert result["urn"] is not None
+        assert result["urn"].startswith("urn:li:document:shared-")
+        assert "created" in result["message"].lower()
+
+    def test_save_document_all_valid_document_types(self, mock_client, mock_user_info):
+        """Test that all valid document types work."""
+        valid_types = [
+            "Insight",
+            "Decision",
+            "FAQ",
+            "Analysis",
+            "Summary",
+            "Recommendation",
+            "Note",
+            "Context",
+        ]
+
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with DataHubContext(mock_client):
+            for document_type in valid_types:
+                result = save_document(
+                    document_type=document_type,  # type: ignore
+                    title=f"Test {document_type}",
+                    content=f"Content for {document_type}",
+                )
+                assert result["success"] is True, (
+                    f"Failed for document_type: {document_type}"
+                )
+
+    def test_save_document_exception_handling(self, mock_client, mock_user_info):
+        """Test handling of exceptions during save."""
+        mock_client.entities.get.return_value = Mock()
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+        mock_client.entities.upsert.side_effect = Exception("Network error")
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="Test Document",
+                content="Some content",
+            )
+
+        assert result["success"] is False
+        assert "Error saving document" in result["message"]
+
+    def test_save_document_without_user_info(self, mock_client):
+        """Test saving when user info is not available."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {"me": None}
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="Test Document",
+                content="Some content",
+            )
+
+        assert result["success"] is True
+        assert result["author"] is None
+
+    def test_save_document_whitespace_title_fails(self, mock_client):
+        """Test that whitespace-only title returns error."""
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="   ",
+                content="Some content",
+            )
+
+        assert result["success"] is False
+        assert "title cannot be empty" in result["message"]
+
+    def test_save_document_whitespace_content_fails(self, mock_client):
+        """Test that whitespace-only content returns error."""
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="Some title",
+                content="   ",
+            )
+
+        assert result["success"] is False
+        assert "content cannot be empty" in result["message"]
+
+    def test_save_document_organize_by_user_disabled(self, mock_client, mock_user_info):
+        """Test saving when organize by user is disabled."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with (
+            patch.dict(os.environ, {"SAVE_DOCUMENT_ORGANIZE_BY_USER": "false"}),
+            DataHubContext(mock_client),
+        ):
+            result = save_document(
+                document_type="Insight",
+                title="Test Document",
+                content="Some content",
+            )
+
+        assert result["success"] is True
+        # Should still have author info
+        assert result["author"] == "John Doe"
+
+    def test_save_document_custom_parent_title(self, mock_client, mock_user_info):
+        """Test saving with custom parent title."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with (
+            patch.dict(os.environ, {"SAVE_DOCUMENT_PARENT_TITLE": "My Custom Folder"}),
+            DataHubContext(mock_client),
+        ):
+            result = save_document(
+                document_type="Insight",
+                title="Test Document",
+                content="Some content",
+            )
+
+        assert result["success"] is True
+
+
+class TestRootParentId:
+    """Tests for root parent ID generation."""
+
+    def test_get_root_parent_id_is_fixed(self):
+        """Test that root parent ID is a fixed constant regardless of title."""
+        # The root parent ID should be fixed and independent of the title
+        # This allows changing the title without data migration
+        assert _get_root_parent_id() == "__system_shared_documents"
+
+    def test_get_root_parent_id_ignores_title_env(self):
+        """Test that root parent ID ignores custom title env var."""
+        with patch.dict(os.environ, {"SAVE_DOCUMENT_PARENT_TITLE": "Custom Folder"}):
+            # Should still return the fixed ID, not derive from title
+            assert _get_root_parent_id() == "__system_shared_documents"
+
+    def test_get_root_parent_urn(self):
+        """Test that root parent URN is correctly formatted."""
+        expected = "urn:li:document:__system_shared_documents"
+        assert _get_root_parent_urn() == expected
+
+
+class TestDocumentInSharedFolder:
+    """Tests for the _is_document_in_shared_folder validation function."""
+
+    def test_document_in_shared_folder_returns_true(self, mock_client):
+        """Test that document directly under shared folder is valid."""
+        root_urn = _get_root_parent_urn()
+
+        # Mock document with parent = shared folder
+        mock_parent = Mock()
+        mock_parent.document = root_urn
+        mock_doc_info = Mock()
+        mock_doc_info.parentDocument = mock_parent
+        mock_doc = Mock()
+        mock_doc.aspects = {"documentInfo": mock_doc_info}
+        mock_client.entities.get.return_value = mock_doc
+
+        with DataHubContext(mock_client):
+            is_valid, error = _is_document_in_shared_folder(
+                "urn:li:document:test-doc-123"
+            )
+
+        assert is_valid is True
+        assert error is None
+
+    def test_document_not_in_shared_folder_returns_false(self, mock_client):
+        """Test that document with different parent is invalid."""
+        # Mock document with parent = some other folder
+        mock_parent = Mock()
+        mock_parent.document = "urn:li:document:some-other-folder"
+        mock_doc_info = Mock()
+        mock_doc_info.parentDocument = mock_parent
+        mock_doc = Mock()
+        mock_doc.aspects = {"documentInfo": mock_doc_info}
+        mock_client.entities.get.return_value = mock_doc
+
+        with DataHubContext(mock_client):
+            is_valid, error = _is_document_in_shared_folder(
+                "urn:li:document:external-doc-123"
+            )
+
+        assert is_valid is False
+        assert "not in the shared documents folder" in error
+
+    def test_document_without_parent_returns_false(self, mock_client):
+        """Test that document with no parent is invalid."""
+        mock_doc_info = Mock()
+        mock_doc_info.parentDocument = None
+        mock_doc = Mock()
+        mock_doc.aspects = {"documentInfo": mock_doc_info}
+        mock_client.entities.get.return_value = mock_doc
+
+        with DataHubContext(mock_client):
+            is_valid, error = _is_document_in_shared_folder(
+                "urn:li:document:orphan-doc-123"
+            )
+
+        assert is_valid is False
+        assert "not in the shared documents folder" in error
+
+    def test_nonexistent_document_returns_true(self, mock_client):
+        """Test that non-existent document is allowed (will be created)."""
+        mock_client.entities.get.return_value = None
+
+        with DataHubContext(mock_client):
+            is_valid, error = _is_document_in_shared_folder(
+                "urn:li:document:new-doc-123"
+            )
+
+        assert is_valid is True
+        assert error is None
+
+    def test_root_folder_cannot_be_updated(self, mock_client):
+        """Test that the root shared folder itself cannot be updated."""
+        root_urn = _get_root_parent_urn()
+
+        with DataHubContext(mock_client):
+            is_valid, error = _is_document_in_shared_folder(root_urn)
+
+        assert is_valid is False
+        assert "Cannot update the root shared documents folder" in error
+
+    def test_document_without_document_info_returns_false(self, mock_client):
+        """Test that document without documentInfo aspect is invalid."""
+        mock_doc = Mock()
+        mock_doc.aspects = {}  # No documentInfo
+        mock_client.entities.get.return_value = mock_doc
+
+        with DataHubContext(mock_client):
+            is_valid, error = _is_document_in_shared_folder(
+                "urn:li:document:no-info-doc-123"
+            )
+
+        assert is_valid is False
+        assert "has no document info" in error
+
+
+class TestTopicsToTags:
+    """Tests for topics-to-tags conversion."""
+
+    def test_save_document_converts_topics_to_tag_urns(
+        self, mock_client, mock_user_info
+    ):
+        """Test that topics are converted to tag URNs."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        # Capture what gets passed to upsert
+        captured_doc = None
+
+        def capture_upsert(doc):
+            nonlocal captured_doc
+            captured_doc = doc
+
+        mock_client.entities.upsert = capture_upsert
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="Test Document",
+                content="Some content",
+                topics=["data-quality", "customer-data"],
+            )
+
+        assert result["success"] is True
+        # The Document SDK should have received tag URNs
+        assert captured_doc is not None
+
+
+class TestUpdateOwnership:
+    """Tests for ownership behavior during updates."""
+
+    def test_new_document_sets_owner(self, mock_client, mock_user_info):
+        """Test that new documents have owner set."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="New Document",
+                content="Content",
+            )
+
+        assert result["success"] is True
+        assert result["author"] == "John Doe"
+
+    def test_update_preserves_existing_ownership(self, mock_client, mock_user_info):
+        """Test that updating a document does not overwrite ownership."""
+        # Mock existing document in shared folder
+        root_urn = _get_root_parent_urn()
+        mock_parent = Mock()
+        mock_parent.document = root_urn
+        mock_doc_info = Mock()
+        mock_doc_info.parentDocument = mock_parent
+        mock_doc = Mock()
+        mock_doc.aspects = {"documentInfo": mock_doc_info}
+        mock_client.entities.get.return_value = mock_doc
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        existing_urn = "urn:li:document:shared-existing-doc-123"
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="Updated Title",
+                content="Updated content",
+                urn=existing_urn,
+            )
+
+        assert result["success"] is True
+        assert "updated" in result["message"].lower()
+
+
+class TestOrganizeByUser:
+    """Tests for organize-by-user functionality."""
+
+    def test_organize_by_user_enabled(self, mock_client, mock_user_info):
+        """Test saving when organize by user is enabled."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with (
+            patch.dict(os.environ, {"SAVE_DOCUMENT_ORGANIZE_BY_USER": "true"}),
+            DataHubContext(mock_client),
+        ):
+            result = save_document(
+                document_type="Insight",
+                title="Test Document",
+                content="Some content",
+            )
+
+        assert result["success"] is True
+        assert result["author"] == "John Doe"
+
+
+class TestRelatedDocuments:
+    """Tests for related documents functionality."""
+
+    def test_save_document_with_related_documents(self, mock_client, mock_user_info):
+        """Test saving a document with related documents."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Insight",
+                title="Test Document",
+                content="Some content",
+                related_documents=[
+                    "urn:li:document:related-doc-1",
+                    "urn:li:document:related-doc-2",
+                ],
+            )
+
+        assert result["success"] is True
+
+    def test_save_document_with_multiple_related_assets(
+        self, mock_client, mock_user_info
+    ):
+        """Test saving a document with multiple related assets."""
+        mock_client.entities.get.return_value = None
+        mock_client._graph.execute_graphql.return_value = {
+            "me": {"corpUser": mock_user_info}
+        }
+
+        with DataHubContext(mock_client):
+            result = save_document(
+                document_type="Analysis",
+                title="Cross-Dataset Analysis",
+                content="Analysis of multiple datasets...",
+                related_assets=[
+                    "urn:li:dataset:(urn:li:dataPlatform:snowflake,orders,PROD)",
+                    "urn:li:dataset:(urn:li:dataPlatform:snowflake,customers,PROD)",
+                    "urn:li:dashboard:(urn:li:dataPlatform:looker,sales_dashboard)",
+                ],
+            )
+
+        assert result["success"] is True

--- a/datahub-agent-context/tests/unit/mcp_tools/test_search.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_search.py
@@ -9,11 +9,12 @@ from datahub_agent_context.mcp_tools.search import search
 
 
 @pytest.fixture
-def mock_graph():
-    """Create a mock DataHubGraph."""
+def mock_client():
+    """Create a mock DataHubClient."""
     mock = Mock()
-    mock.execute_graphql = Mock()
-    mock.frontend_base_url = "http://localhost:9002"  # For cloud detection
+    mock._graph = Mock()
+    mock.graph.execute_graphql = Mock()
+    mock.graph.frontend_base_url = "http://localhost:9002"  # For cloud detection
     return mock
 
 
@@ -52,11 +53,11 @@ def mock_search_response():
     }
 
 
-def test_basic_search(mock_graph, mock_search_response):
+def test_basic_search(mock_client, mock_search_response):
     """Test basic search with query."""
-    mock_graph.execute_graphql.return_value = mock_search_response
+    mock_client._graph.execute_graphql.return_value = mock_search_response
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = search(query="users")
 
     assert "total" in result
@@ -65,62 +66,62 @@ def test_basic_search(mock_graph, mock_search_response):
     assert len(result["searchResults"]) == 2
 
 
-def test_search_with_filters(mock_graph, mock_search_response):
+def test_search_with_filters(mock_client, mock_search_response):
     """Test search with entity type filter."""
-    mock_graph.execute_graphql.return_value = mock_search_response
+    mock_client._graph.execute_graphql.return_value = mock_search_response
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = search(query="*", filters={"entity_type": ["dataset"]})
 
     assert result is not None
     # Note: execute_graphql is called twice - once for fetch_global_default_view, once for search
-    assert mock_graph.execute_graphql.called
+    assert mock_client._graph.execute_graphql.called
 
 
-def test_search_with_pagination(mock_graph, mock_search_response):
+def test_search_with_pagination(mock_client, mock_search_response):
     """Test search pagination parameters."""
-    mock_graph.execute_graphql.return_value = mock_search_response
+    mock_client._graph.execute_graphql.return_value = mock_search_response
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         search(query="*", num_results=20, offset=10)
 
-    call_args = mock_graph.execute_graphql.call_args
+    call_args = mock_client._graph.execute_graphql.call_args
     variables = call_args.kwargs["variables"]
     assert variables["count"] == 20
     assert variables["start"] == 10
 
 
-def test_search_with_sorting(mock_graph, mock_search_response):
+def test_search_with_sorting(mock_client, mock_search_response):
     """Test search with sorting."""
-    mock_graph.execute_graphql.return_value = mock_search_response
+    mock_client._graph.execute_graphql.return_value = mock_search_response
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         search(query="*", sort_by="lastModified", sort_order="desc")
 
-    call_args = mock_graph.execute_graphql.call_args
+    call_args = mock_client._graph.execute_graphql.call_args
     variables = call_args.kwargs["variables"]
     assert "sortInput" in variables
     assert variables["sortInput"]["sortCriteria"][0]["field"] == "lastModified"
     assert variables["sortInput"]["sortCriteria"][0]["sortOrder"] == "DESCENDING"
 
 
-def test_search_num_results_capped_at_50(mock_graph, mock_search_response):
+def test_search_num_results_capped_at_50(mock_client, mock_search_response):
     """Test that num_results is capped at 50."""
-    mock_graph.execute_graphql.return_value = mock_search_response
+    mock_client._graph.execute_graphql.return_value = mock_search_response
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         search(query="*", num_results=100)
 
-    call_args = mock_graph.execute_graphql.call_args
+    call_args = mock_client._graph.execute_graphql.call_args
     variables = call_args.kwargs["variables"]
     assert variables["count"] == 50
 
 
-def test_search_facet_only_query(mock_graph, mock_search_response):
+def test_search_facet_only_query(mock_client, mock_search_response):
     """Test facet-only query with num_results=0."""
-    mock_graph.execute_graphql.return_value = mock_search_response
+    mock_client._graph.execute_graphql.return_value = mock_search_response
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = search(query="*", num_results=0)
 
     # Verify searchResults is removed for facet-only queries
@@ -129,9 +130,9 @@ def test_search_facet_only_query(mock_graph, mock_search_response):
     assert "facets" in result
 
 
-def test_search_with_complex_filters(mock_graph, mock_search_response):
+def test_search_with_complex_filters(mock_client, mock_search_response):
     """Test search with complex AND/OR filters."""
-    mock_graph.execute_graphql.return_value = mock_search_response
+    mock_client._graph.execute_graphql.return_value = mock_search_response
 
     filters = {
         "and": [
@@ -139,32 +140,32 @@ def test_search_with_complex_filters(mock_graph, mock_search_response):
             {"platform": ["snowflake"]},
         ]
     }
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = search(query="*", filters=filters)
 
     assert result is not None
     # Note: execute_graphql is called twice - once for fetch_global_default_view, once for search
-    assert mock_graph.execute_graphql.called
+    assert mock_client._graph.execute_graphql.called
 
 
-def test_search_with_string_filters(mock_graph, mock_search_response):
+def test_search_with_string_filters(mock_client, mock_search_response):
     """Test search with JSON string filters."""
     import json
 
-    mock_graph.execute_graphql.return_value = mock_search_response
+    mock_client._graph.execute_graphql.return_value = mock_search_response
 
     filters_str = json.dumps({"entity_type": ["dataset"]})
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = search(query="*", filters=filters_str)
 
     assert result is not None
     # Note: execute_graphql is called twice - once for fetch_global_default_view, once for search
-    assert mock_graph.execute_graphql.called
+    assert mock_client._graph.execute_graphql.called
 
 
-def test_search_response_cleaned(mock_graph):
+def test_search_response_cleaned(mock_client):
     """Test that response is cleaned (no __typename)."""
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "searchAcrossEntities": {
             "__typename": "SearchResults",
             "total": 1,
@@ -180,7 +181,7 @@ def test_search_response_cleaned(mock_graph):
         }
     }
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = search(query="*")
 
     # Verify __typename is removed

--- a/datahub-agent-context/tests/unit/mcp_tools/test_tags.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_tags.py
@@ -7,14 +7,15 @@ from datahub_agent_context.mcp_tools.tags import add_tags, remove_tags
 
 
 @pytest.fixture
-def mock_graph():
-    """Fixture for mocking DataHubGraph."""
+def mock_client():
+    """Fixture for mocking DataHubClient."""
     mock = Mock()
-    mock.execute_graphql = Mock()
+    mock._graph = Mock()
+    mock.graph.execute_graphql = Mock()
     return mock
 
 
-def test_add_tags_to_multiple_datasets(mock_graph):
+def test_add_tags_to_multiple_datasets(mock_client):
     """Test adding tags to multiple datasets (entity-level)."""
     tag_urns = ["urn:li:tag:PII", "urn:li:tag:Sensitive"]
     entity_urns = [
@@ -23,7 +24,7 @@ def test_add_tags_to_multiple_datasets(mock_graph):
     ]
 
     # Mock validation response showing tags exist
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}},
@@ -37,16 +38,16 @@ def test_add_tags_to_multiple_datasets(mock_graph):
         {"batchAddTags": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = add_tags(tag_urns=tag_urns, entity_urns=entity_urns)
     assert result["success"] is True
     assert "Successfully added 2 tag(s) to 2 entit(ies)" in result["message"]
 
     # Verify GraphQL was called twice: once for validation, once for mutation
-    assert mock_graph.execute_graphql.call_count == 2
+    assert mock_client._graph.execute_graphql.call_count == 2
 
     # Check the mutation call (second call)
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
 
     assert variables["input"]["tagUrns"] == tag_urns
@@ -55,7 +56,7 @@ def test_add_tags_to_multiple_datasets(mock_graph):
     assert "subResource" not in variables["input"]["resources"][0]
 
 
-def test_add_tags_to_columns(mock_graph):
+def test_add_tags_to_columns(mock_client):
     """Test adding tags to specific columns (column-level)."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = [
@@ -64,7 +65,7 @@ def test_add_tags_to_columns(mock_graph):
     ]
     column_paths = ["email", "phone_number"]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}
@@ -73,7 +74,7 @@ def test_add_tags_to_columns(mock_graph):
         {"batchAddTags": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = add_tags(
             tag_urns=tag_urns,
             entity_urns=entity_urns,
@@ -82,7 +83,7 @@ def test_add_tags_to_columns(mock_graph):
 
     assert result["success"] is True
 
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
     resources = variables["input"]["resources"]
 
@@ -93,7 +94,7 @@ def test_add_tags_to_columns(mock_graph):
     assert resources[1]["subResourceType"] == "DATASET_FIELD"
 
 
-def test_add_tags_mixed_entity_and_column_level(mock_graph):
+def test_add_tags_mixed_entity_and_column_level(mock_client):
     """Test adding tags with mixed entity-level and column-level targets."""
     tag_urns = ["urn:li:tag:Deprecated"]
     entity_urns = [
@@ -102,7 +103,7 @@ def test_add_tags_mixed_entity_and_column_level(mock_graph):
     ]
     column_paths = [None, "deprecated_column"]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {
@@ -115,7 +116,7 @@ def test_add_tags_mixed_entity_and_column_level(mock_graph):
         {"batchAddTags": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = add_tags(
             tag_urns=tag_urns,
             entity_urns=entity_urns,
@@ -124,7 +125,7 @@ def test_add_tags_mixed_entity_and_column_level(mock_graph):
 
     assert result["success"] is True
 
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
     resources = variables["input"]["resources"]
 
@@ -137,33 +138,33 @@ def test_add_tags_mixed_entity_and_column_level(mock_graph):
     assert resources[1]["subResourceType"] == "DATASET_FIELD"
 
 
-def test_add_tags_empty_tag_urns(mock_graph):
+def test_add_tags_empty_tag_urns(mock_client):
     """Test that empty tag_urns raises ValueError."""
     with pytest.raises(ValueError, match="tag_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_tags(tag_urns=[], entity_urns=["urn:li:dataset:test"])
 
 
-def test_add_tags_empty_entity_urns(mock_graph):
+def test_add_tags_empty_entity_urns(mock_client):
     """Test that empty entity_urns raises ValueError."""
     with pytest.raises(ValueError, match="entity_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_tags(tag_urns=["urn:li:tag:PII"], entity_urns=[])
 
 
-def test_add_tags_mismatched_column_paths_length(mock_graph):
+def test_add_tags_mismatched_column_paths_length(mock_client):
     """Test that mismatched column_paths length raises ValueError."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = ["urn:li:dataset:test1", "urn:li:dataset:test2"]
     column_paths = ["column1"]  # Only 1 subresource for 2 resources
 
     # Mock validation success (validation happens before length check)
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "entities": [{"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}]
     }
 
     with pytest.raises(ValueError, match="column_paths length.*must match"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_tags(
                 tag_urns=tag_urns,
                 entity_urns=entity_urns,
@@ -171,13 +172,13 @@ def test_add_tags_mismatched_column_paths_length(mock_graph):
             )
 
 
-def test_add_tags_graphql_failure(mock_graph):
+def test_add_tags_graphql_failure(mock_client):
     """Test handling of GraphQL mutation returning false."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation success, then mutation failure
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}
@@ -187,17 +188,17 @@ def test_add_tags_graphql_failure(mock_graph):
     ]
 
     with pytest.raises(RuntimeError, match="Failed to add tags"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_tags(tag_urns=tag_urns, entity_urns=entity_urns)
 
 
-def test_add_tags_graphql_exception(mock_graph):
+def test_add_tags_graphql_exception(mock_client):
     """Test handling of GraphQL exceptions during mutation."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation success, then mutation exception
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}
@@ -207,14 +208,14 @@ def test_add_tags_graphql_exception(mock_graph):
     ]
 
     with pytest.raises(RuntimeError, match="Error add tags"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_tags(tag_urns=tag_urns, entity_urns=entity_urns)
 
 
 # Tests for remove_tags
 
 
-def test_remove_tags_from_multiple_datasets(mock_graph):
+def test_remove_tags_from_multiple_datasets(mock_client):
     """Test removing tags from multiple datasets (entity-level)."""
     tag_urns = ["urn:li:tag:Deprecated", "urn:li:tag:Legacy"]
     entity_urns = [
@@ -222,7 +223,7 @@ def test_remove_tags_from_multiple_datasets(mock_graph):
         "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.old_customers,PROD)",
     ]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {
@@ -236,19 +237,19 @@ def test_remove_tags_from_multiple_datasets(mock_graph):
         {"batchRemoveTags": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = remove_tags(tag_urns=tag_urns, entity_urns=entity_urns)
     assert result["success"] is True
     assert "Successfully removed 2 tag(s) from 2 entit(ies)" in result["message"]
 
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
 
     assert variables["input"]["tagUrns"] == tag_urns
     assert len(variables["input"]["resources"]) == 2
 
 
-def test_remove_tags_from_columns(mock_graph):
+def test_remove_tags_from_columns(mock_client):
     """Test removing tags from specific columns (column-level)."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = [
@@ -257,7 +258,7 @@ def test_remove_tags_from_columns(mock_graph):
     ]
     column_paths = ["old_email_field", "deprecated_phone"]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}
@@ -266,7 +267,7 @@ def test_remove_tags_from_columns(mock_graph):
         {"batchRemoveTags": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = remove_tags(
             tag_urns=tag_urns,
             entity_urns=entity_urns,
@@ -275,7 +276,7 @@ def test_remove_tags_from_columns(mock_graph):
 
     assert result["success"] is True
 
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
     resources = variables["input"]["resources"]
 
@@ -284,7 +285,7 @@ def test_remove_tags_from_columns(mock_graph):
     assert resources[1]["subResource"] == "deprecated_phone"
 
 
-def test_remove_tags_mixed_entity_and_column_level(mock_graph):
+def test_remove_tags_mixed_entity_and_column_level(mock_client):
     """Test removing tags with mixed entity-level and column-level targets."""
     tag_urns = ["urn:li:tag:Experimental"]
     entity_urns = [
@@ -293,7 +294,7 @@ def test_remove_tags_mixed_entity_and_column_level(mock_graph):
     ]
     column_paths = [None, "test_column"]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {
@@ -306,7 +307,7 @@ def test_remove_tags_mixed_entity_and_column_level(mock_graph):
         {"batchRemoveTags": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = remove_tags(
             tag_urns=tag_urns,
             entity_urns=entity_urns,
@@ -315,7 +316,7 @@ def test_remove_tags_mixed_entity_and_column_level(mock_graph):
 
     assert result["success"] is True
 
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
     resources = variables["input"]["resources"]
 
@@ -327,33 +328,33 @@ def test_remove_tags_mixed_entity_and_column_level(mock_graph):
     assert resources[1]["subResourceType"] == "DATASET_FIELD"
 
 
-def test_remove_tags_empty_tag_urns(mock_graph):
+def test_remove_tags_empty_tag_urns(mock_client):
     """Test that empty tag_urns raises ValueError."""
     with pytest.raises(ValueError, match="tag_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_tags(tag_urns=[], entity_urns=["urn:li:dataset:test"])
 
 
-def test_remove_tags_empty_entity_urns(mock_graph):
+def test_remove_tags_empty_entity_urns(mock_client):
     """Test that empty entity_urns raises ValueError."""
     with pytest.raises(ValueError, match="entity_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_tags(tag_urns=["urn:li:tag:PII"], entity_urns=[])
 
 
-def test_remove_tags_mismatched_column_paths_length(mock_graph):
+def test_remove_tags_mismatched_column_paths_length(mock_client):
     """Test that mismatched column_paths length raises ValueError."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = ["urn:li:dataset:test1", "urn:li:dataset:test2"]
     column_paths = ["column1"]  # Only 1 subresource for 2 resources
 
     # Mock validation success (validation happens before length check)
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "entities": [{"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}]
     }
 
     with pytest.raises(ValueError, match="column_paths length.*must match"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_tags(
                 tag_urns=tag_urns,
                 entity_urns=entity_urns,
@@ -361,12 +362,12 @@ def test_remove_tags_mismatched_column_paths_length(mock_graph):
             )
 
 
-def test_remove_tags_graphql_failure(mock_graph):
+def test_remove_tags_graphql_failure(mock_client):
     """Test handling of GraphQL mutation returning false."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = ["urn:li:dataset:test"]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}
@@ -376,16 +377,16 @@ def test_remove_tags_graphql_failure(mock_graph):
     ]
 
     with pytest.raises(RuntimeError, match="Failed to remove tags"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_tags(tag_urns=tag_urns, entity_urns=entity_urns)
 
 
-def test_remove_tags_graphql_exception(mock_graph):
+def test_remove_tags_graphql_exception(mock_client):
     """Test handling of GraphQL exceptions during mutation."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = ["urn:li:dataset:test"]
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}
@@ -395,17 +396,17 @@ def test_remove_tags_graphql_exception(mock_graph):
     ]
 
     with pytest.raises(RuntimeError, match="Error remove tags"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_tags(tag_urns=tag_urns, entity_urns=entity_urns)
 
 
-def test_add_tags_with_empty_string_subresource(mock_graph):
+def test_add_tags_with_empty_string_subresource(mock_client):
     """Test that empty string subresource is treated as None (entity-level)."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = ["urn:li:dataset:test"]
     column_paths = [""]  # Empty string should be treated as entity-level
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}
@@ -414,7 +415,7 @@ def test_add_tags_with_empty_string_subresource(mock_graph):
         {"batchAddTags": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = add_tags(
             tag_urns=tag_urns,
             entity_urns=entity_urns,
@@ -423,7 +424,7 @@ def test_add_tags_with_empty_string_subresource(mock_graph):
 
     assert result["success"] is True
 
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
     resources = variables["input"]["resources"]
 
@@ -432,13 +433,13 @@ def test_add_tags_with_empty_string_subresource(mock_graph):
     assert "subResourceType" not in resources[0]
 
 
-def test_remove_tags_with_empty_string_subresource(mock_graph):
+def test_remove_tags_with_empty_string_subresource(mock_client):
     """Test that empty string subresource is treated as None (entity-level)."""
     tag_urns = ["urn:li:tag:PII"]
     entity_urns = ["urn:li:dataset:test"]
     column_paths = [""]  # Empty string should be treated as entity-level
 
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": tag_urns[0], "type": "TAG", "properties": {"name": "PII"}}
@@ -447,7 +448,7 @@ def test_remove_tags_with_empty_string_subresource(mock_graph):
         {"batchRemoveTags": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = remove_tags(
             tag_urns=tag_urns,
             entity_urns=entity_urns,
@@ -456,7 +457,7 @@ def test_remove_tags_with_empty_string_subresource(mock_graph):
 
     assert result["success"] is True
 
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
     resources = variables["input"]["resources"]
 
@@ -465,57 +466,57 @@ def test_remove_tags_with_empty_string_subresource(mock_graph):
     assert "subResourceType" not in resources[0]
 
 
-def test_add_tags_with_nonexistent_tag(mock_graph):
+def test_add_tags_with_nonexistent_tag(mock_client):
     """Test that adding nonexistent tag URN returns error."""
     tag_urns = ["urn:li:tag:NonExistent"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation returning empty entities (tag doesn't exist)
-    mock_graph.execute_graphql.return_value = {"entities": []}
+    mock_client._graph.execute_graphql.return_value = {"entities": []}
 
     with pytest.raises(ValueError, match="do not exist in DataHub"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_tags(tag_urns=tag_urns, entity_urns=entity_urns)
 
 
-def test_add_tags_with_non_tag_urn(mock_graph):
+def test_add_tags_with_non_tag_urn(mock_client):
     """Test that adding non-tag URN returns error."""
     tag_urns = ["urn:li:dataset:not_a_tag"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation returning a dataset entity instead of tag
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "entities": [{"urn": tag_urns[0], "type": "DATASET"}]
     }
 
     with pytest.raises(ValueError, match="not tag entities"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_tags(tag_urns=tag_urns, entity_urns=entity_urns)
 
 
-def test_remove_tags_with_nonexistent_tag(mock_graph):
+def test_remove_tags_with_nonexistent_tag(mock_client):
     """Test that removing nonexistent tag URN returns error."""
     tag_urns = ["urn:li:tag:NonExistent"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation returning empty entities (tag doesn't exist)
-    mock_graph.execute_graphql.return_value = {"entities": []}
+    mock_client._graph.execute_graphql.return_value = {"entities": []}
 
     with pytest.raises(ValueError, match="do not exist in DataHub"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_tags(tag_urns=tag_urns, entity_urns=entity_urns)
 
 
-def test_remove_tags_with_non_tag_urn(mock_graph):
+def test_remove_tags_with_non_tag_urn(mock_client):
     """Test that removing non-tag URN returns error."""
     tag_urns = ["urn:li:dataset:not_a_tag"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation returning a dataset entity instead of tag
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "entities": [{"urn": tag_urns[0], "type": "DATASET"}]
     }
 
     with pytest.raises(ValueError, match="not tag entities"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_tags(tag_urns=tag_urns, entity_urns=entity_urns)

--- a/datahub-agent-context/tests/unit/mcp_tools/test_terms.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_terms.py
@@ -12,17 +12,18 @@ from datahub_agent_context.mcp_tools.terms import (
 
 
 @pytest.fixture
-def mock_graph():
-    """Create a mock DataHubGraph with a mock execute_graphql."""
+def mock_client():
+    """Create a mock DataHubClient with a mock execute_graphql."""
     mock = Mock()
-    mock.execute_graphql = Mock()
+    mock._graph = Mock()
+    mock.graph.execute_graphql = Mock()
     return mock
 
 
 # ===== Tests for add_glossary_terms =====
 
 
-def test_add_glossary_terms_to_multiple_datasets(mock_graph):
+def test_add_glossary_terms_to_multiple_datasets(mock_client):
     """Test adding glossary terms to multiple datasets (entity-level)."""
     term_urns = [
         "urn:li:glossaryTerm:CustomerData",
@@ -34,7 +35,7 @@ def test_add_glossary_terms_to_multiple_datasets(mock_graph):
     ]
 
     # Mock validation response showing glossary terms exist
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "CustomerData"},
@@ -48,17 +49,17 @@ def test_add_glossary_terms_to_multiple_datasets(mock_graph):
         {"batchAddTerms": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = add_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)
 
     assert result["success"] is True
     assert "Successfully added 2 glossary term(s) to 2 entit(ies)" in result["message"]
 
     # Verify GraphQL was called twice: once for validation, once for mutation
-    assert mock_graph.execute_graphql.call_count == 2
+    assert mock_client._graph.execute_graphql.call_count == 2
 
     # Check the mutation call (second call)
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
 
     assert variables["input"]["termUrns"] == term_urns
@@ -71,7 +72,7 @@ def test_add_glossary_terms_to_multiple_datasets(mock_graph):
     assert "subResource" not in variables["input"]["resources"][1]
 
 
-def test_add_glossary_terms_to_columns(mock_graph):
+def test_add_glossary_terms_to_columns(mock_client):
     """Test adding glossary terms to specific columns (column-level)."""
     term_urns = ["urn:li:glossaryTerm:EmailAddress"]
     entity_urns = [
@@ -81,7 +82,7 @@ def test_add_glossary_terms_to_columns(mock_graph):
     column_paths = ["email", "contact_email"]
 
     # Mock validation response
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {
@@ -94,7 +95,7 @@ def test_add_glossary_terms_to_columns(mock_graph):
         {"batchAddTerms": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = add_glossary_terms(
             term_urns=term_urns,
             entity_urns=entity_urns,
@@ -105,7 +106,7 @@ def test_add_glossary_terms_to_columns(mock_graph):
     assert "Successfully added 1 glossary term(s) to 2 entit(ies)" in result["message"]
 
     # Check the mutation call
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
 
     # Verify subResource fields are set for column-level glossary terms
@@ -115,7 +116,7 @@ def test_add_glossary_terms_to_columns(mock_graph):
     assert variables["input"]["resources"][1]["subResourceType"] == "DATASET_FIELD"
 
 
-def test_add_glossary_terms_mixed_entity_and_column(mock_graph):
+def test_add_glossary_terms_mixed_entity_and_column(mock_client):
     """Test adding glossary terms to both entity-level and column-level."""
     term_urns = ["urn:li:glossaryTerm:Revenue"]
     entity_urns = [
@@ -125,7 +126,7 @@ def test_add_glossary_terms_mixed_entity_and_column(mock_graph):
     column_paths = [None, "total_amount"]  # Entity-level for first, column for second
 
     # Mock validation response
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Revenue"}
@@ -134,7 +135,7 @@ def test_add_glossary_terms_mixed_entity_and_column(mock_graph):
         {"batchAddTerms": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = add_glossary_terms(
             term_urns=term_urns,
             entity_urns=entity_urns,
@@ -144,7 +145,7 @@ def test_add_glossary_terms_mixed_entity_and_column(mock_graph):
     assert result["success"] is True
 
     # Check the mutation call
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
 
     # First resource should not have subResource (entity-level)
@@ -154,49 +155,49 @@ def test_add_glossary_terms_mixed_entity_and_column(mock_graph):
     assert variables["input"]["resources"][1]["subResourceType"] == "DATASET_FIELD"
 
 
-def test_add_glossary_terms_with_nonexistent_term(mock_graph):
+def test_add_glossary_terms_with_nonexistent_term(mock_client):
     """Test that adding nonexistent glossary term URN returns error."""
     term_urns = ["urn:li:glossaryTerm:NonExistent"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation returning empty entities (term doesn't exist)
-    mock_graph.execute_graphql.return_value = {"entities": []}
+    mock_client._graph.execute_graphql.return_value = {"entities": []}
 
     with pytest.raises(ValueError, match="do not exist in DataHub"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)
 
 
-def test_add_glossary_terms_with_non_term_urn(mock_graph):
+def test_add_glossary_terms_with_non_term_urn(mock_client):
     """Test that adding a URN that is not a glossary term returns error."""
     term_urns = ["urn:li:tag:NotATerm"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation returning a Tag entity instead of GlossaryTerm
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "entities": [
             {"urn": term_urns[0], "type": "TAG", "properties": {"name": "NotATerm"}}
         ]
     }
 
     with pytest.raises(ValueError, match="not glossary term entities"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)
 
 
-def test_add_glossary_terms_mismatched_column_paths_length(mock_graph):
+def test_add_glossary_terms_mismatched_column_paths_length(mock_client):
     """Test that mismatched column_paths length raises ValueError."""
     term_urns = ["urn:li:glossaryTerm:Test"]
     entity_urns = ["urn:li:dataset:test1", "urn:li:dataset:test2"]
     column_paths = ["column1"]  # Mismatched length: 1 vs 2
 
     # Mock successful validation
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "entities": [{"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Test"}]
     }
 
     with pytest.raises(ValueError, match="column_paths length"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_glossary_terms(
                 term_urns=term_urns,
                 entity_urns=entity_urns,
@@ -204,56 +205,56 @@ def test_add_glossary_terms_mismatched_column_paths_length(mock_graph):
             )
 
 
-def test_add_glossary_terms_empty_term_urns(mock_graph):
+def test_add_glossary_terms_empty_term_urns(mock_client):
     """Test that empty term_urns raises ValueError."""
     with pytest.raises(ValueError, match="term_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_glossary_terms(term_urns=[], entity_urns=["urn:li:dataset:test"])
 
 
-def test_add_glossary_terms_empty_entity_urns(mock_graph):
+def test_add_glossary_terms_empty_entity_urns(mock_client):
     """Test that empty entity_urns raises ValueError."""
     with pytest.raises(ValueError, match="entity_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_glossary_terms(term_urns=["urn:li:glossaryTerm:Test"], entity_urns=[])
 
 
-def test_add_glossary_terms_mutation_returns_false(mock_graph):
+def test_add_glossary_terms_mutation_returns_false(mock_client):
     """Test handling of mutation returning false."""
     term_urns = ["urn:li:glossaryTerm:Test"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation success, mutation failure
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {"entities": [{"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Test"}]},
         {"batchAddTerms": False},
     ]
 
     with pytest.raises(RuntimeError, match="Failed to add glossary terms"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)
 
 
-def test_add_glossary_terms_graphql_exception(mock_graph):
+def test_add_glossary_terms_graphql_exception(mock_client):
     """Test handling of GraphQL execution exception."""
     term_urns = ["urn:li:glossaryTerm:Test"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation success, mutation raises exception
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {"entities": [{"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Test"}]},
         Exception("GraphQL error"),
     ]
 
     with pytest.raises(RuntimeError, match="Error add glossary terms"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             add_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)
 
 
 # ===== Tests for remove_glossary_terms =====
 
 
-def test_remove_glossary_terms_from_multiple_datasets(mock_graph):
+def test_remove_glossary_terms_from_multiple_datasets(mock_client):
     """Test removing glossary terms from multiple datasets (entity-level)."""
     term_urns = [
         "urn:li:glossaryTerm:Deprecated",
@@ -265,7 +266,7 @@ def test_remove_glossary_terms_from_multiple_datasets(mock_graph):
     ]
 
     # Mock validation response
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Deprecated"},
@@ -275,7 +276,7 @@ def test_remove_glossary_terms_from_multiple_datasets(mock_graph):
         {"batchRemoveTerms": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = remove_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)
 
     assert result["success"] is True
@@ -284,10 +285,10 @@ def test_remove_glossary_terms_from_multiple_datasets(mock_graph):
     )
 
     # Verify GraphQL was called twice: once for validation, once for mutation
-    assert mock_graph.execute_graphql.call_count == 2
+    assert mock_client._graph.execute_graphql.call_count == 2
 
     # Check the mutation call (second call)
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     assert mutation_call.kwargs["operation_name"] == "batchRemoveTerms"
     variables = mutation_call.kwargs["variables"]
 
@@ -295,7 +296,7 @@ def test_remove_glossary_terms_from_multiple_datasets(mock_graph):
     assert len(variables["input"]["resources"]) == 2
 
 
-def test_remove_glossary_terms_from_columns(mock_graph):
+def test_remove_glossary_terms_from_columns(mock_client):
     """Test removing glossary terms from specific columns (column-level)."""
     term_urns = ["urn:li:glossaryTerm:Confidential"]
     entity_urns = [
@@ -305,7 +306,7 @@ def test_remove_glossary_terms_from_columns(mock_graph):
     column_paths = ["old_ssn_field", "legacy_tax_id"]
 
     # Mock validation response
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Confidential"}
@@ -314,7 +315,7 @@ def test_remove_glossary_terms_from_columns(mock_graph):
         {"batchRemoveTerms": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = remove_glossary_terms(
             term_urns=term_urns,
             entity_urns=entity_urns,
@@ -324,7 +325,7 @@ def test_remove_glossary_terms_from_columns(mock_graph):
     assert result["success"] is True
 
     # Check the mutation call
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
 
     # Verify subResource fields are set for column-level glossary terms
@@ -334,7 +335,7 @@ def test_remove_glossary_terms_from_columns(mock_graph):
     assert variables["input"]["resources"][1]["subResourceType"] == "DATASET_FIELD"
 
 
-def test_remove_glossary_terms_mixed_entity_and_column(mock_graph):
+def test_remove_glossary_terms_mixed_entity_and_column(mock_client):
     """Test removing glossary terms from both entity-level and column-level."""
     term_urns = ["urn:li:glossaryTerm:Experimental"]
     entity_urns = [
@@ -344,7 +345,7 @@ def test_remove_glossary_terms_mixed_entity_and_column(mock_graph):
     column_paths = [None, "beta_feature"]  # Entity-level for first, column for second
 
     # Mock validation response
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {
             "entities": [
                 {"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Experimental"}
@@ -353,7 +354,7 @@ def test_remove_glossary_terms_mixed_entity_and_column(mock_graph):
         {"batchRemoveTerms": True},
     ]
 
-    with DataHubContext(mock_graph):
+    with DataHubContext(mock_client):
         result = remove_glossary_terms(
             term_urns=term_urns,
             entity_urns=entity_urns,
@@ -363,7 +364,7 @@ def test_remove_glossary_terms_mixed_entity_and_column(mock_graph):
     assert result["success"] is True
 
     # Check the mutation call
-    mutation_call = mock_graph.execute_graphql.call_args_list[1]
+    mutation_call = mock_client._graph.execute_graphql.call_args_list[1]
     variables = mutation_call.kwargs["variables"]
 
     # First resource should not have subResource (entity-level)
@@ -373,49 +374,49 @@ def test_remove_glossary_terms_mixed_entity_and_column(mock_graph):
     assert variables["input"]["resources"][1]["subResourceType"] == "DATASET_FIELD"
 
 
-def test_remove_glossary_terms_with_nonexistent_term(mock_graph):
+def test_remove_glossary_terms_with_nonexistent_term(mock_client):
     """Test that removing nonexistent glossary term URN returns error."""
     term_urns = ["urn:li:glossaryTerm:NonExistent"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation returning empty entities (term doesn't exist)
-    mock_graph.execute_graphql.return_value = {"entities": []}
+    mock_client._graph.execute_graphql.return_value = {"entities": []}
 
     with pytest.raises(ValueError, match="do not exist in DataHub"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)
 
 
-def test_remove_glossary_terms_with_non_term_urn(mock_graph):
+def test_remove_glossary_terms_with_non_term_urn(mock_client):
     """Test that removing a URN that is not a glossary term returns error."""
     term_urns = ["urn:li:tag:NotATerm"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation returning a Tag entity instead of GlossaryTerm
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "entities": [
             {"urn": term_urns[0], "type": "TAG", "properties": {"name": "NotATerm"}}
         ]
     }
 
     with pytest.raises(ValueError, match="not glossary term entities"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)
 
 
-def test_remove_glossary_terms_mismatched_column_paths_length(mock_graph):
+def test_remove_glossary_terms_mismatched_column_paths_length(mock_client):
     """Test that mismatched column_paths length raises ValueError."""
     term_urns = ["urn:li:glossaryTerm:Test"]
     entity_urns = ["urn:li:dataset:test1", "urn:li:dataset:test2"]
     column_paths = ["column1"]  # Mismatched length: 1 vs 2
 
     # Mock successful validation
-    mock_graph.execute_graphql.return_value = {
+    mock_client._graph.execute_graphql.return_value = {
         "entities": [{"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Test"}]
     }
 
     with pytest.raises(ValueError, match="column_paths length"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_glossary_terms(
                 term_urns=term_urns,
                 entity_urns=entity_urns,
@@ -423,49 +424,49 @@ def test_remove_glossary_terms_mismatched_column_paths_length(mock_graph):
             )
 
 
-def test_remove_glossary_terms_empty_term_urns(mock_graph):
+def test_remove_glossary_terms_empty_term_urns(mock_client):
     """Test that empty term_urns raises ValueError."""
     with pytest.raises(ValueError, match="term_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_glossary_terms(term_urns=[], entity_urns=["urn:li:dataset:test"])
 
 
-def test_remove_glossary_terms_empty_entity_urns(mock_graph):
+def test_remove_glossary_terms_empty_entity_urns(mock_client):
     """Test that empty entity_urns raises ValueError."""
     with pytest.raises(ValueError, match="entity_urns cannot be empty"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_glossary_terms(
                 term_urns=["urn:li:glossaryTerm:Test"], entity_urns=[]
             )
 
 
-def test_remove_glossary_terms_mutation_returns_false(mock_graph):
+def test_remove_glossary_terms_mutation_returns_false(mock_client):
     """Test handling of mutation returning false."""
     term_urns = ["urn:li:glossaryTerm:Test"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation success, mutation failure
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {"entities": [{"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Test"}]},
         {"batchRemoveTerms": False},
     ]
 
     with pytest.raises(RuntimeError, match="Failed to remove glossary terms"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)
 
 
-def test_remove_glossary_terms_graphql_exception(mock_graph):
+def test_remove_glossary_terms_graphql_exception(mock_client):
     """Test handling of GraphQL execution exception."""
     term_urns = ["urn:li:glossaryTerm:Test"]
     entity_urns = ["urn:li:dataset:test"]
 
     # Mock validation success, mutation raises exception
-    mock_graph.execute_graphql.side_effect = [
+    mock_client._graph.execute_graphql.side_effect = [
         {"entities": [{"urn": term_urns[0], "type": "GLOSSARY_TERM", "name": "Test"}]},
         Exception("GraphQL error"),
     ]
 
     with pytest.raises(RuntimeError, match="Error remove glossary terms"):
-        with DataHubContext(mock_graph):
+        with DataHubContext(mock_client):
             remove_glossary_terms(term_urns=term_urns, entity_urns=entity_urns)


### PR DESCRIPTION
…text

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

Port over save_document tool into datahub-agent-context kit. Unifies documentation. 

BREAKING CHANGE: Unifies API to take `DataHubClient` everywhere instead of DatahubGraph some places and DataHubClient in others. This was an oversight in the initial PR to not standardize.