### PR TITLE
(fix: asset downloads) Asset download queries do not apply filters and download all assets

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -168,9 +168,9 @@ export const EmbeddedListSearch = ({
         variables: {
             input: {
                 types: entityTypes || [],
-                query,
+                query: finalQuery,
                 count: SearchCfg.RESULTS_PER_PAGE,
-                orFilters: generateOrFilters(unionType, filters),
+                orFilters: finalFilters,
                 scrollId: null,
             },
         },

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -206,9 +206,9 @@ export const EmbeddedListSearch = ({
         variables: {
             input: {
                 types: entityTypes || [],
-                query,
+                query: finalQuery,
                 count: SearchCfg.RESULTS_PER_PAGE,
-                orFilters: generateOrFilters(unionType, filters),
+                orFilters: finalFilters,
                 scrollId: null,
                 searchFlags,
             },


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
For asset downloads on any given page, we do not apply filters and download all available assets on the platform. This PR fixes the query on the frontend. 