### PR TITLE
feat(semantic document search): add semantic document search to datah…

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/document_semantic_search.gql
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/gql/document_semantic_search.gql
@@ -89,6 +89,7 @@ query documentSemanticSearch(
     count
     total
     searchResults {
+      score                                                        #[NEWER_GMS]
       entity {
         ... on Document {
           ...DocumentSearchInfo

--- a/datahub-agent-context/tests/unit/mcp_tools/test_documents.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_documents.py
@@ -5,7 +5,15 @@ from unittest.mock import Mock
 import pytest
 
 from datahub_agent_context.context import DataHubContext
-from datahub_agent_context.mcp_tools.documents import grep_documents, search_documents
+from datahub_agent_context.mcp_tools.documents import (
+    _add_top_results,
+    _annotate_search_type,
+    _build_urn_lookup,
+    _interleave_remaining_results,
+    _merge_search_results,
+    grep_documents,
+    search_documents,
+)
 
 
 @pytest.fixture
@@ -584,3 +592,426 @@ def test_grep_documents_start_offset_beyond_document_length(mock_graph):
     # Should only find match in doc2 (doc1 is skipped)
     assert result["documents_with_matches"] == 1
     assert result["results"][0]["urn"] == "urn:li:document:doc2"
+
+
+# Tests for helper functions
+
+
+def test_annotate_search_type_adds_type_to_results():
+    """Test that _annotate_search_type adds searchType to all results."""
+    results = {
+        "searchResults": [
+            {"entity": {"urn": "urn:li:document:doc1"}},
+            {"entity": {"urn": "urn:li:document:doc2"}},
+        ]
+    }
+
+    annotated = _annotate_search_type(results, "keyword")
+
+    assert annotated["searchResults"][0]["searchType"] == "keyword"
+    assert annotated["searchResults"][1]["searchType"] == "keyword"
+
+
+def test_annotate_search_type_handles_empty_results():
+    """Test that _annotate_search_type handles empty searchResults."""
+    results = {"searchResults": []}
+
+    annotated = _annotate_search_type(results, "semantic")
+
+    assert annotated["searchResults"] == []
+
+
+def test_annotate_search_type_returns_same_dict():
+    """Test that _annotate_search_type returns the same dict object."""
+    results = {"searchResults": [{"entity": {"urn": "urn:li:document:doc1"}}]}
+
+    annotated = _annotate_search_type(results, "both")
+
+    # Should be the same object (mutated in place)
+    assert annotated is results
+
+
+def test_build_urn_lookup_creates_correct_mapping():
+    """Test that _build_urn_lookup builds correct URN to result mapping."""
+    results = [
+        {"entity": {"urn": "urn:li:document:doc1"}, "score": 10},
+        {"entity": {"urn": "urn:li:document:doc2"}, "score": 8},
+    ]
+
+    urn_map = _build_urn_lookup(results)
+
+    assert len(urn_map) == 2
+    assert "urn:li:document:doc1" in urn_map
+    assert "urn:li:document:doc2" in urn_map
+    assert urn_map["urn:li:document:doc1"]["score"] == 10
+    assert urn_map["urn:li:document:doc2"]["score"] == 8
+
+
+def test_build_urn_lookup_handles_missing_urns():
+    """Test that _build_urn_lookup skips results without URNs."""
+    results = [
+        {"entity": {"urn": "urn:li:document:doc1"}},
+        {"entity": {}},  # No URN
+        {"other": "data"},  # No entity
+    ]
+
+    urn_map = _build_urn_lookup(results)
+
+    assert len(urn_map) == 1
+    assert "urn:li:document:doc1" in urn_map
+
+
+def test_build_urn_lookup_empty_list():
+    """Test that _build_urn_lookup handles empty list."""
+    urn_map = _build_urn_lookup([])
+
+    assert urn_map == {}
+
+
+def test_add_top_results_both_present():
+    """Test _add_top_results with both keyword and semantic results."""
+    merged_results = []
+    seen_urns = set()
+    keyword_results = [
+        {"entity": {"urn": "urn:li:document:k1"}},
+        {"entity": {"urn": "urn:li:document:k2"}},
+    ]
+    semantic_results = [
+        {"entity": {"urn": "urn:li:document:s1"}},
+        {"entity": {"urn": "urn:li:document:s2"}},
+    ]
+    both_urns = set()
+
+    _add_top_results(
+        merged_results, seen_urns, keyword_results, semantic_results, both_urns
+    )
+
+    # Should have 2 results: top keyword and top semantic
+    assert len(merged_results) == 2
+    assert merged_results[0]["entity"]["urn"] == "urn:li:document:k1"
+    assert merged_results[0]["searchType"] == "keyword"
+    assert merged_results[1]["entity"]["urn"] == "urn:li:document:s1"
+    assert merged_results[1]["searchType"] == "semantic"
+    assert len(seen_urns) == 2
+
+
+def test_add_top_results_duplicate_top_result():
+    """Test _add_top_results when top result appears in both searches."""
+    merged_results = []
+    seen_urns = set()
+    keyword_results = [{"entity": {"urn": "urn:li:document:same"}}]
+    semantic_results = [{"entity": {"urn": "urn:li:document:same"}}]
+    both_urns = {"urn:li:document:same"}
+
+    _add_top_results(
+        merged_results, seen_urns, keyword_results, semantic_results, both_urns
+    )
+
+    # Should have only 1 result (deduplicated)
+    assert len(merged_results) == 1
+    assert merged_results[0]["entity"]["urn"] == "urn:li:document:same"
+    assert merged_results[0]["searchType"] == "both"
+
+
+def test_add_top_results_empty_keyword():
+    """Test _add_top_results with empty keyword results."""
+    merged_results = []
+    seen_urns = set()
+    keyword_results = []
+    semantic_results = [{"entity": {"urn": "urn:li:document:s1"}}]
+    both_urns = set()
+
+    _add_top_results(
+        merged_results, seen_urns, keyword_results, semantic_results, both_urns
+    )
+
+    # Should have only semantic result
+    assert len(merged_results) == 1
+    assert merged_results[0]["entity"]["urn"] == "urn:li:document:s1"
+
+
+def test_add_top_results_empty_semantic():
+    """Test _add_top_results with empty semantic results."""
+    merged_results = []
+    seen_urns = set()
+    keyword_results = [{"entity": {"urn": "urn:li:document:k1"}}]
+    semantic_results = []
+    both_urns = set()
+
+    _add_top_results(
+        merged_results, seen_urns, keyword_results, semantic_results, both_urns
+    )
+
+    # Should have only keyword result
+    assert len(merged_results) == 1
+    assert merged_results[0]["entity"]["urn"] == "urn:li:document:k1"
+
+
+def test_interleave_remaining_results_alternates():
+    """Test _interleave_remaining_results alternates between sources."""
+    merged_results = []
+    seen_urns = set()
+    keyword_remaining = [
+        {"entity": {"urn": "urn:li:document:k1"}},
+        {"entity": {"urn": "urn:li:document:k2"}},
+    ]
+    semantic_remaining = [
+        {"entity": {"urn": "urn:li:document:s1"}},
+        {"entity": {"urn": "urn:li:document:s2"}},
+    ]
+    both_urns = set()
+
+    _interleave_remaining_results(
+        merged_results, seen_urns, keyword_remaining, semantic_remaining, both_urns
+    )
+
+    # Should alternate: k1, s1, k2, s2
+    assert len(merged_results) == 4
+    assert merged_results[0]["entity"]["urn"] == "urn:li:document:k1"
+    assert merged_results[1]["entity"]["urn"] == "urn:li:document:s1"
+    assert merged_results[2]["entity"]["urn"] == "urn:li:document:k2"
+    assert merged_results[3]["entity"]["urn"] == "urn:li:document:s2"
+
+
+def test_interleave_remaining_results_unequal_lengths():
+    """Test _interleave_remaining_results with unequal list lengths."""
+    merged_results = []
+    seen_urns = set()
+    keyword_remaining = [{"entity": {"urn": "urn:li:document:k1"}}]
+    semantic_remaining = [
+        {"entity": {"urn": "urn:li:document:s1"}},
+        {"entity": {"urn": "urn:li:document:s2"}},
+        {"entity": {"urn": "urn:li:document:s3"}},
+    ]
+    both_urns = set()
+
+    _interleave_remaining_results(
+        merged_results, seen_urns, keyword_remaining, semantic_remaining, both_urns
+    )
+
+    # Should handle unequal lengths: k1, s1, s2, s3
+    assert len(merged_results) == 4
+
+
+def test_interleave_remaining_results_deduplicates():
+    """Test _interleave_remaining_results deduplicates already-seen URNs."""
+    merged_results = []
+    seen_urns = {"urn:li:document:k1"}  # k1 already seen
+    keyword_remaining = [
+        {"entity": {"urn": "urn:li:document:k1"}},  # Should be skipped
+        {"entity": {"urn": "urn:li:document:k2"}},
+    ]
+    semantic_remaining = [{"entity": {"urn": "urn:li:document:s1"}}]
+    both_urns = set()
+
+    _interleave_remaining_results(
+        merged_results, seen_urns, keyword_remaining, semantic_remaining, both_urns
+    )
+
+    # k1 should be skipped, but alternation continues, so result is: s1, k2
+    assert len(merged_results) == 2
+    assert merged_results[0]["entity"]["urn"] == "urn:li:document:s1"
+    assert merged_results[1]["entity"]["urn"] == "urn:li:document:k2"
+
+
+def test_interleave_remaining_results_marks_both():
+    """Test _interleave_remaining_results marks results in both_urns as 'both'."""
+    merged_results = []
+    seen_urns = set()
+    keyword_remaining = [{"entity": {"urn": "urn:li:document:k1"}}]
+    semantic_remaining = [{"entity": {"urn": "urn:li:document:s1"}}]
+    both_urns = {"urn:li:document:k1"}  # k1 appears in both
+
+    _interleave_remaining_results(
+        merged_results, seen_urns, keyword_remaining, semantic_remaining, both_urns
+    )
+
+    assert merged_results[0]["searchType"] == "both"
+    assert merged_results[1]["searchType"] == "semantic"
+
+
+def test_merge_search_results_both_empty():
+    """Test _merge_search_results with both results empty."""
+    result = _merge_search_results(None, None)
+
+    assert result == {"searchResults": [], "total": 0, "count": 0}
+
+
+def test_merge_search_results_only_keyword():
+    """Test _merge_search_results with only keyword results."""
+    keyword_results = {
+        "searchResults": [{"entity": {"urn": "urn:li:document:k1"}}],
+        "total": 1,
+        "count": 1,
+    }
+
+    result = _merge_search_results(keyword_results, None)
+
+    assert len(result["searchResults"]) == 1
+    assert result["searchResults"][0]["searchType"] == "keyword"
+
+
+def test_merge_search_results_only_semantic():
+    """Test _merge_search_results with only semantic results."""
+    semantic_results = {
+        "searchResults": [{"entity": {"urn": "urn:li:document:s1"}}],
+        "total": 1,
+        "count": 1,
+    }
+
+    result = _merge_search_results(None, semantic_results)
+
+    assert len(result["searchResults"]) == 1
+    assert result["searchResults"][0]["searchType"] == "semantic"
+
+
+def test_merge_search_results_empty_semantic_with_keyword_logs_warning(caplog):
+    """Test _merge_search_results logs warning for empty semantic with non-empty keyword."""
+    keyword_results = {
+        "searchResults": [{"entity": {"urn": "urn:li:document:k1"}}],
+        "total": 1,
+        "count": 1,
+    }
+    semantic_results = {"searchResults": [], "total": 0, "count": 0}
+
+    result = _merge_search_results(keyword_results, semantic_results)
+
+    # Should return keyword results with warning logged
+    assert len(result["searchResults"]) == 1
+    assert result["searchResults"][0]["searchType"] == "keyword"
+    assert "Semantic search returned 0 results" in caplog.text
+
+
+def test_merge_search_results_deduplicates_by_urn():
+    """Test _merge_search_results deduplicates results by URN."""
+    keyword_results = {
+        "searchResults": [
+            {"entity": {"urn": "urn:li:document:both"}},
+            {"entity": {"urn": "urn:li:document:k1"}},
+        ]
+    }
+    semantic_results = {
+        "searchResults": [
+            {"entity": {"urn": "urn:li:document:both"}},
+            {"entity": {"urn": "urn:li:document:s1"}},
+        ]
+    }
+
+    result = _merge_search_results(keyword_results, semantic_results)
+
+    # Should have 3 unique results: both (deduplicated), k1, s1
+    assert len(result["searchResults"]) == 3
+    urns = [r["entity"]["urn"] for r in result["searchResults"]]
+    assert urns.count("urn:li:document:both") == 1  # Not duplicated
+
+
+def test_merge_search_results_marks_duplicates_as_both():
+    """Test _merge_search_results marks duplicates with searchType='both'."""
+    keyword_results = {"searchResults": [{"entity": {"urn": "urn:li:document:both"}}]}
+    semantic_results = {"searchResults": [{"entity": {"urn": "urn:li:document:both"}}]}
+
+    result = _merge_search_results(keyword_results, semantic_results)
+
+    assert result["searchResults"][0]["searchType"] == "both"
+
+
+def test_merge_search_results_keyword_first():
+    """Test _merge_search_results places keyword result first."""
+    keyword_results = {
+        "searchResults": [
+            {"entity": {"urn": "urn:li:document:k1"}},
+            {"entity": {"urn": "urn:li:document:k2"}},
+        ]
+    }
+    semantic_results = {
+        "searchResults": [
+            {"entity": {"urn": "urn:li:document:s1"}},
+            {"entity": {"urn": "urn:li:document:s2"}},
+        ]
+    }
+
+    result = _merge_search_results(keyword_results, semantic_results)
+
+    # First result should be top keyword
+    assert result["searchResults"][0]["entity"]["urn"] == "urn:li:document:k1"
+    # Second should be top semantic
+    assert result["searchResults"][1]["entity"]["urn"] == "urn:li:document:s1"
+
+
+def test_merge_search_results_interleaves_remaining():
+    """Test _merge_search_results interleaves remaining results."""
+    keyword_results = {
+        "searchResults": [
+            {"entity": {"urn": "urn:li:document:k1"}},
+            {"entity": {"urn": "urn:li:document:k2"}},
+            {"entity": {"urn": "urn:li:document:k3"}},
+        ]
+    }
+    semantic_results = {
+        "searchResults": [
+            {"entity": {"urn": "urn:li:document:s1"}},
+            {"entity": {"urn": "urn:li:document:s2"}},
+            {"entity": {"urn": "urn:li:document:s3"}},
+        ]
+    }
+
+    result = _merge_search_results(keyword_results, semantic_results)
+
+    # Should be: k1, s1 (tops), k2, s2, k3, s3 (interleaved)
+    urns = [r["entity"]["urn"] for r in result["searchResults"]]
+    assert urns == [
+        "urn:li:document:k1",
+        "urn:li:document:s1",
+        "urn:li:document:k2",
+        "urn:li:document:s2",
+        "urn:li:document:k3",
+        "urn:li:document:s3",
+    ]
+
+
+def test_merge_search_results_preserves_facets():
+    """Test _merge_search_results preserves facets from keyword search."""
+    keyword_results = {
+        "searchResults": [{"entity": {"urn": "urn:li:document:k1"}}],
+        "facets": [{"field": "platform", "aggregations": []}],
+    }
+    semantic_results = {
+        "searchResults": [{"entity": {"urn": "urn:li:document:s1"}}],
+    }
+
+    result = _merge_search_results(keyword_results, semantic_results)
+
+    assert "facets" in result
+    assert result["facets"] == keyword_results["facets"]
+
+
+def test_merge_search_results_preserves_start_offset():
+    """Test _merge_search_results preserves start/offset from keyword search."""
+    keyword_results = {
+        "searchResults": [{"entity": {"urn": "urn:li:document:k1"}}],
+        "start": 10,
+    }
+    semantic_results = {
+        "searchResults": [{"entity": {"urn": "urn:li:document:s1"}}],
+    }
+
+    result = _merge_search_results(keyword_results, semantic_results)
+
+    assert result["start"] == 10
+
+
+def test_merge_search_results_updates_total_and_count():
+    """Test _merge_search_results updates total and count correctly."""
+    keyword_results = {
+        "searchResults": [
+            {"entity": {"urn": "urn:li:document:k1"}},
+            {"entity": {"urn": "urn:li:document:k2"}},
+        ]
+    }
+    semantic_results = {"searchResults": [{"entity": {"urn": "urn:li:document:s1"}}]}
+
+    result = _merge_search_results(keyword_results, semantic_results)
+
+    # Should have correct count based on merged results
+    assert result["total"] == 3
+    assert result["count"] == 3


### PR DESCRIPTION
…ub-agent-context

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

add semantic search support to datahub-agent-context toolset. Search does hybrid search to make sure that both semantic and keyword work. 

```
DEBUG:datahub_agent_context.mcp_tools.documents:Hybrid document search completed in 0.405s (keyword='*', semantic='Finance', results=10)
```