### PR TITLE
fix(snowflake): add missing tenacity dependency for retry logic

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -284,6 +284,7 @@ snowflake_common = {
     "pandas<3.0.0",
     "cryptography<47.0.0",
     "msal<2.0.0",
+    "tenacity>=8.0.1,<9.0.0",
     *cachetools_lib,
     *classification_lib,
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

## Summary

Fixes a regression introduced in #15898 where the `tenacity` library was added to `snowflake_connection.py` for retry logic but was not included in the `snowflake_common` dependencies in `setup.py`.

This caused `ModuleNotFoundError: No module named 'tenacity'` when importing the Snowflake source, breaking both Snowflake and Fivetran connectors (since Fivetran depends on `snowflake_common`).

## The Issue

PR #15898 added retry logic using `tenacity` in `snowflake_connection.py`:
But the dependency was not added to setup.py, causing import failures:
ModuleNotFoundError: No module named 'tenacity'```
Failed connector tests: https://github.com/acryldata/connector-tests/actions/runs/21670268032
## The Fix

Added `tenacity>=8.0.1,<9.0.0` to `snowflake_common` dependencies in `setup.py`. This version constraint matches other sources in the codebase (slack, mode, hive-metastore, dataplex) that also use tenacity.

## Tests Affected

The following connector tests were failing and should now pass:

- `validate / validate (snowflake, test_snowflake_standard.py)`
- `validate / validate (snowflake, test_snowflake_enterprise.py)`
- `validate / validate (snowflake, test_snowflake_profiling.py)`
- `validate / validate (snowflake, test_snowflake_queries_v2.py)`
- `validate / validate (fivetran, test_fivetran_with_snowflake_dest.py)`
- `validate / validate (fivetran, test_fivetran_with_databricks_dest.py)`
- `validate / validate (fivetran, test_fivetran_with_bigquery_dest.py)`

verified test:
https://github.com/acryldata/connector-tests/actions/runs/21676792002

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues (if applicable)
- [ ] Tests added/updated (not applicable - dependency fix only)
- [ ] Docs added/updated (not applicable)
