### PR TITLE
Enable scrolling on Groups tab

### DIFF
--- a/datahub-web-react/src/app/identity/group/GroupList.tsx
+++ b/datahub-web-react/src/app/identity/group/GroupList.tsx
@@ -27,13 +27,15 @@ import { CorpGroup } from '@types';
 const GroupContainer = styled.div`
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    height: calc(100vh - 240px);
 `;
 
 const GroupStyledList = styled(List)`
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    flex: 1;
+    overflow-y: scroll;
+    min-height: 0;
     &&& {
         width: 100%;
         border-color: ${(props) => props.theme.styles['border-color-base']};


### PR DESCRIPTION
Groups container should be scrollable now.


https://github.com/user-attachments/assets/d9a74207-7f32-461f-a772-d44247810750


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
