### PR TITLE
fix(ci): run validate-plugin-deps on PR approval when src/ files change

### DIFF
--- a/.github/workflows/metadata-ingestion.yml
+++ b/.github/workflows/metadata-ingestion.yml
@@ -165,7 +165,7 @@ jobs:
         run: |
           # Manual dispatch - always run
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "Running due to manual workflow dispatch"
             exit 0
           fi
@@ -173,7 +173,7 @@ jobs:
           # For pull_request_review events, only proceed if it's an approval
           if [ "${{ github.event_name }}" == "pull_request_review" ]; then
             if [ "${{ github.event.review.state }}" != "approved" ]; then
-              echo "should_run=false" >> $GITHUB_OUTPUT
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
               echo "Review was not an approval, skipping"
               exit 0
             fi
@@ -182,7 +182,7 @@ jobs:
             git fetch origin "$BASE_REF"
             DIFF_RANGE="origin/$BASE_REF...HEAD"
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            git fetch origin ${{ github.base_ref }}
+            git fetch origin "${{ github.base_ref }}"
             DIFF_RANGE="origin/${{ github.base_ref }}...HEAD"
           else
             # For push events
@@ -190,8 +190,8 @@ jobs:
           fi
 
           # Always run if setup.py was modified
-          if git diff --name-only $DIFF_RANGE | grep -q '^metadata-ingestion/setup.py$'; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+          if git diff --name-only "$DIFF_RANGE" | grep -q '^metadata-ingestion/setup.py$'; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "setup.py was modified, running validation"
             exit 0
           fi
@@ -199,15 +199,15 @@ jobs:
           # For pull_request events (not approval), check if PR is already approved and has src/ changes
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # Check if src/ files were modified
-            if git diff --name-only $DIFF_RANGE | grep -q '^metadata-ingestion/src/.*\.py$'; then
+            if git diff --name-only "$DIFF_RANGE" | grep -q '^metadata-ingestion/src/.*\.py$'; then
               # Check if PR is approved
               APPROVAL_STATE=$(gh pr view ${{ github.event.pull_request.number }} --json reviewDecision -q '.reviewDecision' 2>/dev/null || echo "")
               if [ "$APPROVAL_STATE" == "APPROVED" ]; then
-                echo "should_run=true" >> $GITHUB_OUTPUT
+                echo "should_run=true" >> "$GITHUB_OUTPUT"
                 echo "PR is approved and has source changes, running validation"
                 exit 0
               else
-                echo "should_run=false" >> $GITHUB_OUTPUT
+                echo "should_run=false" >> "$GITHUB_OUTPUT"
                 echo "PR has source changes but is not yet approved, skipping"
                 exit 0
               fi
@@ -216,15 +216,15 @@ jobs:
 
           # For pull_request_review (approval) events, check if src/ files were modified
           if [ "${{ github.event_name }}" == "pull_request_review" ]; then
-            if git diff --name-only $DIFF_RANGE | grep -q '^metadata-ingestion/src/.*\.py$'; then
-              echo "should_run=true" >> $GITHUB_OUTPUT
+            if git diff --name-only "$DIFF_RANGE" | grep -q '^metadata-ingestion/src/.*\.py$'; then
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
               echo "Approved PR with source changes, running validation"
               exit 0
             fi
           fi
 
           # For push events, only run if setup.py was modified (already checked above)
-          echo "should_run=false" >> $GITHUB_OUTPUT
+          echo "should_run=false" >> "$GITHUB_OUTPUT"
           echo "No setup.py changes or approved PR with src/ changes, skipping"
       - name: Set up JDK 17
         if: steps.check-changes.outputs.should_run == 'true'


### PR DESCRIPTION
## Summary

Fixes a gap in the `validate-plugin-deps` CI job that caused regressions like #15898 (missing `tenacity` dependency) to slip through.

**The problem:** Previously, `validate-plugin-deps` only ran when `setup.py` was modified. This missed cases where a developer adds a new import to a source file but forgets to add the dependency to `setup.py`.

## Changes

### New trigger: `pull_request_review`

Added `pull_request_review` event to trigger validation when a PR is approved.

### Updated `validate-plugin-deps` logic

The job now runs when:

| Condition | Runs? |
|-----------|-------|
| `setup.py` modified | ✅ Yes (same as before) |
| PR approved + `metadata-ingestion/src/*.py` changed | ✅ Yes (NEW) |
| `src/*.py` changed but not approved | ❌ No (wait for approval) |
| Manual dispatch | ✅ Yes (same as before) |

### Other jobs unaffected

Added `if: github.event_name != 'pull_request_review'` to `ci` and `event-file` jobs so they skip on approval events (they already ran on PR creation).

## Flow Example

```
1. PR created with src/ changes     → validate-plugin-deps skips (not approved)
2. Reviewer approves                → validate-plugin-deps RUNS
3. Job fails (missing dependency)   → developer pushes fix
4. Push triggers job again          → validate-plugin-deps RUNS (PR already approved)
5. Job passes                       → PR can be merged
```

## Why this approach?

- **Not too aggressive:** Doesn't run expensive validation on every push
- **Catches issues before merge:** Runs at approval time
- **No re-approval needed:** If job fails and you push a fix, it re-runs automatically

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Links to related issues: #15898
- [ ] Tests added/updated (CI workflow change - will be tested by the workflow itself)
- [ ] Docs added/updated (not applicable)