### PR TITLE
refactor: default semantic search to OpenAI text-embedding-3-large

### DIFF
--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/EmbeddingProviderConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/EmbeddingProviderConfiguration.java
@@ -21,10 +21,10 @@ import lombok.NoArgsConstructor;
 public class EmbeddingProviderConfiguration {
 
   /**
-   * Type of embedding provider. Supported values: "aws-bedrock", "openai", "cohere". Defaults to
-   * "aws-bedrock".
+   * Type of embedding provider. Supported values: "openai", "aws-bedrock", "cohere". Defaults to
+   * "openai".
    */
-  private String type = "aws-bedrock";
+  private String type = "openai";
 
   /**
    * AWS region where Bedrock is available (e.g., "us-west-2", "us-east-1"). Required for
@@ -66,14 +66,14 @@ public class EmbeddingProviderConfiguration {
      * OpenAI embedding model. Supported models:
      *
      * <ul>
-     *   <li><b>text-embedding-3-small</b> (default): 1536 dimensions, optimized for speed and cost
-     *   <li><b>text-embedding-3-large</b>: 3072 dimensions, highest quality
+     *   <li><b>text-embedding-3-large</b> (default): 3072 dimensions, highest quality
+     *   <li><b>text-embedding-3-small</b>: 1536 dimensions, optimized for speed and cost
      *   <li><b>text-embedding-ada-002</b>: 1536 dimensions, legacy model
      * </ul>
      *
-     * Defaults to "text-embedding-3-small".
+     * Defaults to "text-embedding-3-large".
      */
-    private String model = "text-embedding-3-small";
+    private String model = "text-embedding-3-large";
 
     /**
      * OpenAI API endpoint. Defaults to "https://api.openai.com/v1/embeddings". For Azure OpenAI,

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/ModelEmbeddingConfig.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/ModelEmbeddingConfig.java
@@ -10,8 +10,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ModelEmbeddingConfig {
 
-  /** Dimensionality of the embedding vectors for this model. */
-  private int vectorDimension = 1024;
+  /**
+   * Dimensionality of the embedding vectors for this model. Defaults to 3072 (OpenAI
+   * text-embedding-3-large).
+   */
+  private int vectorDimension = 3072;
 
   /**
    * k-NN engine to use. Options: "faiss", "nmslib", "lucene". Defaults to "faiss" for best

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -403,7 +403,7 @@ elasticsearch:
       #     m: 16
       models:
         cohere_embed_v3:
-          vectorDimension: ${ELASTICSEARCH_SEMANTIC_VECTOR_DIMENSION:1024}
+          vectorDimension: ${ELASTICSEARCH_SEMANTIC_VECTOR_DIMENSION:3072}
           knnEngine: ${ELASTICSEARCH_SEMANTIC_KNN_ENGINE:faiss}
           spaceType: ${ELASTICSEARCH_SEMANTIC_SPACE_TYPE:cosinesimil}
           efConstruction: ${ELASTICSEARCH_SEMANTIC_EF_CONSTRUCTION:128}
@@ -412,7 +412,7 @@ elasticsearch:
       # Supports three providers: "aws-bedrock", "openai", "cohere"
       embeddingProvider:
         # Provider type: "aws-bedrock", "openai", or "cohere"
-        type: ${EMBEDDING_PROVIDER_TYPE:aws-bedrock}
+        type: ${EMBEDDING_PROVIDER_TYPE:openai}
 
         # AWS Bedrock configuration (used when type is "aws-bedrock")
         # AWS region where Bedrock is available (e.g., us-west-2, us-east-1)
@@ -425,7 +425,7 @@ elasticsearch:
         # OpenAI configuration (used when type is "openai")
         openai:
           apiKey: ${OPENAI_API_KEY:}
-          model: ${OPENAI_EMBEDDING_MODEL:text-embedding-3-small}
+          model: ${OPENAI_EMBEDDING_MODEL:text-embedding-3-large}
           endpoint: ${OPENAI_EMBEDDING_ENDPOINT:https://api.openai.com/v1/embeddings}
 
         # Cohere configuration (used when type is "cohere")


### PR DESCRIPTION
## Summary
- Change default embedding provider from `aws-bedrock` to `openai` — OpenAI is easier to set up and more widely recognized
- Change default model from `text-embedding-3-small` to `text-embedding-3-large` (3072 dimensions) for higher quality embeddings
- Update Java defaults in `EmbeddingProviderConfiguration`, `ModelEmbeddingConfig`, and `application.yaml` to be consistent

## Test plan
- [ ] Verify semantic search still works with explicit `aws-bedrock` provider config (env var override)
- [ ] Verify semantic search works with OpenAI provider using default config (no env var overrides needed)
- [ ] Confirm vector dimension mismatch detection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)