### PR TITLE
feat(graphql): configurable parent traversal depth and visit limits

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GraphQLEngine.java
@@ -120,9 +120,13 @@ public class GraphQLEngine {
             .variables(variables)
             .dataLoaderRegistry(register)
             .context(context)
-            // https://www.graphql-java.com/documentation/upgrade-notes/#how-to-use-the-inputinterceptor-to-use-the-legacy-parsevalue-behaviour-prior-to-v220
             .graphQLContext(
-                Map.of(InputInterceptor.class, LegacyCoercingInputInterceptor.migratesValues()))
+                Map.of(
+                    // https://www.graphql-java.com/documentation/upgrade-notes/#how-to-use-the-inputinterceptor-to-use-the-legacy-parsevalue-behaviour-prior-to-v220
+                    InputInterceptor.class,
+                    LegacyCoercingInputInterceptor.migratesValues(),
+                    QueryContext.class,
+                    context))
             .build();
 
     /*

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/QueryContext.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/QueryContext.java
@@ -3,8 +3,10 @@ package com.linkedin.datahub.graphql;
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.Authentication;
 import com.datahub.plugins.auth.authorization.Authorizer;
+import com.linkedin.datahub.graphql.context.RelationshipTraversalContext;
 import com.linkedin.metadata.config.DataHubAppConfiguration;
 import io.datahubproject.metadata.context.OperationContext;
+import java.util.Optional;
 
 /** Provided as input to GraphQL resolvers; used to carry information about GQL request context. */
 public interface QueryContext {
@@ -34,4 +36,19 @@ public interface QueryContext {
   OperationContext getOperationContext();
 
   DataHubAppConfiguration getDataHubAppConfig();
+
+  /**
+   * Max depth when traversing parent chains (glossary nodes, domains, containers, documents).
+   * Configurable via {@link com.linkedin.metadata.config.graphql.GraphQLQueryConfiguration}.
+   */
+  int getMaxParentDepth();
+
+  /**
+   * Optional request-scoped context for tracking visited URNs during relationship resolution (cycle
+   * detection). Present for GraphQL requests; resolvers should short-circuit when a URN was already
+   * visited in this request.
+   */
+  default Optional<RelationshipTraversalContext> getRelationshipTraversalContext() {
+    return Optional.empty();
+  }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/context/RelationshipTraversalContext.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/context/RelationshipTraversalContext.java
@@ -1,0 +1,52 @@
+package com.linkedin.datahub.graphql.context;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nonnull;
+
+/**
+ * Request-scoped context for tracking visited URNs during GraphQL relationship resolution. Used to
+ * detect cycles and prevent unbounded recursion when the same entity is reached again via
+ * relationships. One instance per GraphQL request, provided via {@link
+ * com.linkedin.datahub.graphql.QueryContext#getRelationshipTraversalContext()}.
+ *
+ * <p>Enforces a maximum number of distinct URNs per request so that even with a very large or
+ * cyclic graph we short-circuit and avoid OOM. The limit is configurable via {@link
+ * com.linkedin.metadata.config.graphql.GraphQLQueryConfiguration#getMaxVisitedUrns()}.
+ */
+public class RelationshipTraversalContext {
+
+  private final int _maxVisitedUrns;
+  private final Set<String> _visitedUrns = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Creates a traversal context with the given cap on distinct URNs per request.
+   *
+   * @param maxVisitedUrns max distinct URNs to visit; beyond this we short-circuit to prevent OOM
+   */
+  public RelationshipTraversalContext(int maxVisitedUrns) {
+    this._maxVisitedUrns = maxVisitedUrns;
+  }
+
+  /**
+   * Marks the given URN as visited for this request. Call before resolving relationships for that
+   * entity.
+   *
+   * @param urn entity URN being visited
+   * @return true if under the cap (caller should proceed); false only when at cap (caller should
+   *     short-circuit). Resolving multiple relationship types for the same entity in one request is
+   *     allowed and does not short-circuit.
+   */
+  public boolean tryVisit(@Nonnull String urn) {
+    if (_visitedUrns.size() >= _maxVisitedUrns) {
+      return false;
+    }
+    _visitedUrns.add(urn);
+    return true;
+  }
+
+  /** Returns whether the URN has already been visited in this request. */
+  public boolean isVisited(@Nonnull String urn) {
+    return _visitedUrns.contains(urn);
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GetRootGlossaryNodesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GetRootGlossaryNodesResolver.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 
 import com.google.common.collect.ImmutableList;
@@ -41,8 +42,7 @@ public class GetRootGlossaryNodesResolver
   public CompletableFuture<GetRootGlossaryNodesResult> get(
       final DataFetchingEnvironment environment) throws Exception {
 
-    final QueryContext context = environment.getContext();
-
+    final QueryContext context = getQueryContext(environment);
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           final GetRootGlossaryEntitiesInput input =

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GetRootGlossaryTermsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GetRootGlossaryTermsResolver.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 
 import com.google.common.collect.ImmutableList;
@@ -41,8 +42,7 @@ public class GetRootGlossaryTermsResolver
   public CompletableFuture<GetRootGlossaryTermsResult> get(
       final DataFetchingEnvironment environment) throws Exception {
 
-    final QueryContext context = environment.getContext();
-
+    final QueryContext context = getQueryContext(environment);
     return GraphQLConcurrencyUtils.supplyAsync(
         () -> {
           final GetRootGlossaryEntitiesInput input =

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryChildrenSearchResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryChildrenSearchResolver.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
 
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Entity;
@@ -37,7 +38,7 @@ public class GlossaryChildrenSearchResolver
   @Override
   public CompletableFuture<ScrollResults> get(DataFetchingEnvironment environment) {
     final Entity entity = environment.getSource();
-    final QueryContext context = environment.getContext();
+    final QueryContext context = getQueryContext(environment);
     final ScrollAcrossEntitiesInput input =
         bindArgument(environment.getArgument("input"), ScrollAcrossEntitiesInput.class);
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryNodeChildrenCountResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryNodeChildrenCountResolver.java
@@ -1,5 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.glossary;
 
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
+
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -34,7 +36,7 @@ public class GlossaryNodeChildrenCountResolver
   @Override
   public CompletableFuture<GlossaryNodeChildrenCount> get(final DataFetchingEnvironment environment)
       throws Exception {
-    final QueryContext context = environment.getContext();
+    final QueryContext context = getQueryContext(environment);
     final String urn = ((Entity) environment.getSource()).getUrn();
 
     final CriterionArray andArray = new CriterionArray();

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolver.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.search;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
 
 import com.linkedin.common.urn.UrnUtils;
@@ -42,7 +43,7 @@ public class ScrollAcrossEntitiesResolver implements DataFetcher<CompletableFutu
 
   @Override
   public CompletableFuture<ScrollResults> get(DataFetchingEnvironment environment) {
-    final QueryContext context = environment.getContext();
+    final QueryContext context = getQueryContext(environment);
     final ScrollAcrossEntitiesInput input =
         bindArgument(environment.getArgument("input"), ScrollAcrossEntitiesInput.class);
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolver.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.search;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.getQueryContext;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.getEntityNames;
 
@@ -47,7 +48,7 @@ public class SearchAcrossEntitiesResolver implements DataFetcher<CompletableFutu
 
   @Override
   public CompletableFuture<SearchResults> get(DataFetchingEnvironment environment) {
-    final QueryContext context = environment.getContext();
+    final QueryContext context = getQueryContext(environment);
     final SearchAcrossEntitiesInput input =
         bindArgument(environment.getArgument("input"), SearchAcrossEntitiesInput.class);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/TestUtils.java
@@ -71,6 +71,7 @@ public class TestUtils {
 
     when(mockContext.getAuthorizer()).thenReturn(mockAuthorizer);
     when(mockContext.getAuthentication()).thenReturn(authentication);
+    when(mockContext.getMaxParentDepth()).thenReturn(50);
 
     OperationContext operationContext =
         TestOperationContexts.userContextNoSearchAuthorization(mockAuthorizer, authentication);
@@ -108,6 +109,7 @@ public class TestUtils {
 
     when(mockContext.getAuthorizer()).thenReturn(mockAuthorizer);
     when(mockContext.getAuthentication()).thenReturn(authentication);
+    when(mockContext.getMaxParentDepth()).thenReturn(50);
 
     OperationContext operationContext =
         TestOperationContexts.userContextNoSearchAuthorization(mockAuthorizer, authentication);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ParentContainersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/container/ParentContainersResolverTest.java
@@ -33,6 +33,7 @@ public class ParentContainersResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     QueryContext mockContext = Mockito.mock(QueryContext.class);
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getMaxParentDepth()).thenReturn(50);
     Mockito.when(mockContext.getOperationContext())
         .thenReturn(TestOperationContexts.systemContextNoSearchAuthorization());
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/datacontract/DataContractUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/datacontract/DataContractUtilsTest.java
@@ -66,6 +66,11 @@ public class DataContractUtilsTest {
               public DataHubAppConfiguration getDataHubAppConfig() {
                 return new DataHubAppConfiguration();
               }
+
+              @Override
+              public int getMaxParentDepth() {
+                return 50;
+              }
             },
             testUrn);
     Assert.assertTrue(result);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/ParentDomainsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/ParentDomainsResolverTest.java
@@ -30,6 +30,7 @@ public class ParentDomainsResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     QueryContext mockContext = Mockito.mock(QueryContext.class);
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getMaxParentDepth()).thenReturn(50);
     Mockito.when(mockContext.getOperationContext())
         .thenReturn(TestOperationContexts.systemContextNoSearchAuthorization());
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryUtilsTest.java
@@ -42,6 +42,7 @@ public class GlossaryUtilsTest {
   @BeforeMethod
   private void setUpTests() throws Exception {
     Mockito.when(mockContext.getActorUrn()).thenReturn(userUrn);
+    when(mockContext.getMaxParentDepth()).thenReturn(50);
     when(mockContext.getOperationContext()).thenReturn(mock(OperationContext.class));
 
     GlossaryNodeInfo parentNode1 =

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/ParentNodesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/ParentNodesResolverTest.java
@@ -35,6 +35,7 @@ public class ParentNodesResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     QueryContext mockContext = Mockito.mock(QueryContext.class);
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getMaxParentDepth()).thenReturn(50);
     Mockito.when(mockContext.getOperationContext())
         .thenReturn(TestOperationContexts.systemContextNoSearchAuthorization());
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
@@ -144,6 +145,7 @@ public class ParentNodesResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     QueryContext mockContext = Mockito.mock(QueryContext.class);
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getMaxParentDepth()).thenReturn(50);
     Mockito.when(mockContext.getOperationContext())
         .thenReturn(TestOperationContexts.systemContextNoSearchAuthorization());
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/ParentDocumentsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/knowledge/ParentDocumentsResolverTest.java
@@ -34,6 +34,7 @@ public class ParentDocumentsResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     QueryContext mockContext = Mockito.mock(QueryContext.class);
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getMaxParentDepth()).thenReturn(50);
     Mockito.when(mockContext.getOperationContext())
         .thenReturn(TestOperationContexts.systemContextNoSearchAuthorization());
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
@@ -174,6 +175,7 @@ public class ParentDocumentsResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     QueryContext mockContext = Mockito.mock(QueryContext.class);
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    Mockito.when(mockContext.getMaxParentDepth()).thenReturn(50);
     Mockito.when(mockContext.getOperationContext())
         .thenReturn(TestOperationContexts.systemContextNoSearchAuthorization());
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/EntityRelationshipsResultResolverTest.java
@@ -3,14 +3,21 @@ package com.linkedin.datahub.graphql.resolvers.load;
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.linkedin.common.EntityRelationship;
 import com.linkedin.common.EntityRelationshipArray;
 import com.linkedin.common.EntityRelationships;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.context.RelationshipTraversalContext;
 import com.linkedin.datahub.graphql.generated.*;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphClient;
@@ -18,6 +25,7 @@ import graphql.schema.DataFetchingEnvironment;
 import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.testng.annotations.BeforeMethod;
@@ -115,6 +123,167 @@ public class EntityRelationshipsResultResolverTest {
     expected.setCount(1);
     expected.setTotal(1);
     assertEquals(resolver.get(mockEnv).get().toString(), expected.toString());
+  }
+
+  @Test
+  public void testResolverWithGraphClientOnlyUsesNullEntityService()
+      throws ExecutionException, InterruptedException {
+    EntityRelationshipsResultResolver resolverGraphOnly =
+        new EntityRelationshipsResultResolver(_graphClient);
+    EntityRelationshipsResult result = resolverGraphOnly.get(mockEnv).get();
+    assertNotNull(result);
+    assertEquals(result.getCount(), 2);
+    assertEquals(result.getRelationships().size(), 2);
+  }
+
+  @Test
+  public void testRelationshipTraversalContextTryVisitAndIsVisited() {
+    RelationshipTraversalContext ctx = new RelationshipTraversalContext(20_000);
+    String urn = "urn:li:dataset:(urn:li:dataPlatform:foo,bar,PROD)";
+    assertTrue(ctx.tryVisit(urn));
+    assertTrue(ctx.isVisited(urn));
+    // Same URN again: still proceed (multiple relationship types for one entity in one request)
+    assertTrue(ctx.tryVisit(urn));
+    assertFalse(ctx.isVisited("urn:li:other:xyz"));
+  }
+
+  @Test
+  public void testRelationshipTraversalContextAtCapShortCircuits() {
+    RelationshipTraversalContext ctx = new RelationshipTraversalContext(1);
+    assertTrue(ctx.tryVisit("urn:li:dataset:one"));
+    assertFalse(ctx.tryVisit("urn:li:dataset:two"));
+  }
+
+  @Test
+  public void testNullContextReturnsEmptyAndDoesNotCallGraphClient()
+      throws ExecutionException, InterruptedException {
+    when(mockEnv.getContext()).thenReturn(null);
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    assertNotNull(result);
+    assertTrue(result.getRelationships() == null || result.getRelationships().isEmpty());
+    assertEquals(result.getCount(), 0);
+    verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testFirstVisitWithTraversalContextPresentProceedsAndCallsGraphClient()
+      throws ExecutionException, InterruptedException {
+    RelationshipTraversalContext traversalContext = new RelationshipTraversalContext(20_000);
+    QueryContext queryContext = getMockAllowContext();
+    when(queryContext.getRelationshipTraversalContext()).thenReturn(Optional.of(traversalContext));
+    when(mockEnv.getContext()).thenReturn(queryContext);
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+    assertNotNull(result);
+    assertEquals(result.getCount(), 2);
+    verify(_graphClient).getRelatedEntities(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testMapEntityRelationshipWithCreatedStamp()
+      throws ExecutionException, InterruptedException {
+    com.linkedin.common.AuditStamp created =
+        new com.linkedin.common.AuditStamp().setTime(12345L).setActor(existentUser);
+    EntityRelationship withCreated =
+        new EntityRelationship().setEntity(existentUser).setType("SomeType").setCreated(created);
+    EntityRelationships entityRelationships =
+        new EntityRelationships()
+            .setStart(0)
+            .setCount(1)
+            .setTotal(1)
+            .setRelationships(new EntityRelationshipArray(withCreated));
+    when(_graphClient.getRelatedEntities(any(), any(), any(), any(), any(), any()))
+        .thenReturn(entityRelationships);
+    when(_entityService.exists(any(), eq(Set.of(existentUser)), eq(false)))
+        .thenReturn(Set.of(existentUser));
+    when(_entityService.exists(any(), eq(Set.of(existentUser)), eq(true)))
+        .thenReturn(Set.of(existentUser));
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+    assertNotNull(result);
+    assertEquals(result.getRelationships().size(), 1);
+    assertNotNull(result.getRelationships().get(0).getCreated());
+  }
+
+  /**
+   * When the traversal context is at its URN cap, the resolver must return empty and must not call
+   * the graph client. This prevents OOM on very large or cyclic graphs.
+   */
+  @Test
+  public void testAtCapReturnsEmptyAndDoesNotCallGraphClient()
+      throws ExecutionException, InterruptedException {
+    String sourceUrn = "urn:li:glossaryNode:0fdc52a7d97255a4568a3255ad7e8414";
+    CorpGroup source = new CorpGroup();
+    source.setUrn(sourceUrn);
+    when(mockEnv.getSource()).thenReturn(source);
+
+    RelationshipTraversalContext traversalContext = new RelationshipTraversalContext(1);
+    traversalContext.tryVisit("urn:li:other:already-visited");
+
+    QueryContext queryContext = getMockAllowContext();
+    when(queryContext.getRelationshipTraversalContext()).thenReturn(Optional.of(traversalContext));
+    when(mockEnv.getContext()).thenReturn(queryContext);
+
+    RelationshipsInput cycleInput = new RelationshipsInput();
+    cycleInput.setTypes(List.of("IsPartOf"));
+    cycleInput.setDirection(RelationshipDirection.INCOMING);
+    cycleInput.setCount(500);
+    when(mockEnv.getArgument(eq("input"))).thenReturn(cycleInput);
+
+    EntityRelationshipsResult result = resolver.get(mockEnv).get();
+
+    assertNotNull(result);
+    assertTrue(result.getRelationships() == null || result.getRelationships().isEmpty());
+    assertEquals(result.getCount(), 0);
+    verify(_graphClient, never()).getRelatedEntities(any(), any(), any(), any(), any(), any());
+  }
+
+  /**
+   * Same entity can have multiple relationship types resolved in one request (e.g. ML model
+   * features and trainedBy). Both resolutions must succeed and call the graph client.
+   */
+  @Test
+  public void testSameUrnMultipleRelationshipTypesBothSucceed()
+      throws ExecutionException, InterruptedException {
+    String sourceUrn = "urn:li:mlModel:(urn:li:dataPlatform:sagemaker,cypress-model,PROD)";
+    CorpGroup source = new CorpGroup();
+    source.setUrn(sourceUrn);
+    when(mockEnv.getSource()).thenReturn(source);
+
+    EntityRelationships twoRelationships =
+        new EntityRelationships()
+            .setStart(0)
+            .setCount(2)
+            .setTotal(2)
+            .setRelationships(
+                new EntityRelationshipArray(
+                    new EntityRelationship().setEntity(existentUser).setType("SomeType"),
+                    new EntityRelationship().setEntity(softDeletedUser).setType("SomeType")));
+    when(_graphClient.getRelatedEntities(eq(sourceUrn), any(), any(), any(), any(), any()))
+        .thenReturn(twoRelationships);
+
+    RelationshipTraversalContext traversalContext = new RelationshipTraversalContext(20_000);
+    QueryContext queryContext = getMockAllowContext();
+    when(queryContext.getRelationshipTraversalContext()).thenReturn(Optional.of(traversalContext));
+    when(mockEnv.getContext()).thenReturn(queryContext);
+
+    RelationshipsInput cycleInput = new RelationshipsInput();
+    cycleInput.setTypes(List.of("IsPartOf"));
+    cycleInput.setDirection(RelationshipDirection.INCOMING);
+    cycleInput.setCount(500);
+    when(mockEnv.getArgument(eq("input"))).thenReturn(cycleInput);
+
+    EntityRelationshipsResult firstResult = resolver.get(mockEnv).get();
+    assertNotNull(firstResult);
+    assertEquals(firstResult.getCount(), 2);
+
+    EntityRelationshipsResult secondResult = resolver.get(mockEnv).get();
+    assertNotNull(secondResult);
+    assertEquals(secondResult.getCount(), 2);
+
+    verify(_graphClient, times(2)).getRelatedEntities(any(), any(), any(), any(), any(), any());
   }
 
   private com.linkedin.datahub.graphql.generated.EntityRelationship resultRelationship(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossEntitiesResolverTest.java
@@ -1,0 +1,142 @@
+package com.linkedin.datahub.graphql.resolvers.search;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.*;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.ScrollAcrossEntitiesInput;
+import com.linkedin.datahub.graphql.generated.ScrollResults;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.search.ScrollResult;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import com.linkedin.metadata.service.ViewService;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collections;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ScrollAcrossEntitiesResolverTest {
+
+  private EntityClient _entityClient;
+  private ViewService _viewService;
+  private DataFetchingEnvironment _env;
+  private ScrollAcrossEntitiesResolver _resolver;
+
+  @BeforeMethod
+  public void setup() {
+    _entityClient = Mockito.mock(EntityClient.class);
+    _viewService = Mockito.mock(ViewService.class);
+    _env = Mockito.mock(DataFetchingEnvironment.class);
+    _resolver = new ScrollAcrossEntitiesResolver(_entityClient, _viewService);
+  }
+
+  @Test
+  public void testGetSuccessWithExplicitTypes() throws Exception {
+    ScrollResult mockResult = new ScrollResult();
+    mockResult.setScrollId("scroll-1");
+    mockResult.setPageSize(2);
+    mockResult.setNumEntities(2);
+    mockResult.setMetadata(new SearchResultMetadata());
+    mockResult.setEntities(new SearchEntityArray());
+
+    ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setTypes(Collections.singletonList(EntityType.DATASET));
+    input.setQuery("test");
+    input.setCount(5);
+
+    Mockito.when(_env.getArgument("input")).thenReturn(input);
+    QueryContext context = getMockAllowContext();
+    Mockito.when(_env.getContext()).thenReturn(context);
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(),
+                eq(Collections.singletonList(Constants.DATASET_ENTITY_NAME)),
+                eq("test"),
+                any(),
+                eq(null),
+                eq("5m"),
+                eq(Collections.emptyList()),
+                eq(5)))
+        .thenReturn(mockResult);
+
+    ScrollResults result = _resolver.get(_env).get();
+
+    assertNotNull(result);
+    assertEquals(result.getNextScrollId(), "scroll-1");
+    assertEquals(result.getCount(), 2);
+    assertEquals(result.getTotal(), 2);
+    verify(_entityClient)
+        .scrollAcrossEntities(
+            any(),
+            eq(Collections.singletonList(Constants.DATASET_ENTITY_NAME)),
+            eq("test"),
+            any(),
+            eq(null),
+            eq("5m"),
+            eq(Collections.emptyList()),
+            eq(5));
+  }
+
+  @Test
+  public void testGetSuccessWithScrollIdAndKeepAlive() throws Exception {
+    ScrollResult mockResult = new ScrollResult();
+    mockResult.setPageSize(0);
+    mockResult.setNumEntities(0);
+    mockResult.setMetadata(new SearchResultMetadata());
+    mockResult.setEntities(new SearchEntityArray());
+
+    ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setTypes(Collections.singletonList(EntityType.DATASET));
+    input.setQuery("*");
+    input.setScrollId("next-scroll-id");
+    input.setKeepAlive("2m");
+    input.setCount(10);
+
+    QueryContext context = getMockAllowContext();
+    Mockito.when(_env.getArgument("input")).thenReturn(input);
+    Mockito.when(_env.getContext()).thenReturn(context);
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(), any(), eq("*"), any(), eq("next-scroll-id"), eq("2m"), any(), eq(10)))
+        .thenReturn(mockResult);
+
+    ScrollResults result = _resolver.get(_env).get();
+
+    assertNotNull(result);
+    assertEquals(result.getTotal(), 0);
+  }
+
+  @Test
+  public void testGetExceptionThrowsRuntimeException() throws Exception {
+    ScrollAcrossEntitiesInput input = new ScrollAcrossEntitiesInput();
+    input.setTypes(Collections.singletonList(EntityType.DATASET));
+    input.setQuery("fail");
+    input.setCount(10);
+
+    QueryContext context = getMockAllowContext();
+    Mockito.when(_env.getArgument("input")).thenReturn(input);
+    Mockito.when(_env.getContext()).thenReturn(context);
+    Mockito.when(
+            _entityClient.scrollAcrossEntities(
+                any(), any(), eq("fail"), any(), any(), any(), any(), any()))
+        .thenThrow(new RemoteInvocationException("scroll failed"));
+
+    try {
+      _resolver.get(_env).join();
+      Assert.fail("expected CompletionException");
+    } catch (CompletionException e) {
+      assertTrue(e.getCause() instanceof RuntimeException);
+      assertTrue(e.getCause().getMessage().contains("Failed to execute search"));
+    }
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolverTest.java
@@ -4,6 +4,8 @@ import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
 import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
@@ -16,6 +18,10 @@ import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.FacetFilterInput;
 import com.linkedin.datahub.graphql.generated.FilterOperator;
 import com.linkedin.datahub.graphql.generated.SearchAcrossEntitiesInput;
+import com.linkedin.datahub.graphql.generated.SearchFlags;
+import com.linkedin.datahub.graphql.generated.SearchSortInput;
+import com.linkedin.datahub.graphql.generated.SortCriterion;
+import com.linkedin.datahub.graphql.generated.SortOrder;
 import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
@@ -423,6 +429,88 @@ public class SearchAcrossEntitiesResolverTest {
         10);
 
     verifyMockViewService(mockService, TEST_VIEW_URN);
+  }
+
+  @Test
+  public static void testSearchWithSearchFlagsAndSortInput() throws Exception {
+    ViewService mockService = Mockito.mock(ViewService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    SearchResult emptyResult =
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setNumEntities(0)
+            .setFrom(0)
+            .setPageSize(0)
+            .setMetadata(new SearchResultMetadata());
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(), any(), eq("query"), any(), eq(0), eq(10), any(), any()))
+        .thenReturn(emptyResult);
+
+    SearchAcrossEntitiesInput input =
+        new SearchAcrossEntitiesInput(
+            ImmutableList.of(EntityType.DATASET),
+            "query",
+            0,
+            10,
+            null,
+            null,
+            null,
+            new SearchFlags(),
+            null);
+    SearchSortInput sortInput = new SearchSortInput();
+    SortCriterion sortCriterion = new SortCriterion();
+    sortCriterion.setField("name");
+    sortCriterion.setSortOrder(SortOrder.ASCENDING);
+    sortInput.setSortCriteria(ImmutableList.of(sortCriterion));
+    input.setSortInput(sortInput);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    SearchAcrossEntitiesResolver resolver =
+        new SearchAcrossEntitiesResolver(mockClient, mockService);
+    resolver.get(mockEnv).get();
+
+    Mockito.verify(mockClient, Mockito.times(1))
+        .searchAcrossEntities(any(), any(), eq("query"), any(), eq(0), eq(10), any(), any());
+  }
+
+  @Test
+  public static void testSearchWithStructuredPropertyFacets() throws Exception {
+    ViewService mockService = Mockito.mock(ViewService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    SearchResult emptyResult =
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setNumEntities(0)
+            .setFrom(0)
+            .setPageSize(0)
+            .setMetadata(new SearchResultMetadata());
+    Mockito.when(
+            mockClient.searchAcrossEntities(
+                any(), any(), any(), any(), anyInt(), anyInt(), any(), any()))
+        .thenReturn(emptyResult);
+
+    SearchFlags flags = new SearchFlags();
+    flags.setIncludeStructuredPropertyFacets(true);
+    SearchAcrossEntitiesInput input =
+        new SearchAcrossEntitiesInput(
+            ImmutableList.of(EntityType.DATASET), "q", 0, 10, null, null, null, flags, null);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    SearchAcrossEntitiesResolver resolver =
+        new SearchAcrossEntitiesResolver(mockClient, mockService);
+    resolver.get(mockEnv).get();
+
+    Mockito.verify(mockClient, Mockito.atLeast(1))
+        .searchAcrossEntities(any(), any(), any(), any(), anyInt(), anyInt(), any(), any());
   }
 
   @Test

--- a/metadata-ingestion/examples/recursion/recursion_test.json
+++ b/metadata-ingestion/examples/recursion/recursion_test.json
@@ -1,0 +1,74 @@
+[
+  {
+    "entityType": "glossaryNode",
+    "entityUrn": "urn:li:glossaryNode:RecursionTestRoot",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryNodeInfo",
+    "aspect": {"json": {"customProperties": {}, "definition": "Root node for glossary recursion test. All test nodes and terms sit under this so the /glossary page shows a root and recursion (parent chain) stops here.", "name": "Glossary Recursion Test Root"}},
+    "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}
+  },
+  {"entityType": "glossaryNode", "entityUrn": "urn:li:glossaryNode:RecursionTestRoot", "changeType": "UPSERT", "aspectName": "ownership", "aspect": {"json": {"owners": [{"owner": "urn:li:corpuser:datahub", "type": "DATAOWNER"}], "ownerTypes": {}, "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryNode", "entityUrn": "urn:li:glossaryNode:RecursionTestRoot", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {
+    "entityType": "glossaryNode",
+    "entityUrn": "urn:li:glossaryNode:0fdc52a7d97255a4568a3255ad7e8414",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryNodeInfo",
+    "aspect": {"json": {"customProperties": {}, "definition": "Test node for glossary recursion / cycle detection (EntityRelationshipsResultResolver, ParentNodesResolver).", "name": "Glossary Recursion Test Node", "parentNode": "urn:li:glossaryNode:RecursionTestRoot"}},
+    "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}
+  },
+  {"entityType": "glossaryNode", "entityUrn": "urn:li:glossaryNode:0fdc52a7d97255a4568a3255ad7e8414", "changeType": "UPSERT", "aspectName": "ownership", "aspect": {"json": {"owners": [{"owner": "urn:li:corpuser:datahub", "type": "DATAOWNER"}], "ownerTypes": {}, "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryNode", "entityUrn": "urn:li:glossaryNode:0fdc52a7d97255a4568a3255ad7e8414", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {
+    "entityType": "glossaryNode",
+    "entityUrn": "urn:li:glossaryNode:cycle-parent",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryNodeInfo",
+    "aspect": {"json": {"customProperties": {}, "definition": "Child node under the test node; forms a deep parent chain for testing recursion limits.", "name": "Cycle Parent Node", "parentNode": "urn:li:glossaryNode:0fdc52a7d97255a4568a3255ad7e8414"}},
+    "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}
+  },
+  {"entityType": "glossaryNode", "entityUrn": "urn:li:glossaryNode:cycle-parent", "changeType": "UPSERT", "aspectName": "ownership", "aspect": {"json": {"owners": [{"owner": "urn:li:corpuser:datahub", "type": "DATAOWNER"}], "ownerTypes": {}, "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryNode", "entityUrn": "urn:li:glossaryNode:cycle-parent", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {
+    "entityType": "glossaryTerm",
+    "entityUrn": "urn:li:glossaryTerm:0fdc52a7d97255a4568a3255ad7e8414.TermA",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTermInfo",
+    "aspect": {"json": {"customProperties": {}, "definition": "Term under the test node for nested HasA resolution.", "name": "Term A", "parentNode": "urn:li:glossaryNode:0fdc52a7d97255a4568a3255ad7e8414", "termSource": "INTERNAL"}},
+    "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}
+  },
+  {"entityType": "glossaryTerm", "entityUrn": "urn:li:glossaryTerm:0fdc52a7d97255a4568a3255ad7e8414.TermA", "changeType": "UPSERT", "aspectName": "glossaryRelatedTerms", "aspect": {"json": {"hasRelatedTerms": ["urn:li:glossaryTerm:0fdc52a7d97255a4568a3255ad7e8414.TermB"]}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryTerm", "entityUrn": "urn:li:glossaryTerm:0fdc52a7d97255a4568a3255ad7e8414.TermA", "changeType": "UPSERT", "aspectName": "ownership", "aspect": {"json": {"owners": [{"owner": "urn:li:corpuser:datahub", "type": "DATAOWNER"}], "ownerTypes": {}, "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryTerm", "entityUrn": "urn:li:glossaryTerm:0fdc52a7d97255a4568a3255ad7e8414.TermA", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryTerm", "entityUrn": "urn:li:glossaryTerm:0fdc52a7d97255a4568a3255ad7e8414.TermB", "changeType": "UPSERT", "aspectName": "glossaryTermInfo", "aspect": {"json": {"customProperties": {}, "definition": "Term under the test node (HasA target from Term A).", "name": "Term B", "parentNode": "urn:li:glossaryNode:0fdc52a7d97255a4568a3255ad7e8414", "termSource": "INTERNAL"}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryTerm", "entityUrn": "urn:li:glossaryTerm:0fdc52a7d97255a4568a3255ad7e8414.TermB", "changeType": "UPSERT", "aspectName": "ownership", "aspect": {"json": {"owners": [{"owner": "urn:li:corpuser:datahub", "type": "DATAOWNER"}], "ownerTypes": {}, "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryTerm", "entityUrn": "urn:li:glossaryTerm:0fdc52a7d97255a4568a3255ad7e8414.TermB", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryTerm", "entityUrn": "urn:li:glossaryTerm:RecursionTestRootTerm", "changeType": "UPSERT", "aspectName": "glossaryTermInfo", "aspect": {"json": {"customProperties": {}, "definition": "Root-level term (no parent). Exercises GetRootGlossaryTermsResolver.", "name": "Root Term", "termSource": "INTERNAL"}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryTerm", "entityUrn": "urn:li:glossaryTerm:RecursionTestRootTerm", "changeType": "UPSERT", "aspectName": "ownership", "aspect": {"json": {"owners": [{"owner": "urn:li:corpuser:datahub", "type": "DATAOWNER"}], "ownerTypes": {}, "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "glossaryTerm", "entityUrn": "urn:li:glossaryTerm:RecursionTestRootTerm", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {
+    "entityType": "document",
+    "entityUrn": "urn:li:document:recursion-test-root",
+    "changeType": "UPSERT",
+    "aspectName": "documentInfo",
+    "aspect": {"json": {"title": "Recursion Test Root Document", "definition": "Root document for parent-document recursion test. ParentDocumentsResolver should stop here.", "status": {"state": "PUBLISHED"}, "contents": {"text": ""}, "created": {"time": 0, "actor": "urn:li:corpuser:datahub"}, "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}}},
+    "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}
+  },
+  {"entityType": "document", "entityUrn": "urn:li:document:recursion-test-root", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {
+    "entityType": "document",
+    "entityUrn": "urn:li:document:recursion-test-child",
+    "changeType": "UPSERT",
+    "aspectName": "documentInfo",
+    "aspect": {"json": {"title": "Recursion Test Child", "definition": "Child document under root. Exercises ParentDocumentsResolver depth and visited set.", "status": {"state": "PUBLISHED"}, "contents": {"text": ""}, "created": {"time": 0, "actor": "urn:li:corpuser:datahub"}, "lastModified": {"time": 0, "actor": "urn:li:corpuser:datahub"}, "parentDocument": {"document": "urn:li:document:recursion-test-root"}}},
+    "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}
+  },
+  {"entityType": "document", "entityUrn": "urn:li:document:recursion-test-child", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "domain", "entityUrn": "urn:li:domain:recursion-test-root", "changeType": "UPSERT", "aspectName": "domainProperties", "aspect": {"json": {"name": "Recursion Test Root Domain", "description": "Root domain for parent-domains recursion test. ParentDomainsResolver stops here."}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "domain", "entityUrn": "urn:li:domain:recursion-test-child", "changeType": "UPSERT", "aspectName": "domainProperties", "aspect": {"json": {"name": "Recursion Test Child Domain", "description": "Child domain under root. Exercises ParentDomainsResolver depth and cycle limits.", "parentDomain": "urn:li:domain:recursion-test-root"}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "container", "entityUrn": "urn:li:container:recursion-test-root", "changeType": "UPSERT", "aspectName": "containerProperties", "aspect": {"json": {"name": "Recursion Test Root Container"}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "container", "entityUrn": "urn:li:container:recursion-test-root", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "container", "entityUrn": "urn:li:container:recursion-test-child", "changeType": "UPSERT", "aspectName": "container", "aspect": {"json": {"container": "urn:li:container:recursion-test-root"}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "container", "entityUrn": "urn:li:container:recursion-test-child", "changeType": "UPSERT", "aspectName": "containerProperties", "aspect": {"json": {"name": "Recursion Test Child Container"}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}},
+  {"entityType": "container", "entityUrn": "urn:li:container:recursion-test-child", "changeType": "UPSERT", "aspectName": "status", "aspect": {"json": {"removed": false}}, "systemMetadata": {"lastObserved": 0, "runId": "recursion-test", "lastRunId": "no-run-id-provided"}}
+]

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -665,6 +665,8 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "graphQL.query.complexityLimit",
           "graphQL.query.depthLimit",
           "graphQL.query.introspectionEnabled",
+          "graphQL.query.maxParentDepth",
+          "graphQL.query.maxVisitedUrns",
           "graphService.limit.results.apiDefault",
           "graphService.limit.results.max",
           "graphService.limit.results.strict",

--- a/metadata-io/src/testFixtures/java/io/datahubproject/test/search/SearchTestUtils.java
+++ b/metadata-io/src/testFixtures/java/io/datahubproject/test/search/SearchTestUtils.java
@@ -420,6 +420,11 @@ public class SearchTestUtils {
           public DataHubAppConfiguration getDataHubAppConfig() {
             return new DataHubAppConfiguration();
           }
+
+          @Override
+          public int getMaxParentDepth() {
+            return 50;
+          }
         });
   }
 

--- a/metadata-jobs/mae-consumer-job/src/test/java/com/linkedin/metadata/kafka/MaeConsumerApplicationTestConfiguration.java
+++ b/metadata-jobs/mae-consumer-job/src/test/java/com/linkedin/metadata/kafka/MaeConsumerApplicationTestConfiguration.java
@@ -9,6 +9,7 @@ import com.linkedin.metadata.entity.EntityServiceImpl;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.search.EntitySearchService;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
 import com.linkedin.metadata.systemmetadata.ElasticSearchSystemMetadataService;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
@@ -44,6 +45,8 @@ public class MaeConsumerApplicationTestConfiguration {
   @MockBean private ConfigEntityRegistry _configEntityRegistry;
 
   @MockBean public ElasticSearchService elasticSearchService;
+
+  @MockBean public EntitySearchService entitySearchService;
 
   @MockBean public MetricUtils metricUtils;
 

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/graphql/GraphQLQueryConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/graphql/GraphQLQueryConfiguration.java
@@ -7,4 +7,17 @@ public class GraphQLQueryConfiguration {
   private int complexityLimit;
   private int depthLimit;
   private boolean introspectionEnabled;
+
+  /**
+   * Max depth when traversing parent chains (glossary nodes, domains, containers, documents).
+   * Prevents stack overflow and unbounded work in cyclic or deep hierarchies. Default in
+   * application.yaml.
+   */
+  private int maxParentDepth;
+
+  /**
+   * Max distinct URNs to visit per GraphQL request during relationship resolution. Beyond this we
+   * short-circuit to prevent OOM with large or cyclic graphs. Default in application.yaml.
+   */
+  private int maxVisitedUrns;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1111,6 +1111,10 @@ graphQL:
     complexityLimit: ${GRAPHQL_QUERY_COMPLEXITY_LIMIT:2000}
     depthLimit: ${GRAPHQL_QUERY_DEPTH_LIMIT:50}
     introspectionEnabled: ${GRAPHQL_QUERY_INTROSPECTION_ENABLED:true}
+    # Parent chain traversal (glossary, domains, containers, documents)
+    maxParentDepth: ${GRAPHQL_QUERY_MAX_PARENT_DEPTH:50}
+    # Relationship resolution cap per request (cycle/unbounded protection)
+    maxVisitedUrns: ${GRAPHQL_QUERY_MAX_VISITED_URNS:20000}
   metrics:
     # Master switch for all GraphQL metrics collection via Micrometer
     # When false, no GraphQL metrics are collected (request-level or field-level)

--- a/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/SpringQueryContext.java
+++ b/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/SpringQueryContext.java
@@ -3,13 +3,18 @@ package com.datahub.graphql;
 import com.datahub.authentication.Authentication;
 import com.datahub.plugins.auth.authorization.Authorizer;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.context.RelationshipTraversalContext;
 import com.linkedin.metadata.config.DataHubAppConfiguration;
+import com.linkedin.metadata.config.GraphQLConfiguration;
+import com.linkedin.metadata.config.graphql.GraphQLQueryConfiguration;
 import graphql.language.OperationDefinition;
 import graphql.parser.Parser;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.Getter;
@@ -23,6 +28,8 @@ public class SpringQueryContext implements QueryContext {
   @Getter private final String queryName;
   @Nonnull private final OperationContext operationContext;
   @Nonnull private final DataHubAppConfiguration dataHubAppConfig;
+  @Nonnull private final RelationshipTraversalContext relationshipTraversalContext;
+  private final int maxParentDepth;
 
   public SpringQueryContext(
       final boolean isAuthenticated,
@@ -52,6 +59,17 @@ public class SpringQueryContext implements QueryContext {
                     .map(OperationDefinition::getName)
                     .orElse("graphql");
 
+    GraphQLConfiguration graphQL =
+        Objects.requireNonNull(
+            dataHubAppConfig.getGraphQL(),
+            "graphQL configuration is required; define graphQL in application.yaml");
+    GraphQLQueryConfiguration queryConfig =
+        Objects.requireNonNull(
+            graphQL.getQuery(),
+            "graphQL.query configuration is required; define graphQL.query in application.yaml");
+    this.relationshipTraversalContext =
+        new RelationshipTraversalContext(queryConfig.getMaxVisitedUrns());
+    this.maxParentDepth = queryConfig.getMaxParentDepth();
     this.operationContext =
         OperationContext.asSession(
             systemOperationContext,
@@ -62,5 +80,15 @@ public class SpringQueryContext implements QueryContext {
             true);
 
     this.dataHubAppConfig = dataHubAppConfig;
+  }
+
+  @Override
+  public int getMaxParentDepth() {
+    return maxParentDepth;
+  }
+
+  @Override
+  public Optional<RelationshipTraversalContext> getRelationshipTraversalContext() {
+    return Optional.of(relationshipTraversalContext);
   }
 }


### PR DESCRIPTION
- Add GraphQL query config: maxParentDepth and maxVisitedUrns (no Java defaults)
- Add RelationshipTraversalContext for cycle detection and visit tracking
- Make QueryContext.getMaxParentDepth() abstract; SpringQueryContext reads from config
- Prefer getGraphQlContext() over deprecated getContext() in ResolverUtils
- Apply depth/visit limits in parent resolvers (glossary, domain, container, document)
- Stub getMaxParentDepth() in test mocks and anonymous QueryContexts
- Add recursion example and ScrollAcrossEntitiesResolver tests

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
