### PR TITLE
MFE Config reads from cache, and passing cache headers for /mfe/config endpoint

### DIFF
--- a/datahub-frontend/app/controllers/MfeConfigController.java
+++ b/datahub-frontend/app/controllers/MfeConfigController.java
@@ -5,6 +5,7 @@ import com.typesafe.config.Config;
 import java.nio.file.Files;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import play.Environment;
 import play.mvc.Controller;
@@ -12,11 +13,19 @@ import play.mvc.Result;
 import play.mvc.Results;
 import play.mvc.Security;
 
+/**
+ * Controller for serving MFE (Micro Frontend) configuration. The configuration is read once at
+ * startup and cached in-memory to avoid repeated file I/O. HTTP cache headers are set to allow
+ * browser caching for 5 minutes.
+ */
 @Slf4j
+@Singleton
 public class MfeConfigController extends Controller {
 
+  private static final int CACHE_MAX_AGE_SECONDS = 300; // 5 minutes
+
   private final String configFilePath;
-  private final Environment environment;
+  private final String cachedConfigContent;
 
   @Inject
   public MfeConfigController(@Nonnull Config configs, Environment environment) {
@@ -25,30 +34,39 @@ public class MfeConfigController extends Controller {
       throw new IllegalArgumentException("MfeConfigFilePath is null or not set!");
     }
     this.configFilePath = path;
-    this.environment = environment;
+    // Read and cache the config at startup
+    this.cachedConfigContent = readFromYMLConfig(path, environment);
+    if (cachedConfigContent.isEmpty()) {
+      log.warn("MfeConfigController initialized but config file could not be read from: {}", path);
+    } else {
+      log.info("MfeConfigController initialized with config from: {}", path);
+    }
   }
 
   @Security.Authenticated(Authenticator.class)
   public Result getMfeConfig() {
-    if (configFilePath == null) {
-      log.error("MfeConfigController Config File Path not set!");
-      return Results.internalServerError("MfeConfigController error! Config File Path not set!");
+    if (cachedConfigContent.isEmpty()) {
+      log.error("MfeConfigController: No cached config available (file: {})", configFilePath);
+      return Results.internalServerError("MfeConfigController error! Unable to read config file!");
     }
-    String yamlContent = readFromYMLConfig(configFilePath);
-    if (yamlContent.isEmpty()) {
-      log.error("MFEConfigController unable to read config file at: {}", configFilePath);
-      return Results.internalServerError("MFEConfigController error! Unable to read config file!");
-    } else {
-      log.info("MfeConfigController read yaml success");
-      return Results.ok(yamlContent).as("application/yaml");
-    }
+    log.debug("MfeConfigController: Serving cached config");
+    return Results.ok(cachedConfigContent)
+        .as("application/yaml")
+        .withHeader("Cache-Control", "private, max-age=" + CACHE_MAX_AGE_SECONDS);
   }
 
-  public String readFromYMLConfig(String configFilePath) {
-    log.info("Attempting to read YAML config from: {}", configFilePath);
+  /**
+   * Reads the YAML config file from disk. This is called once at startup.
+   *
+   * @param configFilePath path to the config file
+   * @param environment Play environment for file resolution
+   * @return the file contents, or empty string on error
+   */
+  private String readFromYMLConfig(String configFilePath, Environment environment) {
+    log.debug("Reading YAML config from: {}", configFilePath);
     try {
       String content = Files.readString(environment.getFile(configFilePath).toPath());
-      log.info("Successfully read YAML config");
+      log.debug("Successfully read YAML config ({} bytes)", content.length());
       return content;
     } catch (Exception e) {
       log.error(


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
Based on feedback:
- updated the code to retrieve the config from the cache instead of doing an expensive I/O operation. 
- Also passing cache headers to FE. 
- Some info logs changed to debug logs.