### PR TITLE
fix(ingest/snowflake): map MERGE and COPY operations to semantic types

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
@@ -53,8 +53,8 @@ OPERATION_STATEMENT_TYPES = {
     "CREATE": OperationTypeClass.CREATE,
     "CREATE_TABLE": OperationTypeClass.CREATE,
     "CREATE_TABLE_AS_SELECT": OperationTypeClass.CREATE,
-    "MERGE": OperationTypeClass.CUSTOM,
-    "COPY": OperationTypeClass.CUSTOM,
+    "MERGE": OperationTypeClass.UPDATE,  # Upsert semantics - aligns with BigQuery
+    "COPY": OperationTypeClass.INSERT,  # Bulk load semantics
     "TRUNCATE_TABLE": OperationTypeClass.CUSTOM,
     # TODO: Dataset for below query types are not detected by snowflake in snowflake.access_history.objects_modified.
     # However it seems possible to support these using sql parsing in future.


### PR DESCRIPTION
## Summary
- Maps Snowflake `MERGE` operations to `OperationTypeClass.UPDATE` (upsert semantics)
- Maps Snowflake `COPY` operations to `OperationTypeClass.INSERT` (bulk load semantics)
- Aligns Snowflake with BigQuery and Unity Catalog operation type mappings

## Background
MERGE and COPY operations were previously mapped to `CUSTOM`, causing them to be excluded from write operation counts in usage statistics. This fix ensures these common Snowflake operations are properly categorized.

**Cross-source consistency:**
| Source | MERGE | COPY |
|--------|-------|------|
| BigQuery | UPDATE | - |
| Unity Catalog | UPDATE | INSERT |
| Snowflake (before) | CUSTOM | CUSTOM |
| Snowflake (after) | UPDATE | INSERT |
