### PR TITLE
feat(update): add reindex configuration options

### DIFF
--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -397,27 +397,30 @@ When using traditional username/password authentication, both `CREATE_USER_USERN
 
 #### Build Indices Configuration
 
-| Environment Variable                                       | Default                          | Description                                                 | Components    |
-| ---------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------- | ------------- |
-| `ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH`     | `false`                          | Allow document count mismatch when clone indices is enabled | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES`                | `true`                           | Clone indices                                               | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_RETENTION_UNIT`               | `DAYS`                           | Retention unit for indices                                  | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_RETENTION_VALUE`              | `60`                             | Retention value for indices                                 | System Update |
-| `ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED` | `true`                           | Enable reindex optimization                                 | System Update |
-| `ELASTICSEARCH_NUM_SHARDS_PER_INDEX`                       | `${elasticsearch.dataNodeCount}` | Number of shards per index, defaults to dataNodeCount       | System Update |
-| `ELASTICSEARCH_NUM_REPLICAS_PER_INDEX`                     | `1`                              | Number of replicas per index                                | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_NUM_RETRIES`                  | `3`                              | Index builder number of retries                             | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_REFRESH_INTERVAL_SECONDS`     | `3`                              | Index builder refresh interval                              | System Update |
-| `SEARCH_DOCUMENT_MAX_ARRAY_LENGTH`                         | `1000`                           | Maximum array length in search documents                    | System Update |
-| `SEARCH_DOCUMENT_MAX_OBJECT_KEYS`                          | `1000`                           | Maximum object keys in search documents                     | System Update |
-| `SEARCH_DOCUMENT_MAX_VALUE_LENGTH`                         | `4096`                           | Maximum value length in search documents                    | System Update |
-| `ELASTICSEARCH_MAIN_TOKENIZER`                             | `null`                           | Main tokenizer                                              | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX`             | `false`                          | Enable mappings reindex                                     | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_SETTINGS_REINDEX`             | `false`                          | Enable settings reindex                                     | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_MAX_REINDEX_HOURS`            | `0`                              | Maximum reindex hours (0 = no timeout)                      | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_SETTINGS_OVERRIDES`           | `null`                           | Index builder settings overrides                            | System Update |
-| `ELASTICSEARCH_MIN_SEARCH_FILTER_LENGTH`                   | `3`                              | Minimum search filter length                                | System Update |
-| `ELASTICSEARCH_INDEX_BUILDER_ENTITY_SETTINGS_OVERRIDES`    | `null`                           | Entity settings overrides                                   | System Update |
+| Environment Variable                                            | Default                          | Description                                                          | Components    |
+| --------------------------------------------------------------- | -------------------------------- | -------------------------------------------------------------------- | ------------- |
+| `ELASTICSEARCH_BUILD_INDICES_ALLOW_DOC_COUNT_MISMATCH`          | `false`                          | Allow document count mismatch when clone indices is enabled          | System Update |
+| `ELASTICSEARCH_BUILD_INDICES_CLONE_INDICES`                     | `true`                           | Clone indices                                                        | System Update |
+| `ELASTICSEARCH_BUILD_INDICES_RETENTION_UNIT`                    | `DAYS`                           | Retention unit for indices                                           | System Update |
+| `ELASTICSEARCH_BUILD_INDICES_RETENTION_VALUE`                   | `60`                             | Retention value for indices                                          | System Update |
+| `ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED`      | `true`                           | Enable reindex optimization                                          | System Update |
+| `ELASTICSEARCH_BUILD_INDICES_REINDEX_BATCH_SIZE`                | `5000`                           | Documents per scroll batch during reindex                            | System Update |
+| `ELASTICSEARCH_BUILD_INDICES_REINDEX_MAX_SLICES`                | `256`                            | Maximum parallel reindex slices (capped from target shards)          | System Update |
+| `ELASTICSEARCH_BUILD_INDICES_REINDEX_NO_PROGRESS_RETRY_MINUTES` | `5`                              | Minutes without document-count progress before re-triggering reindex | System Update |
+| `ELASTICSEARCH_NUM_SHARDS_PER_INDEX`                            | `${elasticsearch.dataNodeCount}` | Number of shards per index, defaults to dataNodeCount                | System Update |
+| `ELASTICSEARCH_NUM_REPLICAS_PER_INDEX`                          | `1`                              | Number of replicas per index                                         | System Update |
+| `ELASTICSEARCH_INDEX_BUILDER_NUM_RETRIES`                       | `3`                              | Index builder number of retries                                      | System Update |
+| `ELASTICSEARCH_INDEX_BUILDER_REFRESH_INTERVAL_SECONDS`          | `3`                              | Index builder refresh interval                                       | System Update |
+| `SEARCH_DOCUMENT_MAX_ARRAY_LENGTH`                              | `1000`                           | Maximum array length in search documents                             | System Update |
+| `SEARCH_DOCUMENT_MAX_OBJECT_KEYS`                               | `1000`                           | Maximum object keys in search documents                              | System Update |
+| `SEARCH_DOCUMENT_MAX_VALUE_LENGTH`                              | `4096`                           | Maximum value length in search documents                             | System Update |
+| `ELASTICSEARCH_MAIN_TOKENIZER`                                  | `null`                           | Main tokenizer                                                       | System Update |
+| `ELASTICSEARCH_INDEX_BUILDER_MAPPINGS_REINDEX`                  | `false`                          | Enable mappings reindex                                              | System Update |
+| `ELASTICSEARCH_INDEX_BUILDER_SETTINGS_REINDEX`                  | `false`                          | Enable settings reindex                                              | System Update |
+| `ELASTICSEARCH_INDEX_BUILDER_MAX_REINDEX_HOURS`                 | `0`                              | Maximum reindex hours (0 = no timeout)                               | System Update |
+| `ELASTICSEARCH_INDEX_BUILDER_SETTINGS_OVERRIDES`                | `null`                           | Index builder settings overrides                                     | System Update |
+| `ELASTICSEARCH_MIN_SEARCH_FILTER_LENGTH`                        | `3`                              | Minimum search filter length                                         | System Update |
+| `ELASTICSEARCH_INDEX_BUILDER_ENTITY_SETTINGS_OVERRIDES`         | `null`                           | Entity settings overrides                                            | System Update |
 
 #### Search Configuration
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -93,7 +93,6 @@ public class ESIndexBuilder {
   private static final String INDEX_NUMBER_OF_REPLICAS = "index." + NUMBER_OF_REPLICAS;
   private static final String NUMBER_OF_SHARDS = "number_of_shards";
   private static final String ORIGINALPREFIX = "original";
-  private static final Integer REINDEX_BATCHSIZE = 5000;
   private static final Float MINJVMHEAP = 10.F;
   // for debugging
   // private static final Float MINJVMHEAP = 0.1F;
@@ -742,7 +741,7 @@ public class ESIndexBuilder {
               submitReindex(
                   new String[] {indexState.name()},
                   tempIndexName,
-                  REINDEX_BATCHSIZE,
+                  getReindexBatchSize(),
                   null,
                   null,
                   targetShards);
@@ -805,16 +804,18 @@ public class ESIndexBuilder {
               estimatedMinutesRemaining);
 
           long lastUpdateDelta = System.currentTimeMillis() - documentCountsLastUpdated;
-          if (lastUpdateDelta > (300 * 1000)) {
+          int noProgressRetryMinutes = getReindexNoProgressRetryMinutes();
+          if (lastUpdateDelta > (noProgressRetryMinutes * 60L * 1000)) {
             if (reindexCount <= indexConfig.getNumRetries()) {
               log.warn(
-                  "No change in index count after 5 minutes, re-triggering reindex #{}.",
+                  "No change in index count after {} minutes, re-triggering reindex #{}.",
+                  noProgressRetryMinutes,
                   reindexCount);
               reinfo =
                   submitReindex(
                       new String[] {indexState.name()},
                       tempIndexName,
-                      REINDEX_BATCHSIZE,
+                      getReindexBatchSize(),
                       null,
                       null,
                       targetShards);
@@ -967,6 +968,18 @@ public class ESIndexBuilder {
     }
   }
 
+  private int getReindexBatchSize() {
+    return Objects.requireNonNull(
+        config.getBuildIndices().getReindexBatchSize(),
+        "elasticsearch.buildIndices.reindexBatchSize must be set (e.g. in application.yaml)");
+  }
+
+  private int getReindexNoProgressRetryMinutes() {
+    return Objects.requireNonNull(
+        config.getBuildIndices().getReindexNoProgressRetryMinutes(),
+        "elasticsearch.buildIndices.reindexNoProgressRetryMinutes must be set (e.g. in application.yaml)");
+  }
+
   private Map<String, Object> setReindexOptimalSettings(String tempIndexName, int targetShards)
       throws IOException {
     Map<String, Object> res = new HashMap<>();
@@ -998,11 +1011,12 @@ public class ESIndexBuilder {
     //    }
     // calculate best slices number..., by def == primary shards
     int slices = targetShards;
-    // but if too large, tone it done
-    // we have max of 60 shards as of now in some huge index, and this sounds fine regarding nb of
-    // slices, ES sets the max of slices at 1024, so hour number is quite conservative, just cap it
-    // lower, like 256
-    slices = Math.min(256, slices);
+    // but if too large, tone it down; ES sets the max of slices at 1024
+    int maxSlices =
+        Objects.requireNonNull(
+            config.getBuildIndices().getReindexMaxSlices(),
+            "elasticsearch.buildIndices.reindexMaxSlices must be set (e.g. in application.yaml)");
+    slices = Math.min(maxSlices, slices);
     res.put("optimalSlices", slices);
     return res;
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -537,6 +537,9 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           // Elasticsearch configuration
           "elasticsearch.buildIndices.allowDocCountMismatch",
           "elasticsearch.buildIndices.cloneIndices",
+          "elasticsearch.buildIndices.reindexBatchSize",
+          "elasticsearch.buildIndices.reindexMaxSlices",
+          "elasticsearch.buildIndices.reindexNoProgressRetryMinutes",
           "elasticsearch.buildIndices.reindexOptimizationEnabled",
           "elasticsearch.buildIndices.retentionUnit",
           "elasticsearch.buildIndices.retentionValue",

--- a/metadata-io/src/testFixtures/java/io/datahubproject/test/search/SearchTestUtils.java
+++ b/metadata-io/src/testFixtures/java/io/datahubproject/test/search/SearchTestUtils.java
@@ -128,7 +128,12 @@ public class SearchTestUtils {
                   .minSearchFilterLength(3)
                   .build())
           .buildIndices(
-              BuildIndicesConfiguration.builder().reindexOptimizationEnabled(true).build())
+              BuildIndicesConfiguration.builder()
+                  .reindexOptimizationEnabled(true)
+                  .reindexBatchSize(5000)
+                  .reindexMaxSlices(256)
+                  .reindexNoProgressRetryMinutes(5)
+                  .build())
           .entityIndex(
               EntityIndexConfiguration.builder()
                   .v2(EntityIndexVersionConfiguration.builder().enabled(true).cleanup(true).build())

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/BuildIndicesConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/BuildIndicesConfiguration.java
@@ -18,4 +18,13 @@ public class BuildIndicesConfiguration {
   private String retentionUnit;
   private Long retentionValue;
   private boolean reindexOptimizationEnabled;
+
+  /** Reindex source batch size (documents per scroll batch). Default 5000. */
+  private Integer reindexBatchSize;
+
+  /** Maximum number of slices for reindex (capped from target shard count). Default 256. */
+  private Integer reindexMaxSlices;
+
+  /** Minutes without document-count progress before re-triggering reindex. Default 5. */
+  private Integer reindexNoProgressRetryMinutes;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -492,6 +492,9 @@ elasticsearch:
     retentionUnit: ${ELASTICSEARCH_BUILD_INDICES_RETENTION_UNIT:DAYS}
     retentionValue: ${ELASTICSEARCH_BUILD_INDICES_RETENTION_VALUE:60}
     reindexOptimizationEnabled: ${ELASTICSEARCH_BUILD_INDICES_REINDEX_OPTIMIZATION_ENABLED:true} # Disable when Multi-AZ zone replication is set to required, will prevent index from setting zero replicas during reindexing
+    reindexBatchSize: ${ELASTICSEARCH_BUILD_INDICES_REINDEX_BATCH_SIZE:5000} # documents per scroll batch during reindex
+    reindexMaxSlices: ${ELASTICSEARCH_BUILD_INDICES_REINDEX_MAX_SLICES:256} # max parallel slices (capped from target shard count)
+    reindexNoProgressRetryMinutes: ${ELASTICSEARCH_BUILD_INDICES_REINDEX_NO_PROGRESS_RETRY_MINUTES:5} # minutes without doc-count progress before re-triggering reindex
   search:
     maxTermBucketSize: ${ELASTICSEARCH_QUERY_MAX_TERM_BUCKET_SIZE:60}
     pointInTimeCreationEnabled: ${POINT_IN_TIME_CREATION_ENABLED:false} # Enables creation of point in time snapshots for the scroll API, only works with OpenSearch >= 2.4 or ElasticSearch >= 7.10. Regardless of this flag's value, PIT will be created for sliced scrolls.


### PR DESCRIPTION
## Add config overrides for Elasticsearch reindex (batch size, slices, no-progress retry)

### Summary
Makes Elasticsearch reindex batch size, max slices, and no-progress retry interval configurable via `application.yaml` / env vars instead of hardcoded values.

### Changes
- **BuildIndicesConfiguration**: Added `reindexBatchSize`, `reindexMaxSlices`, `reindexNoProgressRetryMinutes` (optional `Integer` fields).
- **application.yaml**: New env overrides under `elasticsearch.buildIndices`:
  - `reindexBatchSize` (default `5000`)
  - `reindexMaxSlices` (default `256`)
  - `reindexNoProgressRetryMinutes` (default `5`)
- **ESIndexBuilder**: Uses config for reindex batch size, slice cap, and no-progress retry; no Java fallbacks—values must be set (e.g. via application.yaml). Clear `requireNonNull` messages if missing.
- **Docs**: `docs/deploy/environment-vars.md` updated with the new variables.
- **Tests**: `PropertiesCollectorConfigurationTest` updated with new property names; `SearchTestUtils` and `ESIndexBuilderTest` set the new fields explicitly in fixtures/mocks.

### Env vars
| Variable | Default |
|----------|---------|
| `ELASTICSEARCH_BUILD_INDICES_REINDEX_BATCH_SIZE` | `5000` |
| `ELASTICSEARCH_BUILD_INDICES_REINDEX_MAX_SLICES` | `256` |
| `ELASTICSEARCH_BUILD_INDICES_REINDEX_NO_PROGRESS_RETRY_MINUTES` | `5` |