### PR TITLE
chore(deps): update python-json-logger version constraint to <5.0.0

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -29,7 +29,7 @@ base_requirements = {
     # Security is enforced for Docker image builds via docker/snippets/ingestion/constraints.txt.
     "sentry-sdk>=1.33.1,<3.0.0",
     # For JSON logging support via DATAHUB_LOG_CONFIG_FILE
-    "python-json-logger>=2.0.0,<4.0.0",
+    "python-json-logger>=2.0.0,<5.0.0",
 }
 
 framework_common = {


### PR DESCRIPTION
This pull request updates the dependency range for `python-json-logger` in the `metadata-ingestion/setup.py` file to allow newer versions up to, but not including, 5.0.0. This is a minor change to ensure compatibility with the latest releases of the package.