### PR TITLE
chore(docs) Updated recommended CLI Version for v0.3.16

### DIFF
--- a/docs/managed-datahub/release-notes/v_0_3_16.md
+++ b/docs/managed-datahub/release-notes/v_0_3_16.md
@@ -12,7 +12,7 @@ January 19, 2024
 
 #### Recommended Versions
 
-- **CLI/SDK**: 1.3.1.5
+- **CLI/SDK**: 1.4.0.1
 - **Remote Executor**: v0.3.16-acryl (recommended), v0.3.15-acryl, v0.3.14.1-acryl
 - **On-Prem Versions**:
   - **Helm**: 1.5.173


### PR DESCRIPTION
Update recommended CLI version for v0.3.16 to [acryl-datahub 1.4.0.1](https://pypi.org/project/acryl-datahub/1.4.0.1/)) which has setuptools pinned to <82.0.0 as it has breaking changes.
https://setuptools.pypa.io/en/stable/history.html#v82-0-0
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
