### PR TITLE
docs(remote-executor): add network connectivity prerequisites

### DIFF
--- a/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
+++ b/docs/managed-datahub/operator-guide/setting-up-remote-ingestion-executor.md
@@ -51,7 +51,7 @@ Before deploying a Remote Executor, ensure you have the following:
    - `https://<your-company>.acryl.io/*` — DataHub GMS API
    - `https://sqs.*.amazonaws.com/*` — AWS SQS, used for remote execution task dispatch
    - A Python package index (e.g., `https://pypi.org`) or an alternate internal mirror, to download pip packages required by ingestion sources
-   - A container registry hosting the DataHub Remote Executor image (e.g., `docker.datahub.com/re/datahub-executor`)
+   - A container registry hosting the DataHub Remote Executor image (e.g., AWS ECR or `docker.datahub.com`)
 
 4. **Registry Access**
    - For AWS: Provide your AWS account ID to DataHub Cloud


### PR DESCRIPTION
## Summary
- Adds a new **Network Connectivity** prerequisite section to the Remote Executor configuration docs
- Documents the outbound HTTPS (port 443) endpoints required: DataHub GMS, AWS SQS for task dispatch, PyPI (or internal mirror) for pip packages, and the container registry for the executor image
- Clarifies that no inbound connectivity is required

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (specifically the [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issue (if applicable)
- [ ] Tests updated / added (if applicable)
- [x] Docs updated / added (if applicable)

Made with [Cursor](https://cursor.com)