### PR TITLE
fix(docker): Add build constraints to Dockerfiles to fix flatdict build failure

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -307,6 +307,8 @@ COPY --chown=datahub:datahub ./docker/datahub-actions/config /etc/datahub/action
 
 USER datahub
 
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
 ARG RELEASE_VERSION
 RUN test -n "$RELEASE_VERSION" # RELEASE_VERSION is a required build arg
 RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_updater.py \
@@ -315,9 +317,7 @@ RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_u
 
 # Install metadata-ingestion with base extras (network enabled, can install more at runtime)
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,id=datahub-actions,sharing=private \
-  uv pip install \
-    --build-constraint /metadata-ingestion/build-constraints.txt \
-    -e '/metadata-ingestion/[base,s3,gcs,abs]'
+  uv pip install -e '/metadata-ingestion/[base,s3,gcs,abs]'
 
 # Install datahub-actions with all extras
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,id=datahub-actions,sharing=private \
@@ -363,6 +363,8 @@ COPY --chown=datahub:datahub ./docker/datahub-actions/config /etc/datahub/action
 
 USER datahub
 
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
 ARG RELEASE_VERSION
 RUN test -n "$RELEASE_VERSION"
 RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_updater.py \
@@ -371,9 +373,7 @@ RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_u
 
 # Install metadata-ingestion with SLIM extras (no PySpark, network enabled for flexibility)
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,id=datahub-actions,sharing=private \
-  uv pip install \
-    --build-constraint /metadata-ingestion/build-constraints.txt \
-    -e '/metadata-ingestion/[base,s3-slim,gcs-slim,abs-slim]'
+  uv pip install -e '/metadata-ingestion/[base,s3-slim,gcs-slim,abs-slim]'
 
 # Install datahub-actions with all extras
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,id=datahub-actions,sharing=private \
@@ -555,15 +555,15 @@ COPY --chown=datahub:datahub ./datahub-actions /datahub-actions
 
 USER datahub
 
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
 ARG RELEASE_VERSION
 RUN test -n "$RELEASE_VERSION"
 RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_updater.py \
     python /version_updater.py --directory /metadata-ingestion/ --version "$RELEASE_VERSION" --expected-update-count 1 && \
     python /version_updater.py --directory /datahub-actions/ --version "$RELEASE_VERSION" --expected-update-count 1
 
-RUN uv pip install \
-        --build-constraint /metadata-ingestion/build-constraints.txt \
-        -e '/metadata-ingestion/[base,s3-slim,gcs-slim,abs-slim]' && \
+RUN uv pip install -e '/metadata-ingestion/[base,s3-slim,gcs-slim,abs-slim]' && \
     uv pip install -e '/datahub-actions/[kafka,executor,slack,teams,tag_propagation,term_propagation,doc_propagation]'
 
 

--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -178,27 +178,28 @@ RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_u
 
 FROM add-code-slim AS final-slim
 
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \
-    UV_LINK_MODE=copy uv pip install \
-        --build-constraint /metadata-ingestion/build-constraints.txt \
-        -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,snowflake,bigquery,redshift,mysql,postgres,s3-slim,gcs-slim,abs-slim,clickhouse,glue,dbt,looker,lookml,tableau,powerbi,superset,datahub-business-glossary]" && \
+    UV_LINK_MODE=copy uv pip install -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,snowflake,bigquery,redshift,mysql,postgres,s3-slim,gcs-slim,abs-slim,clickhouse,glue,dbt,looker,lookml,tableau,powerbi,superset,datahub-business-glossary]" && \
     datahub --version
 
 FROM add-code-full AS final-full
 
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \
     UV_LINK_MODE=copy uv pip install \
-        --build-constraint /metadata-ingestion/build-constraints.txt \
         -e "/metadata-ingestion/[all]" \
     && datahub --version
 
 FROM add-code-locked AS final-locked
 
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
 # Locked variant: minimal install with s3-slim, network will be blocked
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \
-    UV_LINK_MODE=copy uv pip install \
-        --build-constraint /metadata-ingestion/build-constraints.txt \
-        -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,s3-slim,gcs-slim,abs-slim]" && \
+    UV_LINK_MODE=copy uv pip install -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,s3-slim,gcs-slim,abs-slim]" && \
     datahub --version
 
 # Block network access to PyPI in locked variant
@@ -281,6 +282,8 @@ RUN uv venv --python "$PYTHON_VERSION"
 # (e.g., spacy/blis which don't have pre-built musl wheels)
 FROM alpine-build AS install-slim-alpine
 
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
 COPY --chown=datahub ./metadata-ingestion /metadata-ingestion
 
 ARG RELEASE_VERSION
@@ -289,15 +292,15 @@ RUN test -d /metadata-ingestion/src/datahub/metadata
 RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_updater.py \
     python /version_updater.py --directory /metadata-ingestion/ --version "$RELEASE_VERSION" --expected-update-count 1
 
-RUN uv pip install \
-        --build-constraint /metadata-ingestion/build-constraints.txt \
-        -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,s3-slim,gcs-slim,abs-slim]" && \
+RUN uv pip install -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,s3-slim,gcs-slim,abs-slim]" && \
     datahub --version
 
 
 # Build venv for locked Alpine variant
 FROM alpine-build AS install-locked-alpine
 
+ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
+
 COPY --chown=datahub ./metadata-ingestion /metadata-ingestion
 
 ARG RELEASE_VERSION
@@ -306,9 +309,7 @@ RUN test -d /metadata-ingestion/src/datahub/metadata
 RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_updater.py \
     python /version_updater.py --directory /metadata-ingestion/ --version "$RELEASE_VERSION" --expected-update-count 1
 
-RUN uv pip install \
-        --build-constraint /metadata-ingestion/build-constraints.txt \
-        -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,s3-slim,gcs-slim,abs-slim]" && \
+RUN uv pip install -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,s3-slim,gcs-slim,abs-slim]" && \
     datahub --version
 
 


### PR DESCRIPTION
## Root Cause

- `setuptools>=82.0.0` removed the deprecated `pkg_resources` module
- Third-party packages like `flatdict` still import `pkg_resources` in their `setup.py`
- Commit 9896ae310e added `metadata-ingestion/build-constraints.txt` to constrain `setuptools<82.0.0`
- The constraint file was integrated into `build.gradle` but **not** into the Dockerfiles
- Docker build isolation environments were still using `setuptools>=82`, causing builds to fail

## Solution

Add `--build-constraint /metadata-ingestion/build-constraints.txt` to all `uv pip install` commands that install `metadata-ingestion` in both Dockerfiles.

## Changes

**`docker/datahub-ingestion/Dockerfile`** (5 locations):
- `final-slim` stage
- `final-full` stage
- `final-locked` stage  
- `install-slim-alpine` stage
- `install-locked-alpine` stage

**`docker/datahub-actions/Dockerfile`** (3 locations):
- `final-full` stage
- `final-slim` stage
- `venv-builder-locked` stage

## Testing

Confirm Docker builds complete successfully without `flatdict` build errors.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
