### PR TITLE
fix(airflow-plugin): Register datahub-file connection type with Airflow provider

### DIFF
--- a/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/__init__.py
+++ b/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/__init__.py
@@ -16,11 +16,16 @@ def get_provider_info() -> dict:
                 "hook-class-name": "datahub_airflow_plugin.hooks.datahub.DatahubKafkaHook",
                 "connection-type": "datahub-kafka",
             },
+            {
+                "hook-class-name": "datahub_airflow_plugin.hooks.datahub.SynchronizedFileHook",
+                "connection-type": "datahub-file",
+            },
         ],
         # Deprecated method of providing connection types, kept for backwards compatibility.
         # We can remove with Airflow 3.
         "hook-class-names": [
             "datahub_airflow_plugin.hooks.datahub.DatahubRestHook",
             "datahub_airflow_plugin.hooks.datahub.DatahubKafkaHook",
+            "datahub_airflow_plugin.hooks.datahub.SynchronizedFileHook",
         ],
     }

--- a/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/hooks/datahub.py
+++ b/metadata-ingestion-modules/airflow-plugin/src/datahub_airflow_plugin/hooks/datahub.py
@@ -225,11 +225,28 @@ class DatahubKafkaHook(BaseHook):
 
 
 class SynchronizedFileHook(BaseHook):
+    conn_name_attr = "datahub_file_conn_id"
+    default_conn_name = "datahub_file_default"
     conn_type = "datahub-file"
+    hook_name = "DataHub File Sink"
 
-    def __init__(self, datahub_conn_id: str) -> None:
+    def __init__(self, datahub_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.datahub_conn_id = datahub_conn_id
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        return {}
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behavior"""
+        return {
+            "hidden_fields": ["port", "schema", "login", "password", "extra"],
+            "relabeling": {
+                "host": "Output File Path",
+            },
+        }
 
     def make_emitter(self) -> "SynchronizedFileEmitter":
         from datahub.emitter.synchronized_file_emitter import SynchronizedFileEmitter


### PR DESCRIPTION
## What Changed
- Added missing registration attributes to `SynchronizedFileHook` (`hook_name`, `get_connection_form_widgets`, `get_ui_field_behaviour`)
- Registered `datahub-file` connection type in provider info

## Problem
The `datahub-file` connection type (used for testing) wasn't registered with Airflow's provider system, causing:
- CLI rejected the connection type: `UserWarning: The type provided to --conn-type is invalid: datahub-file`
- Connections created via CLI defaulted to `generic` type instead
- Users had to manually create connections via Python scripts

## Solution
Properly register `SynchronizedFileHook` in the Airflow provider metadata so it appears as a valid connection type in CLI and UI.

## Testing
```bash
# Now works:
airflow connections add datahub_file_default \
  --conn-type datahub-file \
  --conn-host /tmp/datahub_metadata.json