### PR TITLE
feat(glue): enhance partition key metadata extraction

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1170,8 +1170,16 @@ class GlueSource(StatefulIngestionSourceBase):
                     table_stats = p.get("Parameters", {})
                     column_stats = p["StorageDescriptor"]["Columns"]
 
-                    # only support single partition key
-                    partition_spec = str({partition_keys[0]: p["Values"][0]})
+                    # Support multiple partition keys
+                    partition_values = p.get("Values", [])
+                    if len(partition_keys) == len(partition_values):
+                        partition_spec = str({
+                            partition_keys[i]: partition_values[i] 
+                            for i in range(len(partition_keys))
+                        })
+                    else:
+                        # Fallback to single partition key for backward compatibility
+                        partition_spec = str({partition_keys[0]: partition_values[0]}) if partition_values else str({partition_keys[0]: "unknown"})
 
                     if self.source_config.profiling.partition_patterns.allowed(
                         partition_spec
@@ -1509,7 +1517,19 @@ class GlueSource(StatefulIngestionSourceBase):
                 if k not in ["Columns", "Parameters"]
             },
         }
-
+            
+        # Add partition key information to custom properties
+        partition_keys = table.get("PartitionKeys", [])
+        if partition_keys:
+            partition_key_names = [pk["Name"] for pk in partition_keys]
+            partition_key_types = [pk.get("Type", "unknown") for pk in partition_keys]
+            partition_key_comments = [pk.get("Comment", "") for pk in partition_keys]
+            
+            custom_properties["partition_keys"] = ",".join(partition_key_names)
+            custom_properties["partition_key_types"] = ",".join(partition_key_types)
+            custom_properties["partition_key_comments"] = ",".join(partition_key_comments)
+            custom_properties["num_partition_keys"] = str(len(partition_keys))
+        
         return DatasetPropertiesClass(
             description=table.get("Description"),
             customProperties=custom_properties,
@@ -1584,6 +1604,9 @@ class GlueSource(StatefulIngestionSourceBase):
                 default_nullable=False,
             )
             if schema_fields:
+                # Mark partition key fields as partition keys
+                for schema_field in schema_fields:
+                    schema_field.isPartitioningKey = True
                 fields.extend(schema_fields)
 
         return SchemaMetadata(

--- a/metadata-ingestion/tests/unit/glue/glue_deleted_actor_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_deleted_actor_mces_golden.json
@@ -333,7 +333,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe', 'Parameters': {'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "",
+                            "num_partition_keys": "1"
                         },
                         "name": "test_parquet",
                         "qualifiedName": "arn:aws:glue:eu-east-1:795586375822:table/test-database/test_parquet",
@@ -418,7 +422,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
@@ -304,7 +304,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.serde2.avro.AvroSerDe', 'Parameters': {'avro.schema.literal': '{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}', 'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "partition test comment",
+                            "num_partition_keys": "1"
                         },
                         "name": "avro",
                         "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database/avro",
@@ -427,7 +431,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }
@@ -776,7 +781,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe', 'Parameters': {'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "",
+                            "num_partition_keys": "1"
                         },
                         "name": "test_parquet",
                         "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_parquet",
@@ -861,7 +870,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden_table_column_lineage.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden_table_column_lineage.json
@@ -124,7 +124,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.serde2.avro.AvroSerDe', 'Parameters': {'avro.schema.literal': '{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}', 'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "partition test comment",
+                            "num_partition_keys": "1"
                         },
                         "name": "avro",
                         "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database-lineage/avro",
@@ -247,7 +251,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden_table_lineage.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden_table_lineage.json
@@ -304,7 +304,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.serde2.avro.AvroSerDe', 'Parameters': {'avro.schema.literal': '{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}', 'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "partition test comment",
+                            "num_partition_keys": "1"
                         },
                         "name": "avro",
                         "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database/avro",
@@ -427,7 +431,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }
@@ -826,7 +831,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe', 'Parameters': {'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "",
+                            "num_partition_keys": "1"
                         },
                         "name": "test_parquet",
                         "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_parquet",
@@ -911,7 +920,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_lake_formation_tags_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_lake_formation_tags_golden.json
@@ -672,7 +672,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.serde2.avro.AvroSerDe', 'Parameters': {'avro.schema.literal': '{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}', 'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "partition test comment",
+                            "num_partition_keys": "1"
                         },
                         "name": "avro",
                         "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database/avro",
@@ -795,7 +799,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }
@@ -1156,7 +1161,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe', 'Parameters': {'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "",
+                            "num_partition_keys": "1"
                         },
                         "name": "test_parquet",
                         "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_parquet",
@@ -1241,7 +1250,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
@@ -325,7 +325,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.serde2.avro.AvroSerDe', 'Parameters': {'avro.schema.literal': '{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}', 'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "partition test comment",
+                            "num_partition_keys": "1"
                         },
                         "name": "avro",
                         "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database/avro",
@@ -448,7 +452,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }
@@ -807,7 +812,11 @@
                             "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe', 'Parameters': {'serialization.format': '1'}}",
                             "BucketColumns": "[]",
                             "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
+                            "StoredAsSubDirectories": "False",
+                            "partition_keys": "year",
+                            "partition_key_types": "string",
+                            "partition_key_comments": "",
+                            "num_partition_keys": "1"
                         },
                         "name": "test_parquet",
                         "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_parquet",
@@ -892,7 +901,8 @@
                                 },
                                 "nativeDataType": "string",
                                 "recursive": false,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "isPartitioningKey": true
                             }
                         ]
                     }


### PR DESCRIPTION
- Add comprehensive partition key information to dataset properties
- Support multiple partition keys with proper metadata extraction
- Add partition key names, types, and comments to custom properties
- Enhance backward compatibility for single partition key scenarios

Fixes: Missing partition key label in Glue table schema
<img width="315" height="534" alt="image" src="https://github.com/user-attachments/assets/0c94760b-8e07-44e8-9928-965e2d15de3d" />

Added partition key details in dataset properties
<img width="830" height="267" alt="image" src="https://github.com/user-attachments/assets/50ac0ae8-4725-4b19-a421-a17108bf849b" />


