### PR TITLE
Add contributor name to avoid community contribution label

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -70,7 +70,8 @@ jobs:
           "swaroopjagadish",
           "treff7es",
           "v-tarasevich-blitz-brain",
-          "yoonhyejin"
+          "yoonhyejin",
+          "gdatahub"
           ]'),
           github.actor
           )


### PR DESCRIPTION
## Summary

This PR adds the contributor's name for proper attribution and to prevent the change from being categorized as a community contribution.

No functional changes were introduced.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly PR Title Format)
- [ ] Links to related issues (not applicable)
- [ ] Tests for the changes have been added/updated (not applicable)
- [ ] Docs related to the changes have been added/updated (not applicable)
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in Updating DataHub (not applicable)

