### PR TITLE
chore(build): Rename pipIndexUrl to pipIndexUrls

### DIFF
--- a/docker/datahub-ingestion/build.gradle
+++ b/docker/datahub-ingestion/build.gradle
@@ -65,8 +65,8 @@ docker {
     if (project.hasProperty('pipMirrorUrl')) {
         dockerBuildArgs.PIP_MIRROR_URL = project.getProperty('pipMirrorUrl')
     }
-    if (project.hasProperty('pipExtraIndexUrl')) {
-        dockerBuildArgs.PIP_EXTRA_INDEX_URL = project.getProperty('pipExtraIndexUrl')
+    if (project.hasProperty('pipExtraIndexUrls')) {
+        dockerBuildArgs.PIP_EXTRA_INDEX_URL = project.getProperty('pipExtraIndexUrls')
     }
     if (project.hasProperty('debianAptRepositoryUrl')) {
         dockerBuildArgs.DEBIAN_REPO_URL = project.getProperty('debianAptRepositoryUrl')

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,18 +42,18 @@ gnsp.disableApplyOnlyOnRootProjectEnforcement=true
 # Used when building Docker images for datahub-ingestion, datahub-executor, and datahub-actions
 # Default: Use public PyPI
 pipMirrorUrl=https://pypi.python.org/simple
-pipExtraIndexUrl=
+pipExtraIndexUrls=
 
 # Override options (in order of precedence):
 #   1. Command-line: ./gradlew :docker:docker -PpipMirrorUrl=https://your-pypi.com/simple
 #   2. Environment variables:
 #      export ORG_GRADLE_PROJECT_pipMirrorUrl=https://your-pypi.com/simple
-#      export ORG_GRADLE_PROJECT_pipExtraIndexUrl=https://custom-pypi.com/simple
+#      export ORG_GRADLE_PROJECT_pipExtraIndexUrls=https://custom-pypi.com/simple
 #   3. User-level ~/.gradle/gradle.properties (NOT checked into git)
 #
 # Use cases:
 #   - pipMirrorUrl: Replace PyPI entirely (e.g., for airgapped environments)
-#   - pipExtraIndexUrl: Add a secondary index alongside PyPI (e.g., for custom acryl-datahub builds)
+#   - pipExtraIndexUrls: Add a secondary index alongside PyPI (e.g., for custom acryl-datahub builds)
 #
 # Example with authentication:
-#   pipExtraIndexUrl=https://user:password@custom-pypi.company.com/simple
+#   pipExtraIndexUrls=https://user:password@custom-pypi.company.com/simple


### PR DESCRIPTION
Rename pipIndexUrl to pipIndexUrls and make it clear multiple indexes are supported

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
