### PR TITLE
refactor(ui/forms): Request forms for all entity profiles in a separate query

### DIFF
--- a/datahub-web-react/src/app/entity/Entity.tsx
+++ b/datahub-web-react/src/app/entity/Entity.tsx
@@ -108,6 +108,10 @@ export enum EntityCapabilityType {
      * Related context documents for this entity
      */
     RELATED_DOCUMENTS,
+    /**
+     * Forms associated with an entity
+     */
+    FORMS,
 }
 
 /**

--- a/datahub-web-react/src/app/entity/application/ApplicationEntity.tsx
+++ b/datahub-web-react/src/app/entity/application/ApplicationEntity.tsx
@@ -250,6 +250,7 @@ export class ApplicationEntity implements Entity<Application> {
             EntityCapabilityType.GLOSSARY_TERMS,
             EntityCapabilityType.TAGS,
             EntityCapabilityType.DOMAINS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
@@ -283,6 +283,7 @@ export class ChartEntity implements Entity<Chart> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entity/container/ContainerEntity.tsx
+++ b/datahub-web-react/src/app/entity/container/ContainerEntity.tsx
@@ -221,6 +221,7 @@ export class ContainerEntity implements Entity<Container> {
             EntityCapabilityType.DOMAINS,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -289,6 +289,7 @@ export class DashboardEntity implements Entity<Dashboard> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entity/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataFlow/DataFlowEntity.tsx
@@ -212,6 +212,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
@@ -263,6 +263,7 @@ export class DataJobEntity implements Entity<DataJob> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entity/dataProduct/DataProductEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataProduct/DataProductEntity.tsx
@@ -195,6 +195,7 @@ export class DataProductEntity implements Entity<DataProduct> {
             EntityCapabilityType.GLOSSARY_TERMS,
             EntityCapabilityType.TAGS,
             EntityCapabilityType.DOMAINS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -395,6 +395,7 @@ export class DatasetEntity implements Entity<Dataset> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
+++ b/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
@@ -167,6 +167,6 @@ export class DomainEntity implements Entity<Domain> {
 
     supportedCapabilities = () => {
         // TODO.. Determine whether SOFT_DELETE should go into here.
-        return new Set([EntityCapabilityType.OWNERS]);
+        return new Set([EntityCapabilityType.OWNERS, EntityCapabilityType.FORMS]);
     };
 }

--- a/datahub-web-react/src/app/entity/glossaryNode/GlossaryNodeEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryNode/GlossaryNodeEntity.tsx
@@ -171,6 +171,7 @@ class GlossaryNodeEntity implements Entity<GlossaryNode> {
             EntityCapabilityType.OWNERS,
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
@@ -183,6 +183,7 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
             EntityCapabilityType.OWNERS,
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entity/mlFeature/MLFeatureEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlFeature/MLFeatureEntity.tsx
@@ -212,6 +212,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entity/mlFeatureTable/MLFeatureTableEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlFeatureTable/MLFeatureTableEntity.tsx
@@ -193,6 +193,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entity/mlModel/MLModelEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlModel/MLModelEntity.tsx
@@ -179,6 +179,7 @@ export class MLModelEntity implements Entity<MlModel> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entity/mlModelGroup/MLModelGroupEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlModelGroup/MLModelGroupEntity.tsx
@@ -162,6 +162,7 @@ export class MLModelGroupEntity implements Entity<MlModelGroup> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entity/mlPrimaryKey/MLPrimaryKeyEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlPrimaryKey/MLPrimaryKeyEntity.tsx
@@ -199,6 +199,7 @@ export class MLPrimaryKeyEntity implements Entity<MlPrimaryKey> {
             EntityCapabilityType.DEPRECATION,
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components/macro';
 
 import analytics, { EventType } from '@app/analytics';
 import { useUpdateDomainEntityDataOnChange } from '@app/domain/utils';
+import { EntityCapabilityType } from '@app/entity/Entity';
 import { EntityContext } from '@app/entity/shared/EntityContext';
 import { EntityMenuItems } from '@app/entity/shared/EntityDropdown/EntityDropdown';
 import { ANTD_GRAY } from '@app/entity/shared/constants';
@@ -47,6 +48,7 @@ import { ErrorSection } from '@app/shared/error/ErrorSection';
 import { useAppConfig } from '@app/useAppConfig';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
+import { useGetFormsForEntityQuery } from '@graphql/form.generated';
 import { EntityType, Exact } from '@types';
 
 type Props<T, U> = {
@@ -215,8 +217,14 @@ export const EntityProfile = <T, U>({
         [history, entityType, urn, entityRegistry, isHideSiblingMode],
     );
 
+    const { data: formsData } = useGetFormsForEntityQuery({
+        variables: { urn },
+        fetchPolicy: 'cache-first',
+        skip: !entityRegistry.getSupportedEntityCapabilities(entityType).has(EntityCapabilityType.FORMS),
+    });
+
     const { entityData, dataPossiblyCombinedWithSiblings, dataNotCombinedWithSiblings, loading, error, refetch } =
-        useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties });
+        useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties, formsData });
 
     useUpdateGlossaryEntityDataOnChange(entityData, entityType);
     useUpdateDomainEntityDataOnChange(entityData, entityType);

--- a/datahub-web-react/src/app/entity/shared/containers/profile/useGetDataForProfile.ts
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/useGetDataForProfile.ts
@@ -4,6 +4,7 @@ import { getDataForEntityType } from '@app/entity/shared/containers/profile/util
 import { combineEntityDataWithSiblings, useIsSeparateSiblingsMode } from '@app/entity/shared/siblingUtils';
 import { GenericEntityProperties } from '@app/entity/shared/types';
 
+import { GetFormsForEntityQuery } from '@graphql/form.generated';
 import { EntityType, Exact } from '@types';
 
 interface Props<T> {
@@ -23,9 +24,16 @@ interface Props<T> {
         }>
     >;
     getOverrideProperties: (T) => GenericEntityProperties;
+    formsData?: GetFormsForEntityQuery;
 }
 
-export default function useGetDataForProfile<T>({ urn, entityType, useEntityQuery, getOverrideProperties }: Props<T>) {
+export default function useGetDataForProfile<T>({
+    urn,
+    entityType,
+    useEntityQuery,
+    getOverrideProperties,
+    formsData,
+}: Props<T>) {
     const isHideSiblingMode = useIsSeparateSiblingsMode();
     const {
         loading,
@@ -45,7 +53,10 @@ export default function useGetDataForProfile<T>({ urn, entityType, useEntityQuer
         (dataPossiblyCombinedWithSiblings &&
             Object.keys(dataPossiblyCombinedWithSiblings).length > 0 &&
             getDataForEntityType({
-                data: dataPossiblyCombinedWithSiblings[Object.keys(dataPossiblyCombinedWithSiblings)[0]],
+                data: {
+                    ...formsData?.entity,
+                    ...dataPossiblyCombinedWithSiblings[Object.keys(dataPossiblyCombinedWithSiblings)[0]],
+                },
                 entityType,
                 getOverrideProperties,
                 isHideSiblingMode,

--- a/datahub-web-react/src/app/entityV2/Entity.tsx
+++ b/datahub-web-react/src/app/entityV2/Entity.tsx
@@ -109,6 +109,10 @@ export enum EntityCapabilityType {
      * Adding a business attribute to the entity
      */
     BUSINESS_ATTRIBUTES,
+    /**
+     * Forms associated with an entity
+     */
+    FORMS,
 }
 
 export interface EntityMenuActions {

--- a/datahub-web-react/src/app/entityV2/application/ApplicationEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/application/ApplicationEntity.tsx
@@ -240,6 +240,7 @@ export class ApplicationEntity implements Entity<Application> {
             EntityCapabilityType.TAGS,
             EntityCapabilityType.DOMAINS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/chart/ChartEntity.tsx
@@ -384,6 +384,7 @@ export class ChartEntity implements Entity<Chart> {
             EntityCapabilityType.HEALTH,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
@@ -286,6 +286,7 @@ export class ContainerEntity implements Entity<Container> {
             EntityCapabilityType.DATA_PRODUCTS,
             EntityCapabilityType.TEST,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dashboard/DashboardEntity.tsx
@@ -386,6 +386,7 @@ export class DashboardEntity implements Entity<Dashboard> {
             EntityCapabilityType.HEALTH,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
@@ -280,6 +280,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
             EntityCapabilityType.HEALTH,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
@@ -320,6 +320,7 @@ export class DataJobEntity implements Entity<DataJob> {
             EntityCapabilityType.HEALTH,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entityV2/dataProduct/DataProductEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataProduct/DataProductEntity.tsx
@@ -277,6 +277,7 @@ export class DataProductEntity implements Entity<DataProduct> {
             EntityCapabilityType.DOMAINS,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataset/DatasetEntity.tsx
@@ -535,6 +535,7 @@ export class DatasetEntity implements Entity<Dataset> {
             EntityCapabilityType.HEALTH,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/domain/DomainEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/domain/DomainEntity.tsx
@@ -237,6 +237,10 @@ export class DomainEntity implements Entity<Domain> {
 
     supportedCapabilities = () => {
         // TODO.. Determine whether SOFT_DELETE should go into here.
-        return new Set([EntityCapabilityType.OWNERS, EntityCapabilityType.RELATED_DOCUMENTS]);
+        return new Set([
+            EntityCapabilityType.OWNERS,
+            EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
+        ]);
     };
 }

--- a/datahub-web-react/src/app/entityV2/glossaryNode/GlossaryNodeEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryNode/GlossaryNodeEntity.tsx
@@ -222,6 +222,7 @@ class GlossaryNodeEntity implements Entity<GlossaryNode> {
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
@@ -263,6 +263,7 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 

--- a/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
@@ -271,6 +271,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
             EntityCapabilityType.LINEAGE,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
@@ -239,6 +239,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
             EntityCapabilityType.LINEAGE,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
@@ -258,6 +258,7 @@ export class MLModelEntity implements Entity<MlModel> {
             EntityCapabilityType.LINEAGE,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entityV2/mlModelGroup/MLModelGroupEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModelGroup/MLModelGroupEntity.tsx
@@ -235,6 +235,7 @@ export class MLModelGroupEntity implements Entity<MlModelGroup> {
             EntityCapabilityType.LINEAGE,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entityV2/mlPrimaryKey/MLPrimaryKeyEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlPrimaryKey/MLPrimaryKeyEntity.tsx
@@ -232,6 +232,7 @@ export class MLPrimaryKeyEntity implements Entity<MlPrimaryKey> {
             EntityCapabilityType.DATA_PRODUCTS,
             EntityCapabilityType.LINEAGE,
             EntityCapabilityType.RELATED_DOCUMENTS,
+            EntityCapabilityType.FORMS,
         ]);
     };
 }

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/EntityProfile.tsx
@@ -14,6 +14,7 @@ import {
     GenericEntityProperties,
     GenericEntityUpdate,
 } from '@app/entity/shared/types';
+import { EntityCapabilityType } from '@app/entityV2/Entity';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { EntityHeader } from '@app/entityV2/shared/containers/profile/header/EntityHeader';
 import { EntityTabs } from '@app/entityV2/shared/containers/profile/header/EntityTabs';
@@ -52,6 +53,7 @@ import { PageRoutes } from '@conf/Global';
 import useEntityState from '@src/app/entity/shared/useEntityState';
 import { useShowNavBarRedesign } from '@src/app/useShowNavBarRedesign';
 
+import { useGetFormsForEntityQuery } from '@graphql/form.generated';
 import { EntityType, Exact } from '@types';
 
 type Props<T, U> = {
@@ -244,8 +246,14 @@ export const EntityProfile = <T, U>({
         [history, entityType, urn, entityRegistry, isHideSiblingMode],
     );
 
+    const { data: formsData } = useGetFormsForEntityQuery({
+        variables: { urn },
+        fetchPolicy: 'cache-first',
+        skip: !entityRegistry.getSupportedEntityCapabilities(entityType).has(EntityCapabilityType.FORMS),
+    });
+
     const { entityData, dataPossiblyCombinedWithSiblings, dataNotCombinedWithSiblings, loading, error, refetch } =
-        useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties });
+        useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties, formsData });
 
     useUpdateGlossaryEntityDataOnChange(entityData, entityType);
     useUpdateDomainEntityDataOnChangeV2(entityData, entityType);

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/useGetDataForProfile.ts
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/useGetDataForProfile.ts
@@ -6,6 +6,7 @@ import { getDataForEntityType } from '@app/entityV2/shared/containers/profile/ut
 import { useIsSeparateSiblingsMode } from '@app/entityV2/shared/useIsSeparateSiblingsMode';
 import { useAppConfig } from '@src/app/useAppConfig';
 
+import { GetFormsForEntityQuery } from '@graphql/form.generated';
 import { EntityType, Exact } from '@types';
 
 interface Props<T> {
@@ -25,9 +26,16 @@ interface Props<T> {
         }>
     >;
     getOverrideProperties?: (T) => GenericEntityProperties;
+    formsData?: GetFormsForEntityQuery;
 }
 
-export default function useGetDataForProfile<T>({ urn, entityType, useEntityQuery, getOverrideProperties }: Props<T>) {
+export default function useGetDataForProfile<T>({
+    urn,
+    entityType,
+    useEntityQuery,
+    getOverrideProperties,
+    formsData,
+}: Props<T>) {
     const flags = useAppConfig().config.featureFlags;
     const isHideSiblingMode = useIsSeparateSiblingsMode();
     const {
@@ -48,7 +56,10 @@ export default function useGetDataForProfile<T>({ urn, entityType, useEntityQuer
         (dataPossiblyCombinedWithSiblings &&
             Object.keys(dataPossiblyCombinedWithSiblings).length > 0 &&
             getDataForEntityType({
-                data: dataPossiblyCombinedWithSiblings[Object.keys(dataPossiblyCombinedWithSiblings)[0]],
+                data: {
+                    ...formsData?.entity,
+                    ...dataPossiblyCombinedWithSiblings[Object.keys(dataPossiblyCombinedWithSiblings)[0]],
+                },
                 entityType,
                 getOverrideProperties,
                 isHideSiblingMode,

--- a/datahub-web-react/src/graphql/application.graphql
+++ b/datahub-web-react/src/graphql/application.graphql
@@ -14,9 +14,6 @@ query getApplication($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ...notes
     }
 }

--- a/datahub-web-react/src/graphql/chart.graphql
+++ b/datahub-web-react/src/graphql/chart.graphql
@@ -119,9 +119,6 @@ query getChart($urn: String!) {
         activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
             total
         }
-        forms {
-            ...formsFields
-        }
         ...notes
     }
 }

--- a/datahub-web-react/src/graphql/container.graphql
+++ b/datahub-web-react/src/graphql/container.graphql
@@ -75,9 +75,6 @@ query getContainer($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         browsePathV2 {
             ...browsePathV2Fields
         }

--- a/datahub-web-react/src/graphql/dashboard.graphql
+++ b/datahub-web-react/src/graphql/dashboard.graphql
@@ -23,9 +23,6 @@ query getDashboard($urn: String!) {
         activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
             total
         }
-        forms {
-            ...formsFields
-        }
         ...notes
     }
 }

--- a/datahub-web-react/src/graphql/dataFlow.graphql
+++ b/datahub-web-react/src/graphql/dataFlow.graphql
@@ -84,9 +84,6 @@ query getDataFlow($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ...notes
         runs(start: 0, count: 20) {
             count

--- a/datahub-web-react/src/graphql/dataJob.graphql
+++ b/datahub-web-react/src/graphql/dataJob.graphql
@@ -19,9 +19,6 @@ query getDataJob($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         browsePathV2 {
             ...browsePathV2Fields
         }

--- a/datahub-web-react/src/graphql/dataProduct.graphql
+++ b/datahub-web-react/src/graphql/dataProduct.graphql
@@ -14,9 +14,6 @@ query getDataProduct($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ...notes
         settings {
             ...AssetSettingsFields

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -221,9 +221,6 @@ fragment nonSiblingDatasetFields on Dataset {
     privileges {
         ...entityPrivileges
     }
-    forms {
-        ...formsFields
-    }
     institutionalMemory {
         ...institutionalMemoryFields
     }

--- a/datahub-web-react/src/graphql/domain.graphql
+++ b/datahub-web-react/src/graphql/domain.graphql
@@ -30,9 +30,6 @@ query getDomain($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         displayProperties {
             ...displayPropertiesFields
         }

--- a/datahub-web-react/src/graphql/form.graphql
+++ b/datahub-web-react/src/graphql/form.graphql
@@ -5,3 +5,98 @@ mutation submitFormPrompt($urn: String!, $input: SubmitFormPromptInput!) {
 mutation verifyForm($input: VerifyFormInput!) {
     verifyForm(input: $input)
 }
+
+query getFormsForEntity($urn: String!) {
+    entity(urn: $urn) {
+        ... on Dataset {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on Dashboard {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on Chart {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on DataFlow {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on DataJob {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on Container {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on GlossaryTerm {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on GlossaryNode {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on Domain {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on DataProduct {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on CorpUser {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on CorpGroup {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on Application {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on MLFeature {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on MLFeatureTable {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on MLModel {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on MLModelGroup {
+            forms {
+                ...formsFields
+            }
+        }
+        ... on MLPrimaryKey {
+            forms {
+                ...formsFields
+            }
+        }
+    }
+}

--- a/datahub-web-react/src/graphql/glossaryNode.graphql
+++ b/datahub-web-react/src/graphql/glossaryNode.graphql
@@ -43,9 +43,6 @@ fragment glossaryNodeFields on GlossaryNode {
             ...structuredPropertiesFields
         }
     }
-    forms {
-        ...formsFields
-    }
     childrenCount {
         termsCount
         nodesCount

--- a/datahub-web-react/src/graphql/glossaryTerm.graphql
+++ b/datahub-web-react/src/graphql/glossaryTerm.graphql
@@ -97,9 +97,6 @@ query getGlossaryTerm($urn: String!, $start: Int, $count: Int) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ...notes
         settings {
             ...AssetSettingsFields

--- a/datahub-web-react/src/graphql/group.graphql
+++ b/datahub-web-react/src/graphql/group.graphql
@@ -36,9 +36,6 @@ query getGroup($urn: String!, $membersCount: Int!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ownership {
             ...ownershipFields
         }

--- a/datahub-web-react/src/graphql/mlFeature.graphql
+++ b/datahub-web-react/src/graphql/mlFeature.graphql
@@ -17,9 +17,6 @@ query getMLFeature($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ...notes
     }
 }

--- a/datahub-web-react/src/graphql/mlFeatureTable.graphql
+++ b/datahub-web-react/src/graphql/mlFeatureTable.graphql
@@ -14,9 +14,6 @@ query getMLFeatureTable($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ...notes
     }
 }

--- a/datahub-web-react/src/graphql/mlModel.graphql
+++ b/datahub-web-react/src/graphql/mlModel.graphql
@@ -48,9 +48,6 @@ query getMLModel($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ...notes
         ...entityProfileVersionProperties
     }

--- a/datahub-web-react/src/graphql/mlModelGroup.graphql
+++ b/datahub-web-react/src/graphql/mlModelGroup.graphql
@@ -47,9 +47,6 @@ query getMLModelGroup($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ...notes
     }
 }

--- a/datahub-web-react/src/graphql/mlPrimaryKey.graphql
+++ b/datahub-web-react/src/graphql/mlPrimaryKey.graphql
@@ -17,9 +17,6 @@ query getMLPrimaryKey($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         ...notes
     }
 }

--- a/datahub-web-react/src/graphql/user.graphql
+++ b/datahub-web-react/src/graphql/user.graphql
@@ -41,9 +41,6 @@ query getUser($urn: String!, $groupsCount: Int!) {
                 ...structuredPropertiesFields
             }
         }
-        forms {
-            ...formsFields
-        }
         groups: relationships(
             input: {
                 types: ["IsMemberOfGroup", "IsMemberOfNativeGroup"]


### PR DESCRIPTION
Querying forms for an entity can be slow, so it's moved into its own query rather than part of the main getDataset (or other entity type) query
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
