### PR TITLE
fix(cypress) Fix flakiness of v2_glossaryTerm.js test

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossaryTerm.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossaryV2/v2_glossaryTerm.js
@@ -9,7 +9,7 @@ const applyAdvancedSearchFilter = (filterType, value) => {
   cy.clickOptionWithText("Add Filter");
   cy.clickOptionWithText(filterType);
   cy.get("div.ant-select-selection-overflow").click();
-  cy.get(".ant-select-item-option-content").contains(value).click();
+  cy.get(`[data-testid="tag-term-option-${value}"]`).click();
   cy.clickOptionWithText("Add Tags");
   cy.clickOptionWithTestId("add-tag-term-from-modal-btn");
 };


### PR DESCRIPTION
This test was flaky since we were occasionally matching on another tag in the advanced section that started with the same name but wasn't what we were looking for exactly.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
