### PR TITLE
fix(deps): pin cryptography>=46.0.5 for CVE-2026-26007

### DIFF
--- a/datahub-agent-context/setup.py
+++ b/datahub-agent-context/setup.py
@@ -71,7 +71,7 @@ langchain_requirements = {
 
 snowflake_requirements = {
     "click>=8.0.0,<9.0.0",
-    "snowflake-connector-python>=3.0.0,<4.0.0",
+    "snowflake-connector-python>=4.0.0,<5.0.0",
 }
 
 dev_requirements = {

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -281,12 +281,14 @@ snowflake_common = {
     # Reflection failures for case-sensitive object names are a known issue:
     # https://github.com/snowflakedb/snowflake-sqlalchemy/issues/388
     #
-    # As of May 2025, snowflake-sqlalchemy is in maintenance mode. I have commented on the
-    # above issue and we are pinning to a safe version.
-    "snowflake-sqlalchemy>=1.4.3,<1.7.4",
-    "snowflake-connector-python>=3.4.0,<4.0.0",
+    # As of May 2025, snowflake-sqlalchemy is in maintenance mode. 1.8.x allows
+    # snowflake-connector-python 4.x (required for cryptography>=46 / cffi>=2.0).
+    "snowflake-sqlalchemy>=1.8.0,<2.0.0",
+    # >=4.0.0 required for cffi>=2.0 (needed by cryptography>=46). 3.x pins cffi<2.0 and is
+    # incompatible with cryptography 46+. 3.8.0 was yanked.
+    "snowflake-connector-python>=4.0.0,<5.0.0",
     "pandas<3.0.0",
-    "cryptography<47.0.0",
+    "cryptography>=46.0.5,<47.0.0",  # >=46.0.5 for CVE-2026-26007
     "msal<2.0.0",
     "tenacity>=8.0.1,<9.0.0",
     *cachetools_lib,


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
