### PR TITLE
feat(description update): allow updating top level description via th…

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
@@ -18,6 +18,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.generated.SubResourceType;
 import com.linkedin.dataproduct.DataProductProperties;
+import com.linkedin.dataset.EditableDatasetProperties;
 import com.linkedin.domain.DomainProperties;
 import com.linkedin.glossary.GlossaryNodeInfo;
 import com.linkedin.glossary.GlossaryTermInfo;
@@ -47,6 +48,33 @@ public class DescriptionUtils {
           ImmutableList.of(PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType()));
 
   private DescriptionUtils() {}
+
+  public static void updateDatasetDescription(
+      @Nonnull OperationContext opContext,
+      String newDescription,
+      Urn resourceUrn,
+      Urn actor,
+      EntityService<?> entityService) {
+
+    EditableDatasetProperties editableDatasetProperties =
+        (EditableDatasetProperties)
+            EntityUtils.getAspectFromEntity(
+                opContext,
+                resourceUrn.toString(),
+                Constants.EDITABLE_DATASET_PROPERTIES_ASPECT_NAME,
+                entityService,
+                new EditableDatasetProperties());
+
+    editableDatasetProperties.setDescription(newDescription);
+
+    persistAspect(
+        opContext,
+        resourceUrn,
+        Constants.EDITABLE_DATASET_PROPERTIES_ASPECT_NAME,
+        editableDatasetProperties,
+        actor,
+        entityService);
+  }
 
   public static void updateFieldDescription(
       @Nonnull OperationContext opContext,
@@ -267,6 +295,16 @@ public class DescriptionUtils {
         notebookProperties,
         actor,
         entityService);
+  }
+
+  public static Boolean validateDescriptionInput(
+      @Nonnull OperationContext opContext, Urn resourceUrn, EntityService<?> entityService) {
+    if (!entityService.exists(opContext, resourceUrn, true)) {
+      throw new IllegalArgumentException(
+          String.format("Failed to update %s. %s does not exist.", resourceUrn, resourceUrn));
+    }
+
+    return true;
   }
 
   public static Boolean validateFieldDescriptionInput(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtilsTest.java
@@ -1,0 +1,71 @@
+package com.linkedin.datahub.graphql.resolvers.mutate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.entity.EntityService;
+import io.datahubproject.metadata.context.OperationContext;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DescriptionUtilsTest {
+
+  private static final String TEST_DATASET_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:mysql,test.table,PROD)";
+  private static final String TEST_ACTOR_URN = "urn:li:corpuser:testUser";
+  private static final String TEST_DESCRIPTION = "This is a test description for the dataset";
+
+  private EntityService<?> mockEntityService;
+  private OperationContext mockOpContext;
+
+  @BeforeMethod
+  public void setup() {
+    mockEntityService = Mockito.mock(EntityService.class);
+    mockOpContext = Mockito.mock(OperationContext.class);
+  }
+
+  @Test
+  public void testUpdateDatasetDescriptionCallsIngestProposal() throws Exception {
+    Urn datasetUrn = Urn.createFromString(TEST_DATASET_URN);
+    Urn actorUrn = Urn.createFromString(TEST_ACTOR_URN);
+
+    DescriptionUtils.updateDatasetDescription(
+        mockOpContext, TEST_DESCRIPTION, datasetUrn, actorUrn, mockEntityService);
+
+    verify(mockEntityService).ingestProposal(eq(mockOpContext), any(), any(), eq(false));
+  }
+
+  @Test
+  public void testValidateDescriptionInputSuccess() throws Exception {
+    Urn datasetUrn = Urn.createFromString(TEST_DATASET_URN);
+
+    Mockito.when(mockEntityService.exists(mockOpContext, datasetUrn, true)).thenReturn(true);
+
+    Boolean result =
+        DescriptionUtils.validateDescriptionInput(mockOpContext, datasetUrn, mockEntityService);
+
+    assertTrue(result);
+    verify(mockEntityService).exists(mockOpContext, datasetUrn, true);
+  }
+
+  @Test
+  public void testValidateDescriptionInputFailure() throws Exception {
+    Urn datasetUrn = Urn.createFromString(TEST_DATASET_URN);
+
+    Mockito.when(mockEntityService.exists(mockOpContext, datasetUrn, true)).thenReturn(false);
+
+    try {
+      DescriptionUtils.validateDescriptionInput(mockOpContext, datasetUrn, mockEntityService);
+      fail("Expected IllegalArgumentException to be thrown");
+    } catch (IllegalArgumentException exception) {
+      assertTrue(exception.getMessage().contains("does not exist"));
+      assertTrue(exception.getMessage().contains(TEST_DATASET_URN));
+    }
+
+    verify(mockEntityService).exists(mockOpContext, datasetUrn, true);
+  }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->

Allow updating top level description with the updateDescription graphql endpoint. To be used in an MCP server 