### PR TITLE
dockerignore - Exclude Git Objects to speed up the builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@ out
 
 # Content in .git is used to get the git version
 # Just ignore the heavy parts that are not used
+.git/objects
 .git/logs
 .git/COMMIT_*
 .git/index


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
Adding .git/objects to .dockerignore should help speed up the builds. It's unnecessary for our builds.