### PR TITLE
fix(ui/ingestion): fix custom source name used in ingestion form

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/utils.ts
+++ b/datahub-web-react/src/app/ingestV2/source/utils.ts
@@ -43,7 +43,7 @@ dayjs.extend(advancedFormat);
 dayjs.extend(localizedFormat);
 
 export const CUSTOM_SOURCE_NAME = 'custom';
-export const CUSTOM_SOURCE_DISPLAY_NAME = 'Other';
+export const CUSTOM_SOURCE_DISPLAY_NAME = 'Custom';
 
 export const getSourceConfigs = (ingestionSources: SourceConfig[], sourceType: string) => {
     const sourceConfigs = ingestionSources.find((source) => source.name === sourceType);


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-1367/fix-custom-source-name

**Description:**

Custom source name was updated from 'Other' to 'Custom' in sources.json. This updates it at another place used in the create/edit ingestion form.

**Screenshot:**

<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/8a463500-1bae-4866-ad99-930244ff78b0" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
