### PR TITLE
POC for expanding domains as resources in policies

### DIFF
--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/fieldresolverprovider/DomainFieldResolverProvider.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/fieldresolverprovider/DomainFieldResolverProvider.java
@@ -41,6 +41,7 @@ public class DomainFieldResolverProvider implements EntityFieldResolverProvider 
     return FieldResolver.getResolverFromFunction(entitySpec, spec -> getDomains(opContext, spec));
   }
 
+  // i would need to getBatchedParentDomainsForDomains  that's why i can't see the children
   private Set<Urn> getBatchedParentDomains(
       @Nonnull OperationContext opContext, @Nonnull final Set<Urn> urns) {
     final Set<Urn> parentUrns = new HashSet<>();
@@ -91,13 +92,17 @@ public class DomainFieldResolverProvider implements EntityFieldResolverProvider 
 
       final Urn entityUrn = UrnUtils.getUrn(entitySpec.getEntity());
 
+      System.out.println("~~~~~~~~~~~~~~~~HERE2~~~~~~~~~~~~");
+      System.out.println(entityUrn);
+      System.out.println("~~~~~~~~~~~~~~~~HERE2~~~~~~~~~~~~");
+
       // In the case that the entity is a domain, the associated domain is the domain itself
       if (entityUrn.getEntityType().equals(DOMAIN_ENTITY_NAME)) {
+        // would need to call getBatchedParentDomainsForDomains to get all the parents here
         return FieldResolver.FieldValue.builder()
             .values(Collections.singleton(entityUrn.toString()))
             .build();
       }
-
       EntityResponse response =
           _entityClient.getV2(
               opContext,

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/fieldresolverprovider/EntityUrnFieldResolverProvider.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/fieldresolverprovider/EntityUrnFieldResolverProvider.java
@@ -27,6 +27,15 @@ public class EntityUrnFieldResolverProvider implements EntityFieldResolverProvid
     if (entitySpec.getEntity().isEmpty()) {
       return FieldResolver.emptyFieldValue();
     }
+    System.out.println("~~~~~~~~~~~~~~~~~~HERE~~~~~~~~~~~~~~~~~~~");
+    System.out.println(entitySpec.getEntity());
+    System.out.println("~~~~~~~~~~~~~~~~~~HERE~~~~~~~~~~~~~~~~~~~");
+    // could simply add parent urns if this is a domain? i think yes maybe
+    if (!entitySpec.getEntity().equals("urn:li:domain:marketing")) {
+      return FieldResolver.FieldValue.builder()
+          .values(Set.of(entitySpec.getEntity(), "urn:li:domain:marketing"))
+          .build();
+    }
     return FieldResolver.FieldValue.builder().values(Set.of(entitySpec.getEntity())).build();
   }
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -89,7 +89,7 @@ authorization:
   restApiAuthorization: ${REST_API_AUTHORIZATION_ENABLED:true}
   view:
     # Controls whether entity pages can limit access based on policies. If disabled, all entity pages are visible. Does not control if entities show up in search or browse.
-    enabled: ${VIEW_AUTHORIZATION_ENABLED:false}
+    enabled: ${VIEW_AUTHORIZATION_ENABLED:true}
     recommendations:
       # Currently limited to the actor only, see TODO: DataHubAuthorizer
       peerGroupEnabled: ${VIEW_AUTHORIZATION_RECOMMENDATIONS_PEER_GROUP_ENABLED:true}


### PR DESCRIPTION
This PR extends an existing feature where we support applying policies on domains recursively through their domain children to also include the actual domain children now, and not just the assets inside of the domains.

The reason the domain children themselves were not getting affected by policies with Domain set on them is because domain children have a different field for determining what their parent domain is compared to all assets inside of domains. Domains themselves have a `parentDomain` field on their info aspect, while everything inside of a domain uses the `domains` aspect.

This just extends our existing functionality to now include those child domains, which i think was more of a bug than anything else prior.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
