### PR TITLE
fix(frontend): restrict TLS to 1.2+ in CustomHttpClientFactory

### DIFF
--- a/datahub-frontend/app/auth/AuthModule.java
+++ b/datahub-frontend/app/auth/AuthModule.java
@@ -323,7 +323,7 @@ public class AuthModule extends AbstractModule {
     try {
       if (tsConfig.isValid()) {
         return CustomHttpClientFactory.getApacheHttpClient(
-            tsConfig.path, tsConfig.password, tsConfig.type);
+            tsConfig.path, tsConfig.password, tsConfig.type, tsConfig.sslEnabledProtocols);
       } else {
         return HttpClients.createDefault();
       }
@@ -339,7 +339,7 @@ public class AuthModule extends AbstractModule {
     try {
       if (tsConfig.isValid()) {
         return CustomHttpClientFactory.getJavaHttpClient(
-            tsConfig.path, tsConfig.password, tsConfig.type);
+            tsConfig.path, tsConfig.password, tsConfig.type, tsConfig.sslEnabledProtocols);
       } else {
         return HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
       }

--- a/datahub-frontend/app/utils/CustomHttpClientFactory.java
+++ b/datahub-frontend/app/utils/CustomHttpClientFactory.java
@@ -3,6 +3,7 @@ package utils;
 import java.io.FileInputStream;
 import java.net.http.HttpClient;
 import java.security.KeyStore;
+import java.util.List;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
@@ -16,14 +17,21 @@ public class CustomHttpClientFactory {
       LoggerFactory.getLogger(CustomHttpClientFactory.class.getName());
 
   public static SSLContext getSslContext(String path, String pass, String type) throws Exception {
-    return createSslContext(path, pass, type);
+    return createSslContext(path, pass, type, ConfigUtil.DEFAULT_CLIENT_SSL_ENABLED_PROTOCOLS);
   }
 
   public static HttpClient getJavaHttpClient(String path, String pass, String type) {
+    return getJavaHttpClient(path, pass, type, ConfigUtil.DEFAULT_CLIENT_SSL_ENABLED_PROTOCOLS);
+  }
+
+  public static HttpClient getJavaHttpClient(
+      String path, String pass, String type, List<String> sslEnabledProtocols) {
     try {
       log.info(
           "Initializing Java HttpClient with custom truststore at '{}' and type '{}'", path, type);
-      return HttpClient.newBuilder().sslContext(getSslContext(path, pass, type)).build();
+      return HttpClient.newBuilder()
+          .sslContext(createSslContext(path, pass, type, sslEnabledProtocols))
+          .build();
     } catch (Exception e) {
       log.warn(
           "Failed to initialize Java HttpClient with custom truststore at '{}'. Falling back to default HttpClient. Reason: {}",
@@ -35,13 +43,24 @@ public class CustomHttpClientFactory {
   }
 
   public static CloseableHttpClient getApacheHttpClient(String path, String pass, String type) {
+    return getApacheHttpClient(path, pass, type, ConfigUtil.DEFAULT_CLIENT_SSL_ENABLED_PROTOCOLS);
+  }
+
+  public static CloseableHttpClient getApacheHttpClient(
+      String path, String pass, String type, List<String> sslEnabledProtocols) {
     try {
       log.info(
           "Initializing Apache CloseableHttpClient with custom truststore at '{}' and type '{}'",
           path,
           type);
+      String[] protocols = sslEnabledProtocols.toArray(new String[0]);
       return HttpClients.custom()
-          .setSSLSocketFactory(new SSLConnectionSocketFactory(getSslContext(path, pass, type)))
+          .setSSLSocketFactory(
+              new SSLConnectionSocketFactory(
+                  createSslContext(path, pass, type, sslEnabledProtocols),
+                  protocols,
+                  null,
+                  SSLConnectionSocketFactory.getDefaultHostnameVerifier()))
           .build();
     } catch (Exception e) {
       log.warn(
@@ -55,6 +74,19 @@ public class CustomHttpClientFactory {
 
   public static SSLContext createSslContext(
       String truststorePath, String truststorePassword, String truststoreType) throws Exception {
+    return createSslContext(
+        truststorePath,
+        truststorePassword,
+        truststoreType,
+        ConfigUtil.DEFAULT_CLIENT_SSL_ENABLED_PROTOCOLS);
+  }
+
+  public static SSLContext createSslContext(
+      String truststorePath,
+      String truststorePassword,
+      String truststoreType,
+      List<String> sslEnabledProtocols)
+      throws Exception {
     log.info(
         "Creating SSLContext with truststore at '{}' and type '{}'",
         truststorePath,
@@ -66,7 +98,11 @@ public class CustomHttpClientFactory {
     TrustManagerFactory tmf =
         TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
     tmf.init(trustStore);
-    SSLContext sslContext = SSLContext.getInstance("TLS");
+    String protocol =
+        sslEnabledProtocols.isEmpty()
+            ? ConfigUtil.DEFAULT_CLIENT_SSL_ENABLED_PROTOCOLS.get(0)
+            : sslEnabledProtocols.get(0);
+    SSLContext sslContext = SSLContext.getInstance(protocol);
     sslContext.init(null, tmf.getTrustManagers(), null);
     return sslContext;
   }

--- a/datahub-frontend/app/utils/TruststoreConfig.java
+++ b/datahub-frontend/app/utils/TruststoreConfig.java
@@ -1,19 +1,29 @@
 package utils;
 
 import com.typesafe.config.Config;
+import java.util.List;
 
 public class TruststoreConfig {
   public final String path;
   public final String password;
   public final String type;
   public final boolean metadataServiceUseSsl;
+  public final List<String> sslEnabledProtocols;
 
   public TruststoreConfig(
-      String path, String password, String type, boolean metadataServiceUseSsl) {
+      String path,
+      String password,
+      String type,
+      boolean metadataServiceUseSsl,
+      List<String> sslEnabledProtocols) {
     this.path = path;
     this.password = password;
     this.type = type;
     this.metadataServiceUseSsl = metadataServiceUseSsl;
+    this.sslEnabledProtocols =
+        sslEnabledProtocols != null && !sslEnabledProtocols.isEmpty()
+            ? sslEnabledProtocols
+            : ConfigUtil.DEFAULT_CLIENT_SSL_ENABLED_PROTOCOLS;
   }
 
   public boolean isValid() {
@@ -28,6 +38,10 @@ public class TruststoreConfig {
         ConfigUtil.getBoolean(
             config,
             ConfigUtil.METADATA_SERVICE_USE_SSL_CONFIG_PATH,
-            ConfigUtil.DEFAULT_METADATA_SERVICE_USE_SSL));
+            ConfigUtil.DEFAULT_METADATA_SERVICE_USE_SSL),
+        ConfigUtil.getStringList(
+            config,
+            ConfigUtil.METADATA_SERVICE_CLIENT_SSL_ENABLED_PROTOCOLS_CONFIG_PATH,
+            ConfigUtil.DEFAULT_CLIENT_SSL_ENABLED_PROTOCOLS));
   }
 }

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -257,6 +257,9 @@ metadataService.port=${?DATAHUB_GMS_PORT}
 metadataService.basePath=${?DATAHUB_GMS_BASE_PATH}
 metadataService.basePathEnabled=${?DATAHUB_GMS_BASE_PATH_ENABLED}
 metadataService.useSsl=${?DATAHUB_GMS_USE_SSL} # Internal SSL is not fully supported yet.
+# TLS protocols for the frontend HTTP client when connecting to GMS/IdP (not server-side). Comma-separated; same format for this file or env var DATAHUB_GMS_CLIENT_SSL_ENABLED_PROTOCOLS.
+metadataService.clientSslEnabledProtocols = "TLSv1.2,TLSv1.3"
+metadataService.clientSslEnabledProtocols = ${?DATAHUB_GMS_CLIENT_SSL_ENABLED_PROTOCOLS}
 metadataService.truststore.path=${?DATAHUB_GMS_SSL_TRUSTSTORE_PATH}
 metadataService.truststore.password=${?DATAHUB_GMS_SSL_TRUSTSTORE_PASSWORD}
 metadataService.truststore.type=${?DATAHUB_GMS_SSL_TRUSTSTORE_TYPE}

--- a/datahub-frontend/test/utils/ConfigUtilTest.java
+++ b/datahub-frontend/test/utils/ConfigUtilTest.java
@@ -1,0 +1,43 @@
+package utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ConfigUtilTest {
+
+  private static final List<String> DEFAULT = List.of("TLSv1.2", "TLSv1.3");
+
+  @Test
+  void getStringList_missingKey_returnsDefault() {
+    Config config = ConfigFactory.parseString("other = 1");
+    assertEquals(DEFAULT, ConfigUtil.getStringList(config, "missing", DEFAULT));
+  }
+
+  @Test
+  void getStringList_blankValue_returnsDefault() {
+    Config config = ConfigFactory.parseString("key = \"\"");
+    assertEquals(DEFAULT, ConfigUtil.getStringList(config, "key", DEFAULT));
+  }
+
+  @Test
+  void getStringList_commaDelimited_returnsTrimmedList() {
+    Config config = ConfigFactory.parseString("key = \"TLSv1.2, TLSv1.3\"");
+    assertEquals(List.of("TLSv1.2", "TLSv1.3"), ConfigUtil.getStringList(config, "key", DEFAULT));
+  }
+
+  @Test
+  void getStringList_singleValue_returnsSingleElementList() {
+    Config config = ConfigFactory.parseString("key = \"TLSv1.3\"");
+    assertEquals(List.of("TLSv1.3"), ConfigUtil.getStringList(config, "key", DEFAULT));
+  }
+
+  @Test
+  void getStringList_emptySegmentsFiltered() {
+    Config config = ConfigFactory.parseString("key = \"TLSv1.2,, TLSv1.3 , \"");
+    assertEquals(List.of("TLSv1.2", "TLSv1.3"), ConfigUtil.getStringList(config, "key", DEFAULT));
+  }
+}

--- a/datahub-frontend/test/utils/CustomHttpClientFactoryTest.java
+++ b/datahub-frontend/test/utils/CustomHttpClientFactoryTest.java
@@ -69,7 +69,42 @@ class CustomHttpClientFactoryTest {
         CustomHttpClientFactory.createSslContext(
             truststorePath.toString(), TRUSTSTORE_PASSWORD, TRUSTSTORE_TYPE);
     assertNotNull(context);
-    assertEquals("TLS", context.getProtocol());
+    assertEquals("TLSv1.2", context.getProtocol());
+  }
+
+  @Test
+  void testCreateSslContextWithCustomProtocolsUsesFirst() throws Exception {
+    Path truststorePath = generateTempTruststore();
+    SSLContext context =
+        CustomHttpClientFactory.createSslContext(
+            truststorePath.toString(),
+            TRUSTSTORE_PASSWORD,
+            TRUSTSTORE_TYPE,
+            List.of("TLSv1.3", "TLSv1.2"));
+    assertNotNull(context);
+    assertEquals("TLSv1.3", context.getProtocol());
+  }
+
+  @Test
+  void testCreateSslContextWithEmptyListUsesDefaultProtocol() throws Exception {
+    Path truststorePath = generateTempTruststore();
+    SSLContext context =
+        CustomHttpClientFactory.createSslContext(
+            truststorePath.toString(), TRUSTSTORE_PASSWORD, TRUSTSTORE_TYPE, List.of());
+    assertNotNull(context);
+    assertEquals(ConfigUtil.DEFAULT_CLIENT_SSL_ENABLED_PROTOCOLS.get(0), context.getProtocol());
+  }
+
+  @Test
+  void testGetApacheHttpClientWithCustomProtocols() throws Exception {
+    Path truststorePath = generateTempTruststore();
+    CloseableHttpClient client =
+        CustomHttpClientFactory.getApacheHttpClient(
+            truststorePath.toString(),
+            TRUSTSTORE_PASSWORD,
+            TRUSTSTORE_TYPE,
+            List.of("TLSv1.3", "TLSv1.2"));
+    assertNotNull(client);
   }
 
   @Test

--- a/datahub-frontend/test/utils/TruststoreConfigTest.java
+++ b/datahub-frontend/test/utils/TruststoreConfigTest.java
@@ -1,0 +1,34 @@
+package utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TruststoreConfigTest {
+
+  @Test
+  void fromConfig_missingClientSslEnabledProtocols_usesDefault() {
+    Config config =
+        ConfigFactory.parseString(
+            "metadataService.useSsl = true\n"
+                + "metadataService.truststore.path = /path\n"
+                + "metadataService.truststore.password = secret\n");
+    TruststoreConfig ts = TruststoreConfig.fromConfig(config);
+    assertEquals(ConfigUtil.DEFAULT_CLIENT_SSL_ENABLED_PROTOCOLS, ts.sslEnabledProtocols);
+  }
+
+  @Test
+  void fromConfig_clientSslEnabledProtocolsSet_parsesCommaDelimited() {
+    Config config =
+        ConfigFactory.parseString(
+            "metadataService.useSsl = true\n"
+                + "metadataService.truststore.path = /path\n"
+                + "metadataService.truststore.password = secret\n"
+                + "metadataService.clientSslEnabledProtocols = \"TLSv1.3,TLSv1.2\"\n");
+    TruststoreConfig ts = TruststoreConfig.fromConfig(config);
+    assertEquals(List.of("TLSv1.3", "TLSv1.2"), ts.sslEnabledProtocols);
+  }
+}

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -37,6 +37,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
   - Spark integration upgraded from 3.0.3 to 3.3.4 (minimum version required for Java 17 support)
   - Hadoop upgraded from 2.7.2 to 3.3.6 (addresses Hadoop CVEs, bundled with Spark 3.3+)
   - Note: If you're a self-hosted user still running Java 11, you must upgrade to Java 17 before deploying this release. Spark lineage users must upgrade to Spark 3.3.0+.
+- (Frontend) CustomHttpClientFactory now restricts TLS to 1.2 and 1.3 only when using a custom truststore; TLS 1.0 and 1.1 are disabled for security. If the frontend uses a custom truststore to reach GMS or an IdP that only supports TLS 1.0/1.1, those connections will fail until the server is upgraded to support at least TLS 1.2.
 
 ### Known Issues
 


### PR DESCRIPTION
- Restrict TLS to 1.2+ when using custom truststore (disable 1.0/1.1)
- Make allowed protocols configurable via metadataService.clientSslEnabledProtocols
  (default: TLSv1.2,TLSv1.3) and DATAHUB_GMS_CLIENT_SSL_ENABLED_PROTOCOLS env var
- Add ConfigUtil.getStringList for comma-delimited config; TruststoreConfig passes
  sslEnabledProtocols to Apache/Java HTTP client factory
- Add unit tests for ConfigUtil, TruststoreConfig, CustomHttpClientFactory
- Document in docs/how/updating-datahub.md
