### PR TITLE
fix(frontend): use root akkaVersion for Play, document CVE-2023-45865…

### DIFF
--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -29,6 +29,7 @@ play.modules.enabled += "auth.AuthModule"
 play.modules.enabled += "modules.StartupModule"
 
 # Debug configuration dumping, if set to true might log secrets too.
+# Do not enable Akka log-config-on-start (CVE-2023-45865: env vars could be logged).
 debug.dumpFullConfig = false
 
 jwt {

--- a/datahub-frontend/play.gradle
+++ b/datahub-frontend/play.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation("com.nimbusds:oauth2-oidc-sdk:$oauth2OidcSdkVersion")
 
     play(externalDependency.jacksonDataBind)
-    play("com.typesafe.akka:akka-actor_$playScalaVersion:2.6.20")
+    play("com.typesafe.akka:akka-actor_$playScalaVersion:$akkaVersion")
     play(externalDependency.jsonSmart)
     play('io.netty:netty-all:4.1.130.Final')
 


### PR DESCRIPTION
… mitigation

- play.gradle: use $akkaVersion constant instead of hardcoded 2.6.21
- application.conf: add comment to not enable log-config-on-start (CVE-2023-45865)

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
