### PR TITLE
fix(search): add waitForCompletion(false) to ES8 reindex to prevent socket timeout

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShim.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/client/shim/impl/Es8SearchClientShim.java
@@ -1557,6 +1557,7 @@ public class Es8SearchClientShim extends AbstractBulkProcessorShim<BulkIngester<
             .conflicts(Conflicts.Proceed)
             .slices(slices)
             .timeout(time)
+            .waitForCompletion(false)
             .build();
     ReindexResponse esReindexResponse = withTransportOptions(options).reindex(esReindexRequest);
 


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Links to related issues
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


### Summary
Fixes socket timeout errors during Elasticsearch 8.x reindex operations by explicitly setting `waitForCompletion(false)` in the `submitReindexTask` method.

### Problem Statement
When performing large-scale reindex operations with Elasticsearch 8.x client, the following error occurs:
```
java.net.SocketTimeoutException: 30,000 milliseconds timeout on connection http-outgoing-3 [ACTIVE]
at ESIndexBuilder.buildIndex(ESIndexBuilder.java:480)
```

**Root Cause:**
- In Elasticsearch 8.x Java Client, the `waitForCompletion` parameter defaults to `true` (synchronous mode)
- For large datasets, reindex operations take longer than the default socket timeout (30 seconds)
- The HTTP connection remains open waiting for completion, eventually timing out

### Solution
Explicitly set `.waitForCompletion(false)` in the reindex request builder to:
1. Execute reindex as an **asynchronous task**
2. Return immediately with a **task ID** instead of blocking
3. Prevent socket timeout by avoiding long-running HTTP connections

### Technical Details

**Before (PR #14904):**
```java
co.elastic.clients.elasticsearch.core.ReindexRequest esReindexRequest =
    new co.elastic.clients.elasticsearch.core.ReindexRequest.Builder()
        .source(sourceIndex)
        .dest(destinationIndex)
        .conflicts(Conflicts.Proceed)
        .slices(slices)
        .timeout(time)
        // Missing: waitForCompletion defaults to true
        .build();
```

**After (This PR):**
```java
co.elastic.clients.elasticsearch.core.ReindexRequest esReindexRequest =
    new co.elastic.clients.elasticsearch.core.ReindexRequest.Builder()
        .source(sourceIndex)
        .dest(destinationIndex)
        .conflicts(Conflicts.Proceed)
        .slices(slices)
        .timeout(time)
        .waitForCompletion(false) 
        .build();
```

**How It Works:**
- With `waitForCompletion(false)`, the reindex API returns immediately with a task ID
- The method returns `esReindexResponse.task()` (line 1562-1564)
- Callers can monitor task progress using the task ID
- No HTTP connection timeout for long-running operations

### Testing
- Tested with large-scale reindex operations that previously timed out
- Verified task ID is returned successfully
- Confirmed reindex completes asynchronously without blocking

### Related
- Based on PR #14904 (feat(search): implement multi-client search engine shim for ES8 support)
- Aligns with existing pattern in `deleteByQuery` (line 905) which already uses `waitForCompletion(synchronous)`