### PR TITLE
fix(ingest/looker): stop clearing LOOKERSDK_CLIENT_SECRET env var after init

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
@@ -91,11 +91,7 @@ class LookerAPI:
         os.environ["LOOKERSDK_CLIENT_SECRET"] = config.client_secret.get_secret_value()
         os.environ["LOOKERSDK_BASE_URL"] = config.base_url
 
-        try:
-            self.client = looker_sdk.init40()
-        finally:
-            # Always clear secret from environment, even if init40() throws
-            os.environ.pop("LOOKERSDK_CLIENT_SECRET", None)
+        self.client = looker_sdk.init40()
 
         # Somewhat hacky mechanism for enabling retries on the Looker SDK.
         # Unfortunately, it doesn't expose a cleaner way to do this.


### PR DESCRIPTION
## Summary
- Reverts the `try/finally` block added in #16163 that cleared `LOOKERSDK_CLIENT_SECRET` from the environment after `looker_sdk.init40()`
- The Looker SDK's `AuthSession._login()` calls `self.settings.read_config()` on **every** authentication (initial + token refresh), which re-reads `LOOKERSDK_CLIENT_SECRET` from the environment
- Clearing the env var caused immediate `SDKError: Required auth credentials not found.` on the first API call

## Root Cause
The `init40()` call does not eagerly authenticate — it creates a lazy `AuthSession`. The first actual API call (`self.client.me()`) triggers `_login()`, which calls `read_config()` → `_override_from_env()` → `os.getenv("LOOKERSDK_CLIENT_SECRET")`. Since the `finally` block already removed the env var, this returns `None` and authentication fails.

## Test plan
- [ ] Verify Looker ingestion connects successfully with valid credentials
- [ ] Verify long-running ingestions survive token refreshes (tokens expire, SDK re-authenticates using the same env var path)
