### PR TITLE
docs: fix broken ingestion source and deployment documentation links

### DIFF
--- a/docs/actions/sources/kafka-event-source.md
+++ b/docs/actions/sources/kafka-event-source.md
@@ -113,7 +113,7 @@ source:
 
 ### AWS Glue Schema Registry
 
-If you're using AWS Glue Schema Registry, you'll need to configure it differently. See the [AWS deployment guide](/docs/deploy/aws#aws-glue-schema-registry) for details.
+If you're using AWS Glue Schema Registry, you'll need to configure it differently. See the [AWS deployment guide](../../deploy/aws.md/#aws-glue-schema-registry) for details.
 
 ## FAQ
 

--- a/docs/deploy/confluent-cloud.md
+++ b/docs/deploy/confluent-cloud.md
@@ -95,7 +95,7 @@ Specifically `sasl.username` and `sasl.password` are the differences from the ba
 Additionally, you will need to set up environment variables for `KAFKA_PROPERTIES_SASL_USERNAME` and `KAFKA_PROPERTIES_SASL_PASSWORD`
 which will use the same username and API Key you generated for the JAAS config.
 
-See [Overwriting a System Action Config](https://github.com/acryldata/datahub-actions/blob/main/docker/README.md#overwriting-a-system-action-config) for detailed reflection procedures.
+See [Overwriting a System Action Config](https://github.com/datahub-project/datahub/blob/master/docker/datahub-actions/README.md#overwriting-a-system-action-config) for detailed reflection procedures.
 
 Next, configure datahub-actions to connect to Confluent Cloud by changing `docker/datahub-actions/env/docker.env`:
 
@@ -218,7 +218,7 @@ Specifically `sasl.username` and `sasl.password` are the differences from the ba
 Additionally, you will need to set up secrets for `KAFKA_PROPERTIES_SASL_USERNAME` and `KAFKA_PROPERTIES_SASL_PASSWORD`
 which will use the same username and API Key you generated for the JAAS config.
 
-See [Overwriting a System Action Config](https://github.com/acryldata/datahub-actions/blob/main/docker/README.md#overwriting-a-system-action-config) for detailed reflection procedures.
+See [Overwriting a System Action Config](https://github.com/datahub-project/datahub/blob/master/docker/datahub-actions/README.md#overwriting-a-system-action-config) for detailed reflection procedures.
 
 ```yaml
 credentialsAndCertsSecrets:

--- a/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake.md
+++ b/metadata-ingestion/docs/sources/fabric-onelake/fabric-onelake.md
@@ -77,7 +77,7 @@ For schemas-enabled lakehouses, you may also need OneLake data access permission
 
 For detailed information on permissions, see:
 
-- [Fabric REST API Permissions](https://learn.microsoft.com/en-us/rest/api/fabric/articles/api-permissions)
+- [Fabric REST API Permissions](https://learn.microsoft.com/en-us/rest/api/fabric/articles/scopes)
 - [Workspace Roles and Permissions](https://learn.microsoft.com/en-us/fabric/admin/roles)
 - [OneLake Data Access Control](https://learn.microsoft.com/en-us/fabric/onelake/security/data-access-control-model)
 
@@ -392,9 +392,9 @@ source:
 
 **References:**
 
-- [What is the SQL analytics endpoint for a lakehouse?](https://learn.microsoft.com/en-us/fabric/data-warehouse/what-is-the-sql-analytics-endpoint-for-a-lakehouse)
-- [Warehouse connectivity in Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/data-warehouse/warehouse-connectivity)
-- [Connect to Fabric Data Warehouse](https://learn.microsoft.com/en-us/fabric/data-warehouse/connect-to-fabric-data-warehouse)
+- [What is the SQL analytics endpoint for a lakehouse?](https://learn.microsoft.com/en-us/fabric/data-engineering/lakehouse-sql-analytics-endpoint)
+- [Warehouse connectivity in Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/data-warehouse/connectivity)
+- [Connect to Fabric Data Warehouse](https://learn.microsoft.com/en-us/fabric/data-warehouse/how-to-connect)
 
 ### Important Notes
 
@@ -461,7 +461,7 @@ When enabled, the connector will:
 ### Fabric Concepts
 
 - [Microsoft Fabric Overview](https://learn.microsoft.com/en-us/fabric/get-started/microsoft-fabric-overview)
-- [OneLake Overview](https://learn.microsoft.com/en-us/fabric/data-engineering/onelake-overview)
+- [OneLake Overview](https://learn.microsoft.com/en-us/fabric/onelake/onelake-overview)
 - [Workspaces in Fabric](https://learn.microsoft.com/en-us/fabric/get-started/workspaces)
 - [Lakehouses in Fabric](https://learn.microsoft.com/en-us/fabric/data-engineering/lakehouse-overview)
-- [Warehouses in Fabric](https://learn.microsoft.com/en-us/fabric/data-warehouse/warehouse-overview)
+- [Warehouses in Fabric](https://learn.microsoft.com/en-us/fabric/data-warehouse/data-warehousing)

--- a/metadata-ingestion/docs/sources/teradata/teradata_pre.md
+++ b/metadata-ingestion/docs/sources/teradata/teradata_pre.md
@@ -20,11 +20,11 @@
 
    If you want to run profiling, you need to grant select permission on all the tables you want to profile.
 
-3. If lineage or usage extraction is enabled, please, check if query logging is enabled and it is set to size which
+3. If lineage or usage extraction is enabled, please check if query logging is enabled and it is set to size which
    will fit for your queries (the default query text size Teradata captures is max 200 chars)
    An example how you can set it for all users:
-   `sql
-REPLACE QUERY LOGGING LIMIT SQLTEXT=2000 ON ALL;
-`
+   ```sql
+   REPLACE QUERY LOGGING LIMIT SQLTEXT=2000 ON ALL;
+   ```
    See more here about query logging:
-   [https://docs.teradata.com/r/Teradata-VantageCloud-Lake/Database-Reference/Database-Administration/Tracking-Query-Behavior-with-Database-Query-Logging-Operational-DBAs](https://docs.teradata.com/r/Teradata-VantageCloud-Lake/Database-Reference/Database-Administration/Tracking-Query-Behavior-with-Database-Query-Logging-Operational-DBAs)
+   [https://docs.teradata.com/r/Lake-Database-Reference/Database-Administration/Tracking-Query-Behavior-with-Database-Query-Logging-Operational-DBAs/SQL-Statements-to-Control-Logging/LIMIT-Logging-Options](https://docs.teradata.com/r/Lake-Database-Reference/Database-Administration/Tracking-Query-Behavior-with-Database-Query-Logging-Operational-DBAs/SQL-Statements-to-Control-Logging/LIMIT-Logging-Options)


### PR DESCRIPTION
## Summary

Fix multiple broken documentation links across ingestion source and deployment documentation.

## Changes

- Replace deprecated acryl-data/datahub-actions GitHub (deprecated repo) references with correct upstream repository paths
- Fix Semantic Search Configuration Guide relative path in ingestion source generated documentation
- Update Microsoft Fabric OneLake documentation links to current Microsoft Learn URLs
- Correct outdated Teradata query logging documentation link
- Fix incorrect AWS deployment guide reference in Kafka event source docs

## Impact

These fixes prevent users from encountering broken links (404 errors) and improve overall documentation accuracy and developer experience.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (not applicable)
- [ ] Tests for the changes have been added/updated (not applicable - documentation-only changes)
- [X] Docs related to the changes have been added/updated
- [ ] Breaking changes or downtime involved (not applicable)
