### PR TITLE
docs: add frontend theming guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,33 @@ Each Python module has a gradle setup similar to `metadata-ingestion/` (document
   - **Error Handling**: Robust error handling with layers of protection for known failure points
 - **TypeScript**: Use Prettier formatting, strict types (no `any`), React Testing Library
 
+### Frontend Theming (Colors)
+
+**Always use semantic color tokens** from `datahub-web-react/src/conf/theme/colorThemes/types.ts`. Never use hardcoded hex values, `REDESIGN_COLORS`, `ANTD_GRAY`, or direct alchemy `colors.gray[X]` imports.
+
+**In styled-components** (no import needed — `theme` is available via props):
+
+```typescript
+background: ${(props) => props.theme.colors.bg};
+color: ${(props) => props.theme.colors.text};
+border: 1px solid ${(props) => props.theme.colors.border};
+```
+
+**In React component bodies:**
+
+```typescript
+import { useTheme } from 'styled-components';
+const theme = useTheme();
+<Icon color={theme.colors.icon} />
+```
+
+**For alchemy components** (`<Text>`, `<Icon>`, etc.) — do not pass `color`/`colorLevel` props. Let them inherit from themed parent styled-components.
+
+**Do not import from:**
+
+- `datahub-web-react/src/alchemy-components/theme/foundations/colors.ts` (raw palette, only used internally by the theme)
+- `REDESIGN_COLORS` or `ANTD_GRAY` from `entityV2/shared/constants.ts`
+
 ### Code Comments
 
 Only add comments that provide real value beyond what the code already expresses.


### PR DESCRIPTION
Add semantic color token usage rules so AI tools and developers know to use theme tokens from types.ts instead of hardcoded hex values, REDESIGN_COLORS, ANTD_GRAY, or direct alchemy color imports.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
