### PR TITLE
feat(ingest/sigma): add default_db and default_schema to PlatformDetail config

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/config.py
@@ -136,6 +136,16 @@ class PlatformDetail(PlatformInstanceConfigMixin, EnvConfigMixin):
     data_source_platform: str = pydantic.Field(
         description="A chart's data sources platform name.",
     )
+    default_db: Optional[str] = pydantic.Field(
+        default=None,
+        description="Default database name to use when parsing SQL queries. "
+        "Used to generate fully qualified table URNs (e.g., 'prod' for 'prod.public.table').",
+    )
+    default_schema: Optional[str] = pydantic.Field(
+        default=None,
+        description="Default schema name to use when parsing SQL queries. "
+        "Used to generate fully qualified table URNs (e.g., 'public' for 'prod.public.table').",
+    )
 
 
 class SigmaSourceConfig(

--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma.py
@@ -404,7 +404,8 @@ class SigmaSource(StatefulIngestionSourceBase, TestableSource):
             try:
                 sql_parser_in_tables = create_lineage_sql_parsed_result(
                     query=element.query.strip(),
-                    default_db=None,
+                    default_db=data_source_platform_details.default_db,
+                    default_schema=data_source_platform_details.default_schema,
                     platform=data_source_platform_details.data_source_platform,
                     env=data_source_platform_details.env,
                     platform_instance=data_source_platform_details.platform_instance,


### PR DESCRIPTION
Add default_db and default_schema fields to PlatformDetail, allowing users to specify the default database and schema for SQL query parsing. This enables generation of fully qualified table URNs (e.g., prod.public.table) when Sigma queries use unqualified table names.

These are configured per entry in chart_sources_platform_mapping.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

-->
