### PR TITLE
fix(ingest): fix extra forward slash for looker url generation

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/url_util.py
+++ b/metadata-ingestion/src/datahub/utilities/url_util.py
@@ -5,4 +5,4 @@ def remove_port_from_url(base_url: str) -> str:
     m = re.match("^(.*):([0-9]+)$", base_url)
     if m is not None:
         base_url = m[1]
-    return base_url
+    return base_url.rstrip("/")


### PR DESCRIPTION
It's possible that links for Looker will have two forward slashes in the URL like "{base_url}//looks/{self.look_id}" instead of "{base_url}/looks/{self.look_id}". This fixes the issue in several places in looker_common.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
