### PR TITLE
feat(ui): Show data origin in search result and asset page

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/container/mappers/ContainerMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/container/mappers/ContainerMapper.java
@@ -21,6 +21,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Container;
 import com.linkedin.datahub.graphql.generated.DataPlatform;
 import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.FabricType;
 import com.linkedin.datahub.graphql.types.common.mappers.BrowsePathsV2Mapper;
 import com.linkedin.datahub.graphql.types.common.mappers.CustomPropertiesMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.DataPlatformInstanceAspectMapper;
@@ -200,7 +201,9 @@ public class ContainerMapper {
     if (gmsProperties.hasQualifiedName()) {
       propertiesResult.setQualifiedName(gmsProperties.getQualifiedName().toString());
     }
-
+    if (gmsProperties.hasEnv()) {
+      propertiesResult.setEnv(FabricType.valueOf(gmsProperties.getEnv().toString()));
+    }
     return propertiesResult;
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/datajob/mappers/DataJobMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/datajob/mappers/DataJobMapper.java
@@ -19,6 +19,7 @@ import com.linkedin.datahub.graphql.generated.DataJobInputOutput;
 import com.linkedin.datahub.graphql.generated.DataJobProperties;
 import com.linkedin.datahub.graphql.generated.Dataset;
 import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.FabricType;
 import com.linkedin.datahub.graphql.types.application.ApplicationAssociationMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.*;
 import com.linkedin.datahub.graphql.types.common.mappers.util.SystemMetadataUtils;
@@ -176,6 +177,9 @@ public class DataJobMapper implements ModelMapper<EntityResponse, DataJob> {
     }
     if (info.hasCustomProperties()) {
       result.setCustomProperties(CustomPropertiesMapper.map(info.getCustomProperties(), entityUrn));
+    }
+    if (info.hasEnv()) {
+      result.setEnv(FabricType.valueOf(info.getEnv().toString()));
     }
     return result;
   }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -3284,6 +3284,11 @@ type ContainerProperties {
   Fully-qualified name of the Container
   """
   qualifiedName: String
+
+  """
+  Environment of the Asset Container
+  """
+  env: FabricType
 }
 
 """
@@ -7389,6 +7394,11 @@ type DataJobProperties {
   A list of platform specific metadata tuples
   """
   customProperties: [CustomPropertiesEntry!]
+
+  """
+  Environment of the DataJob
+  """
+  env: FabricType
 }
 
 """

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -91,6 +91,7 @@ export type GenericEntityProperties = {
         businessAttributeDataType?: Maybe<string>;
         externalUrl?: Maybe<string>;
         createdOn?: Maybe<ResolvedAuditStamp>;
+        env?: Maybe<FabricType>;
     }>;
     globalTags?: Maybe<GlobalTags>;
     glossaryTerms?: Maybe<GlossaryTerms>;

--- a/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
@@ -264,6 +264,7 @@ export class ContainerEntity implements Entity<Container> {
         return {
             name: this.displayName(data),
             externalUrl: data.properties?.externalUrl,
+            origin: data.properties?.env,
             entityCount: data.entities?.total,
         };
     };

--- a/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
@@ -30,7 +30,7 @@ import { isOutputPort } from '@app/entityV2/shared/utils';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 
 import { GetDataFlowQuery, useGetDataFlowQuery, useUpdateDataFlowMutation } from '@graphql/dataFlow.generated';
-import { DataFlow, EntityType, SearchResult } from '@types';
+import { DataFlow, EntityType, FabricType, SearchResult } from '@types';
 
 const headerDropdownItems = new Set([
     EntityMenuItems.SHARE,
@@ -186,8 +186,10 @@ export class DataFlowEntity implements Entity<DataFlow> {
         // TODO: Get rid of this once we have correctly formed platform coming back.
         const name = dataFlow?.properties?.name;
         const externalUrl = dataFlow?.properties?.externalUrl;
+        const origin = dataFlow?.cluster as FabricType;
         return {
             name,
+            origin,
             externalUrl,
         };
     };

--- a/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
@@ -189,9 +189,11 @@ export class DataJobEntity implements Entity<DataJob> {
         // TODO: Get rid of this once we have correctly formed platform coming back.
         const name = dataJob?.properties?.name;
         const externalUrl = dataJob?.properties?.externalUrl;
+        const origin = dataJob?.properties?.env;
         return {
             name,
             externalUrl,
+            origin,
             platform: getPlatformForDataJob(dataJob),
             lastRun: ((dataJob as any).lastRun as DataProcessInstanceResult)?.runs?.[0],
             lastRunEvent: ((dataJob as any).lastRun as DataProcessInstanceResult)?.runs?.[0]?.state?.[0],

--- a/datahub-web-react/src/app/entityV2/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataset/DatasetEntity.tsx
@@ -248,6 +248,7 @@ export class DatasetEntity implements Entity<Dataset> {
         return {
             name: dataset && this.displayName(dataset),
             externalUrl: dataset?.properties?.externalUrl,
+            origin: dataset?.origin,
             entityTypeOverride: subTypes ? capitalizeFirstLetterOnly(subTypes.typeNames?.[0]) : '',
             properties: extendedProperties,
             lineageUrn,

--- a/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
@@ -85,6 +85,7 @@ export class MLModelEntity implements Entity<MlModel> {
         return {
             // eslint-disable-next-line @typescript-eslint/dot-notation
             name: mlModel && this.displayName(mlModel),
+            origin: mlModel?.origin,
             externalUrl: mlModel?.properties?.externalUrl,
         };
     };

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/header/DefaultEntityHeader.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/header/DefaultEntityHeader.tsx
@@ -19,9 +19,11 @@ import VersioningBadge from '@app/entityV2/shared/versioning/VersioningBadge';
 import ContextPath from '@app/previewV2/ContextPath';
 import HealthIcon from '@app/previewV2/HealthIcon';
 import NotesIcon from '@app/previewV2/NotesIcon';
+import { Pill } from '@components/components/Pills';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { DataPlatform, DisplayProperties, Domain, EntityType, Post } from '@types';
+import { DataPlatform, DisplayProperties, Domain, EntityType, Post, FabricType } from '@types';
+
 
 export const TitleWrapper = styled.div`
     max-width: 100%;
@@ -99,6 +101,7 @@ export type Props = {
     urn: string;
     entityType: EntityType;
     entityUrl: string;
+    origin?: FabricType;
     loading: boolean;
     entityData: GenericEntityProperties | null;
     refetch: () => void;
@@ -115,6 +118,7 @@ export const DefaultEntityHeader = ({
     urn,
     entityType,
     entityUrl,
+    origin,
     loading,
     entityData,
     refetch,
@@ -179,6 +183,15 @@ export const DefaultEntityHeader = ({
                                 <EntityDetailsContainer>
                                     <TitleRow>
                                         <EntityName isNameEditable={showEditName} />
+                                        {origin && (
+                                            <Pill
+                                                label={origin}
+                                                size="sm"
+                                                variant="outline"
+                                                color="gray"
+                                                style={{ marginLeft: 8 }}
+                                            />
+                                        )}
                                         {!!entityData?.notes?.total && (
                                             <NotesIcon
                                                 notes={entityData?.notes?.relationships?.map((r) => r.entity as Post)}

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/header/EntityHeader.tsx
@@ -9,7 +9,8 @@ import { DefaultEntityHeader } from '@app/entityV2/shared/containers/profile/hea
 import { EntityActionItem } from '@app/entityV2/shared/entity/EntityActions';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { DisplayProperties, EntityType, PlatformPrivileges } from '@types';
+import { DisplayProperties, EntityType, FabricType, PlatformPrivileges } from '@types';
+import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 
 const Container = styled.div``;
 
@@ -59,12 +60,16 @@ export const EntityHeader = ({
     const showEditName =
         isNameEditable && getCanEditName(entityType, entityData, me?.platformPrivileges as PlatformPrivileges);
 
+    const rawOrigin = entityData?.origin ?? entityData?.properties?.env;
+    const origin = rawOrigin ? (capitalizeFirstLetterOnly(rawOrigin.toLowerCase()) as FabricType) : undefined;
+
     return (
         <Container data-testid="entity-header-test-id">
             <DefaultEntityHeader
                 entityType={entityType}
                 urn={urn}
                 entityUrl={entityUrl}
+                origin={origin}
                 loading={loading}
                 entityData={entityData}
                 refetch={refetch}

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/SidebarEntityHeader.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/SidebarEntityHeader.tsx
@@ -16,7 +16,9 @@ import NotesIcon from '@app/previewV2/NotesIcon';
 import HorizontalScroller from '@app/sharedV2/carousel/HorizontalScroller';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { DataPlatform, EntityType, Post } from '@types';
+import { Pill } from '@components/components/Pills';
+import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
+import { DataPlatform, EntityType, FabricType, Post } from '@types';
 
 const TitleContainer = styled(HorizontalScroller)`
     display: flex;
@@ -43,6 +45,8 @@ const SidebarEntityHeader = () => {
     const refetch = useRefetch();
     const entityRegistry = useEntityRegistry();
     const entityUrl = entityRegistry.getEntityUrl(entityType, entityData?.urn as string);
+    const rawOrigin = entityData?.origin ?? entityData?.properties?.env;
+    const origin = rawOrigin ? (capitalizeFirstLetterOnly(rawOrigin.toLowerCase()) as FabricType) : undefined;
 
     const displayedEntityType = getDisplayedEntityType(entityData, entityRegistry, entityType);
 
@@ -65,6 +69,15 @@ const SidebarEntityHeader = () => {
             <EntityDetailsContainer>
                 <NameWrapper>
                     <EntityName isNameEditable={false} />
+                    {origin && (
+                        <Pill
+                            label={origin}
+                            size="sm"
+                            variant="outline"
+                            color="gray"
+                            style={{ marginLeft: 8 }}
+                        />
+                    )}
                     {!!entityData?.notes?.total && (
                         <NotesIcon notes={entityData?.notes?.relationships?.map((r) => r.entity as Post) || []} />
                     )}

--- a/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
@@ -266,6 +266,7 @@ export default function DefaultPreviewCard({
     const finalType = type || entityRegistry.getEntityName(entityType);
     const hasPlatformIcons = logoUrl || (logoUrls && logoUrls.length) || isOutputPort;
     const isIconPresent = !!hasPlatformIcons || !!entityIcon;
+    const origin = data?.origin;
 
     const { isFullViewCard } = useSearchContext();
 
@@ -388,6 +389,7 @@ export default function DefaultPreviewCard({
                 />
             )}
             <DefaultPreviewCardFooter
+                origin={origin}
                 glossaryTerms={glossaryTerms}
                 tags={tags}
                 owners={owners}

--- a/datahub-web-react/src/app/previewV2/DefaultPreviewCardFooter.tsx
+++ b/datahub-web-react/src/app/previewV2/DefaultPreviewCardFooter.tsx
@@ -11,9 +11,10 @@ import Pills from '@app/previewV2/Pills';
 import PreviewCardFooterRightSection from '@app/previewV2/PreviewCardFooterRightSection';
 import { entityHasCapability } from '@app/previewV2/utils';
 
-import { DatasetStatsSummary, EntityPath, EntityType, GlobalTags, GlossaryTerms, Maybe, Owner } from '@types';
+import { DatasetStatsSummary, EntityPath, EntityType, FabricType, GlobalTags, GlossaryTerms, Maybe, Owner } from '@types';
 
 interface DefaultPreviewCardFooterProps {
+    origin?: Maybe<FabricType>;
     glossaryTerms?: GlossaryTerms;
     tags?: GlobalTags;
     owners?: Array<Owner> | null;
@@ -81,6 +82,7 @@ const HorizontalDivider = styled(Divider)`
 `;
 
 const DefaultPreviewCardFooter: React.FC<DefaultPreviewCardFooterProps> = ({
+    origin,
     glossaryTerms,
     tags,
     owners,
@@ -111,6 +113,7 @@ const DefaultPreviewCardFooter: React.FC<DefaultPreviewCardFooterProps> = ({
             <Container>
                 {isFullViewCard && (
                     <Pills
+                        origin={origin}
                         glossaryTerms={glossaryTerms}
                         tags={tags}
                         owners={owners}

--- a/datahub-web-react/src/app/previewV2/Pills.tsx
+++ b/datahub-web-react/src/app/previewV2/Pills.tsx
@@ -2,7 +2,7 @@ import { LayoutOutlined } from '@ant-design/icons';
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
 import FindInPageOutlinedIcon from '@mui/icons-material/FindInPageOutlined';
 import SellOutlinedIcon from '@mui/icons-material/SellOutlined';
-import { BookmarkSimple } from '@phosphor-icons/react';
+import { Cylinder, BookmarkSimple } from '@phosphor-icons/react';
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 
@@ -12,8 +12,9 @@ import SearchPill from '@app/previewV2/SearchPill';
 import { entityHasCapability, getHighlightedTag } from '@app/previewV2/utils';
 import { useMatchedFieldsForList } from '@app/search/context/SearchResultContext';
 import MatchesContext, { PreviewSection } from '@app/shared/MatchesContext';
+import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 
-import { EntityPath, EntityType, GlobalTags, GlossaryTerms, LineageDirection, Owner } from '@types';
+import { EntityPath, EntityType, FabricType, GlobalTags, GlossaryTerms, LineageDirection, Maybe, Owner } from '@types';
 
 const PillsContainer = styled.div`
     gap: 5px;
@@ -24,6 +25,7 @@ const PillsContainer = styled.div`
 `;
 
 interface Props {
+    origin?: Maybe<FabricType>;
     glossaryTerms?: GlossaryTerms;
     tags?: GlobalTags;
     owners?: Array<Owner> | null;
@@ -32,11 +34,13 @@ interface Props {
     entityType: EntityType;
 }
 
-const Pills = ({ glossaryTerms, tags, owners, entityCapabilities, paths, entityType }: Props) => {
+const Pills = ({ origin, glossaryTerms, tags, owners, entityCapabilities, paths, entityType }: Props) => {
     const { lineageDirection, isColumnLevelLineage, selectedColumn } = useContext(LineageTabContext);
     const lineageDirectionText = lineageDirection === LineageDirection.Downstream ? 'downstream' : 'upstream';
     const { setExpandedSection, expandedSection } = useContext(MatchesContext);
     const groupedMatches = useMatchedFieldsForList('fieldLabels');
+    const parsedOrigin = origin ? capitalizeFirstLetterOnly(origin.toLowerCase()) : undefined;
+    const showOriginBadge = !!parsedOrigin;
     const showGlossaryTermsBadge = entityHasCapability(entityCapabilities, EntityCapabilityType.GLOSSARY_TERMS);
     const showTagsBadge = entityHasCapability(entityCapabilities, EntityCapabilityType.TAGS);
     const showOwnersBadge = entityHasCapability(entityCapabilities, EntityCapabilityType.OWNERS);
@@ -51,6 +55,15 @@ const Pills = ({ glossaryTerms, tags, owners, entityCapabilities, paths, entityT
 
     return (
         <PillsContainer>
+            {showOriginBadge && (
+                <SearchPill
+                    icon={<Cylinder />}
+                    label={parsedOrigin}
+                    enabled
+                    count={undefined}
+                    countLabel=""
+                />
+            )}
             {showGlossaryTermsBadge && glossaryTerms && (
                 <SearchPill
                     icon={<BookmarkSimple />}

--- a/datahub-web-react/src/app/previewV2/SearchPill.tsx
+++ b/datahub-web-react/src/app/previewV2/SearchPill.tsx
@@ -6,7 +6,7 @@ import { pluralize } from '@app/shared/textUtil';
 
 type Props = {
     icon: any;
-    count: number;
+    count?: number;
     label: string;
     onClick?: (e: React.MouseEvent) => void;
     enabled?: boolean;
@@ -93,30 +93,32 @@ const HighlightedText = styled.div`
 // pluralize
 
 const SearchPill = ({ icon, onClick, enabled, label, count, countLabel, active, highlightedText }: Props) => {
+    const hasCount = typeof count === 'number';
     const isHighlightedTextPresent = !!highlightedText;
+    const tooltipTitle = hasCount
+        ? `${count} ${pluralize(count, countLabel, countLabel === 'match' ? 'es' : 's')}`
+        : label;
+
     return (
-        <Tooltip
-            title={`${count} ${pluralize(count, countLabel, countLabel === 'match' ? 'es' : 's')}`}
-            showArrow={false}
-        >
+        <Tooltip title={tooltipTitle} showArrow={false}>
             <PillContainer
                 active={active}
                 enabled={enabled}
                 onClick={onClick}
                 isHighlightedTextPresent={isHighlightedTextPresent}
             >
-                {isHighlightedTextPresent ? (
-                    <>
-                        <Container>
-                            {icon} {label}
-                            <HighlightedText>{highlightedText}</HighlightedText>
-                        </Container>
+                <Container>
+                    {icon}
+                    <span>{label}</span>
+                    {isHighlightedTextPresent && <HighlightedText>{highlightedText}</HighlightedText>}
+                </Container>
+
+                {hasCount && (
+                    isHighlightedTextPresent ? (
                         <CountContainer active={active}>{count}</CountContainer>
-                    </>
-                ) : (
-                    <>
-                        {icon} {label} {count}
-                    </>
+                    ) : (
+                        <span>{count}</span>
+                    )
                 )}
             </PillContainer>
         </Tooltip>

--- a/datahub-web-react/src/app/searchV2/autoCompleteV2/AutoCompleteEntityItem.tsx
+++ b/datahub-web-react/src/app/searchV2/autoCompleteV2/AutoCompleteEntityItem.tsx
@@ -13,9 +13,10 @@ import { VARIANT_STYLES } from '@app/searchV2/autoCompleteV2/constants';
 import { EntityItemVariant } from '@app/searchV2/autoCompleteV2/types';
 import { getEntityDisplayType } from '@app/searchV2/autoCompleteV2/utils';
 import { useGetModalLinkProps } from '@app/sharedV2/modals/useGetModalLinkProps';
-import { Text } from '@src/alchemy-components';
+import { Text, Pill } from '@src/alchemy-components';
 import { useEntityRegistryV2 } from '@src/app/useEntityRegistry';
 import { Entity, MatchedField } from '@src/types.generated';
+import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 
 const Container = styled.div<{
     $navigateOnlyOnNameClick?: boolean;
@@ -101,6 +102,12 @@ const Icons = styled.div`
     gap: 8px;
 `;
 
+const NameWithOriginContainer = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 8px;
+`;
+
 interface EntityAutocompleteItemProps {
     entity: Entity;
     query?: string;
@@ -113,6 +120,7 @@ interface EntityAutocompleteItemProps {
     hideSubtitle?: boolean;
     hideType?: boolean;
     hideMatches?: boolean;
+    hideOrigin?: boolean;
     padding?: string;
     onClick?: () => void;
     customHoverEntityName?: (entity: Entity, children: React.ReactNode) => React.ReactNode;
@@ -132,6 +140,7 @@ export default function AutoCompleteEntityItem({
     hideSubtitle,
     hideType,
     hideMatches,
+    hideOrigin,
     padding,
     onClick,
     customHoverEntityName,
@@ -145,10 +154,44 @@ export default function AutoCompleteEntityItem({
     const displayName = entityRegistry.getDisplayName(entity.type, entity);
     const displayType = getEntityDisplayType(entity, entityRegistry);
     const variantProps = VARIANT_STYLES.get(variant ?? 'default');
+    const entityProperties = entityRegistry.getGenericEntityProperties(entity.type, entity);
+    const origin = capitalizeFirstLetterOnly(entityProperties?.origin?.toLowerCase() || '');
 
     const DisplayNameHoverComponent = navigateOnlyOnNameClick
         ? DisplayNameHoverFromSelf
         : DisplayNameHoverFromContainer;
+
+    const originPill = !hideOrigin && origin ? (
+        <Pill
+            label={origin}
+            size="sm"
+            variant="outline"
+            showLabel
+            dataTestId="origin-pill"
+        />
+    ) : null;
+
+    const displayProps = {
+        displayName,
+        highlight: query,
+        color: variantProps?.nameColor,
+        colorLevel: variantProps?.nameColorLevel,
+        weight: variantProps?.nameWeight,
+    };
+
+    const innerContent = (
+        <NameWithOriginContainer>
+            {customOnEntityClick || variantProps?.nameCanBeHovered ? (
+                <DisplayNameHoverComponent
+                    {...displayProps}
+                    $decorationColor={getColor(variantProps?.nameColor, variantProps?.nameColorLevel, theme)}
+                />
+            ) : (
+                <DisplayName {...displayProps} showNameTooltipIfTruncated />
+            )}
+            {originPill}
+        </NameWithOriginContainer>
+    );
 
     let displayNameContent;
 
@@ -164,40 +207,17 @@ export default function AutoCompleteEntityItem({
                     }
                 }}
             >
-                <DisplayNameHoverComponent
-                    displayName={displayName}
-                    highlight={query}
-                    color={variantProps?.nameColor}
-                    colorLevel={variantProps?.nameColorLevel}
-                    weight={variantProps?.nameWeight}
-                    $decorationColor={getColor(variantProps?.nameColor, variantProps?.nameColorLevel, theme)}
-                />
+                {innerContent}
             </div>
         );
     } else if (variantProps?.nameCanBeHovered) {
         displayNameContent = (
             <Link to={entityRegistry.getEntityUrl(entity.type, entity.urn)} {...linkProps}>
-                <DisplayNameHoverComponent
-                    displayName={displayName}
-                    highlight={query}
-                    color={variantProps?.nameColor}
-                    colorLevel={variantProps?.nameColorLevel}
-                    weight={variantProps?.nameWeight}
-                    $decorationColor={getColor(variantProps?.nameColor, variantProps?.nameColorLevel, theme)}
-                />
+                {innerContent}
             </Link>
         );
     } else {
-        displayNameContent = (
-            <DisplayName
-                displayName={displayName}
-                highlight={query}
-                color={variantProps?.nameColor}
-                colorLevel={variantProps?.nameColorLevel}
-                weight={variantProps?.nameWeight}
-                showNameTooltipIfTruncated
-            />
-        );
+        displayNameContent = innerContent;
     }
 
     return (

--- a/datahub-web-react/src/graphql/container.graphql
+++ b/datahub-web-react/src/graphql/container.graphql
@@ -12,6 +12,7 @@ query getContainer($urn: String!) {
             qualifiedName
             description
             externalUrl
+            env
             customProperties {
                 key
                 value

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -529,6 +529,7 @@ fragment nonRecursiveDataJobFields on DataJob {
     urn
     properties {
         name
+        env
         description
         externalUrl
         customProperties {
@@ -571,6 +572,7 @@ fragment dataJobFields on DataJob {
     }
     properties {
         name
+        env
         description
         externalUrl
         customProperties {
@@ -1276,6 +1278,7 @@ fragment entityContainer on Container {
     }
     properties {
         name
+        env
     }
     subTypes {
         typeNames

--- a/datahub-web-react/src/graphql/preview.graphql
+++ b/datahub-web-react/src/graphql/preview.graphql
@@ -211,6 +211,7 @@ fragment entityPreview on Entity {
         }
         properties {
             name
+            env
             description
         }
         globalTags {

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -7,6 +7,7 @@ fragment autoCompleteFields on Entity {
     ... on Dataset {
         exists
         name
+        origin
         platform {
             ...platformFields
         }
@@ -162,6 +163,7 @@ fragment autoCompleteFields on Entity {
     }
     ... on DataFlow {
         orchestrator
+        cluster
         properties {
             name
         }
@@ -191,6 +193,7 @@ fragment autoCompleteFields on Entity {
         jobId
         properties {
             name
+            env
         }
         dataPlatformInstance {
             ...dataPlatformInstanceFields
@@ -253,6 +256,7 @@ fragment autoCompleteFields on Entity {
     ... on Container {
         properties {
             name
+            env
         }
         platform {
             ...platformFields
@@ -322,6 +326,7 @@ fragment autoCompleteFields on Entity {
     }
     ... on MLModel {
         name
+        origin
         platform {
             ...platformFields
         }
@@ -971,6 +976,7 @@ fragment searchResultsWithoutSchemaField on Entity {
             name
             description
             externalUrl
+            env
         }
         platform {
             ...platformFields


### PR DESCRIPTION
In our instance of Datahub we store metadata of assets from 3 environments (Dev, Stage, Prod). That means we have many duplicate assets by name and when searching for them it's very hard to understand which comes from which environment. Many of our users complain that they cannot easily differentiate the assets, as the only difference is the URN.

This feature adds a Pill to the footer of the search result, with information on the origin of the asset.
<img width="1632" height="189" alt="image (1)" src="https://github.com/user-attachments/assets/77f59142-32da-4a8d-84ee-67ebcb377200" />

It also adds that information to the search auto complete
<img width="1511" height="367" alt="image (3)" src="https://github.com/user-attachments/assets/bcfe9e0a-77a9-45d5-8865-30d116fcdc1b" />

This also makes the information show up in the "Your Assets" module of the homepage:
<img width="752" height="326" alt="image (4)" src="https://github.com/user-attachments/assets/d9d159da-1d3d-4915-8888-6b5742426226" />

Finally, it also displayed in the asset page and summary:
<img width="1856" height="394" alt="image (2) 1" src="https://github.com/user-attachments/assets/8248403a-9800-4d58-b55a-328fbd641290" />

