### PR TITLE
fix(cypress): fix ingestionv2/source cypress test

### DIFF
--- a/smoke-test/tests/cypress/data.json
+++ b/smoke-test/tests/cypress/data.json
@@ -3966,5 +3966,23 @@
       }
     },
     "proposedDelta": null
+  },
+  {
+    "entityType": "dataHubIngestionSource",
+    "entityUrn": "urn:li:dataHubIngestionSource:cli-cypress-test",
+    "changeType": "UPSERT",
+    "aspectName": "dataHubIngestionSourceInfo",
+    "aspect": {
+      "json": {
+        "name": "[CLI] file (cypress)",
+        "type": "file",
+        "config": {
+          "recipe": "{\"source\": {\"type\": \"file\", \"config\": {\"filename\": \"tests/cypress/query-data.json\"}, \"extractor\": \"generic\", \"extractor_config\": {}}, \"sink\": {\"type\": \"datahub-rest\", \"config\": {\"server\": \"http://localhost:8080\", \"token\": \"********\", \"mode\": \"ASYNC_BATCH\"}}, \"transformers\": null, \"flags\": {\"generate_browse_path_v2\": true, \"generate_browse_path_v2_dry_run\": false, \"generate_memory_profiles\": null, \"set_system_metadata\": true, \"set_system_metadata_pipeline_name\": true}, \"reporting\": [{\"type\": \"datahub\", \"config\": null, \"required\": false}], \"run_id\": \"file-2026_02_19-11_36_20-ioptda\", \"datahub_api\": null, \"pipeline_name\": null, \"failure_log\": {\"enabled\": false, \"log_config\": null}, \"recording\": null}",
+          "executorId": "__datahub_cli_",
+          "version": "unavailable (installed in develop mode)"
+        },
+        "platform": "urn:li:dataPlatform:unknown"
+      }
+    }
   }
 ]


### PR DESCRIPTION
Linear: https://linear.app/acryl-data/issue/PRD-2355/fix-ingestionv2sourcesjs

<img width="2535" height="1265" alt="image" src="https://github.com/user-attachments/assets/a100082b-a22b-4e75-8c6a-53df94c52214" />
This error is reproducible only in `Nightly Docker Test` (e.g. https://github.com/acryldata/datahub-fork/actions/runs/22054892561). Sometimes `[CLI] file` source is not available on UI but it should exist according to logs.

I've added another one CLI source to data.json so we will always see some CLI source in UI.

SaaS PR - https://github.com/acryldata/datahub-fork/pull/8302
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
