### PR TITLE
fix(redirect): fix open rediect on redirect_uri

### DIFF
--- a/datahub-frontend/app/controllers/AuthenticationController.java
+++ b/datahub-frontend/app/controllers/AuthenticationController.java
@@ -132,6 +132,14 @@ public class AuthenticationController extends Controller {
       redirectPath = BasePathUtils.addBasePath("/logOut", this.basePath);
     }
     try {
+      // Reject protocol-relative URLs (e.g. ///google.com) which browsers resolve to
+      // https://host; the URI parser may not set scheme/authority for these.
+      if (redirectPath.trim().startsWith("//")) {
+        throw new RedirectException(
+            "Redirect location must be relative to the base url, cannot "
+                + "use protocol-relative URL: "
+                + redirectPath);
+      }
       URI redirectUri = new URI(redirectPath);
       if (redirectUri.getScheme() != null || redirectUri.getAuthority() != null) {
         throw new RedirectException(

--- a/datahub-frontend/test/app/ApplicationTest.java
+++ b/datahub-frontend/test/app/ApplicationTest.java
@@ -1131,6 +1131,10 @@ public class ApplicationTest extends WithBrowser {
 
     browser.goTo("/authenticate?redirect_uri=localhost%3A9002%2Flogin");
     assertEquals("", browser.url());
+
+    // Protocol-relative URL (///google.com) must not redirect to external host
+    browser.goTo("/authenticate?redirect_uri=%2F%2F%2Fgoogle.com");
+    assertEquals("", browser.url());
   }
 
   /** Test module that provides comprehensive mocks to handle all GMS interactions */


### PR DESCRIPTION
## Summary

Fixes an open redirect in `/authenticate`: the `redirect_uri` query parameter was only validated for absolute URLs (scheme/authority). Values like `///google.com` were accepted and sent as `Location: ///google.com`, which browsers resolve to `https://google.com`.

## Changes

- **Validation:** Reject any `redirect_uri` whose trimmed value starts with `//` (protocol-relative). Invalid values are handled like other bad redirects and fall back to the app root.
- **Tests:** Unit test for `///google.com` and `//google.com` in `AuthenticationControllerTest`; browser test case in `ApplicationTest.testInvalidRedirectUrl`.
