### PR TITLE
fix(search): treat datahub.urn as URN in structured property index ma…

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/StructuredPropertyMappingBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/StructuredPropertyMappingBuilder.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.search.elasticsearch.index.entity.v3;
 
 import static com.linkedin.metadata.models.StructuredPropertyUtils.entityTypeMatches;
+import static com.linkedin.metadata.models.StructuredPropertyUtils.getLogicalValueType;
 import static com.linkedin.metadata.models.StructuredPropertyUtils.toElasticsearchFieldName;
 import static com.linkedin.metadata.search.utils.ESUtils.TYPE;
 
@@ -71,8 +72,7 @@ public class StructuredPropertyMappingBuilder {
 
     Map<String, Object> fieldMapping = new HashMap<>();
 
-    String valueType = definition.getValueType().getId();
-    LogicalValueType logicalValueType = LogicalValueType.valueOf(valueType);
+    LogicalValueType logicalValueType = getLogicalValueType(definition.getValueType());
     String elasticsearchType =
         FieldTypeMapper.getElasticsearchTypeForLogicalValueType(logicalValueType);
 


### PR DESCRIPTION
…ppings

Use StructuredPropertyUtils.getLogicalValueType() instead of getValueType().getId() in V2 and V3 mapping builders so that urn:li:dataType:datahub.urn is resolved to LogicalValueType.URN and gets a proper mapping type. Previously getId() returned "datahub.urn", which matched no branch and produced mappings with no type, causing mapper_parsing_exception during reindex (BuildIndicesStep).

- V2MappingsBuilder: branch on getLogicalValueType() in getIndexMappingsForStructuredProperty
- StructuredPropertyMappingBuilder: use getLogicalValueType() instead of valueOf(getId())
- MultiEntityMappingsBuilder: same as V2 for getIndexMappingsForStructuredProperty

Add tests for datahub.urn value type and reindex (every field has type).


Reference:
https://github.com/datahub-project/datahub/pull/15810

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
