### PR TITLE
ci(pre-commit) Use action lint docker hook

### DIFF
--- a/.github/scripts/pre-commit-override.yaml
+++ b/.github/scripts/pre-commit-override.yaml
@@ -1,13 +1,4 @@
-
 repos:
-  - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.11
-    hooks:
-      - id: actionlint
-        name: Lint GitHub Actions workflow files
-        description: Runs actionlint to lint GitHub Actions workflow files
-        types: ["yaml"]
-        files: ^\.github/workflows/
   - repo: local
     hooks:
       - id: smoke-test-cypress-lint-fix
@@ -34,3 +25,10 @@ repos:
         language: system
         files: ^docker/.*$
         pass_filenames: false
+      - id: actionlint-docker
+        name: Lint GitHub Actions workflow files
+        description: Runs actionlint Docker image to lint GitHub Actions workflow files
+        language: docker_image
+        types: ["yaml"]
+        files: ^\.github/workflows/
+        entry: docker.io/rhysd/actionlint:1.7.11

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,11 +90,25 @@ repos:
         files: ^metadata-dao-impl/kafka-producer/.*\.java$
         pass_filenames: false
 
+      - id: metadata-events-mxe-avro-spotless
+        name: metadata-events/mxe-avro Spotless Apply
+        entry: ./gradlew :metadata-events:mxe-avro:spotlessApply -x generateGitPropertiesGlobal
+        language: system
+        files: ^metadata-events/mxe-avro/.*\.java$
+        pass_filenames: false
+
       - id: metadata-events-mxe-registration-spotless
         name: metadata-events/mxe-registration Spotless Apply
         entry: ./gradlew :metadata-events:mxe-registration:spotlessApply -x generateGitPropertiesGlobal
         language: system
         files: ^metadata-events/mxe-registration/.*\.java$
+        pass_filenames: false
+
+      - id: metadata-events-mxe-schemas-spotless
+        name: metadata-events/mxe-schemas Spotless Apply
+        entry: ./gradlew :metadata-events:mxe-schemas:spotlessApply -x generateGitPropertiesGlobal
+        language: system
+        files: ^metadata-events/mxe-schemas/.*\.java$
         pass_filenames: false
 
       - id: metadata-events-mxe-utils-avro-spotless
@@ -530,13 +544,13 @@ repos:
         language: system
         files: ^docker/.*$
         pass_filenames: false
-  - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.11
-    hooks:
 
-      - id: actionlint
+      - id: actionlint-docker
         name: Lint GitHub Actions workflow files
-        description: Runs actionlint to lint GitHub Actions workflow files
+        description: Runs actionlint Docker image to lint GitHub Actions workflow
+          files
+        language: docker_image
         types:
           - yaml
         files: ^\.github/workflows/
+        entry: docker.io/rhysd/actionlint:1.7.11


### PR DESCRIPTION
The github based install hook required people to install the go toolchain on their systems.
Instead moving to a docker based pre-commit hook to remove that dependency.
 
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
