### PR TITLE
docs(deploy): Fixed two small sets of typos

### DIFF
--- a/docs/deploy/kubernetes.md
+++ b/docs/deploy/kubernetes.md
@@ -8,8 +8,8 @@ title: "Deploying with Kubernetes"
 
 Helm charts for deploying DataHub on a kubernetes cluster is located in
 this [repository](https://github.com/acryldata/datahub-helm). We provide charts for
-deploying [Datahub](https://github.com/acryldata/datahub-helm/tree/master/charts/datahub) and
-it's [dependencies](https://github.com/acryldata/datahub-helm/tree/master/charts/prerequisites)
+deploying [DataHub](https://github.com/acryldata/datahub-helm/tree/master/charts/datahub) and
+its [dependencies](https://github.com/acryldata/datahub-helm/tree/master/charts/prerequisites)
 (Elasticsearch, optionally Neo4j, MySQL, and Kafka) on a Kubernetes cluster.
 
 This doc is a guide to deploy an instance of DataHub on a kubernetes cluster using the above charts from scratch.
@@ -21,7 +21,7 @@ This doc is a guide to deploy an instance of DataHub on a kubernetes cluster usi
      [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine),
      and [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/) OR
    - In local environment using [Minikube](https://minikube.sigs.k8s.io/docs/). Note, more than 7GB of RAM is required
-     to run Datahub and it's dependencies
+     to run DataHub and its dependencies
 2. Install the following tools:
    - [kubectl](https://kubernetes.io/docs/tasks/tools/) to manage kubernetes resources
    - [helm](https://helm.sh/docs/intro/install/) to deploy the resources based on helm charts. Note, we only support
@@ -29,12 +29,12 @@ This doc is a guide to deploy an instance of DataHub on a kubernetes cluster usi
 
 ## Components
 
-Datahub consists of 4 main components: [GMS](https://docs.datahub.com/docs/metadata-service),
+DataHub consists of 4 main components: [GMS](https://docs.datahub.com/docs/metadata-service),
 [MAE Consumer](https://docs.datahub.com/docs/metadata-jobs/mae-consumer-job) (optional),
 [MCE Consumer](https://docs.datahub.com/docs/metadata-jobs/mce-consumer-job) (optional), and
 [Frontend](https://docs.datahub.com/docs/datahub-frontend). Kubernetes deployment for each of the components are
 defined as subcharts under the main
-[Datahub](https://github.com/acryldata/datahub-helm/tree/master/charts/datahub)
+[DataHub](https://github.com/acryldata/datahub-helm/tree/master/charts/datahub)
 helm chart.
 
 The main components are powered by 4 external dependencies:
@@ -44,7 +44,7 @@ The main components are powered by 4 external dependencies:
 - Search Index (Elasticsearch)
 - Graph Index (Supports either Neo4j or Elasticsearch)
 
-The dependencies must be deployed before deploying Datahub. We created a separate
+The dependencies must be deployed before deploying DataHub. We created a separate
 [chart](https://github.com/acryldata/datahub-helm/tree/master/charts/prerequisites)
 for deploying the dependencies with example configuration. They could also be deployed separately on-prem or leveraged
 as managed services. To remove your dependency on Neo4j, set enabled to false in
@@ -100,7 +100,7 @@ prerequisites-neo4j-community-0                    1/1     Running     0        
 prerequisites-zookeeper-0                          1/1     Running     0          62m
 ```
 
-deploy Datahub by running the following
+deploy DataHub by running the following
 
 ```(shell)
 helm install datahub datahub/datahub


### PR DESCRIPTION
docs(deploy): Fixed two small sets of typos

- it's -> its
- Datahub -> DataHub

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)