### PR TITLE
fix(ingest): handle null error_after criteria in dbt source freshness assertions

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_tests.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_tests.py
@@ -72,9 +72,13 @@ def parse_freshness_criteria(data: Optional[Dict]) -> Optional[DBTFreshnessCrite
     """Parse warn_after or error_after criteria dict into DBTFreshnessCriteria."""
     if not data:
         return None
+    count = data.get("count")
+    period = data.get("period")
+    if count is None or period is None:
+        return None
     return DBTFreshnessCriteria(
-        count=data.get("count", 0),
-        period=data.get("period", "hour"),
+        count=count,
+        period=period,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #16293

When a dbt source defines `freshness.warn_after` but not `freshness.error_after`, some dbt versions serialize the missing criteria as `{"count": null, "period": null}` rather than `null`. This caused `parse_freshness_criteria` to create a truthy `DBTFreshnessCriteria(count=None, period=None)` object, bypassing the guard in `make_assertion_from_freshness` and producing an invalid `AssertionInfo` work unit with `"None"` string values — failing validation and blocking stale entity removal.

**Fix:** `parse_freshness_criteria` now returns `None` when `count` or `period` is `None`, treating a dict with null fields the same as a missing/null criteria block.

## Changes

- `parse_freshness_criteria` in `dbt_tests.py`: return `None` when `count` or `period` is `None`
- Added `test_parse_freshness_criteria_with_null_fields`: covers all null/empty input edge cases
- Added `test_make_assertion_from_freshness_warn_only`: end-to-end test for a warn-only freshness assertion including serialization

## Test plan

- [x] `test_parse_freshness_criteria_with_null_fields` — verifies null count/period handling
- [x] `test_make_assertion_from_freshness_warn_only` — verifies warn-only assertion is valid and serializable
- [x] Existing freshness tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)