### PR TITLE
fix(ui) Fix casing typo in DataHub name

### DIFF
--- a/datahub-web-react/src/app/auth/shared/ModalHeader.tsx
+++ b/datahub-web-react/src/app/auth/shared/ModalHeader.tsx
@@ -33,7 +33,7 @@ export default function ModalHeader({ subHeading }: Props) {
             <LogoImage src={themeConfig.assets?.logoUrl} preview={false} />
             <HeaderText>
                 <Text size="3xl" color="gray" colorLevel={600} weight="bold" lineHeight="normal">
-                    Welcome to Datahub
+                    Welcome to DataHub
                 </Text>
                 {subHeading && (
                     <Text size="lg" color="gray" colorLevel={1700} lineHeight="normal">

--- a/datahub-web-react/src/app/sharedV2/ErrorHandling/ErrorBoundary.tsx
+++ b/datahub-web-react/src/app/sharedV2/ErrorHandling/ErrorBoundary.tsx
@@ -16,7 +16,7 @@ const logError = (error: Error, info: { componentStack: string }) => {
     console.error('Component Info:', info);
     console.error('URL:', window.location.href);
 
-    console.warn('🔧 ACTION REQUIRED: Please report this error to your Datahub Administrator');
+    console.warn('🔧 ACTION REQUIRED: Please report this error to your DataHub Administrator');
     console.warn('📧 Include the above error details in your report');
     console.groupEnd();
 };
@@ -28,7 +28,7 @@ export const ErrorBoundary = ({ children, variant = 'route', fallback, resetKeys
             <ErrorFallback
                 variant={variant}
                 // Custom message for on-prem customers
-                actionMessage="Please report the error messages from your browser to your Datahub Administrator"
+                actionMessage="Please report the error messages from your browser to your DataHub Administrator"
             />
         ));
 


### PR DESCRIPTION
Fixes the few places we say "Datahub" instead of "DataHub" in the app.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
