### PR TITLE
fix(ci): fix PR lookup in connector-tests-trigger

### DIFF
--- a/.github/workflows/connector-tests-trigger.yml
+++ b/.github/workflows/connector-tests-trigger.yml
@@ -77,9 +77,9 @@ jobs:
         run: |
           BRANCH="${{ github.event.workflow_run.head_branch }}"
           REPO="${{ github.repository }}"
-          HEAD_REPO="${{ github.event.workflow_run.head_repository.full_name }}"
+          HEAD_OWNER="${{ github.event.workflow_run.head_repository.owner.login }}"
 
-          PR_NUMBER=$(gh api "/repos/${REPO}/pulls?head=${HEAD_REPO}:${BRANCH}&state=open" \
+          PR_NUMBER=$(gh api "/repos/${REPO}/pulls?head=${HEAD_OWNER}:${BRANCH}&state=open" \
             --jq '.[0].number // empty')
 
           if [ -z "$PR_NUMBER" ]; then


### PR DESCRIPTION
## Summary
- One-line fix: GitHub Pulls API `head` parameter expects `owner:branch`, not `owner/repo:branch`
- `head_repository.full_name` (`datahub-project/datahub`) → `head_repository.owner.login` (`datahub-project`)
- This caused PR lookup to always return empty, preventing connector tests dispatch

## Evidence
From the [W2 run logs](https://github.com/datahub-project/datahub/actions/runs/22294338596):
```
HEAD_REPO="datahub-project/datahub"
gh api "/repos/.../pulls?head=datahub-project/datahub:test/connector-tests-e2e-validation&state=open"
→ No open PR found
```

Verified locally:
```bash
# Wrong (returns nothing)
gh api "/repos/.../pulls?head=datahub-project/datahub:branch&state=open"

# Correct (returns PR)
gh api "/repos/.../pulls?head=datahub-project:branch&state=open"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)