### PR TITLE
feat(views): redesign view builder with updated filters and UX improvements AI-377

### DIFF
--- a/datahub-web-react/src/app/entityV2/view/ViewTypeLabel.tsx
+++ b/datahub-web-react/src/app/entityV2/view/ViewTypeLabel.tsx
@@ -1,15 +1,8 @@
-import { Icon, Tooltip } from '@components';
-import { Typography } from 'antd';
+import { Icon, Text, Tooltip } from '@components';
 import React from 'react';
 import styled from 'styled-components';
 
 import { DataHubViewType } from '@types';
-
-const StyledText = styled(Typography.Text)<{ color }>`
-    && {
-        color: ${(props) => props.color};
-    }
-`;
 
 type Props = {
     type: DataHubViewType;
@@ -36,9 +29,9 @@ export const ViewTypeLabel = ({ type, color, onClick }: Props) => {
             <ViewNameContainer onClick={onClick}>
                 {!isPersonal && <Icon source="phosphor" icon="Globe" size="md" />}
                 {isPersonal && <Icon source="phosphor" icon="Lock" size="md" />}
-                <StyledText color={color} type="secondary">
+                <Text type="span" color="gray" style={{ color }}>
                     {!isPersonal ? 'Public' : 'Private'}
-                </StyledText>
+                </Text>
             </ViewNameContainer>
         </Tooltip>
     );

--- a/datahub-web-react/src/app/entityV2/view/builder/SelectFilterValuesTab.tsx
+++ b/datahub-web-react/src/app/entityV2/view/builder/SelectFilterValuesTab.tsx
@@ -1,0 +1,217 @@
+import { Checkbox, Loader, SearchBar, Text, colors } from '@components';
+import React, { useCallback, useMemo, useState } from 'react';
+import styled from 'styled-components';
+
+import { SelectedFilterValues } from '@app/entityV2/view/builder/SelectedFilterValues';
+import { SELECTABLE_ASSET_ENTITY_TYPES } from '@app/entityV2/view/builder/constants';
+import AssetFilters from '@app/homeV3/modules/assetCollection/AssetFilters';
+import AutoCompleteEntityItem from '@app/searchV2/autoCompleteV2/AutoCompleteEntityItem';
+import { getEntityDisplayType } from '@app/searchV2/autoCompleteV2/utils';
+import useAppliedFilters from '@app/searchV2/filtersV2/context/useAppliedFilters';
+import { convertFiltersMapToFilters } from '@app/searchV2/filtersV2/utils';
+import { UnionType } from '@app/searchV2/utils/constants';
+import { generateOrFilters } from '@app/searchV2/utils/generateOrFilters';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
+import { Entity } from '@types';
+
+const Container = styled.div`
+    display: flex;
+    width: 100%;
+    gap: 8px;
+`;
+
+const LeftSection = styled.div`
+    flex: 6;
+    min-width: 0;
+`;
+
+const RightSection = styled.div`
+    flex: 4;
+    width: calc(40% - 20px);
+`;
+
+const VerticalDivider = styled.div`
+    width: 1px;
+    background-color: ${colors.gray[100]};
+`;
+
+const SearchHeader = styled(Text)`
+    margin-bottom: 8px;
+`;
+
+const ResultsContainer = styled.div`
+    margin: 0 -16px 0 -8px;
+    position: relative;
+    max-height: 300px;
+    padding-right: 8px;
+`;
+
+const ScrollableResultsContainer = styled.div`
+    max-height: inherit;
+    overflow-y: auto;
+`;
+
+const LoaderContainer = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+`;
+
+const ItemDetailsContainer = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const EmptyContainer = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+`;
+
+const ResultItemWrapper = styled.div`
+    cursor: pointer;
+`;
+
+type Props = {
+    selectedUrns: string[];
+    onChangeSelectedUrns: (urns: string[]) => void;
+};
+
+export function SelectFilterValuesTab({ selectedUrns, onChangeSelectedUrns }: Props) {
+    const entityRegistry = useEntityRegistryV2();
+    const [searchQuery, setSearchQuery] = useState<string | undefined>();
+    const { appliedFilters, updateFieldFilters } = useAppliedFilters();
+
+    const filters = useMemo(() => convertFiltersMapToFilters(appliedFilters), [appliedFilters]);
+    const orFilters = generateOrFilters(UnionType.AND, filters);
+
+    const { data, loading } = useGetSearchResultsForMultipleQuery({
+        variables: {
+            input: {
+                query: searchQuery || '*',
+                start: 0,
+                count: 20,
+                types: SELECTABLE_ASSET_ENTITY_TYPES,
+                orFilters,
+                searchFlags: {
+                    skipCache: true,
+                },
+            },
+        },
+    });
+
+    const entities = useMemo(
+        () =>
+            data?.searchAcrossEntities?.searchResults
+                ?.map((res) => res.entity)
+                .filter((entity): entity is Entity => !!entity) || [],
+        [data],
+    );
+
+    const handleCheckboxChange = useCallback(
+        (urn: string) => {
+            if (selectedUrns.includes(urn)) {
+                onChangeSelectedUrns(selectedUrns.filter((u) => u !== urn));
+            } else {
+                onChangeSelectedUrns([...selectedUrns, urn]);
+            }
+        },
+        [selectedUrns, onChangeSelectedUrns],
+    );
+
+    const handleRemoveUrn = useCallback(
+        (urn: string) => {
+            onChangeSelectedUrns(selectedUrns.filter((u) => u !== urn));
+        },
+        [selectedUrns, onChangeSelectedUrns],
+    );
+
+    const customDetailsRenderer = useCallback(
+        (entity: Entity) => {
+            const displayType = getEntityDisplayType(entity, entityRegistry);
+            return (
+                <ItemDetailsContainer>
+                    <Text color="gray" size="sm">
+                        {displayType}
+                    </Text>
+                    <Checkbox
+                        size="xs"
+                        isChecked={selectedUrns.includes(entity.urn)}
+                        onCheckboxChange={() => handleCheckboxChange(entity.urn)}
+                        data-testid="filter-value-selection-checkbox"
+                    />
+                </ItemDetailsContainer>
+            );
+        },
+        [selectedUrns, handleCheckboxChange, entityRegistry],
+    );
+
+    const content = useMemo(() => {
+        if (loading) {
+            return (
+                <LoaderContainer>
+                    <Loader />
+                </LoaderContainer>
+            );
+        }
+        if (entities.length > 0) {
+            return entities.map((entity) => (
+                <ResultItemWrapper
+                    key={entity.urn}
+                    onClick={() => handleCheckboxChange(entity.urn)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            handleCheckboxChange(entity.urn);
+                        }
+                    }}
+                >
+                    <AutoCompleteEntityItem
+                        entity={entity}
+                        customDetailsRenderer={customDetailsRenderer}
+                        padding="8px 0 8px 8px"
+                    />
+                </ResultItemWrapper>
+            ));
+        }
+        return (
+            <EmptyContainer>
+                <Text color="gray">No results found.</Text>
+            </EmptyContainer>
+        );
+    }, [loading, entities, handleCheckboxChange, customDetailsRenderer]);
+
+    return (
+        <Container>
+            <LeftSection>
+                <SearchHeader color="gray" weight="bold">
+                    Search and Select Assets
+                </SearchHeader>
+                <SearchBar
+                    value={searchQuery}
+                    onChange={setSearchQuery}
+                    placeholder="Search datasets, dashboards, domains..."
+                />
+                <AssetFilters
+                    searchQuery={searchQuery}
+                    appliedFilters={appliedFilters}
+                    updateFieldFilters={updateFieldFilters}
+                />
+                <ResultsContainer>
+                    <ScrollableResultsContainer data-testid="select-filter-values-search-results">
+                        {content}
+                    </ScrollableResultsContainer>
+                </ResultsContainer>
+            </LeftSection>
+            <VerticalDivider />
+            <RightSection>
+                <SelectedFilterValues selectedUrns={selectedUrns} onRemoveUrn={handleRemoveUrn} />
+            </RightSection>
+        </Container>
+    );
+}

--- a/datahub-web-react/src/app/entityV2/view/builder/SelectedFilterValues.tsx
+++ b/datahub-web-react/src/app/entityV2/view/builder/SelectedFilterValues.tsx
@@ -1,0 +1,127 @@
+import { Icon, Text } from '@components';
+import React, { useCallback, useMemo } from 'react';
+import styled from 'styled-components';
+
+import { buildEntityMap } from '@app/entityV2/view/builder/utils';
+import EntityItem from '@app/homeV3/module/components/EntityItem';
+import { useGetEntities } from '@app/sharedV2/useGetEntities';
+import { useEntityRegistryV2 } from '@app/useEntityRegistry';
+
+import { DataHubPageModuleType, Entity } from '@types';
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+`;
+
+const ResultsContainer = styled.div`
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+    max-height: 300px;
+`;
+
+const EmptyContainer = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 80px;
+`;
+
+const GroupLabel = styled(Text)`
+    margin-top: 4px;
+`;
+
+const StyledIcon = styled(Icon)`
+    :hover {
+        cursor: pointer;
+    }
+`;
+
+type Props = {
+    selectedUrns: string[];
+    onRemoveUrn: (urn: string) => void;
+};
+
+/**
+ * Displays selected assets grouped by entity type, with remove buttons.
+ */
+export function SelectedFilterValues({ selectedUrns, onRemoveUrn }: Props) {
+    const entityRegistry = useEntityRegistryV2();
+    const { entities } = useGetEntities(selectedUrns);
+
+    const entitiesMap = useMemo(() => buildEntityMap(entities), [entities]);
+
+    // Group resolved entities by their entity type for display
+    const groupedByType = useMemo(() => {
+        const groups: Record<string, Entity[]> = {};
+        selectedUrns.forEach((urn) => {
+            const entity = entitiesMap[urn];
+            if (!entity) return;
+            const typeLabel = entityRegistry.getEntityName(entity.type) ?? entity.type;
+            if (!groups[typeLabel]) {
+                groups[typeLabel] = [];
+            }
+            groups[typeLabel].push(entity);
+        });
+        return groups;
+    }, [selectedUrns, entitiesMap, entityRegistry]);
+
+    const renderRemoveButton = useCallback(
+        (entity: Entity) => {
+            return (
+                <StyledIcon
+                    icon="X"
+                    source="phosphor"
+                    color="gray"
+                    size="md"
+                    onClick={(e) => {
+                        e.preventDefault();
+                        onRemoveUrn(entity.urn);
+                    }}
+                />
+            );
+        },
+        [onRemoveUrn],
+    );
+
+    if (selectedUrns.length === 0) {
+        return (
+            <Container>
+                <Text color="gray" weight="bold">
+                    Selected Assets
+                </Text>
+                <EmptyContainer>
+                    <Text color="gray">No assets selected.</Text>
+                </EmptyContainer>
+            </Container>
+        );
+    }
+
+    return (
+        <Container>
+            <Text color="gray" weight="bold">
+                Selected Assets
+            </Text>
+            <ResultsContainer data-testid="selected-filter-values-list">
+                {Object.entries(groupedByType).map(([typeLabel, typeEntities]) => (
+                    <div key={typeLabel}>
+                        <GroupLabel color="gray" size="sm" weight="bold">
+                            {typeLabel}
+                        </GroupLabel>
+                        {typeEntities.map((entity) => (
+                            <EntityItem
+                                key={entity.urn}
+                                entity={entity}
+                                customDetailsRenderer={renderRemoveButton}
+                                navigateOnlyOnNameClick
+                                hideSubtitle
+                                moduleType={DataHubPageModuleType.AssetCollection}
+                            />
+                        ))}
+                    </div>
+                ))}
+            </ResultsContainer>
+        </Container>
+    );
+}

--- a/datahub-web-react/src/app/entityV2/view/builder/ViewBuilder.tsx
+++ b/datahub-web-react/src/app/entityV2/view/builder/ViewBuilder.tsx
@@ -1,5 +1,4 @@
 import { useApolloClient } from '@apollo/client';
-import { message } from 'antd';
 import React from 'react';
 
 import analytics, { EventType } from '@app/analytics';
@@ -10,6 +9,7 @@ import { updateListMyViewsCache, updateViewSelectCache } from '@app/entityV2/vie
 import { ViewBuilderState } from '@app/entityV2/view/types';
 import { DEFAULT_LIST_VIEWS_PAGE_SIZE, convertStateToUpdateInput } from '@app/entityV2/view/utils';
 import { useSearchVersion } from '@app/search/useSearchAndBrowseVersion';
+import { notification } from '@src/alchemy-components';
 
 import { useCreateViewMutation, useUpdateViewMutation } from '@graphql/view.generated';
 import { DataHubView } from '@types';
@@ -109,9 +109,9 @@ export const ViewBuilder = ({ mode, urn, initialState, onSubmit, onCancel }: Pro
                 onSubmit?.(state);
             })
             .catch((_) => {
-                message.destroy();
-                message.error({
-                    content: `Failed to save View! An unexpected error occurred.`,
+                notification.error({
+                    message: 'Failed to save View',
+                    description: 'An unexpected error occurred.',
                     duration: 3,
                 });
             });

--- a/datahub-web-react/src/app/entityV2/view/builder/__tests__/viewBuilderUtils.test.ts
+++ b/datahub-web-react/src/app/entityV2/view/builder/__tests__/viewBuilderUtils.test.ts
@@ -1,0 +1,464 @@
+import { BUILD_FILTERS_TAB_KEY, SELECT_ASSETS_TAB_KEY, URN_FILTER_NAME } from '@app/entityV2/view/builder/constants';
+import {
+    buildEntityMap,
+    buildViewDefinition,
+    filtersToLogicalPredicate,
+    filtersToSelectedUrns,
+    getInitialTabKey,
+    logicalPredicateToFilters,
+    mapConditionToUiOperator,
+    mapUiOperatorToCondition,
+    selectedUrnsToFilters,
+} from '@app/entityV2/view/builder/utils';
+import { LogicalOperatorType, LogicalPredicate } from '@app/sharedV2/queryBuilder/builder/types';
+
+import { FilterOperator, LogicalOperator } from '@types';
+
+describe('View builder conversion utils', () => {
+    describe('selectedUrnsToFilters', () => {
+        it('should store all URNs under the urn filter field', () => {
+            const selectedUrns = ['urn:li:domain:marketing', 'urn:li:dataset:(urn:li:dataPlatform:bigquery,t,PROD)'];
+
+            const result = selectedUrnsToFilters(selectedUrns);
+
+            expect(result).toEqual([
+                {
+                    field: URN_FILTER_NAME,
+                    values: ['urn:li:domain:marketing', 'urn:li:dataset:(urn:li:dataPlatform:bigquery,t,PROD)'],
+                },
+            ]);
+        });
+
+        it('should return empty array when no URNs are provided', () => {
+            expect(selectedUrnsToFilters([])).toEqual([]);
+        });
+
+        it('should produce a single urn filter regardless of entity types', () => {
+            const selectedUrns = [
+                'urn:li:domain:marketing',
+                'urn:li:tag:pii',
+                'urn:li:corpuser:john',
+                'urn:li:dataset:(urn:li:dataPlatform:bigquery,proj.table,PROD)',
+            ];
+
+            const result = selectedUrnsToFilters(selectedUrns);
+
+            expect(result).toHaveLength(1);
+            expect(result[0].field).toBe(URN_FILTER_NAME);
+            expect(result[0].values).toHaveLength(4);
+        });
+    });
+
+    describe('logicalPredicateToFilters', () => {
+        it('should return empty filters for null predicate', () => {
+            const result = logicalPredicateToFilters(null);
+            expect(result).toEqual({ operator: LogicalOperator.And, filters: [] });
+        });
+
+        it('should return empty filters for undefined predicate', () => {
+            const result = logicalPredicateToFilters(undefined);
+            expect(result).toEqual({ operator: LogicalOperator.And, filters: [] });
+        });
+
+        it('should convert AND predicate with property operands and preserve operators', () => {
+            const predicate: LogicalPredicate = {
+                type: 'logical',
+                operator: LogicalOperatorType.AND,
+                operands: [
+                    { type: 'property', property: 'domains', operator: 'equals', values: ['urn:li:domain:marketing'] },
+                    { type: 'property', property: 'tags', operator: 'exists', values: [] },
+                ],
+            };
+
+            const result = logicalPredicateToFilters(predicate);
+
+            expect(result.operator).toBe(LogicalOperator.And);
+            expect(result.filters).toHaveLength(2);
+            expect(result.filters[0].field).toBe('domains');
+            expect(result.filters[0].condition).toBe(FilterOperator.Equal);
+            expect(result.filters[1].field).toBe('tags');
+            expect(result.filters[1].condition).toBe(FilterOperator.Exists);
+        });
+
+        it('should convert OR predicate', () => {
+            const predicate: LogicalPredicate = {
+                type: 'logical',
+                operator: LogicalOperatorType.OR,
+                operands: [
+                    { type: 'property', property: 'domains', operator: 'equals', values: ['urn:li:domain:marketing'] },
+                ],
+            };
+
+            const result = logicalPredicateToFilters(predicate);
+
+            expect(result.operator).toBe(LogicalOperator.Or);
+        });
+
+        it('should flatten nested groups into a flat filter list', () => {
+            const predicate: LogicalPredicate = {
+                type: 'logical',
+                operator: LogicalOperatorType.AND,
+                operands: [
+                    {
+                        type: 'logical',
+                        operator: LogicalOperatorType.AND,
+                        operands: [
+                            {
+                                type: 'property',
+                                property: 'domains',
+                                operator: 'equals',
+                                values: ['urn:li:domain:marketing'],
+                            },
+                        ],
+                    },
+                    {
+                        type: 'logical',
+                        operator: LogicalOperatorType.AND,
+                        operands: [
+                            {
+                                type: 'property',
+                                property: 'tags',
+                                operator: 'equals',
+                                values: ['urn:li:tag:pii'],
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            const result = logicalPredicateToFilters(predicate);
+
+            expect(result.filters).toHaveLength(2);
+            expect(result.filters[0].field).toBe('domains');
+            expect(result.filters[1].field).toBe('tags');
+        });
+
+        it('should inject boolean values for is_true/is_false operators', () => {
+            const predicate: LogicalPredicate = {
+                type: 'logical',
+                operator: LogicalOperatorType.AND,
+                operands: [
+                    { type: 'property', property: 'hasDescription', operator: 'is_true', values: [] },
+                    { type: 'property', property: 'removed', operator: 'is_false', values: [] },
+                ],
+            };
+
+            const result = logicalPredicateToFilters(predicate);
+
+            expect(result.filters).toHaveLength(2);
+            expect(result.filters[0].field).toBe('hasDescription');
+            expect(result.filters[0].values).toEqual(['true']);
+            expect(result.filters[0].condition).toBe(FilterOperator.Equal);
+            expect(result.filters[1].field).toBe('removed');
+            expect(result.filters[1].values).toEqual(['false']);
+            expect(result.filters[1].condition).toBe(FilterOperator.Equal);
+        });
+
+        it('should set negated on filters inside a NOT predicate', () => {
+            const predicate: LogicalPredicate = {
+                type: 'logical',
+                operator: LogicalOperatorType.NOT,
+                operands: [
+                    { type: 'property', property: 'domains', operator: 'equals', values: ['urn:li:domain:marketing'] },
+                ],
+            };
+
+            const result = logicalPredicateToFilters(predicate);
+
+            expect(result.filters).toHaveLength(1);
+            expect(result.filters[0].negated).toBe(true);
+        });
+    });
+
+    describe('filtersToSelectedUrns', () => {
+        it('should extract URNs from the urn filter field', () => {
+            const filters = [
+                {
+                    field: URN_FILTER_NAME,
+                    values: ['urn:li:domain:marketing', 'urn:li:dataset:(urn:li:dataPlatform:bigquery,t,PROD)'],
+                },
+            ];
+
+            const result = filtersToSelectedUrns(filters);
+
+            expect(result).toEqual(['urn:li:domain:marketing', 'urn:li:dataset:(urn:li:dataPlatform:bigquery,t,PROD)']);
+        });
+
+        it('should return empty array when no urn filter exists', () => {
+            const filters = [
+                { field: '_entityType', values: ['DATASETS'] },
+                { field: 'domains', values: ['urn:li:domain:marketing'] },
+            ];
+
+            expect(filtersToSelectedUrns(filters)).toEqual([]);
+        });
+
+        it('should return empty array for empty filters', () => {
+            expect(filtersToSelectedUrns([])).toEqual([]);
+        });
+
+        it('should ignore non-urn filter fields', () => {
+            const filters = [
+                { field: 'domains', values: ['urn:li:domain:marketing'] },
+                { field: 'tags', values: ['urn:li:tag:pii'] },
+                { field: URN_FILTER_NAME, values: ['urn:li:dataset:(urn:li:dataPlatform:bigquery,t,PROD)'] },
+            ];
+
+            const result = filtersToSelectedUrns(filters);
+
+            expect(result).toEqual(['urn:li:dataset:(urn:li:dataPlatform:bigquery,t,PROD)']);
+        });
+    });
+
+    describe('filtersToLogicalPredicate', () => {
+        it('should convert AND filters to a LogicalPredicate', () => {
+            const filters = [
+                { field: 'domains', values: ['urn:li:domain:marketing'] },
+                { field: 'tags', values: ['urn:li:tag:pii'] },
+            ];
+
+            const result = filtersToLogicalPredicate(LogicalOperator.And, filters);
+
+            expect(result.operator).toBe(LogicalOperatorType.AND);
+            expect(result.operands).toHaveLength(2);
+        });
+
+        it('should convert OR operator', () => {
+            const filters = [{ field: 'domains', values: ['urn:li:domain:marketing'] }];
+            const result = filtersToLogicalPredicate(LogicalOperator.Or, filters);
+            expect(result.operator).toBe(LogicalOperatorType.OR);
+        });
+
+        it('should default to AND when operator is undefined', () => {
+            const result = filtersToLogicalPredicate(undefined, []);
+            expect(result.operator).toBe(LogicalOperatorType.AND);
+            expect(result.operands).toHaveLength(0);
+        });
+
+        it('should restore UI operator from filter condition', () => {
+            const filters = [
+                { field: 'domains', values: ['urn:li:domain:marketing'], condition: FilterOperator.Equal },
+                { field: 'tags', values: [], condition: FilterOperator.Exists },
+            ];
+
+            const result = filtersToLogicalPredicate(LogicalOperator.And, filters);
+
+            expect(result.operands).toHaveLength(2);
+            const op0 = result.operands[0] as { operator?: string };
+            const op1 = result.operands[1] as { operator?: string };
+            expect(op0.operator).toBe('equals');
+            expect(op1.operator).toBe('exists');
+        });
+
+        it('should use NOT operator when all filters are negated', () => {
+            const filters = [
+                { field: 'domains', values: ['urn:li:domain:marketing'], negated: true },
+                { field: 'tags', values: ['urn:li:tag:pii'], negated: true },
+            ];
+
+            const result = filtersToLogicalPredicate(LogicalOperator.And, filters);
+
+            expect(result.operator).toBe(LogicalOperatorType.NOT);
+        });
+
+        it('should default to equals when condition is undefined', () => {
+            const filters = [{ field: 'domains', values: ['urn:li:domain:marketing'] }];
+
+            const result = filtersToLogicalPredicate(LogicalOperator.And, filters);
+
+            const op0 = result.operands[0] as { operator?: string };
+            expect(op0.operator).toBe('equals');
+        });
+
+        it('should restore is_true/is_false and clear boolean values', () => {
+            const filters = [
+                { field: 'hasDescription', values: ['true'], condition: FilterOperator.Equal },
+                { field: 'removed', values: ['false'], condition: FilterOperator.Equal },
+            ];
+
+            const result = filtersToLogicalPredicate(LogicalOperator.And, filters);
+
+            const op0 = result.operands[0] as { operator?: string; values?: string[] };
+            const op1 = result.operands[1] as { operator?: string; values?: string[] };
+            expect(op0.operator).toBe('is_true');
+            expect(op0.values).toEqual([]);
+            expect(op1.operator).toBe('is_false');
+            expect(op1.values).toEqual([]);
+        });
+    });
+
+    describe('getInitialTabKey', () => {
+        it('should return Build Filters tab when filters are empty', () => {
+            expect(getInitialTabKey([])).toBe(BUILD_FILTERS_TAB_KEY);
+        });
+
+        it('should return Select Assets tab when filters contain the "urn" field', () => {
+            const filters = [
+                { field: URN_FILTER_NAME, values: ['urn:li:dataset:(urn:li:dataPlatform:bigquery,t,PROD)'] },
+            ];
+            expect(getInitialTabKey(filters)).toBe(SELECT_ASSETS_TAB_KEY);
+        });
+
+        it('should return Build Filters tab for domain filters', () => {
+            const filters = [{ field: 'domains', values: ['urn:li:domain:marketing'] }];
+            expect(getInitialTabKey(filters)).toBe(BUILD_FILTERS_TAB_KEY);
+        });
+
+        it('should return Build Filters tab for dynamic-only fields', () => {
+            const filters = [{ field: '_entityType', values: ['DATASETS'] }];
+            expect(getInitialTabKey(filters)).toBe(BUILD_FILTERS_TAB_KEY);
+        });
+
+        it('should return Select Assets tab when urn field is mixed with other fields', () => {
+            const filters = [
+                { field: URN_FILTER_NAME, values: ['urn:li:dataset:(urn:li:dataPlatform:bigquery,t,PROD)'] },
+                { field: 'domains', values: ['urn:li:domain:marketing'] },
+            ];
+            expect(getInitialTabKey(filters)).toBe(SELECT_ASSETS_TAB_KEY);
+        });
+    });
+
+    describe('buildViewDefinition', () => {
+        it('should build a valid view definition with AND operator', () => {
+            const filters = [{ field: URN_FILTER_NAME, values: ['urn:li:domain:marketing'] }];
+
+            const result = buildViewDefinition(LogicalOperator.And, filters);
+
+            expect(result.entityTypes).toEqual([]);
+            expect(result.filter?.operator).toBe(LogicalOperator.And);
+            expect(result.filter?.filters).toHaveLength(1);
+        });
+    });
+
+    describe('mapUiOperatorToCondition', () => {
+        it('should map known UI operators to backend FilterOperator', () => {
+            expect(mapUiOperatorToCondition('equals')).toBe(FilterOperator.Equal);
+            expect(mapUiOperatorToCondition('exists')).toBe(FilterOperator.Exists);
+            expect(mapUiOperatorToCondition('contains_str')).toBe(FilterOperator.Contain);
+            expect(mapUiOperatorToCondition('greater_than')).toBe(FilterOperator.GreaterThan);
+            expect(mapUiOperatorToCondition('less_than')).toBe(FilterOperator.LessThan);
+        });
+
+        it('should map boolean operators to Equal', () => {
+            expect(mapUiOperatorToCondition('is_true')).toBe(FilterOperator.Equal);
+            expect(mapUiOperatorToCondition('is_false')).toBe(FilterOperator.Equal);
+        });
+
+        it('should return undefined for undefined input', () => {
+            expect(mapUiOperatorToCondition(undefined)).toBeUndefined();
+        });
+
+        it('should fall back to Equal for unknown operators', () => {
+            expect(mapUiOperatorToCondition('some_unknown_op')).toBe(FilterOperator.Equal);
+        });
+    });
+
+    describe('mapConditionToUiOperator', () => {
+        it('should map known backend conditions to UI operators', () => {
+            expect(mapConditionToUiOperator(FilterOperator.Equal)).toBe('equals');
+            expect(mapConditionToUiOperator(FilterOperator.Exists)).toBe('exists');
+            expect(mapConditionToUiOperator(FilterOperator.Contain)).toBe('contains_str');
+            expect(mapConditionToUiOperator(FilterOperator.GreaterThan)).toBe('greater_than');
+        });
+
+        it('should detect is_true from Equal condition with value ["true"]', () => {
+            expect(mapConditionToUiOperator(FilterOperator.Equal, ['true'])).toBe('is_true');
+        });
+
+        it('should detect is_false from Equal condition with value ["false"]', () => {
+            expect(mapConditionToUiOperator(FilterOperator.Equal, ['false'])).toBe('is_false');
+        });
+
+        it('should return equals for Equal condition with non-boolean values', () => {
+            expect(mapConditionToUiOperator(FilterOperator.Equal, ['urn:li:domain:marketing'])).toBe('equals');
+            expect(mapConditionToUiOperator(FilterOperator.Equal, ['true', 'false'])).toBe('equals');
+        });
+
+        it('should default to equals for null/undefined', () => {
+            expect(mapConditionToUiOperator(null)).toBe('equals');
+            expect(mapConditionToUiOperator(undefined)).toBe('equals');
+        });
+    });
+
+    describe('round-trip: logicalPredicateToFilters → filtersToLogicalPredicate', () => {
+        it('should preserve operators through a full save/load cycle', () => {
+            const original: LogicalPredicate = {
+                type: 'logical',
+                operator: LogicalOperatorType.AND,
+                operands: [
+                    { type: 'property', property: 'domains', operator: 'equals', values: ['urn:li:domain:finance'] },
+                    { type: 'property', property: 'platform', operator: 'exists', values: [] },
+                ],
+            };
+
+            const { operator, filters } = logicalPredicateToFilters(original);
+            const restored = filtersToLogicalPredicate(operator, filters);
+
+            expect(restored.operator).toBe(LogicalOperatorType.AND);
+            expect(restored.operands).toHaveLength(2);
+            const op0 = restored.operands[0] as { property?: string; operator?: string; values?: string[] };
+            const op1 = restored.operands[1] as { property?: string; operator?: string; values?: string[] };
+            expect(op0.property).toBe('domains');
+            expect(op0.operator).toBe('equals');
+            expect(op0.values).toEqual(['urn:li:domain:finance']);
+            expect(op1.property).toBe('platform');
+            expect(op1.operator).toBe('exists');
+        });
+
+        it('should round-trip boolean is_true/is_false operators correctly', () => {
+            const original: LogicalPredicate = {
+                type: 'logical',
+                operator: LogicalOperatorType.AND,
+                operands: [
+                    { type: 'property', property: 'hasDescription', operator: 'is_true', values: [] },
+                    { type: 'property', property: 'removed', operator: 'is_false', values: [] },
+                ],
+            };
+
+            const { operator, filters } = logicalPredicateToFilters(original);
+
+            expect(filters[0].values).toEqual(['true']);
+            expect(filters[0].condition).toBe(FilterOperator.Equal);
+            expect(filters[1].values).toEqual(['false']);
+            expect(filters[1].condition).toBe(FilterOperator.Equal);
+
+            const restored = filtersToLogicalPredicate(operator, filters);
+            const op0 = restored.operands[0] as { property?: string; operator?: string; values?: string[] };
+            const op1 = restored.operands[1] as { property?: string; operator?: string; values?: string[] };
+
+            expect(op0.operator).toBe('is_true');
+            expect(op0.values).toEqual([]);
+            expect(op1.operator).toBe('is_false');
+            expect(op1.values).toEqual([]);
+        });
+    });
+
+    describe('buildEntityMap', () => {
+        it('should build a map keyed by URN', () => {
+            const entities = [
+                { urn: 'urn:li:domain:marketing', type: 'DOMAIN' },
+                { urn: 'urn:li:tag:pii', type: 'TAG' },
+            ];
+
+            const result = buildEntityMap(entities);
+
+            expect(result['urn:li:domain:marketing']).toEqual({ urn: 'urn:li:domain:marketing', type: 'DOMAIN' });
+            expect(result['urn:li:tag:pii']).toEqual({ urn: 'urn:li:tag:pii', type: 'TAG' });
+        });
+
+        it('should return an empty map for an empty array', () => {
+            expect(buildEntityMap([])).toEqual({});
+        });
+
+        it('should use the last entity when URNs are duplicated', () => {
+            const entities = [
+                { urn: 'urn:li:domain:a', name: 'first' },
+                { urn: 'urn:li:domain:a', name: 'second' },
+            ];
+
+            const result = buildEntityMap(entities);
+
+            expect(result['urn:li:domain:a'].name).toBe('second');
+        });
+    });
+});

--- a/datahub-web-react/src/app/entityV2/view/builder/constants.ts
+++ b/datahub-web-react/src/app/entityV2/view/builder/constants.ts
@@ -1,0 +1,48 @@
+import { LogicalOperatorType, LogicalPredicate } from '@app/sharedV2/queryBuilder/builder/types';
+
+import { EntityType } from '@types';
+
+export const URN_FILTER_NAME = 'urn';
+
+/**
+ * Entity types that can be searched and selected as individual assets in the View builder.
+ * All selected entities are stored as URN filters, so the View shows exactly those assets.
+ */
+export const SELECTABLE_ASSET_ENTITY_TYPES = [
+    EntityType.Dataset,
+    EntityType.Dashboard,
+    EntityType.Chart,
+    EntityType.DataFlow,
+    EntityType.DataJob,
+    EntityType.Container,
+    EntityType.Domain,
+    EntityType.GlossaryTerm,
+    EntityType.GlossaryNode,
+    EntityType.Tag,
+    EntityType.CorpUser,
+    EntityType.CorpGroup,
+    EntityType.DataPlatform,
+    EntityType.Mlmodel,
+    EntityType.MlfeatureTable,
+    EntityType.MlprimaryKey,
+    EntityType.Notebook,
+    EntityType.Document,
+    EntityType.Application,
+];
+
+/**
+ * Tab keys for the view definition builder.
+ * Build Filters (dynamic) is the default tab.
+ */
+export const BUILD_FILTERS_TAB_KEY = 'buildFilters';
+export const SELECT_ASSETS_TAB_KEY = 'selectAssets';
+
+/**
+ * Default filter state for the Build Filters tab.
+ * Starts with one blank condition row so users can immediately pick a property.
+ */
+export const DEFAULT_DYNAMIC_FILTER: LogicalPredicate = {
+    type: 'logical',
+    operator: LogicalOperatorType.AND,
+    operands: [{ type: 'property' }],
+};

--- a/datahub-web-react/src/app/entityV2/view/builder/types.ts
+++ b/datahub-web-react/src/app/entityV2/view/builder/types.ts
@@ -1,3 +1,5 @@
+import { FacetFilter } from '@types';
+
 export enum ViewBuilderMode {
     /**
      * See a View definition in Preview Mode.
@@ -8,3 +10,15 @@ export enum ViewBuilderMode {
      */
     EDITOR,
 }
+
+/**
+ * Represents a single filter criterion within a View definition.
+ * Used as the intermediate representation between the UI filter tabs
+ * and the backend-compatible FacetFilter format.
+ */
+export type ViewFilter = {
+    field: string;
+    values: string[];
+    condition?: FacetFilter['condition'];
+    negated?: boolean;
+};

--- a/datahub-web-react/src/app/entityV2/view/builder/utils.ts
+++ b/datahub-web-react/src/app/entityV2/view/builder/utils.ts
@@ -1,124 +1,215 @@
-import {
-    ENTITY_FILTER_NAME,
-    ENTITY_SUB_TYPE_FILTER_NAME,
-    FILTER_DELIMITER,
-    TYPE_NAMES_FILTER_NAME,
-    UnionType,
-} from '@app/search/utils/constants';
+import { BUILD_FILTERS_TAB_KEY, SELECT_ASSETS_TAB_KEY, URN_FILTER_NAME } from '@app/entityV2/view/builder/constants';
+import { ViewFilter } from '@app/entityV2/view/builder/types';
+import { ViewBuilderState } from '@app/entityV2/view/types';
+import { LogicalOperatorType, LogicalPredicate, PropertyPredicate } from '@app/sharedV2/queryBuilder/builder/types';
 
-import { DataHubViewType, Entity, EntityType, FacetFilter, FacetFilterInput, LogicalOperator } from '@types';
+import { FacetFilter, FilterOperator, LogicalOperator } from '@types';
 
-/**
- * Extract the special "Entity Type" filter values from a list
- * of filters.
- */
-export const extractEntityTypesFilterValues = (filters: Array<FacetFilterInput>) => {
-    // Currently we only support 1 entity type filter.
-    return filters
-        .filter((filter) => filter.field === ENTITY_FILTER_NAME)
-        .flatMap((filter) => filter.values as EntityType[]);
-};
+/** Non-nullable shorthand for the definition property of ViewBuilderState. */
+type ViewDefinition = NonNullable<ViewBuilderState['definition']>;
 
 /**
- * Converts the nested subtype filter to be split into entity type filters and subType filters.
- * Right now we don't allow mixing of entity type and subType filters when creating a view since
- * this filter requires an OR between entity type and subType but AND between other filter types (like tags).
- * Example: { field: "_entityType␞typeNames" values: ["DATASETS␞table"] } -> { field: "typeNames", values: ["table"]}
- * Example: { field: "_entityType␞typeNames" values: ["DATASETS", "CONTAINERS"] } -> { field: "_entityType", values: ["DATASETS", "CONTAINERS"]}
+ * Maps a UI operator ID (from PropertyPredicate.operator) to the backend FilterOperator.
+ * Falls back to FilterOperator.Equal for unknown operators.
  */
-export function convertNestedSubTypeFilter(filters: Array<FacetFilterInput>) {
-    const convertedFilters = filters.filter((f) => f.field !== ENTITY_SUB_TYPE_FILTER_NAME) || [];
-    const nestedSubTypeFilter = filters.find((f) => f.field === ENTITY_SUB_TYPE_FILTER_NAME);
-    if (nestedSubTypeFilter) {
-        const entityTypeFilterValues: string[] = [];
-        const subTypeFilterValues: string[] = [];
-        nestedSubTypeFilter.values?.forEach((value) => {
-            if (!value.includes(FILTER_DELIMITER)) {
-                entityTypeFilterValues.push(value);
-            } else {
-                const nestedValues = value.split(FILTER_DELIMITER);
-                subTypeFilterValues.push(nestedValues[nestedValues.length - 1]);
-            }
-        });
-        if (entityTypeFilterValues.length) {
-            convertedFilters.push({ field: ENTITY_FILTER_NAME, values: entityTypeFilterValues });
-        }
-        if (subTypeFilterValues.length) {
-            convertedFilters.push({ field: TYPE_NAMES_FILTER_NAME, values: subTypeFilterValues });
-        }
-    }
-    return convertedFilters;
+export function mapUiOperatorToCondition(operator: string | undefined): FilterOperator | undefined {
+    if (!operator) return undefined;
+    const map: Record<string, FilterOperator> = {
+        equals: FilterOperator.Equal,
+        exists: FilterOperator.Exists,
+        contains_str: FilterOperator.Contain,
+        contains_any: FilterOperator.Contain,
+        starts_with: FilterOperator.StartWith,
+        regex_match: FilterOperator.Contain,
+        greater_than: FilterOperator.GreaterThan,
+        less_than: FilterOperator.LessThan,
+        is_true: FilterOperator.Equal,
+        is_false: FilterOperator.Equal,
+    };
+    return map[operator] ?? FilterOperator.Equal;
 }
 
 /**
- * Build an object representation of a View Definition, which consists of a list of entity types +
- * a set of filters joined in either conjunction or disjunction.
- *
- * @param filters a list of Facet Filter Inputs representing the view filters. This can include the entity type filter.
- * @param operatorType a logical operator to be used when joining the filters into the View definition.
+ * Maps a backend FilterOperator back to a UI operator ID string.
+ * For EQUAL with boolean values ("true"/"false"), returns the is_true/is_false
+ * operator so the query builder renders the correct unary toggle.
+ * Falls back to 'equals' for unknown conditions.
  */
-export const buildViewDefinition = (filters: Array<FacetFilterInput>, operatorType: LogicalOperator) => {
-    const convertedFilters = convertNestedSubTypeFilter(filters);
-    const entityTypes = extractEntityTypesFilterValues(convertedFilters);
-    const filteredFilters = convertedFilters.filter((filter) => filter.field !== ENTITY_FILTER_NAME);
+export function mapConditionToUiOperator(condition: FilterOperator | null | undefined, values?: string[]): string {
+    if (!condition) return 'equals';
+
+    if (condition === FilterOperator.Equal && values?.length === 1) {
+        if (values[0] === 'true') return 'is_true';
+        if (values[0] === 'false') return 'is_false';
+    }
+
+    const map: Record<string, string> = {
+        [FilterOperator.Equal]: 'equals',
+        [FilterOperator.Exists]: 'exists',
+        [FilterOperator.Contain]: 'contains_str',
+        [FilterOperator.StartWith]: 'starts_with',
+        [FilterOperator.GreaterThan]: 'greater_than',
+        [FilterOperator.LessThan]: 'less_than',
+    };
+    return map[condition] ?? 'equals';
+}
+
+/**
+ * Converts selected asset URNs into a single "urn" filter.
+ * All assets are stored under the "urn" field so the View shows exactly
+ * those entities — it does NOT use entity-type-specific filter fields.
+ */
+export function selectedUrnsToFilters(selectedUrns: string[]): ViewFilter[] {
+    if (selectedUrns.length === 0) return [];
+    return [{ field: URN_FILTER_NAME, values: selectedUrns }];
+}
+
+/**
+ * Resolves the filter values for a PropertyPredicate.
+ * Boolean operators (is_true/is_false) are unary — the UI provides no value
+ * input, so we inject "true"/"false" as the value to send to the backend.
+ */
+function resolveFilterValues(prop: PropertyPredicate): string[] {
+    if (prop.operator === 'is_true') return ['true'];
+    if (prop.operator === 'is_false') return ['false'];
+    return prop.values || [];
+}
+
+/**
+ * Recursively extracts all PropertyPredicates from a LogicalPredicate tree,
+ * flattening nested groups into a single-level list of ViewFilters.
+ * Propagates negation from NOT groups down to each filter.
+ */
+function flattenPredicateToFilters(predicate: LogicalPredicate | PropertyPredicate, isNegated: boolean): ViewFilter[] {
+    if (predicate.type === 'property') {
+        const prop = predicate as PropertyPredicate;
+        if (!prop.property) return [];
+        return [
+            {
+                field: prop.property,
+                values: resolveFilterValues(prop),
+                condition: mapUiOperatorToCondition(prop.operator),
+                negated: isNegated || undefined,
+            },
+        ];
+    }
+
+    const logical = predicate as LogicalPredicate;
+    const childNegated = logical.operator === LogicalOperatorType.NOT ? !isNegated : isNegated;
+
+    return (logical.operands || []).flatMap((op) => flattenPredicateToFilters(op, childNegated));
+}
+
+/**
+ * Converts a LogicalPredicate from the query builder into flat filter objects.
+ * Recursively flattens nested groups and preserves each condition's operator
+ * as the ViewFilter.condition field.
+ */
+export function logicalPredicateToFilters(predicate: LogicalPredicate | null | undefined): {
+    operator: LogicalOperator;
+    filters: ViewFilter[];
+} {
+    if (!predicate || !predicate.operands?.length) {
+        return { operator: LogicalOperator.And, filters: [] };
+    }
+
+    const operator = predicate.operator === LogicalOperatorType.OR ? LogicalOperator.Or : LogicalOperator.And;
+    const isNegated = predicate.operator === LogicalOperatorType.NOT;
+    const filters = (predicate.operands || []).flatMap((op) => flattenPredicateToFilters(op, isNegated));
+
+    return { operator, filters };
+}
+
+/**
+ * Extracts selected asset URNs from saved view filters.
+ * Only reads URNs from the "urn" filter field (produced by the Select Assets tab).
+ */
+export function filtersToSelectedUrns(filters: ViewFilter[]): string[] {
+    const urnFilter = filters.find((f) => f.field === URN_FILTER_NAME);
+    return urnFilter?.values ?? [];
+}
+
+/**
+ * Converts existing ViewBuilderState filters back to a LogicalPredicate
+ * for the Build Filters tab. Restores each filter's condition back to
+ * the UI operator, and wraps in NOT if all filters are negated.
+ */
+export function filtersToLogicalPredicate(
+    operator: LogicalOperator | undefined,
+    filters: ViewFilter[],
+): LogicalPredicate {
+    const allNegated = filters.length > 0 && filters.every((f) => f.negated);
+
+    const operands: PropertyPredicate[] = filters.map((filter) => {
+        const uiOperator = mapConditionToUiOperator(filter.condition, filter.values);
+        const isBooleanOp = uiOperator === 'is_true' || uiOperator === 'is_false';
+        return {
+            type: 'property' as const,
+            property: filter.field,
+            operator: uiOperator,
+            values: isBooleanOp ? [] : filter.values || [],
+        };
+    });
+
+    if (allNegated) {
+        return {
+            type: 'logical',
+            operator: LogicalOperatorType.NOT,
+            operands,
+        };
+    }
+
+    const logicalOperator = operator === LogicalOperator.Or ? LogicalOperatorType.OR : LogicalOperatorType.AND;
+
     return {
-        entityTypes,
+        type: 'logical',
+        operator: logicalOperator,
+        operands,
+    };
+}
+
+/**
+ * Determines which tab should be active based on saved filter state.
+ *
+ * Heuristic:
+ * 1. Empty filters → Build Filters (default for new views).
+ * 2. Any filter uses the "urn" field → Select Assets (only that tab produces it).
+ * 3. Otherwise → Build Filters.
+ */
+export function getInitialTabKey(filters: ViewFilter[]): string {
+    const hasUrnField = filters.some((f) => f.field === URN_FILTER_NAME);
+    if (hasUrnField) {
+        return SELECT_ASSETS_TAB_KEY;
+    }
+    return BUILD_FILTERS_TAB_KEY;
+}
+
+/**
+ * Builds a view definition object compatible with ViewBuilderState.
+ * ViewFilter is structurally compatible with FacetFilter; the cast bridges
+ * the generated __typename field that ViewFilter intentionally omits.
+ */
+export function buildViewDefinition(operator: LogicalOperator, filters: ViewFilter[]): ViewDefinition {
+    return {
+        entityTypes: [],
         filter: {
-            operator: operatorType,
-            filters: (filteredFilters.length > 0 ? filteredFilters : []) as FacetFilter[],
+            operator,
+            filters: filters as FacetFilter[],
         },
     };
-};
+}
 
 /**
- * Build an object representation of a View Definition, which consists of a list of entity types +
- * a set of filters joined in either conjunction or disjunction.
- *
- * @param filters a list of Facet Filter Inputs representing the view filters. This can include the entity type filter.
- * @param operatorType a logical operator to be used when joining the filters into the View definition.
+ * Builds a lookup map from entity URN to entity object.
+ * Shared by ViewDefinitionBuilder and SelectedFilterValues to avoid duplication.
  */
-export const buildInitialViewState = (filters: Array<FacetFilterInput>, operatorType: LogicalOperator) => {
-    return {
-        viewType: DataHubViewType.Personal,
-        name: '',
-        description: null,
-        definition: buildViewDefinition(filters, operatorType),
-    };
-};
+export function buildEntityMap<T extends { urn: string }>(entities: T[]): Record<string, T> {
+    const map: Record<string, T> = {};
+    entities.forEach((entity) => {
+        map[entity.urn] = entity;
+    });
+    return map;
+}
 
-/**
- * Convert a LogicalOperator to the equivalent UnionType.
- */
-export const toUnionType = (operator: LogicalOperator) => {
-    if (operator === LogicalOperator.And) {
-        return UnionType.AND;
-    }
-    return UnionType.OR;
-};
-
-/**
- * Convert a UnionType to the equivalent LogicalOperator.
- */
-export const fromUnionType = (unionType: UnionType) => {
-    if (unionType === 0) {
-        return LogicalOperator.And;
-    }
-    return LogicalOperator.Or;
-};
-
-/**
- * Returns a map of entity urn to entity from a list of entities.
- */
-export const buildEntityCache = (entities: Entity[]) => {
-    const cache = new Map();
-    entities.forEach((entity) => cache.set(entity.urn, entity));
-    return cache;
-};
-
-/**
- * Returns 'true' if any urns are not present in an entity cache, 'false' otherwise.
- */
-export const isResolutionRequired = (urns: string[], cache: Map<string, Entity>) => {
-    const uncachedUrns = urns.filter((urn) => !cache.has(urn));
-    return uncachedUrns.length > 0;
-};
+// Re-export V1 utils that other files import from this path
+export { convertNestedSubTypeFilter, buildEntityCache, isResolutionRequired } from '@app/entity/view/builder/utils';

--- a/datahub-web-react/src/app/entityV2/view/builder/viewBuilderProperties.ts
+++ b/datahub-web-react/src/app/entityV2/view/builder/viewBuilderProperties.ts
@@ -1,0 +1,194 @@
+import { Property } from '@app/sharedV2/queryBuilder/builder/property/types/properties';
+import { SelectInputMode, ValueTypeId } from '@app/sharedV2/queryBuilder/builder/property/types/values';
+
+import { EntityType } from '@types';
+
+/**
+ * View-specific properties for the Dynamic Filter tab in the View builder.
+ * Matches the filter capabilities from VIEW_BUILDER_FIELDS while using
+ * the query builder property format.
+ */
+export const viewBuilderProperties: Property[] = [
+    {
+        id: '_entityType',
+        displayName: 'Type',
+        description: 'The type of the asset.',
+        valueType: ValueTypeId.ENUM,
+        valueOptions: {
+            mode: SelectInputMode.MULTIPLE,
+            options: [
+                { id: 'dataset', displayName: 'Dataset' },
+                { id: 'dataProduct', displayName: 'Data Product' },
+                { id: 'document', displayName: 'Document' },
+                { id: 'dashboard', displayName: 'Dashboard' },
+                { id: 'domain', displayName: 'Domain' },
+                { id: 'glossaryTerm', displayName: 'Glossary Term' },
+                { id: 'glossaryNode', displayName: 'Term Group' },
+                { id: 'chart', displayName: 'Chart' },
+                { id: 'dataJob', displayName: 'Data Job (Task)' },
+                { id: 'dataFlow', displayName: 'Data Flow (Pipeline)' },
+                { id: 'container', displayName: 'Container' },
+                { id: 'application', displayName: 'Application' },
+                { id: 'mlModel', displayName: 'ML Model' },
+                { id: 'mlModelGroup', displayName: 'ML Model Group' },
+                { id: 'mlFeature', displayName: 'ML Feature' },
+                { id: 'mlFeatureTable', displayName: 'ML Feature Table' },
+                { id: 'mlPrimaryKey', displayName: 'ML Primary Key' },
+            ],
+        },
+    },
+    {
+        id: 'typeNames',
+        displayName: 'Sub Type',
+        description: 'The sub type of the asset (e.g. Table, View, Topic).',
+        valueType: ValueTypeId.ENUM,
+        valueOptions: {
+            aggregationField: 'typeNames',
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'platform',
+        displayName: 'Platform',
+        description: 'The data platform where the asset lives.',
+        valueType: ValueTypeId.URN,
+        valueOptions: {
+            entityTypes: [EntityType.DataPlatform],
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'owners',
+        displayName: 'Owner',
+        description: 'The owners of an asset.',
+        valueType: ValueTypeId.URN,
+        valueOptions: {
+            entityTypes: [EntityType.CorpUser, EntityType.CorpGroup],
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'domains',
+        displayName: 'Domain',
+        description: 'The domain that the asset is a part of.',
+        valueType: ValueTypeId.URN,
+        valueOptions: {
+            entityTypes: [EntityType.Domain],
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'dataProducts',
+        displayName: 'Data Product',
+        description: 'The data product the asset belongs to.',
+        valueType: ValueTypeId.URN,
+        valueOptions: {
+            entityTypes: [EntityType.DataProduct],
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'tags',
+        displayName: 'Tags',
+        description: 'The tags applied to an asset.',
+        valueType: ValueTypeId.URN,
+        valueOptions: {
+            entityTypes: [EntityType.Tag],
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'glossaryTerms',
+        displayName: 'Glossary Terms',
+        description: 'The glossary terms applied to an asset.',
+        valueType: ValueTypeId.URN,
+        valueOptions: {
+            entityTypes: [EntityType.GlossaryTerm],
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'container',
+        displayName: 'Container',
+        description: 'The parent container of the asset.',
+        valueType: ValueTypeId.URN,
+        valueOptions: {
+            entityTypes: [EntityType.Container],
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'fieldPaths',
+        displayName: 'Column Name',
+        description: 'The name of a schema field / column.',
+        valueType: ValueTypeId.STRING,
+    },
+    {
+        id: 'fieldTags',
+        displayName: 'Column Tag',
+        description: 'Tags applied to a schema field / column.',
+        valueType: ValueTypeId.URN,
+        valueOptions: {
+            entityTypes: [EntityType.Tag],
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'fieldGlossaryTerms',
+        displayName: 'Column Glossary Term',
+        description: 'Glossary terms applied to a schema field / column.',
+        valueType: ValueTypeId.URN,
+        valueOptions: {
+            entityTypes: [EntityType.GlossaryTerm],
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+    {
+        id: 'hasDescription',
+        displayName: 'Has Description',
+        description: 'Whether the asset has a description.',
+        valueType: ValueTypeId.BOOLEAN,
+    },
+    {
+        id: 'removed',
+        displayName: 'Soft Deleted',
+        description: 'Whether the asset has been soft deleted.',
+        valueType: ValueTypeId.BOOLEAN,
+    },
+    {
+        id: 'hasActiveIncidents',
+        displayName: 'Has Active Incidents',
+        description: 'Whether the asset has active incidents.',
+        valueType: ValueTypeId.BOOLEAN,
+    },
+    {
+        id: 'hasFailingAssertions',
+        displayName: 'Has Failing Assertions',
+        description: 'Whether the asset has failing data quality assertions.',
+        valueType: ValueTypeId.BOOLEAN,
+    },
+    {
+        id: 'origin',
+        displayName: 'Environment',
+        description: 'The environment / origin of the asset (e.g. PROD, DEV).',
+        valueType: ValueTypeId.ENUM,
+        valueOptions: {
+            mode: SelectInputMode.MULTIPLE,
+            options: [
+                { id: 'PROD', displayName: 'Production' },
+                { id: 'DEV', displayName: 'Development' },
+                { id: 'STAGING', displayName: 'Staging' },
+            ],
+        },
+    },
+    {
+        id: 'platformInstance',
+        displayName: 'Platform Instance',
+        description: 'The specific platform instance where the asset lives.',
+        valueType: ValueTypeId.ENUM,
+        valueOptions: {
+            aggregationField: 'platformInstance',
+            mode: SelectInputMode.MULTIPLE,
+        },
+    },
+];

--- a/datahub-web-react/src/app/entityV2/view/select/ViewSelectContext.tsx
+++ b/datahub-web-react/src/app/entityV2/view/select/ViewSelectContext.tsx
@@ -191,8 +191,8 @@ export default function ViewSelectContextProvider({ isOpen, onOpenChange, childr
 
     const onSelectView = (newUrn) => {
         const selectedView =
-            highlightedPrivateViewData?.find((view) => view?.urn === selectedUrn) ||
-            highlightedPublicViewData?.find((view) => view?.urn === selectedUrn);
+            highlightedPrivateViewData?.find((view) => view?.urn === newUrn) ||
+            highlightedPublicViewData?.find((view) => view?.urn === newUrn);
         setSelectedView(selectedView?.name ?? '');
         userContext.updateLocalState({
             ...userContext.localState,

--- a/datahub-web-react/src/app/homeV3/modules/assetCollection/AssetFilters.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/assetCollection/AssetFilters.tsx
@@ -21,6 +21,7 @@ const AssetFilters = ({ searchQuery, appliedFilters, updateFieldFilters }: Props
                 query={searchQuery ?? '*'}
                 appliedFilters={appliedFilters}
                 updateFieldAppliedFilters={updateFieldFilters}
+                viewUrn={null}
             />
         </FiltersContainer>
     );

--- a/datahub-web-react/src/app/homeV3/modules/assetCollection/DynamicSelectAssetsTab.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/assetCollection/DynamicSelectAssetsTab.tsx
@@ -4,10 +4,11 @@ import LogicalFiltersBuilder from '@app/sharedV2/queryBuilder/LogicalFiltersBuil
 import { LogicalOperatorType, LogicalPredicate } from '@app/sharedV2/queryBuilder/builder/types';
 import { properties } from '@app/sharedV2/queryBuilder/properties';
 
-const EMPTY_FILTER: LogicalPredicate = {
+/** Start with one blank condition row so users can immediately pick a property. */
+const DEFAULT_FILTER: LogicalPredicate = {
     type: 'logical',
     operator: LogicalOperatorType.AND,
-    operands: [],
+    operands: [{ type: 'property' }],
 };
 
 type Props = {
@@ -18,7 +19,7 @@ type Props = {
 const DynamicSelectAssetsTab = ({ dynamicFilter, setDynamicFilter }: Props) => {
     return (
         <LogicalFiltersBuilder
-            filters={dynamicFilter ?? EMPTY_FILTER}
+            filters={dynamicFilter ?? DEFAULT_FILTER}
             onChangeFilters={setDynamicFilter}
             properties={properties}
         />

--- a/datahub-web-react/src/app/searchV2/searchBarV2/components/Filters.tsx
+++ b/datahub-web-react/src/app/searchV2/searchBarV2/components/Filters.tsx
@@ -54,18 +54,19 @@ interface Props {
     appliedFilters?: FieldToAppliedFieldFiltersMap;
     updateFieldAppliedFilters?: AppliedFieldFilterUpdater;
     facets?: FacetMetadata[];
+    viewUrn?: string | null;
 }
 
-export default function Filters({ query, appliedFilters, updateFieldAppliedFilters, facets }: Props) {
+export default function Filters({ query, appliedFilters, updateFieldAppliedFilters, facets, viewUrn }: Props) {
     const userContext = useUserContext();
-    const viewUrn = userContext.localState?.selectedViewUrn;
+    const resolvedViewUrn = viewUrn === undefined ? userContext.localState?.selectedViewUrn : viewUrn;
     const fieldToFacetStateMap = useMemo(() => convertFacetsToFieldToFacetStateMap(facets), [facets]);
 
     return (
         <SearchFilters
             fields={FILTER_FIELDS}
             query={query}
-            viewUrn={viewUrn}
+            viewUrn={resolvedViewUrn}
             appliedFilters={appliedFilters}
             updateFieldAppliedFilters={updateFieldAppliedFilters}
             filtersRenderer={MemoFiltersRenderer}

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/Condition.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/Condition.tsx
@@ -84,6 +84,7 @@ const Condition = ({ selectedPredicate, onDeletePredicate, onChangePredicate, pr
                     options={valueOptions}
                     onChangeValues={handleValuesChange}
                     property={selectedPredicate?.property}
+                    propertyDisplayName={property?.displayName}
                 />
             </SelectContainer>
             <IconsContainer>

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/GroupHeader.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/GroupHeader.tsx
@@ -19,6 +19,8 @@ interface Props {
     index: number;
     operator?: LogicalOperatorType;
     showDeleteButton?: boolean;
+    /** When true, hides the "Add Group" button (e.g., when the backend model is flat). */
+    hideAddGroup?: boolean;
 }
 
 const GroupHeader = ({
@@ -29,6 +31,7 @@ const GroupHeader = ({
     index,
     operator,
     showDeleteButton,
+    hideAddGroup,
 }: Props) => {
     const [selectedOperation, setSelectedOperation] = useState<LogicalOperatorType>(
         operator ?? LogicalOperatorType.AND,
@@ -99,13 +102,15 @@ const GroupHeader = ({
                 >
                     Add Condition
                 </ButtonComponent>
-                <ButtonComponent
-                    variant="text"
-                    onClick={handleAddLogicalPredicate}
-                    data-testid="query-builder-add-group-button"
-                >
-                    Add Group
-                </ButtonComponent>
+                {!hideAddGroup && (
+                    <ButtonComponent
+                        variant="text"
+                        onClick={handleAddLogicalPredicate}
+                        data-testid="query-builder-add-group-button"
+                    >
+                        Add Group
+                    </ButtonComponent>
+                )}
                 <CardIcons>
                     {showDeleteButton && (
                         <Icon

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/LogicalFiltersBuilder.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/LogicalFiltersBuilder.tsx
@@ -8,9 +8,11 @@ interface Props {
     filters: LogicalPredicate | PropertyPredicate;
     onChangeFilters: (newPredicate?: LogicalPredicate) => void;
     properties: Property[];
+    /** When true, hides the "Add Group" button (use when the backend model is flat). */
+    hideAddGroup?: boolean;
 }
 
-const LogicalFiltersBuilder = ({ filters, onChangeFilters, properties }: Props) => {
+const LogicalFiltersBuilder = ({ filters, onChangeFilters, properties, hideAddGroup }: Props) => {
     const clearFilters = () => {
         onChangeFilters(undefined);
     };
@@ -23,6 +25,7 @@ const LogicalFiltersBuilder = ({ filters, onChangeFilters, properties }: Props) 
             clearFilters={clearFilters}
             depth={0}
             index={0}
+            hideAddGroup={hideAddGroup}
         />
     );
 };

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/Operands.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/Operands.tsx
@@ -13,9 +13,10 @@ interface Props {
     onDeletePredicate: (index) => void;
     properties: Property[];
     depth: number;
+    hideAddGroup?: boolean;
 }
 
-const Operands = ({ operands, onChangeOperands, onDeletePredicate, properties, depth }: Props) => {
+const Operands = ({ operands, onChangeOperands, onDeletePredicate, properties, depth, hideAddGroup }: Props) => {
     const onUpdatePredicate = (newPredicate, index) => {
         const newOperands = [...operands];
         if (newPredicate === undefined) {
@@ -53,6 +54,7 @@ const Operands = ({ operands, onChangeOperands, onDeletePredicate, properties, d
                             properties={properties}
                             depth={depth + 1}
                             index={index}
+                            hideAddGroup={hideAddGroup}
                         />
                     )}
                 </>

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/OperatorSelect.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/OperatorSelect.tsx
@@ -29,7 +29,7 @@ const OperatorSelect = ({ selectedOperator, operators, onChangeOperator }: Props
                 onUpdate={(val) => onChangeOperator(val[0])}
                 values={selectedOperator ? [selectedOperator.toLowerCase()] : []}
                 isDisabled={!operators}
-                data-testid="condition-operator-select"
+                dataTestId="condition-operator-select"
                 width="full"
                 showClear={false}
             />

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/PropertySelect.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/PropertySelect.tsx
@@ -28,7 +28,7 @@ const PropertySelect = ({ selectedProperty, properties, onChangeProperty }: Prop
                 onUpdate={(val) => onChangeProperty(val[0])}
                 values={selectedProperty ? [selectedProperty] : []}
                 placeholder="Select a property"
-                data-testid="condition-select"
+                dataTestId="condition-select"
                 width="full"
                 showClear={false}
             />

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/QueryBuilder.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/QueryBuilder.tsx
@@ -24,9 +24,19 @@ interface Props {
     depth: number;
     index: number;
     clearFilters?: () => void;
+    /** When true, hides the "Add Group" button at every level. */
+    hideAddGroup?: boolean;
 }
 
-const QueryBuilder = ({ selectedPredicate, onChangePredicate, properties, depth, index, clearFilters }: Props) => {
+const QueryBuilder = ({
+    selectedPredicate,
+    onChangePredicate,
+    properties,
+    depth,
+    index,
+    clearFilters,
+    hideAddGroup,
+}: Props) => {
     const [isExpanded, setIsExpanded] = useState(true);
 
     const logicalPredicate = convertToLogicalPredicate(selectedPredicate);
@@ -108,6 +118,7 @@ const QueryBuilder = ({ selectedPredicate, onChangePredicate, properties, depth,
                         index={index}
                         operator={logicalPredicate.operator}
                         showDeleteButton={operands.length > 0 || depth > 0}
+                        hideAddGroup={hideAddGroup}
                     />
                 }
                 showArrow={operands.length > 0}
@@ -118,6 +129,7 @@ const QueryBuilder = ({ selectedPredicate, onChangePredicate, properties, depth,
                     properties={properties}
                     onDeletePredicate={onDeleteCondition}
                     depth={depth}
+                    hideAddGroup={hideAddGroup}
                 />
             </Collapse.Panel>
         </StyledCollapse>

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/ValuesSelect.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/ValuesSelect.tsx
@@ -1,7 +1,14 @@
+import { Input } from '@components';
 import React, { useMemo } from 'react';
 
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
-import { SelectParams, ValueInputType, ValueOptions } from '@app/sharedV2/queryBuilder/builder/property/types/values';
+import {
+    AggregationParams,
+    SelectParams,
+    ValueInputType,
+    ValueOptions,
+} from '@app/sharedV2/queryBuilder/builder/property/types/values';
+import AggregationValueInput from '@app/sharedV2/queryBuilder/valueInputs/AggregationValueInput';
 import { EntitySearchValueInput } from '@app/sharedV2/queryBuilder/valueInputs/EntitySearchValueInput';
 import SelectValueInput from '@app/sharedV2/queryBuilder/valueInputs/SelectValueInput';
 
@@ -13,6 +20,14 @@ function propertyToValueInputLabel(property: string | undefined): string | undef
             return 'Terms';
         case '_entityType':
             return 'Types';
+        case 'typeNames':
+            return 'Sub Types';
+        case 'fieldPaths':
+            return 'Columns';
+        case 'platformInstance':
+            return 'Instances';
+        case 'owners':
+            return 'Owners';
         default:
             return property ? capitalizeFirstLetterOnly(property) : undefined;
     }
@@ -23,13 +38,25 @@ interface Props {
     options?: ValueOptions;
     onChangeValues: (newValues: string[]) => void;
     property?: string;
+    propertyDisplayName?: string;
 }
 
-const ValuesSelect = ({ selectedValues, options, onChangeValues, property }: Props) => {
+const ValuesSelect = ({ selectedValues, options, onChangeValues, property, propertyDisplayName }: Props) => {
     const label = useMemo(() => propertyToValueInputLabel(property), [property]);
+    const placeholder = propertyDisplayName ? `Select ${propertyDisplayName.toLowerCase()}...` : 'Select a value...';
 
     return (
         <>
+            {options?.inputType === ValueInputType.AGGREGATION && (
+                <AggregationValueInput
+                    facetField={(options.options as AggregationParams)?.facetField}
+                    selectedValues={selectedValues || []}
+                    onChangeSelectedValues={(newSelected) => onChangeValues(newSelected)}
+                    mode={(options.options as any)?.mode || 'multiple'}
+                    label={label}
+                    placeholder={placeholder}
+                />
+            )}
             {options?.inputType === ValueInputType.ENTITY_SEARCH && (
                 <EntitySearchValueInput
                     selectedUrns={selectedValues || []}
@@ -37,16 +64,24 @@ const ValuesSelect = ({ selectedValues, options, onChangeValues, property }: Pro
                     entityTypes={(options.options as any)?.entityTypes || []}
                     mode={(options.options as any)?.mode || 'single'}
                     label={label}
+                    placeholder={placeholder}
                 />
             )}
             {options?.inputType === ValueInputType.SELECT && (
                 <SelectValueInput
                     selected={selectedValues}
                     onChangeSelected={(selected) => onChangeValues(selected as string[])}
-                    placeholder="Select a value..."
+                    placeholder={placeholder}
                     options={(options.options as SelectParams)?.options}
                     mode={(options.options as any)?.mode || 'single'}
                     label={label}
+                />
+            )}
+            {options?.inputType === ValueInputType.TEXT && (
+                <Input
+                    value={selectedValues?.[0] ?? ''}
+                    setValue={(val) => onChangeValues(val ? [val] : [])}
+                    placeholder={placeholder}
                 />
             )}
         </>

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/builder/property/types/values.ts
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/builder/property/types/values.ts
@@ -81,7 +81,7 @@ export const valueTypes = [
     {
         id: ValueTypeId.BOOLEAN,
         displayName: 'Boolean',
-        operators: [OperatorId.IS_TRUE, OperatorId.IS_FALSE, OperatorId.EXISTS],
+        operators: [OperatorId.IS_TRUE, OperatorId.IS_FALSE],
     },
     {
         id: ValueTypeId.NUMBER,
@@ -181,6 +181,10 @@ export enum ValueInputType {
      */
     TIME_SELECT,
     /**
+     * Aggregation-based value input that dynamically fetches values from the backend
+     */
+    AGGREGATION,
+    /**
      * No input type
      */
     NONE,
@@ -205,11 +209,16 @@ export type EntitySearchParams = {
     entityTypes: EntityType[];
 };
 
+export type AggregationParams = {
+    facetField: string;
+    mode?: 'multiple' | 'single';
+};
+
 /**
  * Options provided to customize the value select experience for
  * well-known properties.
  */
 export type ValueOptions = {
     inputType: ValueInputType;
-    options: EntitySearchParams | SelectParams | undefined;
+    options: EntitySearchParams | SelectParams | AggregationParams | undefined;
 };

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/builder/property/utils.ts
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/builder/property/utils.ts
@@ -45,6 +45,13 @@ const isTimeProperty = (property: Property): boolean => {
 };
 
 /**
+ * Returns true if a Property uses aggregation-based value fetching.
+ */
+const isAggregationProperty = (property: Property): boolean => {
+    return !!property.valueOptions?.aggregationField;
+};
+
+/**
  * Returns a list of properties supported fora given entity type.
  */
 export const getPropertiesForEntityType = (type: EntityType): Property[] => {
@@ -116,6 +123,16 @@ export const getOperatorOptions = (valueType: ValueTypeId): Operator[] | undefin
 export const getValueOptions = (property: Property, predicate: PropertyPredicate): ValueOptions | undefined => {
     if (!predicate.operator || isUnaryOperator(predicate.operator)) {
         return undefined;
+    }
+    // Display an aggregation-based values input.
+    if (isAggregationProperty(property)) {
+        return {
+            inputType: ValueInputType.AGGREGATION,
+            options: {
+                facetField: property.valueOptions.aggregationField,
+                mode: property.valueOptions.mode,
+            },
+        };
     }
     // Display an Entity Search values input.
     if (isSearchableProperty(property)) {

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/AggregationValueInput.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/AggregationValueInput.tsx
@@ -1,0 +1,104 @@
+import { Select, SelectOption } from '@components';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
+
+import { useAggregateAcrossEntitiesLazyQuery } from '@graphql/search.generated';
+
+type Props = {
+    facetField: string;
+    selectedValues: string[];
+    mode?: 'multiple' | 'single';
+    onChangeSelectedValues: (newValues: string[]) => void;
+    label?: string;
+    placeholder?: string;
+};
+
+export default function AggregationValueInput({
+    facetField,
+    selectedValues,
+    mode,
+    label,
+    placeholder,
+    onChangeSelectedValues,
+}: Props) {
+    const [searchQuery, setSearchQuery] = useState('');
+
+    const [fetchAggregations, { data, loading }] = useAggregateAcrossEntitiesLazyQuery({
+        fetchPolicy: 'cache-first',
+    });
+
+    useEffect(() => {
+        fetchAggregations({
+            variables: {
+                input: {
+                    query: '*',
+                    facets: [facetField],
+                },
+            },
+        });
+    }, [facetField, fetchAggregations]);
+
+    const aggregations = useMemo(
+        () => data?.aggregateAcrossEntities?.facets?.find((f) => f.field === facetField)?.aggregations || [],
+        [data, facetField],
+    );
+
+    const options: SelectOption[] = useMemo(() => {
+        const aggOptions = aggregations.map((agg) => ({
+            value: agg.value,
+            label: capitalizeFirstLetterOnly(agg.value) || agg.value,
+        }));
+
+        const selectedSet = new Set(selectedValues);
+        const existingValues = new Set(aggOptions.map((o) => o.value));
+
+        const extraSelectedOptions = selectedValues
+            .filter((v) => !existingValues.has(v))
+            .map((v) => ({
+                value: v,
+                label: capitalizeFirstLetterOnly(v) || v,
+            }));
+
+        const allOptions = [...aggOptions, ...extraSelectedOptions];
+
+        const filtered = searchQuery
+            ? allOptions.filter((o) => o.label.toLowerCase().includes(searchQuery.toLowerCase()))
+            : allOptions;
+
+        return filtered.sort((a, b) => {
+            const aSelected = selectedSet.has(a.value) ? 0 : 1;
+            const bSelected = selectedSet.has(b.value) ? 0 : 1;
+            return aSelected - bSelected;
+        });
+    }, [aggregations, selectedValues, searchQuery]);
+
+    const onSearch = useCallback((text: string) => {
+        setSearchQuery(text);
+    }, []);
+
+    const isMultiSelect = mode === 'multiple';
+
+    return (
+        <Select
+            options={options}
+            values={selectedValues}
+            isMultiSelect={isMultiSelect}
+            onUpdate={onChangeSelectedValues}
+            onSearchChange={onSearch}
+            placeholder={placeholder || 'Select a value...'}
+            isLoading={loading}
+            selectLabelProps={
+                isMultiSelect && selectedValues.length > 0
+                    ? {
+                          variant: 'labeled',
+                          label: label ?? 'Items',
+                      }
+                    : undefined
+            }
+            showClear
+            width="full"
+            showSearch
+        />
+    );
+}

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/EntitySearchValueInput.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/EntitySearchValueInput.tsx
@@ -20,6 +20,7 @@ type Props = {
     mode?: 'multiple' | 'single';
     onChangeSelectedUrns: (newUrns: string[]) => void;
     label?: string;
+    placeholder?: string;
 };
 
 const addManyToCache = (cache: Map<string, Entity>, entities: Entity[]) => {
@@ -38,7 +39,14 @@ const isResolutionRequired = (urns: string[], cache: Map<string, Entity>) => {
  *
  * FYI: redesigned version of this component -  src/app/entityV2/shared/EntitySearchInput/EntitySearchInput.tsx
  */
-export const EntitySearchValueInput = ({ selectedUrns, entityTypes, mode, label, onChangeSelectedUrns }: Props) => {
+export const EntitySearchValueInput = ({
+    selectedUrns,
+    entityTypes,
+    mode,
+    label,
+    placeholder,
+    onChangeSelectedUrns,
+}: Props) => {
     const entityRegistry = useEntityRegistry();
     const [entityCache, setEntityCache] = useState<Map<string, Entity>>(new Map());
 
@@ -110,12 +118,17 @@ export const EntitySearchValueInput = ({ selectedUrns, entityTypes, mode, label,
 
         const mergedEntities = mergeArraysOfObjects(searchedEntities, selectedEntities, (item) => item.urn);
 
-        return mergedEntities.map((entity) => {
-            return {
+        const selectedSet = new Set(selectedUrns);
+        return mergedEntities
+            .map((entity) => ({
                 value: entity.urn,
                 label: entityRegistry.getDisplayName(entity.type, entity),
-            };
-        });
+            }))
+            .sort((a, b) => {
+                const aSelected = selectedSet.has(a.value) ? 0 : 1;
+                const bSelected = selectedSet.has(b.value) ? 0 : 1;
+                return aSelected - bSelected;
+            });
     }, [searchResults, entityCache, selectedUrns, entityRegistry]);
 
     const customOptionRenderer = useCallback(
@@ -159,10 +172,10 @@ export const EntitySearchValueInput = ({ selectedUrns, entityTypes, mode, label,
             isMultiSelect={isMultiSelect}
             onUpdate={onUpdate}
             onSearchChange={onSearch}
-            placeholder="Select entities..."
+            placeholder={placeholder || 'Select a value...'}
             data-testid="entity-search-input"
             selectLabelProps={
-                isMultiSelect
+                isMultiSelect && selectedUrns.length > 0
                     ? {
                           variant: 'labeled',
                           label: label ?? 'Items',

--- a/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/SelectValueInput.tsx
+++ b/datahub-web-react/src/app/sharedV2/queryBuilder/valueInputs/SelectValueInput.tsx
@@ -22,17 +22,23 @@ export default function SelectValueInput({ options, selected, label, mode, place
 
     const isMultiSelect = mode === 'multiple';
 
+    const hasSelection = (selected?.length ?? 0) > 0;
+
     return (
         <Select
             values={selected}
             onUpdate={onChangeSelected}
-            placeholder={placeholder}
+            placeholder={placeholder || 'Select a value...'}
             options={selectOptions}
             isMultiSelect={isMultiSelect}
-            selectLabelProps={{
-                variant: 'labeled',
-                label: label ?? 'Items',
-            }}
+            selectLabelProps={
+                hasSelection
+                    ? {
+                          variant: 'labeled',
+                          label: label ?? 'Items',
+                      }
+                    : undefined
+            }
             width="full"
             showClear
         />

--- a/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_manage_views.js
+++ b/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_manage_views.js
@@ -11,6 +11,17 @@ describe("manage views", () => {
     cy.wait(1000);
     cy.clickOptionWithText("Create View");
     cy.get('[data-testid="view-name-input"]').click().type(viewName);
+    // Add a filter condition — Save requires at least one.
+    cy.get('[data-testid="condition-select"]', { timeout: 10000 })
+      .first()
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="option-hasDescription"]', { timeout: 10000 }).click();
+    cy.get('[data-testid="condition-operator-select"]', { timeout: 10000 })
+      .first()
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="option-is_true"]', { timeout: 10000 }).click();
     cy.clickOptionWithTestId("view-builder-save");
 
     // Confirm that the test has been created.
@@ -18,7 +29,7 @@ describe("manage views", () => {
 
     // Now edit the View
     cy.clickFirstOptionWithTestId("views-table-dropdown");
-    cy.get('[data-testid="view-dropdown-edit"]').click({ force: true });
+    cy.get('[data-testid="menu-item-edit"]').click({ force: true });
     cy.get('[data-testid="view-name-input"]')
       .click()
       .clear()
@@ -28,19 +39,19 @@ describe("manage views", () => {
 
     // Now make the view the default
     cy.clickFirstOptionWithTestId("views-table-dropdown");
-    cy.get('[data-testid="view-dropdown-set-user-default"]').click({
+    cy.get('[data-testid="menu-item-set-default"]').click({
       force: true,
     });
 
     // Now unset as the default
     cy.clickFirstOptionWithTestId("views-table-dropdown");
-    cy.get('[data-testid="view-dropdown-remove-user-default"]').click({
+    cy.get('[data-testid="menu-item-remove-default"]').click({
       force: true,
     });
 
     // Now delete the View
     cy.clickFirstOptionWithTestId("views-table-dropdown");
-    cy.get('[data-testid="view-dropdown-delete"]').click({ force: true });
+    cy.get('[data-testid="menu-item-delete"]').click({ force: true });
     cy.clickOptionWithText("Yes");
   });
 });

--- a/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_view_select.js
+++ b/smoke-test/tests/cypress/cypress/e2e/viewV2/v2_view_select.js
@@ -26,14 +26,39 @@ describe("view select", () => {
     cy.ensureElementPresent('[data-testid="view-name-input"]');
     cy.enterTextInTestId("view-name-input", viewName);
 
-    // Add Column Glossary Term Filter
-    cy.clickOptionWithText("Add filter");
-    cy.contains("Column Term").scrollIntoView();
-    cy.clickOptionWithText("Column Term");
-    cy.ensureElementPresent('[placeholder="Search for Column Term"]');
-    cy.get('[data-testid="search-input"]').last().type("CypressColumnInfoType");
-    cy.get(".ant-checkbox").should("be.visible").click();
-    cy.clickOptionWithTestId("update-filters");
+    // Add Column Glossary Term filter via query builder.
+    // The Build Filters tab opens with a blank condition row by default.
+    // Step 1: Select the property
+    cy.get('[data-testid="condition-select"]', { timeout: 10000 })
+      .first()
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="option-fieldGlossaryTerms"]', {
+      timeout: 10000,
+    }).click();
+    // Step 2: Select the operator — value input only renders after this
+    cy.get('[data-testid="condition-operator-select"]', { timeout: 10000 })
+      .first()
+      .should("be.visible")
+      .click();
+    cy.get('[data-testid="option-equals"]', { timeout: 10000 }).click();
+    // Step 3: Select the glossary term entity value
+    cy.get('[data-testid="entity-search-input"]', { timeout: 20000 })
+      .should("exist")
+      .and("be.visible")
+      .click();
+    cy.get('[data-testid="dropdown-search-input"]', { timeout: 10000 })
+      .last()
+      .type("CypressColumnInfoType");
+    // The Alchemy BasicSelect renders options as <label> elements in a portal
+    // (not as [role="option"] children of entity-search-input).
+    // For multi-select, click the checkbox to toggle it, then confirm with Update.
+    cy.contains("CypressColumnInfoType", { timeout: 20000 })
+      .should("be.visible")
+      .closest("label")
+      .find(".ant-checkbox-wrapper")
+      .click();
+    cy.clickOptionWithTestId("footer-button-update");
     cy.clickOptionWithText("Save");
     cy.ensureTextNotPresent("Save");
     cy.waitTextVisible(viewName);
@@ -48,42 +73,37 @@ describe("view select", () => {
       .click({ force: true });
     cy.ensureTextNotPresent("of 3 results");
 
-    // Now edit the view
+    // Now edit the view (rename only)
     cy.clickOptionWithTestId("views-icon");
     cy.ensureElementWithTestIdPresent("views-type-select");
-    openViewEditDropDownAndClickId("view-dropdown-edit");
+    openViewEditDropDownAndClickId("menu-item-edit");
     cy.clickOptionWithTestId("view-name-input").clear().type(newViewName);
-
-    // Update the actual filters by adding another filter
-    cy.clickOptionWithText("Add filter");
-    cy.get(".anticon-file-text").eq(0).scrollIntoView().click();
-    cy.enterTextInTestId("edit-text-input", "log event");
-    cy.clickOptionWithText("Apply");
     cy.clickOptionWithTestId("view-builder-save");
-    cy.waitTextVisible("cypress_logging_events");
-    cy.waitTextVisible("of 1 result");
-    cy.get("[class*=dataset]").should("have.length", 1);
+    cy.waitTextVisible("SampleCypressHdfsDataset");
+    cy.waitTextVisible("of 3 results");
+    cy.get("[class*=dataset]").should("have.length", 3);
     cy.clickOptionWithId("#v2-search-bar-views");
-    openViewEditDropDownAndClickId("view-dropdown-set-user-default");
-    cy.waitTextVisible("of 1 result");
-    cy.get("[class*=dataset]").should("have.length", 1);
+    openViewEditDropDownAndClickId("menu-item-set-default");
+    cy.waitTextVisible(newViewName);
+    cy.waitTextVisible("of 3 results");
+    cy.get("[class*=dataset]").should("have.length", 3);
     cy.clickOptionWithId("#v2-search-bar-views");
     cy.get('[data-testid="CloseIcon"]').last().click({ force: true });
     cy.clickOptionWithTestId("views-icon");
     cy.ensureElementWithTestIdPresent("views-type-select");
-    openViewEditDropDownAndClickId("view-dropdown-remove-user-default");
+    openViewEditDropDownAndClickId("menu-item-remove-default");
 
     // Now delete the View
     cy.clickOptionWithId("#v2-search-bar-views");
     cy.clickOptionWithTestId("views-icon");
     cy.ensureElementWithTestIdPresent("views-type-select");
-    openViewEditDropDownAndClickId("view-dropdown-delete");
+    openViewEditDropDownAndClickId("menu-item-delete");
     cy.clickOptionWithText("Yes");
 
     // Ensure that the view was deleted
     cy.goToViewsSettings();
     cy.waitTextVisible("Permissions");
     cy.ensureTextNotPresent(newViewName);
-    cy.ensureTextNotPresent("of 1 result");
+    cy.ensureTextNotPresent("of 3 results");
   });
 });


### PR DESCRIPTION
## Summary

- Redesigns the Create/Edit View modal using Alchemy components with a tabbed interface (Build Filters + Select Filter Values)
- Replaces the old filter selection UI with a query-builder-based approach using `LogicalFiltersBuilder` for a more intuitive filter construction experience
- Adds new `ViewBuilderProperties` configuration, `SelectFilterValuesTab`, and `SelectedFilterValues` components to support the redesigned flow
- Updates smoke tests to match the new query-builder-driven view creation workflow

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated (if applicable)


Made with [Cursor](https://cursor.com)