### PR TITLE
fix(ui) Fix infinite loop with tracking calls edge case

### DIFF
--- a/datahub-web-react/src/app/shared/FilesUploadingDownloadingLatencyTracker.tsx
+++ b/datahub-web-react/src/app/shared/FilesUploadingDownloadingLatencyTracker.tsx
@@ -7,7 +7,18 @@ function isResource(entry: PerformanceEntry): entry is PerformanceResourceTiming
 }
 
 function isUploading(entry: PerformanceResourceTiming) {
-    return entry.name.includes('amazonaws') && entry.initiatorType === 'fetch';
+    // S3 presigned upload URLs have X-Amz-Signature query parameter
+    // This specifically identifies S3 uploads and excludes all other requests
+    try {
+        const url = new URL(entry.name);
+        return (
+            url.hostname.endsWith('.amazonaws.com') &&
+            url.searchParams.has('X-Amz-Signature') &&
+            entry.initiatorType === 'fetch'
+        );
+    } catch {
+        return false;
+    }
 }
 
 function isDownloading(entry: PerformanceResourceTiming) {


### PR DESCRIPTION
Previously an OSS deployment could get stuck in an infinite loop with our tracking calls if their hostname included `amazonaws`. This is because in `FilesUploadingDownloadingLatencyTracker` we checked if this was included and if so we counted it as an upload event. The problem is other API calls could include this and just keep triggering the event which the tracking call triggers another event and so on.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
