### PR TITLE
fix(graphql) Fix discrepancy with count in entities per platform chart

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/resolver/GetChartsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/resolver/GetChartsResolver.java
@@ -405,13 +405,16 @@ public final class GetChartsResolver implements DataFetcher<List<AnalyticsChartG
     }
 
     // Chart 2: Entities per platform
+    // Excludes query entities from this count as they are not expected and over-inflate numbers per
+    // platform
     final List<NamedBar> entitiesPerPlatform =
         _analyticsService.getBarChart(
             _analyticsService.getAllEntityIndexName(),
             Optional.empty(),
             ImmutableList.of("platform.keyword"),
             Collections.emptyMap(),
-            ImmutableMap.of("removed", ImmutableList.of("true")),
+            ImmutableMap.of(
+                "removed", ImmutableList.of("true"), "_index", ImmutableList.of("*queryindex_v2*")),
             Optional.empty(),
             false);
     AnalyticsUtil.hydrateDisplayNameForBars(


### PR DESCRIPTION
Fixes an issue where our chat for "Entities by Platform" was showing over-inflated numbers because query entities were being included. This simply filters those entities out now when we are generating this chart on the backend.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
