### PR TITLE
fix(test/s3): sort os.listdir() to ensure deterministic test parametrize order

### DIFF
--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -168,11 +168,13 @@ def touch_local_files(pytestconfig):
 
 SHARED_SOURCE_FILES_PATH = "./tests/integration/s3/sources/shared"
 shared_source_files = [
-    (SHARED_SOURCE_FILES_PATH, p) for p in os.listdir(SHARED_SOURCE_FILES_PATH)
+    (SHARED_SOURCE_FILES_PATH, p) for p in sorted(os.listdir(SHARED_SOURCE_FILES_PATH))
 ]
 
 S3_SOURCE_FILES_PATH = "./tests/integration/s3/sources/s3"
-s3_source_files = [(S3_SOURCE_FILES_PATH, p) for p in os.listdir(S3_SOURCE_FILES_PATH)]
+s3_source_files = [
+    (S3_SOURCE_FILES_PATH, p) for p in sorted(os.listdir(S3_SOURCE_FILES_PATH))
+]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# Summary
Fix CI test regression due to `--continue-on-collection-errors` pytest flag

sort os.listdir() to ensure deterministic test parametrize order

os.listdir() returns files in filesystem-internal order which differs between macOS (HFS+) and Linux CI (ext4), causing non-deterministic test execution order for all parametrized S3/GCS/local integration tests.

This matches the sorted() pattern already used throughout the same file in s3_populate, touch_local_files, and local_browser.

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
