### PR TITLE
fix(ingestion/tableau): apply project filters to embedded datasources when emit_all_embedded_datasources is enabled

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau/tableau.py
@@ -2744,27 +2744,20 @@ class TableauSiteSource:
         workbook: Optional[dict] = None,
         is_embedded_ds: bool = False,
     ) -> Iterable[MetadataWorkUnit]:
+        is_not_allowed = self._get_datasource_project_luid(datasource) is None
+
+        if is_not_allowed:
+            ds_type = "embedded" if is_embedded_ds else "published"
+            logger.warning(
+                f"Skip ingesting {ds_type} datasource {datasource.get(c.NAME)} because of filtered project"
+            )
+            return
+
         datasource_info = workbook
         if not is_embedded_ds:
             datasource_info = datasource
 
         browse_path = self._get_project_browse_path_name(datasource)
-        if (
-            is_embedded_ds
-            and self._get_embedded_datasource_project_luid(datasource) is None
-        ):
-            logger.warning(
-                f"Skip ingesting embedded datasource {datasource.get(c.NAME)} because of filtered project"
-            )
-            return
-        elif (
-            not is_embedded_ds
-            and self._get_published_datasource_project_luid(datasource) is None
-        ):
-            logger.warning(
-                f"Skip ingesting published datasource {datasource.get(c.NAME)} because of filtered project"
-            )
-            return
 
         logger.debug(f"datasource {datasource.get(c.NAME)} browse-path {browse_path}")
         datasource_id = datasource[c.ID]


### PR DESCRIPTION
## Summary

- emit_all_embedded_datasources=True was fetching all embedded datasources from the entire Tableau server, ignoring any configured project_pattern / project_path_pattern filters
- Published datasources already had a project check in emit_datasource(), but embedded datasources skipped it entirely due to a not is_embedded_ds condition guard
- Fixed by extending the project check to also apply to embedded datasources using the existing _get_embedded_datasource_project_luid(), which walks the datasource → workbook → project chain and returns None if the project is not in the allowed registry