### PR TITLE
docs(release-notes): add known issue for v0.3.16.3 scroll pagination regression

### DIFF
--- a/docs/managed-datahub/release-notes/v_0_3_16.md
+++ b/docs/managed-datahub/release-notes/v_0_3_16.md
@@ -140,4 +140,4 @@ Fixes:
 
 ## Known Issues
 
-- TODO
+- System upgrades may hang on v0.3.16.3 due to a scroll pagination issue. Upgrade to Helm chart `1.6.12` or later, or set `ELASTICSEARCH_QUERY_RESCORE_ENABLED=false` on GMS and restart.


### PR DESCRIPTION
## Summary

- Add known issue to v0.3.16 release notes for scroll pagination regression in v0.3.16.3
- Documents fix options: upgrade to Helm chart `1.6.12` or set `ELASTICSEARCH_QUERY_RESCORE_ENABLED=false`
