### PR TITLE
fix(views): align entity types across View builder tabs and pass search facets to filters

### DIFF
--- a/datahub-web-react/src/app/entityV2/view/builder/SelectFilterValuesTab.tsx
+++ b/datahub-web-react/src/app/entityV2/view/builder/SelectFilterValuesTab.tsx
@@ -14,7 +14,7 @@ import { generateOrFilters } from '@app/searchV2/utils/generateOrFilters';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 
 import { useGetSearchResultsForMultipleQuery } from '@graphql/search.generated';
-import { Entity } from '@types';
+import { Entity, FacetMetadata } from '@types';
 
 const Container = styled.div`
     display: flex;
@@ -112,6 +112,11 @@ export function SelectFilterValuesTab({ selectedUrns, onChangeSelectedUrns }: Pr
         [data],
     );
 
+    const facets = useMemo(
+        () => (data?.searchAcrossEntities?.facets as FacetMetadata[] | undefined) ?? undefined,
+        [data],
+    );
+
     const handleCheckboxChange = useCallback(
         (urn: string) => {
             if (selectedUrns.includes(urn)) {
@@ -201,6 +206,7 @@ export function SelectFilterValuesTab({ selectedUrns, onChangeSelectedUrns }: Pr
                     searchQuery={searchQuery}
                     appliedFilters={appliedFilters}
                     updateFieldFilters={updateFieldFilters}
+                    facets={facets}
                 />
                 <ResultsContainer>
                     <ScrollableResultsContainer data-testid="select-filter-values-search-results">

--- a/datahub-web-react/src/app/entityV2/view/builder/constants.ts
+++ b/datahub-web-react/src/app/entityV2/view/builder/constants.ts
@@ -5,30 +5,37 @@ import { EntityType } from '@types';
 export const URN_FILTER_NAME = 'urn';
 
 /**
- * Entity types that can be searched and selected as individual assets in the View builder.
- * All selected entities are stored as URN filters, so the View shows exactly those assets.
+ * Single source of truth for entity types available in the View builder.
+ * Used by both the "Build Filters" tab (type dropdown) and the "Select Assets" tab.
+ * To add/remove a type from Views, update this list only.
  */
-export const SELECTABLE_ASSET_ENTITY_TYPES = [
-    EntityType.Dataset,
-    EntityType.Dashboard,
-    EntityType.Chart,
-    EntityType.DataFlow,
-    EntityType.DataJob,
-    EntityType.Container,
-    EntityType.Domain,
-    EntityType.GlossaryTerm,
-    EntityType.GlossaryNode,
-    EntityType.Tag,
-    EntityType.CorpUser,
-    EntityType.CorpGroup,
-    EntityType.DataPlatform,
-    EntityType.Mlmodel,
-    EntityType.MlfeatureTable,
-    EntityType.MlprimaryKey,
-    EntityType.Notebook,
-    EntityType.Document,
-    EntityType.Application,
+export const VIEW_ENTITY_TYPES: { type: EntityType; id: string; displayName: string }[] = [
+    { type: EntityType.Dataset, id: 'dataset', displayName: 'Dataset' },
+    { type: EntityType.Dashboard, id: 'dashboard', displayName: 'Dashboard' },
+    { type: EntityType.Chart, id: 'chart', displayName: 'Chart' },
+    { type: EntityType.DataFlow, id: 'dataFlow', displayName: 'Data Flow (Pipeline)' },
+    { type: EntityType.DataJob, id: 'dataJob', displayName: 'Data Job (Task)' },
+    { type: EntityType.Container, id: 'container', displayName: 'Container' },
+    { type: EntityType.Domain, id: 'domain', displayName: 'Domain' },
+    { type: EntityType.DataProduct, id: 'dataProduct', displayName: 'Data Product' },
+    { type: EntityType.GlossaryTerm, id: 'glossaryTerm', displayName: 'Glossary Term' },
+    { type: EntityType.GlossaryNode, id: 'glossaryNode', displayName: 'Term Group' },
+    { type: EntityType.Tag, id: 'tag', displayName: 'Tag' },
+    { type: EntityType.CorpUser, id: 'corpuser', displayName: 'User' },
+    { type: EntityType.CorpGroup, id: 'corpGroup', displayName: 'Group' },
+    { type: EntityType.DataPlatform, id: 'dataPlatform', displayName: 'Platform' },
+    { type: EntityType.Mlmodel, id: 'mlModel', displayName: 'ML Model' },
+    { type: EntityType.MlmodelGroup, id: 'mlModelGroup', displayName: 'ML Model Group' },
+    { type: EntityType.Mlfeature, id: 'mlFeature', displayName: 'ML Feature' },
+    { type: EntityType.MlfeatureTable, id: 'mlFeatureTable', displayName: 'ML Feature Table' },
+    { type: EntityType.MlprimaryKey, id: 'mlPrimaryKey', displayName: 'ML Primary Key' },
+    { type: EntityType.Notebook, id: 'notebook', displayName: 'Notebook' },
+    { type: EntityType.Document, id: 'document', displayName: 'Document' },
+    { type: EntityType.Application, id: 'application', displayName: 'Application' },
 ];
+
+/** Derived from VIEW_ENTITY_TYPES for the Select Assets tab search query. */
+export const SELECTABLE_ASSET_ENTITY_TYPES = VIEW_ENTITY_TYPES.map((e) => e.type);
 
 /**
  * Tab keys for the view definition builder.

--- a/datahub-web-react/src/app/entityV2/view/builder/viewBuilderProperties.ts
+++ b/datahub-web-react/src/app/entityV2/view/builder/viewBuilderProperties.ts
@@ -1,3 +1,4 @@
+import { VIEW_ENTITY_TYPES } from '@app/entityV2/view/builder/constants';
 import { Property } from '@app/sharedV2/queryBuilder/builder/property/types/properties';
 import { SelectInputMode, ValueTypeId } from '@app/sharedV2/queryBuilder/builder/property/types/values';
 
@@ -16,25 +17,7 @@ export const viewBuilderProperties: Property[] = [
         valueType: ValueTypeId.ENUM,
         valueOptions: {
             mode: SelectInputMode.MULTIPLE,
-            options: [
-                { id: 'dataset', displayName: 'Dataset' },
-                { id: 'dataProduct', displayName: 'Data Product' },
-                { id: 'document', displayName: 'Document' },
-                { id: 'dashboard', displayName: 'Dashboard' },
-                { id: 'domain', displayName: 'Domain' },
-                { id: 'glossaryTerm', displayName: 'Glossary Term' },
-                { id: 'glossaryNode', displayName: 'Term Group' },
-                { id: 'chart', displayName: 'Chart' },
-                { id: 'dataJob', displayName: 'Data Job (Task)' },
-                { id: 'dataFlow', displayName: 'Data Flow (Pipeline)' },
-                { id: 'container', displayName: 'Container' },
-                { id: 'application', displayName: 'Application' },
-                { id: 'mlModel', displayName: 'ML Model' },
-                { id: 'mlModelGroup', displayName: 'ML Model Group' },
-                { id: 'mlFeature', displayName: 'ML Feature' },
-                { id: 'mlFeatureTable', displayName: 'ML Feature Table' },
-                { id: 'mlPrimaryKey', displayName: 'ML Primary Key' },
-            ],
+            options: VIEW_ENTITY_TYPES.map((e) => ({ id: e.id, displayName: e.displayName })),
         },
     },
     {

--- a/datahub-web-react/src/app/homeV3/modules/assetCollection/AssetFilters.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/assetCollection/AssetFilters.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 import { AppliedFieldFilterUpdater, FieldToAppliedFieldFiltersMap } from '@app/searchV2/filtersV2/types';
 import Filters from '@app/searchV2/searchBarV2/components/Filters';
+import { FacetMetadata } from '@src/types.generated';
 
 const FiltersContainer = styled.div`
     margin: -8px;
@@ -12,9 +13,10 @@ type Props = {
     searchQuery: string | undefined;
     appliedFilters?: FieldToAppliedFieldFiltersMap;
     updateFieldFilters?: AppliedFieldFilterUpdater;
+    facets?: FacetMetadata[];
 };
 
-const AssetFilters = ({ searchQuery, appliedFilters, updateFieldFilters }: Props) => {
+const AssetFilters = ({ searchQuery, appliedFilters, updateFieldFilters, facets }: Props) => {
     return (
         <FiltersContainer>
             <Filters
@@ -22,6 +24,7 @@ const AssetFilters = ({ searchQuery, appliedFilters, updateFieldFilters }: Props
                 appliedFilters={appliedFilters}
                 updateFieldAppliedFilters={updateFieldFilters}
                 viewUrn={null}
+                facets={facets}
             />
         </FiltersContainer>
     );


### PR DESCRIPTION
## Summary
- Consolidates the duplicated entity type lists between the View builder's "Build Filters" and "Select Assets" tabs into a single `VIEW_ENTITY_TYPES` constant, adding missing types like Data Product, ML Model Group, and ML Feature
- Passes search result facets from the Select Assets tab down to the `AssetFilters` → `Filters` component so the Types dropdown reflects the scoped entity types

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

Made with [Cursor](https://cursor.com)