### PR TITLE
fix(ci): Update paths to coverage reports

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -56,7 +56,7 @@ jobs:
           #handle_no_reports_found: true
           fail_ci_if_error: false
           disable_search: true
-          files: ./datahub-actions/.coverage
+          directory: ./build/coverage-reports/datahub-actions/
           name: datahub-actions
           verbose: true
           override_branch: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/agent-context.yml
+++ b/.github/workflows/agent-context.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true
-          files: ./datahub-agent-context/.coverage
+          files: ./build/coverage-reports/datahub-agent-context/
           #handle_no_reports_found: true
           fail_ci_if_error: false
           name: datahub-agent-context


### PR DESCRIPTION
Some python projects had the wrong coverage path for CodeCov uploads added in a previous PR.
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
