### PR TITLE
style(frontend): redesign search filters to match alchemy SimpleSelect

### DIFF
--- a/datahub-web-react/src/app/searchV2/context/constants.ts
+++ b/datahub-web-react/src/app/searchV2/context/constants.ts
@@ -7,7 +7,7 @@ export const LAST_MODIFIED_TIME_FIELD = 'lastModifiedAt';
 export const DEFAULT_SORT_OPTION = RELEVANCE;
 
 export const SORT_OPTIONS = {
-    [RELEVANCE]: { label: 'Relevance (Default)', field: RELEVANCE, sortOrder: SortOrder.Descending },
+    [RELEVANCE]: { label: 'Relevance', field: RELEVANCE, sortOrder: SortOrder.Descending },
     [`${ENTITY_NAME_FIELD}_${SortOrder.Ascending}`]: {
         label: 'Name A to Z',
         field: ENTITY_NAME_FIELD,

--- a/datahub-web-react/src/app/searchV2/filters/ActiveFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/ActiveFilter.tsx
@@ -1,9 +1,8 @@
 import { CloseCircleOutlined } from '@ant-design/icons';
-import { Button } from 'antd';
+import { Tooltip } from '@components';
 import React from 'react';
 import styled from 'styled-components';
 
-import { ANTD_GRAY } from '@app/entity/shared/constants';
 import { useFilterRendererRegistry } from '@app/searchV2/filters/render/useFilterRenderer';
 import { IconSpacer, Label } from '@app/searchV2/filters/styledComponents';
 import useGetBrowseV2LabelOverride from '@app/searchV2/filters/useGetBrowseV2LabelOverride';
@@ -13,7 +12,7 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 import { FacetFilterInput, FacetMetadata } from '@types';
 
 const ActiveFilterWrapper = styled.div`
-    border: 1px solid ${ANTD_GRAY[5]};
+    border: 1px solid ${(props) => props.theme.colors.border};
     border-radius: 4px;
     padding: 2px 8px;
     display: flex;
@@ -21,15 +20,25 @@ const ActiveFilterWrapper = styled.div`
     font-size: 14px;
     height: 24px;
     margin: 8px 8px 0 0;
+    color: ${(props) => props.theme.colors.text};
 `;
 
-const StyledButton = styled(Button)`
+const CloseButton = styled.button`
     border: none;
+    background: none;
     box-shadow: none;
     padding: 0;
     margin-left: 6px;
     height: 16px;
     width: 11px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    color: ${(props) => props.theme.colors.textSecondary};
+
+    &:hover {
+        color: ${(props) => props.theme.colors.text};
+    }
 `;
 
 interface ActiveFilterProps {
@@ -68,14 +77,12 @@ function ActiveFilter({
         <ActiveFilterWrapper data-testid={`active-filter-${label}`}>
             {icon}
             {icon && <IconSpacer />}
-            <Label ellipsis={{ tooltip: label }} style={{ maxWidth: 150 }}>
-                {label}
-            </Label>
-            <StyledButton
-                icon={<CloseCircleOutlined />}
-                onClick={removeFilter}
-                data-testid={`remove-filter-${label}`}
-            />
+            <Tooltip title={label as string}>
+                <Label style={{ maxWidth: 150 }}>{label}</Label>
+            </Tooltip>
+            <CloseButton onClick={removeFilter} data-testid={`remove-filter-${label}`}>
+                <CloseCircleOutlined />
+            </CloseButton>
         </ActiveFilterWrapper>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/FilterOption.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/FilterOption.tsx
@@ -1,11 +1,8 @@
-import { CaretUpOutlined } from '@ant-design/icons';
-import { Button, Checkbox } from 'antd';
+import { Checkbox, Pill } from '@components';
+import { CaretUp } from '@phosphor-icons/react';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-import colors from '@components/theme/foundations/colors';
-
-import { ANTD_GRAY } from '@app/entity/shared/constants';
 import { generateColor } from '@app/entityV2/shared/components/styled/StyledTag';
 import ParentEntities from '@app/searchV2/filters/ParentEntities';
 import { Label } from '@app/searchV2/filters/styledComponents';
@@ -33,40 +30,25 @@ const FilterOptionWrapper = styled.div<{ addPadding?: boolean }>`
     display: flex;
     align-items: center;
     border-radius: 8px;
-    margin: 0px 4px;
-
-    label {
-        padding: 12px;
-        width: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
-    }
-
-    ${(props) => props.addPadding && 'padding-left: 16px;'}
-    &:hover {
-        background-color: ${ANTD_GRAY[3]};
-    }
-`;
-
-const StyledCheckbox = styled(Checkbox)`
+    padding: 8px 4px;
+    gap: 4px;
+    cursor: pointer;
     font-size: 14px;
+    color: ${(props) => props.theme.colors.text};
 
-    .ant-checkbox-inner {
-        border-color: ${ANTD_GRAY[7]};
-    }
+    ${(props) => props.addPadding && 'padding-left: 24px;'}
 
-    .ant-checkbox-checked {
-        .ant-checkbox-inner {
-            border-color: ${(props) => props.theme.styles['primary-color']};
-        }
+    &:hover {
+        background-color: ${(props) => props.theme.colors.bgHover};
     }
 `;
 
 const CheckboxContent = styled.div`
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 4px;
+    overflow: hidden;
+    flex: 1;
 `;
 
 export const TagColor = styled.span<{ color: string; colorHash?: string | null }>`
@@ -77,38 +59,26 @@ export const TagColor = styled.span<{ color: string; colorHash?: string | null }
     margin-right: 3px;
 `;
 
-const CountText = styled.span`
-    font-size: 12px;
-    margin-left: 6px;
-    color: ${ANTD_GRAY[8]};
-`;
-
 const LabelCountWrapper = styled.div`
     display: flex;
     align-items: baseline;
 `;
 
-const ArrowButton = styled(Button)<{ isOpen: boolean }>`
+const ArrowButton = styled.button<{ $isOpen: boolean }>`
     margin-left: 4px;
-    background-color: transparent;
-    height: 24px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    color: ${(props) => props.theme.colors.icon};
+    transition: transform 0.2s ease;
+    ${(props) => props.$isOpen && 'transform: rotate(180deg);'}
 
-    svg {
-        height: 12px;
-        width: 12px;
+    &:hover {
+        color: ${(props) => props.theme.colors.iconHover};
     }
-
-    &:hover,
-    &:focus,
-    &:active {
-        background-color: transparent;
-    }
-
-    ${(props) =>
-        props.isOpen &&
-        `
-        transform: rotate(180deg);
-    `}
 `;
 
 const ParentWrapper = styled.div`
@@ -151,9 +121,13 @@ export default function FilterOption({
     const showParentEntityPath = field === DOMAINS_FILTER_NAME && entity?.type === EntityType.Domain;
     const isSubTypeFilter = field === TYPE_NAMES_FILTER_NAME;
     const parentEntities: Entity[] = getParentEntities(entity as Entity) || [];
+    const isSelected = isFilterOptionSelected(selectedFilterOptions, value);
+    const isIndeterminate = isAnyOptionSelected(
+        selectedFilterOptions,
+        nestedOptions?.map((o) => o.value),
+    );
 
     const getCountText = () => {
-        // only entity type filters return 10,000 max aggs
         return count === MAX_COUNT_VAL && field === ENTITY_SUB_TYPE_FILTER_NAME ? '10k+' : formatNumber(count);
     };
 
@@ -161,7 +135,6 @@ export default function FilterOption({
         if (isFilterOptionSelected(selectedFilterOptions, value)) {
             setSelectedFilterOptions(selectedFilterOptions.filter((option) => option.value !== value));
         } else {
-            // if selecting parent filter, remove nested filter values
             const filteredSelectedOptions = selectedFilterOptions.filter(
                 (o) => !nestedOptions?.some((nestedOption) => nestedOption.value === o.value),
             );
@@ -171,52 +144,41 @@ export default function FilterOption({
 
     return (
         <>
-            <FilterOptionWrapper addPadding={addPadding}>
-                <StyledCheckbox
-                    checked={isFilterOptionSelected(selectedFilterOptions, value)}
-                    // show indeterminate if a nested option is selected
-                    indeterminate={isAnyOptionSelected(
-                        selectedFilterOptions,
-                        nestedOptions?.map((o) => o.value),
-                    )}
-                    onClick={updateFilterValues}
-                    data-testid={`filter-option-${label}`}
-                >
-                    <CheckboxContent>
-                        <FilterEntityIcon field={field} entity={entity} icon={icon} />
-                        <LabelWrapper className="test-label">
-                            {!showParentEntityPath && parentEntities.length > 0 && (
-                                <ParentWrapper>
-                                    <ParentEntities parentEntities={parentEntities} />
-                                </ParentWrapper>
-                            )}
-                            <LabelCountWrapper>
-                                <Label
-                                    ellipsis={{
-                                        tooltip: {
-                                            title: label,
-                                            showArrow: false,
-                                            color: 'white',
-                                            overlayInnerStyle: { color: colors.gray[1700] },
-                                        },
+            <FilterOptionWrapper addPadding={addPadding} onClick={updateFilterValues}>
+                <Checkbox
+                    isChecked={isSelected}
+                    isIntermediate={isIndeterminate}
+                    onCheckboxChange={() => updateFilterValues()}
+                    dataTestId={`filter-option-${label}`}
+                    size="xs"
+                />
+                <CheckboxContent>
+                    <FilterEntityIcon field={field} entity={entity} icon={icon} />
+                    <LabelWrapper className="test-label">
+                        {!showParentEntityPath && parentEntities.length > 0 && (
+                            <ParentWrapper>
+                                <ParentEntities parentEntities={parentEntities} />
+                            </ParentWrapper>
+                        )}
+                        <LabelCountWrapper>
+                            <Label style={{ maxWidth: 150 }}>
+                                {isSubTypeFilter ? capitalizeFirstLetterOnly(label as string) : label}
+                            </Label>
+                            {nestedOptions && nestedOptions.length > 0 && (
+                                <ArrowButton
+                                    $isOpen={areChildrenVisible}
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        setAreChildrenVisible(!areChildrenVisible);
                                     }}
-                                    style={{ maxWidth: 150 }}
                                 >
-                                    {isSubTypeFilter ? capitalizeFirstLetterOnly(label as string) : label}
-                                </Label>
-                                {includeCount && <CountText>{getCountText()}</CountText>}
-                                {nestedOptions && nestedOptions.length > 0 && (
-                                    <ArrowButton
-                                        icon={<CaretUpOutlined />}
-                                        type="text"
-                                        onClick={() => setAreChildrenVisible(!areChildrenVisible)}
-                                        isOpen={areChildrenVisible}
-                                    />
-                                )}
-                            </LabelCountWrapper>
-                        </LabelWrapper>
-                    </CheckboxContent>
-                </StyledCheckbox>
+                                    <CaretUp size={12} />
+                                </ArrowButton>
+                            )}
+                        </LabelCountWrapper>
+                    </LabelWrapper>
+                </CheckboxContent>
+                {includeCount && <Pill label={getCountText()} size="xs" variant="filled" color="gray" />}
             </FilterOptionWrapper>
             {areChildrenVisible && (
                 <>

--- a/datahub-web-react/src/app/searchV2/filters/MoreFilterOption.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/MoreFilterOption.tsx
@@ -1,34 +1,20 @@
-import { RightOutlined } from '@ant-design/icons';
-import { Typography } from 'antd';
-import React, { useRef } from 'react';
+import { CaretRight } from '@phosphor-icons/react';
+import React, { useMemo, useRef } from 'react';
 import styled from 'styled-components';
 
-import colors from '@components/theme/foundations/colors';
-
-import { IconWrapper } from '@app/searchV2/filters/SearchFilterView';
 import { MoreFilterOptionLabel } from '@app/searchV2/filters/styledComponents';
 import { FilterPredicate } from '@app/searchV2/filters/types';
 import useSearchFilterDropdown from '@app/searchV2/filters/useSearchFilterDropdown';
-import { getFilterDropdownIcon, useElementDimensions, useFilterDisplayName } from '@app/searchV2/filters/utils';
+import { useElementDimensions, useFilterDisplayName } from '@app/searchV2/filters/utils';
 import ValueSelector from '@app/searchV2/filters/value/ValueSelector';
 
 import { FacetFilterInput, FacetMetadata } from '@types';
 
-const IconNameWrapper = styled.span`
-    display: flex;
-    align-items: center;
+const OptionDisplayName = styled.span`
     overflow: hidden;
-`;
-
-const StyledValueSelector = styled(ValueSelector)<{ width: number; height: number; isElementOutsideWindow: boolean }>`
-    position: absolute;
-    top: -${(props) => props.height}px;
-    ${(props) => (props.isElementOutsideWindow ? 'right' : 'left')}: ${(props) => props.width}px;
-`;
-
-const StyledRightOutlined = styled(RightOutlined)`
-    font-size: 12px;
-    height: 12px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: inherit;
 `;
 
 interface Props {
@@ -45,9 +31,17 @@ export default function MoreFilterOption({ filter, filterPredicates, activeFilte
         onChangeFilters,
     });
     const displayName = useFilterDisplayName(filter);
-    const filterIcon = getFilterDropdownIcon(filter.field);
     const labelRef = useRef<HTMLDivElement>(null);
-    const elementDimensions = useElementDimensions(labelRef);
+    const { width, height, isElementOutsideWindow } = useElementDimensions(labelRef);
+
+    const menuStyle = useMemo(
+        () => ({
+            top: -height,
+            left: isElementOutsideWindow ? undefined : width,
+            right: isElementOutsideWindow ? width : undefined,
+        }),
+        [width, height, isElementOutsideWindow],
+    );
 
     const onChangeFilterValues = (currentFilterPredicate: FilterPredicate, newValues) => {
         if (currentFilterPredicate.values !== newValues) {
@@ -60,37 +54,24 @@ export default function MoreFilterOption({ filter, filterPredicates, activeFilte
     ) as FilterPredicate;
 
     return (
-        <StyledValueSelector
+        <ValueSelector
             field={currentFilterPredicate?.field}
             values={currentFilterPredicate?.values}
             defaultOptions={finalAggregations}
             onChangeValues={(newValues) => onChangeFilterValues(currentFilterPredicate, newValues)}
             manuallyUpdateFilters={manuallyUpdateFilters}
-            {...elementDimensions}
+            menuStyle={menuStyle}
         >
             <MoreFilterOptionLabel
                 $isActive={!!numActiveFilters}
                 data-testid={`more-filter-${displayName?.replace(/\s/g, '-')}`}
                 ref={labelRef}
             >
-                <IconNameWrapper>
-                    {filterIcon && <IconWrapper>{filterIcon}</IconWrapper>}
-                    <Typography.Text
-                        ellipsis={{
-                            tooltip: {
-                                title: displayName,
-                                showArrow: false,
-                                color: 'white',
-                                overlayInnerStyle: { color: colors.gray[1700] },
-                                placement: 'left',
-                            },
-                        }}
-                    >
-                        {displayName} {numActiveFilters ? `(${numActiveFilters}) ` : ''}
-                    </Typography.Text>
-                </IconNameWrapper>
-                <StyledRightOutlined />
+                <OptionDisplayName>
+                    {displayName} {numActiveFilters ? `(${numActiveFilters}) ` : ''}
+                </OptionDisplayName>
+                <CaretRight size={12} />
             </MoreFilterOptionLabel>
-        </StyledValueSelector>
+        </ValueSelector>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/MoreFilters.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/MoreFilters.tsx
@@ -1,7 +1,8 @@
-import { CaretDownFilled } from '@ant-design/icons';
-import { Dropdown } from 'antd';
-import React, { useState } from 'react';
+import { CaretDown } from '@phosphor-icons/react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
+
+import useClickOutside from '@components/components/Utils/ClickOutside/useClickOutside';
 
 import MoreFilterOption from '@app/searchV2/filters/MoreFilterOption';
 import { FilterScenarioType } from '@app/searchV2/filters/render/types';
@@ -14,15 +15,27 @@ import { useAppConfig } from '@src/app/useAppConfig';
 
 import { FacetFilterInput, FacetMetadata } from '@types';
 
-const DropdownMenu = styled.div<{ padding?: string }>`
-    background-color: white;
-    border-radius: 5px;
-    box-shadow: ${(props) => props.theme.styles['box-shadow']};
-    overflow: hidden;
+const DropdownWrapper = styled.div`
+    position: relative;
+`;
+
+const DropdownPanel = styled.div`
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 1050;
+    background-color: ${(props) => props.theme.colors.bg};
+    border: 1px solid ${(props) => props.theme.colors.border};
+    border-radius: 12px;
+    box-shadow: ${(props) => props.theme.colors.shadowMd};
     min-width: 200px;
     max-width: 400px;
+    padding: 4px;
+`;
 
-    ${(props) => props.padding !== undefined && `padding: ${props.padding};`}
+const CaretIcon = styled(CaretDown)<{ $isOpen?: boolean }>`
+    transition: transform 0.2s ease;
+    ${(props) => props.$isOpen && 'transform: rotate(180deg);'}
 `;
 
 interface Props {
@@ -38,22 +51,30 @@ export default function MoreFilters({ filters, filterPredicates, activeFilters, 
     const numActiveFilters = getNumActiveFiltersForGroupOfFilters(activeFilters, filters);
     const filterRendererRegistry = useFilterRendererRegistry();
     const { config } = useAppConfig();
+    const wrapperRef = useRef<HTMLDivElement>(null);
 
     function updateFiltersAndClose(newFilters: FacetFilterInput[]) {
         onChangeFilters(newFilters);
         setIsMenuOpen(false);
     }
 
-    function onOpenChange(isOpen: boolean) {
-        if (isOpen) trackShowMoreEvent(activeFilters.length, filters.length);
-        setIsMenuOpen(isOpen);
+    function toggleMenu() {
+        if (!isMenuOpen) trackShowMoreEvent(activeFilters.length, filters.length);
+        setIsMenuOpen((prev) => !prev);
     }
 
+    const handleClickOutside = useCallback(() => setIsMenuOpen(false), []);
+    const clickOutsideOptions = useMemo(() => ({ wrappers: [wrapperRef] }), []);
+    useClickOutside(handleClickOutside, clickOutsideOptions);
+
     return (
-        <Dropdown
-            trigger={['click']}
-            dropdownRender={() => (
-                <DropdownMenu padding="4px 0px">
+        <DropdownWrapper ref={wrapperRef}>
+            <SearchFilterLabel data-testid="more-filters-dropdown" $isActive={!!numActiveFilters} onClick={toggleMenu}>
+                More {numActiveFilters ? `(${numActiveFilters}) ` : ''}
+                <CaretIcon size={12} $isOpen={isMenuOpen} />
+            </SearchFilterLabel>
+            {isMenuOpen && (
+                <DropdownPanel>
                     {filters.map((filter) => {
                         return filterRendererRegistry.hasRenderer(filter.field) ? (
                             filterRendererRegistry.render(filter.field, {
@@ -73,15 +94,8 @@ export default function MoreFilters({ filters, filterPredicates, activeFilters, 
                             />
                         );
                     })}
-                </DropdownMenu>
+                </DropdownPanel>
             )}
-            open={isMenuOpen}
-            onOpenChange={onOpenChange}
-        >
-            <SearchFilterLabel data-testid="more-filters-dropdown" $isActive={!!numActiveFilters}>
-                More {numActiveFilters ? `(${numActiveFilters}) ` : ''}
-                <CaretDownFilled style={{ fontSize: '12px', height: '12px' }} />
-            </SearchFilterLabel>
-        </Dropdown>
+        </DropdownWrapper>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/OptionsDropdownMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/OptionsDropdownMenu.tsx
@@ -1,51 +1,36 @@
 import { LoadingOutlined } from '@ant-design/icons';
-import { Button } from 'antd';
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { ANTD_GRAY } from '@app/entityV2/shared/constants';
-import { SearchBar } from '@app/searchV2/SearchBar';
-import { useEnterKeyListener } from '@app/shared/useEnterKeyListener';
-import { useEntityRegistry } from '@app/useEntityRegistry';
+import DropdownSearchBar from '@components/components/Select/private/DropdownSearchBar';
 
-const StyledButton = styled(Button)`
-    width: 100%;
-    text-align: center;
-    background-color: ${(p) => p.theme.styles['primary-color']};
-    color: white;
-    border-radius: 0;
-`;
-
-export const DropdownMenu = styled.div<{ type: 'card' | 'default' }>`
-    background-color: white;
-    ${(props) => props.type === 'card' && 'border-radius: 5px;'}
-    ${(props) =>
-        props.type === 'card' &&
-        'box-shadow: 0 3px 6px -4px rgba(0, 0, 0, 0.12), 0 6px 16px 0 rgba(0, 0, 0, 0.08), 0 9px 28px 8px rgba(0, 0, 0, 0.05);'}
+const DropdownCard = styled.div`
+    background-color: ${(props) => props.theme.colors.bg};
+    border-radius: 12px;
+    box-shadow: ${(props) => props.theme.colors.shadowMd};
     overflow: hidden;
     min-width: 200px;
-
-    .ant-dropdown-menu-title-content {
-        background-color: white;
-        &:hover {
-            background-color: white;
-        }
-    }
-    .ant-dropdown-menu {
-        padding: 7px;
-    }
 `;
 
 const ScrollableContent = styled.div`
-    max-height: 380px;
+    max-height: 360px;
     overflow: auto;
     min-width: 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 4px;
+`;
+
+const SearchBarWrapper = styled.div`
+    padding: 8px 8px 4px 8px;
 `;
 
 const LoadingWrapper = styled.div`
     display: flex;
     justify-content: center;
     padding: 9px;
+    color: ${(props) => props.theme.colors.textSecondary};
 
     svg {
         height: 16px;
@@ -55,66 +40,42 @@ const LoadingWrapper = styled.div`
 
 interface Props {
     menu: React.ReactNode;
-    updateFilters: () => void;
     isLoading?: boolean;
     searchQuery?: string;
     updateSearchQuery?: (query: string) => void;
     searchPlaceholder?: string;
     showSearchBar?: boolean;
-    type?: 'card' | 'default';
     className?: string;
 }
 
 export default function OptionsDropdownMenu({
     menu,
-    updateFilters,
     isLoading,
     searchQuery,
     updateSearchQuery,
     searchPlaceholder,
     showSearchBar = true,
-    type = 'card',
     className,
 }: Props) {
-    const entityRegistry = useEntityRegistry();
-
-    useEnterKeyListener({ querySelectorToExecuteClick: '#updateFiltersButton' });
-
     return (
-        <DropdownMenu type={type} data-testid="filter-dropdown" className={className}>
-            <ScrollableContent>
-                {showSearchBar && (
-                    <SearchBar
-                        initialQuery={searchQuery}
-                        placeholderText={searchPlaceholder || ''}
-                        suggestions={[]}
-                        hideRecommendations
-                        style={{
-                            padding: 12,
-                            paddingBottom: 5,
-                        }}
-                        inputStyle={{
-                            height: 30,
-                            fontSize: 12,
-                            borderRadius: 8,
-                        }}
-                        onSearch={() => null}
-                        onQueryChange={updateSearchQuery}
-                        entityRegistry={entityRegistry}
-                        textColor={ANTD_GRAY[9]}
-                        placeholderColor={ANTD_GRAY[6]}
+        <DropdownCard data-testid="filter-dropdown" className={className}>
+            {showSearchBar && (
+                <SearchBarWrapper>
+                    <DropdownSearchBar
+                        placeholder={searchPlaceholder || 'Search...'}
+                        value={searchQuery}
+                        onChange={updateSearchQuery}
                     />
-                )}
-                {React.cloneElement(menu as React.ReactElement, { style: { boxShadow: 'none' } })}
+                </SearchBarWrapper>
+            )}
+            <ScrollableContent>
+                {menu}
                 {isLoading && (
                     <LoadingWrapper>
                         <LoadingOutlined />
                     </LoadingWrapper>
                 )}
             </ScrollableContent>
-            <StyledButton id="updateFiltersButton" type="text" onClick={updateFilters} data-testid="update-filters">
-                Update
-            </StyledButton>
-        </DropdownMenu>
+        </DropdownCard>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/SaveViewButton.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/SaveViewButton.tsx
@@ -44,7 +44,7 @@ export default function SaveViewButton({ activeFilters, unionType }: Props) {
                     </>
                 }
             >
-                <TextButton type="text" onClick={toggleViewBuilder} marginTop={0} data-testid="save-as-view">
+                <TextButton type="button" onClick={toggleViewBuilder} marginTop={0} data-testid="save-as-view">
                     Save as a View
                 </TextButton>
             </Tooltip>

--- a/datahub-web-react/src/app/searchV2/filters/SearchFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/SearchFilter.tsx
@@ -4,7 +4,7 @@ import { CSSProperties } from 'styled-components';
 import SearchFilterView from '@app/searchV2/filters/SearchFilterView';
 import { FilterPredicate } from '@app/searchV2/filters/types';
 import useSearchFilterDropdown from '@app/searchV2/filters/useSearchFilterDropdown';
-import { getFilterDropdownIcon, useFilterDisplayName } from '@app/searchV2/filters/utils';
+import { useFilterDisplayName } from '@app/searchV2/filters/utils';
 
 import { FacetFilterInput, FacetMetadata } from '@types';
 
@@ -31,7 +31,6 @@ export default function SearchFilter({
         onChangeFilters,
         shouldUseAggregationsFromFilter,
     });
-    const filterIcon = getFilterDropdownIcon(filter.field);
 
     const currentFilterPredicate = filterPredicates?.find((obj) =>
         obj.field.field.includes(filter.field),
@@ -44,7 +43,6 @@ export default function SearchFilter({
             filterPredicate={currentFilterPredicate}
             numActiveFilters={numActiveFilters}
             filterOptions={finalAggregations}
-            filterIcon={filterIcon}
             displayName={displayName}
             onChangeValues={updateFilters}
             labelStyle={labelStyle}

--- a/datahub-web-react/src/app/searchV2/filters/SearchFilterOptions.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/SearchFilterOptions.tsx
@@ -22,6 +22,7 @@ export const FlexWrapper = styled.div`
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    gap: 8px;
 `;
 
 export const FlexSpacer = styled.div`

--- a/datahub-web-react/src/app/searchV2/filters/SearchFilterView.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/SearchFilterView.tsx
@@ -1,4 +1,4 @@
-import { CaretDownFilled } from '@ant-design/icons';
+import { CaretDown } from '@phosphor-icons/react';
 import React from 'react';
 import styled, { CSSProperties } from 'styled-components';
 
@@ -16,9 +16,13 @@ export const IconWrapper = styled.div`
     }
 `;
 
+const CaretIcon = styled(CaretDown)<{ $isOpen?: boolean }>`
+    transition: transform 0.2s ease;
+    ${(props) => props.$isOpen && 'transform: rotate(180deg);'}
+`;
+
 interface Props {
     numActiveFilters: number;
-    filterIcon?: JSX.Element;
     displayName: string;
     filterPredicate: FilterPredicate;
     onChangeValues: (newValues: FilterValue[]) => void;
@@ -29,7 +33,6 @@ interface Props {
 
 export default function SearchFilterView({
     numActiveFilters,
-    filterIcon,
     displayName,
     filterPredicate,
     onChangeValues,
@@ -50,9 +53,8 @@ export default function SearchFilterView({
                 style={labelStyle}
                 data-testid={`filter-dropdown-${displayName?.replace(/\s/g, '-')}`}
             >
-                {filterIcon && <IconWrapper>{filterIcon}</IconWrapper>}
                 {displayName} {numActiveFilters ? `(${numActiveFilters}) ` : ''}
-                <CaretDownFilled style={{ fontSize: '12px', height: '12px' }} />
+                <CaretIcon size={12} />
             </SearchFilterLabel>
         </ValueSelector>
     );

--- a/datahub-web-react/src/app/searchV2/filters/SearchFilters.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/SearchFilters.tsx
@@ -1,4 +1,4 @@
-import { Icon, Tooltip, colors } from '@components';
+import { Icon, Tooltip } from '@components';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -33,13 +33,13 @@ import { useShowNavBarRedesign } from '@src/app/useShowNavBarRedesign';
 import { FacetFilterInput, FacetMetadata } from '@types';
 
 const Container = styled.div<{ $isShowNavBarRedesign?: boolean }>`
-    background-color: ${colors.white};
+    background-color: ${(props) => props.theme.colors.bg};
     border-radius: ${(props) =>
         props.$isShowNavBarRedesign ? props.theme.styles['border-radius-navbar-redesign'] : '8px'};
     padding: 16px 0px 8px 0px;
-    border: 1px solid ${colors.gray[100]};
+    border: 1px solid ${(props) => props.theme.colors.border};
     box-shadow: ${(props) =>
-        props.$isShowNavBarRedesign ? props.theme.styles['box-shadow-navbar-redesign'] : '0px 4px 10px 0px #a8a8a840'};
+        props.$isShowNavBarRedesign ? props.theme.styles['box-shadow-navbar-redesign'] : props.theme.colors.shadowSm};
 `;
 
 const FiltersContainerTop = styled.div`
@@ -52,7 +52,7 @@ const FiltersContainerTop = styled.div`
 `;
 
 const CustomSwitch = styled.div`
-    border: 1px solid ${colors.gray[100]};
+    border: 1px solid ${(props) => props.theme.colors.border};
     border-radius: 30px;
     display: flex;
     gap: 2px;
@@ -68,14 +68,14 @@ const IconContainer = styled.div<{ isActive?: boolean }>`
     display: flex;
     padding: 4px;
     transition: left 0.5s ease;
-    color: ${colors.gray[1800]};
+    color: ${(props) => props.theme.colors.icon};
 
     ${(props) =>
         props.isActive &&
         `
-        background: ${colors.gray[100]};
+        background: ${props.theme.colors.bgHover};
         border-radius: 100%;
-        color: ${colors.gray[1700]};
+        color: ${props.theme.colors.text};
     `}
 `;
 
@@ -109,7 +109,7 @@ const ControlsContainer = styled.div`
 `;
 
 const RecommendedFiltersContainer = styled.div`
-    border-top: 1px solid ${colors.gray[100]};
+    border-top: 1px solid ${(props) => props.theme.colors.border};
     padding: 16px 16px 8px 16px;
 `;
 

--- a/datahub-web-react/src/app/searchV2/filters/field/fields.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/field/fields.tsx
@@ -1,20 +1,22 @@
 import {
-    BuildOutlined,
-    CloseCircleOutlined,
-    DatabaseOutlined,
-    DeleteOutlined,
-    EnvironmentOutlined,
-    FileOutlined,
-    FileTextOutlined,
-    FolderOutlined,
-    LayoutOutlined,
-    TagOutlined,
-    UserOutlined,
-    WarningOutlined,
-} from '@ant-design/icons';
-import Icon from '@ant-design/icons/lib/components/Icon';
-import { TimerOutlined } from '@mui/icons-material';
-import { BookmarkSimple, Globe } from '@phosphor-icons/react';
+    BookmarkSimple,
+    Clock,
+    Database,
+    File,
+    FileText,
+    Folder,
+    GitFork,
+    Globe,
+    Layout,
+    ListDashes,
+    MapPin,
+    Storefront,
+    Tag,
+    Trash,
+    User,
+    Warning,
+    XCircle,
+} from '@phosphor-icons/react';
 import React from 'react';
 
 import { FieldType, FilterField } from '@app/searchV2/filters/types';
@@ -45,7 +47,6 @@ import {
     TAGS_FILTER_NAME,
     TYPE_NAMES_FILTER_NAME,
 } from '@app/searchV2/utils/constants';
-import TableIcon from '@src/images/table-icon.svg?react';
 
 import { EntityType } from '@types';
 
@@ -53,21 +54,21 @@ export const ENTITY_SUB_TYPE_FILTER: FilterField = {
     field: ENTITY_SUB_TYPE_FILTER_NAME,
     displayName: FIELD_TO_LABEL[ENTITY_SUB_TYPE_FILTER_NAME],
     type: FieldType.NESTED_ENTITY_TYPE,
-    icon: <FileOutlined />,
+    icon: <File size={14} />,
 };
 
 export const ENTITY_TYPE_FILTER: FilterField = {
     field: ENTITY_FILTER_NAME,
     displayName: FIELD_TO_LABEL[ENTITY_FILTER_NAME],
     type: FieldType.ENTITY_TYPE,
-    icon: <FileOutlined />,
+    icon: <File size={14} />,
 };
 
 export const TYPE_NAMES_FILTER: FilterField = {
     field: TYPE_NAMES_FILTER_NAME,
     displayName: FIELD_TO_LABEL[TYPE_NAMES_FILTER_NAME],
     type: FieldType.ENUM,
-    icon: <FileOutlined />,
+    icon: <File size={14} />,
 };
 
 export const PLATFORM_FILTER: FilterField = {
@@ -75,7 +76,7 @@ export const PLATFORM_FILTER: FilterField = {
     displayName: FIELD_TO_LABEL[PLATFORM_FILTER_NAME],
     type: FieldType.ENTITY,
     entityTypes: [EntityType.DataPlatform],
-    icon: <DatabaseOutlined />,
+    icon: <Database size={14} />,
 };
 
 export const OWNERS_FILTER: FilterField = {
@@ -83,7 +84,7 @@ export const OWNERS_FILTER: FilterField = {
     displayName: FIELD_TO_LABEL[OWNERS_FILTER_NAME],
     type: FieldType.ENTITY,
     entityTypes: [EntityType.CorpUser, EntityType.CorpGroup],
-    icon: <UserOutlined />,
+    icon: <User size={14} />,
 };
 
 export const DOMAINS_FILTER: FilterField = {
@@ -91,7 +92,7 @@ export const DOMAINS_FILTER: FilterField = {
     displayName: FIELD_TO_LABEL[DOMAINS_FILTER_NAME],
     type: FieldType.ENTITY,
     entityTypes: [EntityType.Domain],
-    icon: <Globe />,
+    icon: <Globe size={14} />,
 };
 
 export const TAGS_FILTER: FilterField = {
@@ -99,7 +100,7 @@ export const TAGS_FILTER: FilterField = {
     displayName: FIELD_TO_LABEL[TAGS_FILTER_NAME],
     type: FieldType.ENTITY,
     entityTypes: [EntityType.Tag],
-    icon: <TagOutlined />,
+    icon: <Tag size={14} />,
 };
 
 export const GLOSSARY_TERMS_FILTER: FilterField = {
@@ -107,7 +108,7 @@ export const GLOSSARY_TERMS_FILTER: FilterField = {
     displayName: FIELD_TO_LABEL[GLOSSARY_TERMS_FILTER_NAME],
     type: FieldType.ENTITY,
     entityTypes: [EntityType.GlossaryTerm],
-    icon: <BookmarkSimple />,
+    icon: <BookmarkSimple size={14} />,
 };
 
 export const CONTAINER_FILTER: FilterField = {
@@ -115,14 +116,14 @@ export const CONTAINER_FILTER: FilterField = {
     displayName: FIELD_TO_LABEL[CONTAINER_FILTER_NAME],
     type: FieldType.ENTITY,
     entityTypes: [EntityType.Container],
-    icon: <FolderOutlined />,
+    icon: <Folder size={14} />,
 };
 
 export const FIELD_PATHS_FILTER: FilterField = {
     field: FIELD_PATHS_FILTER_NAME,
     displayName: FIELD_TO_LABEL[FIELD_PATHS_FILTER_NAME],
     type: FieldType.TEXT,
-    icon: <LayoutOutlined />,
+    icon: <Layout size={14} />,
 };
 
 export const FIELD_TAGS_FILTER: FilterField = {
@@ -130,7 +131,7 @@ export const FIELD_TAGS_FILTER: FilterField = {
     displayName: FIELD_TO_LABEL[FIELD_TAGS_FILTER_NAME],
     type: FieldType.ENTITY,
     entityTypes: [EntityType.Tag],
-    icon: <TagOutlined />,
+    icon: <Tag size={14} />,
 };
 
 export const FIELD_GLOSSARY_TERMS_FILTER: FilterField = {
@@ -138,56 +139,56 @@ export const FIELD_GLOSSARY_TERMS_FILTER: FilterField = {
     displayName: FIELD_TO_LABEL[FIELD_GLOSSARY_TERMS_FILTER_NAME],
     type: FieldType.ENTITY,
     entityTypes: [EntityType.GlossaryTerm],
-    icon: <BookmarkSimple />,
+    icon: <BookmarkSimple size={14} />,
 };
 
 export const DESCRIPTION_FILTER: FilterField = {
     field: DESCRIPTION_FILTER_NAME,
     displayName: FIELD_TO_LABEL[DESCRIPTION_FILTER_NAME],
     type: FieldType.TEXT,
-    icon: <FileTextOutlined />,
+    icon: <FileText size={14} />,
 };
 
 export const FIELD_DESCRIPTIONS_FILTER: FilterField = {
     field: FIELD_DESCRIPTIONS_FILTER_NAME,
     displayName: FIELD_TO_LABEL[FIELD_DESCRIPTIONS_FILTER_NAME],
     type: FieldType.TEXT,
-    icon: <FileTextOutlined />,
+    icon: <FileText size={14} />,
 };
 
 export const REMOVED_FILTER: FilterField = {
     field: REMOVED_FILTER_NAME,
     displayName: FIELD_TO_LABEL[REMOVED_FILTER_NAME],
     type: FieldType.BOOLEAN,
-    icon: <DeleteOutlined />,
+    icon: <Trash size={14} />,
 };
 
 export const HAS_ACTIVE_INCIDENTS_FILTER: FilterField = {
     field: HAS_ACTIVE_INCIDENTS_FILTER_NAME,
     displayName: FIELD_TO_LABEL[HAS_ACTIVE_INCIDENTS_FILTER_NAME],
     type: FieldType.BOOLEAN,
-    icon: <WarningOutlined />,
+    icon: <Warning size={14} />,
 };
 
 export const HAS_FAILING_ASSERTIONS_FILTER: FilterField = {
     field: HAS_FAILING_ASSERTIONS_FILTER_NAME,
     displayName: FIELD_TO_LABEL[HAS_FAILING_ASSERTIONS_FILTER_NAME],
     type: FieldType.BOOLEAN,
-    icon: <CloseCircleOutlined />,
+    icon: <XCircle size={14} />,
 };
 
 export const ORIGIN_FILTER: FilterField = {
     field: ORIGIN_FILTER_NAME,
     displayName: FIELD_TO_LABEL[ORIGIN_FILTER_NAME],
     type: FieldType.ENUM,
-    icon: <EnvironmentOutlined />,
+    icon: <MapPin size={14} />,
 };
 
 export const DATA_PLATFORM_INSTANCE_FILTER: FilterField = {
     field: DATA_PLATFORM_INSTANCE_FILTER_NAME,
     displayName: FIELD_TO_LABEL[DATA_PLATFORM_INSTANCE_FILTER_NAME],
     type: FieldType.ENTITY,
-    icon: <DatabaseOutlined />,
+    icon: <Database size={14} />,
     entityTypes: [EntityType.DataPlatformInstance],
 };
 
@@ -196,20 +197,21 @@ export const DATA_PRODUCT_FILTER: FilterField = {
     displayName: FIELD_TO_LABEL[DATA_PRODUCT_FILTER_NAME],
     type: FieldType.ENTITY,
     entityTypes: [EntityType.DataProduct],
+    icon: <Storefront size={14} />,
 };
 
 export const STRUCTURED_PROPERTY_FILTER: FilterField = {
     field: STRUCTURED_PROPERTIES_FILTER_NAME,
     displayName: FIELD_TO_LABEL[STRUCTURED_PROPERTIES_FILTER_NAME],
     type: FieldType.TEXT,
-    icon: <Icon component={TableIcon} />,
+    icon: <ListDashes size={14} />,
 };
 
 export const HAS_SIBLINGS_FILTER: FilterField = {
     field: HAS_SIBLINGS_FILTER_NAME,
     displayName: FIELD_TO_LABEL[HAS_SIBLINGS_FILTER_NAME],
     type: FieldType.BOOLEAN,
-    icon: <BuildOutlined />,
+    icon: <GitFork size={14} />,
 };
 
 const DAY_IN_MILLIS = 24 * 60 * 60 * 1000;
@@ -218,7 +220,7 @@ export const LAST_MODIFIED_FILTER: FilterField = {
     field: LAST_MODIFIED_FILTER_NAME,
     displayName: FIELD_TO_LABEL[LAST_MODIFIED_FILTER_NAME],
     type: FieldType.BUCKETED_TIMESTAMP,
-    icon: <TimerOutlined fontSize="inherit" color="inherit" />,
+    icon: <Clock size={14} />,
     useDatePicker: true,
     options: [
         {
@@ -260,7 +262,7 @@ export const BROWSE_FILTER: FilterField = {
     field: BROWSE_PATH_V2_FILTER_NAME,
     displayName: FIELD_TO_LABEL[BROWSE_PATH_V2_FILTER_NAME],
     type: FieldType.BROWSE_PATH,
-    icon: <FolderOutlined />,
+    icon: <Folder size={14} />,
 };
 
 export const DEFAULT_FILTER_FIELDS: FilterField[] = [

--- a/datahub-web-react/src/app/searchV2/filters/mapFilterOption.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/mapFilterOption.tsx
@@ -8,7 +8,6 @@ import { EntityRegistry } from '@src/entityRegistryContext';
 export interface DisplayedFilterOption {
     key: string;
     label: React.ReactNode;
-    style: any;
     displayName?: string | null;
     nestedOptions?: FilterOptionType[];
 }
@@ -50,7 +49,6 @@ export function mapFilterOption({
                 includeCount={includeCount}
             />
         ),
-        style: { padding: 0 },
         displayName: displayName as string,
         nestedOptions,
     };

--- a/datahub-web-react/src/app/searchV2/filters/render/assertion/HasFailingAssertionsFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/assertion/HasFailingAssertionsFilter.tsx
@@ -12,10 +12,9 @@ export interface Props {
     filter: FacetMetadata;
     activeFilters: FacetFilterInput[];
     onChangeFilters: (newFilters: FacetFilter[]) => void;
-    icon?: React.ReactNode;
 }
 
-export function HasFailingAssertionsFilter({ icon, scenario, filter, activeFilters, onChangeFilters }: Props) {
+export function HasFailingAssertionsFilter({ scenario, filter, activeFilters, onChangeFilters }: Props) {
     const isSelected = activeFilters?.find((f) => f.field === 'hasFailingAssertions')?.values?.includes('true');
 
     const toggleFilter = () => {
@@ -48,7 +47,6 @@ export function HasFailingAssertionsFilter({ icon, scenario, filter, activeFilte
             )}
             {scenario === FilterScenarioType.SEARCH_V2_PRIMARY && (
                 <BooleanSearchFilter
-                    icon={icon}
                     title="Assertions"
                     option="Has failing assertions"
                     initialSelected={isSelected || false}
@@ -58,7 +56,6 @@ export function HasFailingAssertionsFilter({ icon, scenario, filter, activeFilte
             )}
             {scenario === FilterScenarioType.SEARCH_V2_SECONDARY && (
                 <BooleanMoreFilter
-                    icon={icon}
                     title="Assertions"
                     option="Has failing assertions"
                     initialSelected={isSelected || false}

--- a/datahub-web-react/src/app/searchV2/filters/render/assertion/HasFailingAssertionsRenderer.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/assertion/HasFailingAssertionsRenderer.tsx
@@ -1,4 +1,4 @@
-import { CloseCircleOutlined } from '@ant-design/icons';
+import { XCircle } from '@phosphor-icons/react';
 import React from 'react';
 
 import { FilterRenderer } from '@app/searchV2/filters/render/FilterRenderer';
@@ -8,9 +8,9 @@ import { FilterRenderProps } from '@app/searchV2/filters/render/types';
 export class HasFailingAssertionsRenderer implements FilterRenderer {
     field = 'hasFailingAssertions';
 
-    render = (props: FilterRenderProps) => <HasFailingAssertionsFilter {...props} icon={this.icon()} />;
+    render = (props: FilterRenderProps) => <HasFailingAssertionsFilter {...props} />;
 
-    icon = () => <CloseCircleOutlined />;
+    icon = () => <XCircle size={14} />;
 
     valueLabel = (value: string) => {
         if (value === 'true') {

--- a/datahub-web-react/src/app/searchV2/filters/render/deprecation/DeprecationFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/deprecation/DeprecationFilter.tsx
@@ -12,10 +12,9 @@ export interface Props {
     filter: FacetMetadata;
     activeFilters: FacetFilterInput[];
     onChangeFilters: (newFilters: FacetFilter[]) => void;
-    icon?: React.ReactNode;
 }
 
-export function DeprecationFilter({ icon, scenario, filter, activeFilters, onChangeFilters }: Props) {
+export function DeprecationFilter({ scenario, filter, activeFilters, onChangeFilters }: Props) {
     const isSelected = activeFilters?.find((f) => f.field === 'deprecated')?.values?.includes('true');
 
     const toggleFilter = () => {
@@ -48,7 +47,6 @@ export function DeprecationFilter({ icon, scenario, filter, activeFilters, onCha
             )}
             {scenario === FilterScenarioType.SEARCH_V2_PRIMARY && (
                 <BooleanSearchFilter
-                    icon={icon}
                     title="Deprecation"
                     option="Is Deprecated"
                     initialSelected={isSelected || false}
@@ -58,7 +56,6 @@ export function DeprecationFilter({ icon, scenario, filter, activeFilters, onCha
             )}
             {scenario === FilterScenarioType.SEARCH_V2_SECONDARY && (
                 <BooleanMoreFilter
-                    icon={icon}
                     title="Deprecation"
                     option="Is Deprecated"
                     initialSelected={isSelected || false}

--- a/datahub-web-react/src/app/searchV2/filters/render/deprecation/DeprecationRenderer.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/deprecation/DeprecationRenderer.tsx
@@ -21,7 +21,7 @@ const StyledDeprecatedIcon = styled(DeprecatedIcon)`
 export class DeprecationRenderer implements FilterRenderer {
     field = 'deprecated';
 
-    render = (props: FilterRenderProps) => <DeprecationFilter {...props} icon={this.icon()} />;
+    render = (props: FilterRenderProps) => <DeprecationFilter {...props} />;
 
     icon = () => <StyledDeprecatedIcon />;
 

--- a/datahub-web-react/src/app/searchV2/filters/render/incident/HasActiveIncidentsFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/incident/HasActiveIncidentsFilter.tsx
@@ -12,10 +12,9 @@ export interface Props {
     filter: FacetMetadata;
     activeFilters: FacetFilterInput[];
     onChangeFilters: (newFilters: FacetFilter[]) => void;
-    icon?: React.ReactNode;
 }
 
-export function HasActiveIncidentsFilter({ scenario, filter, activeFilters, icon, onChangeFilters }: Props) {
+export function HasActiveIncidentsFilter({ scenario, filter, activeFilters, onChangeFilters }: Props) {
     const isSelected = activeFilters?.find((f) => f.field === 'hasActiveIncidents')?.values?.includes('true');
 
     const toggleFilter = () => {
@@ -48,7 +47,6 @@ export function HasActiveIncidentsFilter({ scenario, filter, activeFilters, icon
             )}
             {scenario === FilterScenarioType.SEARCH_V2_PRIMARY && (
                 <BooleanSearchFilter
-                    icon={icon}
                     title="Incidents"
                     option="Has active incidents"
                     initialSelected={isSelected || false}
@@ -58,7 +56,6 @@ export function HasActiveIncidentsFilter({ scenario, filter, activeFilters, icon
             )}
             {scenario === FilterScenarioType.SEARCH_V2_SECONDARY && (
                 <BooleanMoreFilter
-                    icon={icon}
                     title="Incidents"
                     option="Has active incidents"
                     initialSelected={isSelected || false}

--- a/datahub-web-react/src/app/searchV2/filters/render/incident/HasActiveIncidentsRenderer.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/incident/HasActiveIncidentsRenderer.tsx
@@ -1,4 +1,4 @@
-import { WarningOutlined } from '@ant-design/icons';
+import { Warning } from '@phosphor-icons/react';
 import React from 'react';
 
 import { FilterRenderer } from '@app/searchV2/filters/render/FilterRenderer';
@@ -8,9 +8,9 @@ import { FilterRenderProps } from '@app/searchV2/filters/render/types';
 export class HasActiveIncidentsRenderer implements FilterRenderer {
     field = 'hasActiveIncidents';
 
-    render = (props: FilterRenderProps) => <HasActiveIncidentsFilter {...props} icon={this.icon()} />;
+    render = (props: FilterRenderProps) => <HasActiveIncidentsFilter {...props} />;
 
-    icon = () => <WarningOutlined />;
+    icon = () => <Warning size={14} />;
 
     valueLabel = (value: string) => {
         if (value === 'true') {

--- a/datahub-web-react/src/app/searchV2/filters/render/shared/BooleanMoreFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/shared/BooleanMoreFilter.tsx
@@ -1,24 +1,19 @@
-import { RightOutlined } from '@ant-design/icons';
-import { Dropdown } from 'antd';
-import React, { useRef, useState } from 'react';
+import { CaretRight } from '@phosphor-icons/react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
+
+import useClickOutside from '@components/components/Utils/ClickOutside/useClickOutside';
 
 import FilterOption from '@app/searchV2/filters/FilterOption';
 import BooleanSearchFilterMenu from '@app/searchV2/filters/render/shared/BooleanMoreFilterMenu';
 import { MoreFilterOptionLabel } from '@app/searchV2/filters/styledComponents';
 import { useElementDimensions } from '@app/searchV2/filters/utils';
 
-const IconNameWrapper = styled.span`
-    display: flex;
-    align-items: center;
-`;
-
-const IconWrapper = styled.span`
-    margin-right: 8px;
+const SubMenuWrapper = styled.div`
+    position: relative;
 `;
 
 interface Props {
-    icon?: React.ReactNode;
     title: string;
     option: string;
     count: number;
@@ -26,10 +21,11 @@ interface Props {
     onUpdate: (newValue: boolean) => void;
 }
 
-export default function BooleanMoreFilter({ icon, title, option, count, initialSelected, onUpdate }: Props) {
+export default function BooleanMoreFilter({ title, option, count, initialSelected, onUpdate }: Props) {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [isSelected, setIsSelected] = useState<boolean>(initialSelected);
     const labelRef = useRef<HTMLDivElement>(null);
+    const wrapperRef = useRef<HTMLDivElement>(null);
     const { width, height, isElementOutsideWindow } = useElementDimensions(labelRef);
 
     function updateSelected() {
@@ -37,31 +33,31 @@ export default function BooleanMoreFilter({ icon, title, option, count, initialS
         setIsMenuOpen(false);
     }
 
-    const filterOptions = [
-        {
-            key: option,
-            // Re-use the Normal Filter object
-            label: (
-                <FilterOption
-                    filterOption={{ field: title, value: option, count }}
-                    selectedFilterOptions={isSelected ? [{ field: title, value: option }] : []}
-                    setSelectedFilterOptions={() => setIsSelected(!isSelected)}
-                />
-            ),
-            style: { padding: 0 },
-            displayName: title,
-        },
-    ];
+    const handleClickOutside = useCallback(() => setIsMenuOpen(false), []);
+    const clickOutsideOptions = useMemo(() => ({ wrappers: [wrapperRef] }), []);
+    useClickOutside(handleClickOutside, clickOutsideOptions);
 
     return (
-        <Dropdown
-            trigger={['click']}
-            menu={{ items: filterOptions }}
-            open={isMenuOpen}
-            onOpenChange={(open) => setIsMenuOpen(open)}
-            dropdownRender={(menuOption) => (
+        <SubMenuWrapper ref={wrapperRef}>
+            <MoreFilterOptionLabel
+                onClick={() => setIsMenuOpen(!isMenuOpen)}
+                isOpen={isMenuOpen}
+                $isActive={isSelected}
+                data-testid={`more-filter-${title.replace(/\s/g, '-')}`}
+                ref={labelRef}
+            >
+                {title} {isSelected ? `(1) ` : ''}
+                <CaretRight size={12} />
+            </MoreFilterOptionLabel>
+            {isMenuOpen && (
                 <BooleanSearchFilterMenu
-                    menuOption={menuOption}
+                    filterOption={
+                        <FilterOption
+                            filterOption={{ field: title, value: option, count }}
+                            selectedFilterOptions={isSelected ? [{ field: title, value: option }] : []}
+                            setSelectedFilterOptions={() => setIsSelected(!isSelected)}
+                        />
+                    }
                     onUpdate={updateSelected}
                     style={{
                         position: 'absolute',
@@ -70,20 +66,6 @@ export default function BooleanMoreFilter({ icon, title, option, count, initialS
                     }}
                 />
             )}
-        >
-            <MoreFilterOptionLabel
-                onClick={() => setIsMenuOpen(!isMenuOpen)}
-                isOpen={isMenuOpen}
-                $isActive={isSelected}
-                data-testid={`more-filter-${title.replace(/\s/g, '-')}`}
-                ref={labelRef}
-            >
-                <IconNameWrapper>
-                    {icon && <IconWrapper>{icon}</IconWrapper>}
-                    {title} {isSelected ? `(1) ` : ''}
-                </IconNameWrapper>
-                <RightOutlined style={{ fontSize: '12px', height: '12px' }} />
-            </MoreFilterOptionLabel>
-        </Dropdown>
+        </SubMenuWrapper>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/render/shared/BooleanMoreFilterMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/shared/BooleanMoreFilterMenu.tsx
@@ -1,31 +1,13 @@
-import { Button } from 'antd';
 import React, { CSSProperties } from 'react';
 import styled from 'styled-components/macro';
 
-const StyledButton = styled(Button)`
-    width: 100%;
-    text-align: center;
-    background-color: ${(props) => props.theme.styles['primary-color']};
-    color: white;
-    border-radius: 0;
-`;
-
-export const DropdownMenu = styled.div`
-    background-color: white;
-    border-radius: 5px;
-    box-shadow:
-        0 3px 6px -4px rgba(0, 0, 0, 0.12),
-        0 6px 16px 0 rgba(0, 0, 0, 0.08),
-        0 9px 28px 8px rgba(0, 0, 0, 0.05);
+const DropdownCard = styled.div`
+    background-color: ${(props) => props.theme.colors.bg};
+    border-radius: 12px;
+    box-shadow: ${(props) => props.theme.colors.shadowMd};
     overflow: hidden;
     min-width: 200px;
-
-    .ant-dropdown-menu-title-content {
-        background-color: white;
-        &:hover {
-            background-color: white;
-        }
-    }
+    padding: 4px;
 `;
 
 const ScrollableContent = styled.div`
@@ -34,20 +16,15 @@ const ScrollableContent = styled.div`
 `;
 
 interface Props {
-    menuOption: React.ReactNode;
+    filterOption: React.ReactNode;
     onUpdate: () => void;
     style?: CSSProperties;
 }
 
-export default function BooleanMoreFilterMenu({ menuOption, onUpdate, style }: Props) {
+export default function BooleanMoreFilterMenu({ filterOption, onUpdate, style }: Props) {
     return (
-        <DropdownMenu data-testid="filter-dropdown" style={style}>
-            <ScrollableContent>
-                {React.cloneElement(menuOption as React.ReactElement, { style: { boxShadow: 'none' } })}
-            </ScrollableContent>
-            <StyledButton type="text" onClick={onUpdate} data-testid="update-filters">
-                Update
-            </StyledButton>
-        </DropdownMenu>
+        <DropdownCard data-testid="filter-dropdown" style={style} onClick={onUpdate}>
+            <ScrollableContent>{filterOption}</ScrollableContent>
+        </DropdownCard>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/render/shared/BooleanSearchFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/shared/BooleanSearchFilter.tsx
@@ -1,25 +1,30 @@
-import { CaretDownFilled } from '@ant-design/icons';
-import { Dropdown } from 'antd';
-import React, { useEffect, useState } from 'react';
+import { CaretDown } from '@phosphor-icons/react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
+
+import useClickOutside from '@components/components/Utils/ClickOutside/useClickOutside';
 
 import FilterOption from '@app/searchV2/filters/FilterOption';
 import BooleanSearchFilterMenu from '@app/searchV2/filters/render/shared/BooleanMoreFilterMenu';
 import { SearchFilterLabel } from '@app/searchV2/filters/styledComponents';
 
-const IconNameWrapper = styled.div`
-    display: flex;
-    align-items: center;
+const DropdownWrapper = styled.div`
+    position: relative;
 `;
 
-const IconWrapper = styled.span`
-    margin-right: 8px;
-    display: flex;
-    flex-direction: column;
+const MenuContainer = styled.div`
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 1050;
+`;
+
+const CaretIcon = styled(CaretDown)<{ $isOpen?: boolean }>`
+    transition: transform 0.2s ease;
+    ${(props) => props.$isOpen && 'transform: rotate(180deg);'}
 `;
 
 interface Props {
-    icon?: React.ReactNode;
     title: string;
     option: string;
     count: number;
@@ -27,9 +32,10 @@ interface Props {
     onUpdate: (newValue: boolean) => void;
 }
 
-export default function BooleanSearchFilter({ icon, title, option, count, initialSelected, onUpdate }: Props) {
+export default function BooleanSearchFilter({ title, option, count, initialSelected, onUpdate }: Props) {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [isSelected, setIsSelected] = useState<boolean>(initialSelected);
+    const wrapperRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => setIsSelected(initialSelected), [initialSelected]);
 
@@ -38,43 +44,34 @@ export default function BooleanSearchFilter({ icon, title, option, count, initia
         setIsMenuOpen(false);
     }
 
-    const filterOptions = [
-        {
-            key: option,
-            // Re-use the Normal Filter object
-            label: (
-                <FilterOption
-                    filterOption={{ field: title, value: option, count }}
-                    selectedFilterOptions={isSelected ? [{ field: title, value: option }] : []}
-                    setSelectedFilterOptions={() => setIsSelected(!isSelected)}
-                />
-            ),
-            style: { padding: 0 },
-            displayName: title,
-        },
-    ];
+    const handleClickOutside = useCallback(() => setIsMenuOpen(false), []);
+    const clickOutsideOptions = useMemo(() => ({ wrappers: [wrapperRef] }), []);
+    useClickOutside(handleClickOutside, clickOutsideOptions);
 
     return (
-        <Dropdown
-            trigger={['click']}
-            menu={{ items: filterOptions }}
-            open={isMenuOpen}
-            onOpenChange={(open) => setIsMenuOpen(open)}
-            dropdownRender={(menuOption) => (
-                <BooleanSearchFilterMenu menuOption={menuOption} onUpdate={updateSelected} />
-            )}
-        >
+        <DropdownWrapper ref={wrapperRef}>
             <SearchFilterLabel
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
                 $isActive={isSelected}
                 data-testid={`filter-dropdown-${title.replace(/\s/g, '-')}`}
             >
-                <IconNameWrapper>
-                    {icon && <IconWrapper>{icon}</IconWrapper>}
-                    {title} {isSelected ? `(1) ` : ''}
-                </IconNameWrapper>
-                <CaretDownFilled style={{ fontSize: '12px', height: '12px' }} />
+                {title} {isSelected ? `(1) ` : ''}
+                <CaretIcon size={12} $isOpen={isMenuOpen} />
             </SearchFilterLabel>
-        </Dropdown>
+            {isMenuOpen && (
+                <MenuContainer>
+                    <BooleanSearchFilterMenu
+                        filterOption={
+                            <FilterOption
+                                filterOption={{ field: title, value: option, count }}
+                                selectedFilterOptions={isSelected ? [{ field: title, value: option }] : []}
+                                setSelectedFilterOptions={() => setIsSelected(!isSelected)}
+                            />
+                        }
+                        onUpdate={updateSelected}
+                    />
+                </MenuContainer>
+            )}
+        </DropdownWrapper>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/render/siblings/HasSiblingsFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/siblings/HasSiblingsFilter.tsx
@@ -12,10 +12,9 @@ export interface Props {
     filter: FacetMetadata;
     activeFilters: FacetFilterInput[];
     onChangeFilters: (newFilters: FacetFilter[]) => void;
-    icon?: React.ReactNode;
 }
 
-export function HasSiblingsFilter({ icon, scenario, filter, activeFilters, onChangeFilters }: Props) {
+export function HasSiblingsFilter({ scenario, filter, activeFilters, onChangeFilters }: Props) {
     const isSelected = activeFilters?.find((f) => f.field === 'hasSiblings')?.values?.includes('true');
 
     const toggleFilter = () => {
@@ -49,7 +48,6 @@ export function HasSiblingsFilter({ icon, scenario, filter, activeFilters, onCha
             )}
             {scenario === FilterScenarioType.SEARCH_V2_PRIMARY && (
                 <BooleanSearchFilter
-                    icon={icon}
                     title="Siblings"
                     option="Has siblings"
                     initialSelected={isSelected || false}
@@ -60,7 +58,6 @@ export function HasSiblingsFilter({ icon, scenario, filter, activeFilters, onCha
             )}
             {scenario === FilterScenarioType.SEARCH_V2_SECONDARY && (
                 <BooleanMoreFilter
-                    icon={icon}
                     title="Siblings"
                     option="Has siblings"
                     initialSelected={isSelected || false}

--- a/datahub-web-react/src/app/searchV2/filters/render/siblings/HasSiblingsRenderer.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/render/siblings/HasSiblingsRenderer.tsx
@@ -1,4 +1,4 @@
-import { BuildOutlined } from '@ant-design/icons';
+import { GitFork } from '@phosphor-icons/react';
 import React from 'react';
 
 import { FilterRenderer } from '@app/searchV2/filters/render/FilterRenderer';
@@ -12,10 +12,10 @@ export class HasSiblingsRenderer implements FilterRenderer {
         if (!props.config?.featureFlags?.showHasSiblingsFilter) {
             return <></>;
         }
-        return <HasSiblingsFilter {...props} icon={this.icon()} />;
+        return <HasSiblingsFilter {...props} />;
     };
 
-    icon = () => <BuildOutlined />;
+    icon = () => <GitFork size={14} />;
 
     valueLabel = (value: string) => {
         if (value === 'true') {

--- a/datahub-web-react/src/app/searchV2/filters/styledComponents.ts
+++ b/datahub-web-react/src/app/searchV2/filters/styledComponents.ts
@@ -1,27 +1,33 @@
-import { Button, Typography } from 'antd';
 import styled from 'styled-components';
 
-import { getColor } from '@components/theme/utils';
-
-import { ANTD_GRAY } from '@app/entity/shared/constants';
-import { REDESIGN_COLORS } from '@app/entityV2/shared/constants';
-
-export const SearchFilterLabel = styled(Button)<{ $isActive: boolean }>`
+export const SearchFilterLabel = styled.div<{ $isActive: boolean }>`
     font-size: 14px;
-    font-weight: 700;
-    border: none;
+    font-weight: 400;
+    line-height: none;
+    border: 1px solid ${(props) => (props.$isActive ? props.theme.colors.borderSelected : props.theme.colors.border)};
     border-radius: 8px;
     display: flex;
     align-items: center;
-    box-shadow: none;
-    color: ${REDESIGN_COLORS.TEXT_HEADING};
-    ${(props) =>
-        props.$isActive &&
-        `
-        background-color: ${props.theme.styles['primary-color']};
-        border: 1px solid ${getColor('primary', 0, props.theme)};
-        color: white;
-    `}
+    gap: 4px;
+    padding: 4px 8px;
+    min-height: 36px;
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+    color: ${(props) => (props.$isActive ? props.theme.colors.textSelected : props.theme.colors.text)};
+    background-color: ${(props) => (props.$isActive ? props.theme.colors.bgSelected : props.theme.colors.bg)};
+    box-shadow: ${(props) => props.theme.colors.shadowXs};
+    transition:
+        box-shadow 0.15s ease,
+        border-color 0.15s ease;
+
+    svg {
+        color: ${(props) => props.theme.colors.icon};
+    }
+
+    &:hover {
+        box-shadow: ${(props) => props.theme.colors.shadowSm};
+    }
 `;
 
 export const MoreFilterOptionLabel = styled.div<{ $isActive: boolean; isOpen?: boolean }>`
@@ -30,30 +36,46 @@ export const MoreFilterOptionLabel = styled.div<{ $isActive: boolean; isOpen?: b
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 8px;
     cursor: pointer;
-
+    border-radius: 8px;
     max-width: 100%;
-    &:hover {
-        background-color: ${ANTD_GRAY[3]};
+    color: ${(props) => (props.$isActive ? props.theme.colors.textBrand : props.theme.colors.text)};
+    background-color: ${(props) => (props.isOpen ? props.theme.colors.bgHover : 'transparent')};
+
+    svg {
+        color: ${(props) => props.theme.colors.icon};
+        flex-shrink: 0;
     }
 
-    ${(props) => props.$isActive && `color: ${props.theme.styles['primary-color']};`}
-    ${(props) => props.isOpen && `background-color: ${ANTD_GRAY[3]};`}
+    &:hover {
+        background-color: ${(props) => props.theme.colors.bgHover};
+    }
 `;
 
-export const TextButton = styled(Button)<{ marginTop?: number; height?: number }>`
-    color: ${(p) => p.theme.styles['primary-color']};
+export const TextButton = styled.button<{ marginTop?: number; height?: number }>`
+    color: ${(props) => props.theme.colors.textBrand};
+    background: none;
+    border: none;
     padding: 0px 6px;
+    cursor: pointer;
+    font-size: 14px;
     margin-top: ${(props) => (props.marginTop !== undefined ? `${props.marginTop}px` : '8px')};
     ${(props) => props.height !== undefined && `height: ${props.height}px;`}
 
     &:hover {
-        background-color: white;
+        background-color: ${(props) => props.theme.colors.bgHover};
+        border-radius: 4px;
     }
 `;
 
-export const Label = styled(Typography.Text)`
+export const Label = styled.span`
     max-width: 125px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: inline-block;
+    color: inherit;
 `;
 
 export const IconSpacer = styled.span`

--- a/datahub-web-react/src/app/searchV2/filters/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/utils.tsx
@@ -1,7 +1,10 @@
 import { FolderFilled } from '@ant-design/icons';
+import { Avatar } from '@components';
 import moment from 'moment-timezone';
 import React, { useLayoutEffect, useState } from 'react';
 import styled from 'styled-components';
+
+import { AvatarType } from '@components/components/AvatarStack/types';
 
 import { IconStyleType } from '@app/entity/Entity';
 import { getSubTypeIcon } from '@app/entityV2/shared/components/subtypes';
@@ -56,6 +59,8 @@ import { EntityRegistry } from '@src/entityRegistryContext';
 import { GetAutoCompleteMultipleResultsQuery } from '@graphql/search.generated';
 import {
     AggregationMetadata,
+    CorpGroup,
+    CorpUser,
     DataPlatform,
     DataPlatformInstance,
     Document,
@@ -626,10 +631,29 @@ export const FilterEntityIcon: React.FC<FilterEntityIconProps> = ({ field, entit
             return <TagColor color={(entity as Tag).properties?.colorHex || ''} colorHash={entity?.urn} />;
 
         case field === DOMAINS_FILTER_NAME && entity?.type === EntityType.Domain:
-            return <DomainColoredIcon domain={entity as Domain} size={28} />;
+            return <DomainColoredIcon domain={entity as Domain} size={22} fontSize={11} />;
+
+        case field === OWNERS_FILTER_NAME && entity?.type === EntityType.CorpUser:
+            return (
+                <Avatar
+                    name={(entity as CorpUser).editableProperties?.displayName || (entity as CorpUser).username || ''}
+                    imageUrl={(entity as CorpUser).editableProperties?.pictureLink}
+                    size="sm"
+                    type={AvatarType.user}
+                />
+            );
+
+        case field === OWNERS_FILTER_NAME && entity?.type === EntityType.CorpGroup:
+            return (
+                <Avatar
+                    name={(entity as CorpGroup).properties?.displayName || (entity as CorpGroup).name || ''}
+                    size="sm"
+                    type={AvatarType.group}
+                />
+            );
 
         default:
-            return null; // default
+            return null;
     }
 };
 

--- a/datahub-web-react/src/app/searchV2/filters/value/BooleanValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/BooleanValueMenu.tsx
@@ -1,12 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import OptionsDropdownMenu from '@app/searchV2/filters/OptionsDropdownMenu';
 import { mapFilterOption } from '@app/searchV2/filters/mapFilterOption';
 import { FilterField, FilterValue } from '@app/searchV2/filters/types';
-import { OptionMenu } from '@app/searchV2/filters/value/styledComponents';
+import { OptionList } from '@app/searchV2/filters/value/styledComponents';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-// Since we are working with a boolean field, always simply have the base options.
 const OPTIONS = [
     { value: 'true', count: undefined, entity: null },
     { value: 'false', count: undefined, entity: null },
@@ -16,16 +15,11 @@ interface Props {
     field: FilterField;
     values: FilterValue[];
     onChangeValues: (newValues: FilterValue[]) => void;
-    onApply: () => void;
-    type?: 'card' | 'default';
     className?: string;
 }
 
-export default function BooleanValueMenu({ field, values, type = 'card', onChangeValues, onApply, className }: Props) {
+export default function BooleanValueMenu({ field, values, onChangeValues, className }: Props) {
     const entityRegistry = useEntityRegistry();
-
-    // Ideally we would not have staged values, and filters would update automatically.
-    const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
 
     const filterMenuOptions = OPTIONS.map((option) =>
         mapFilterOption({
@@ -50,13 +44,14 @@ export default function BooleanValueMenu({ field, values, type = 'card', onChang
 
     return (
         <OptionsDropdownMenu
-            menu={<OptionMenu items={filterMenuOptions} />}
-            updateFilters={onApply}
-            searchQuery={searchQuery || ''}
-            updateSearchQuery={setSearchQuery}
-            isLoading={false}
+            menu={
+                <OptionList>
+                    {filterMenuOptions.map((opt) => (
+                        <React.Fragment key={opt.key}>{opt.label}</React.Fragment>
+                    ))}
+                </OptionList>
+            }
             showSearchBar={false}
-            type={type}
             className={className}
         />
     );

--- a/datahub-web-react/src/app/searchV2/filters/value/EntityTypeMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EntityTypeMenu.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import OptionsDropdownMenu from '@app/searchV2/filters/OptionsDropdownMenu';
 import { mapFilterOption } from '@app/searchV2/filters/mapFilterOption';
 import { FilterField, FilterValue, FilterValueOption } from '@app/searchV2/filters/types';
-import { OptionMenu } from '@app/searchV2/filters/value/styledComponents';
+import { OptionList } from '@app/searchV2/filters/value/styledComponents';
 import {
     deduplicateOptions,
     useFilterOptionsBySearchQuery,
@@ -19,8 +19,6 @@ interface Props {
     values: FilterValue[];
     defaultOptions: FilterValueOption[];
     onChangeValues: (newValues: FilterValue[]) => void;
-    onApply: () => void;
-    type?: 'card' | 'default';
     includeSubTypes?: boolean;
     includeCount?: boolean;
     className?: string;
@@ -31,9 +29,7 @@ export default function EntityTypeMenu({
     field,
     values,
     defaultOptions,
-    type = 'card',
     onChangeValues,
-    onApply,
     includeSubTypes = true,
     includeCount = false,
     className,
@@ -42,10 +38,8 @@ export default function EntityTypeMenu({
     const entityRegistry = useEntityRegistry();
     const { displayName } = field;
 
-    // Ideally we would not have staged values, and filters would update automatically.
     const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
 
-    // Here we optionally load the aggregation options, which are the options that are displayed by default.
     const { options: aggOptions, loading: aggLoading } = useLoadAggregationOptions({
         field,
         visible: true,
@@ -57,11 +51,10 @@ export default function EntityTypeMenu({
 
     const localSearchOptions = useFilterOptionsBySearchQuery(allOptions, searchQuery);
 
-    // Compute the final options to show to the user.
     const finalOptions = searchQuery ? localSearchOptions : allOptions;
 
     const filterMenuOptions = finalOptions
-        .filter((option) => !option.value.includes(FILTER_DELIMITER)) // remove nested options
+        .filter((option) => !option.value.includes(FILTER_DELIMITER))
         .map((option) => {
             const nestedOptions = includeSubTypes
                 ? aggOptions
@@ -96,13 +89,17 @@ export default function EntityTypeMenu({
 
     return (
         <OptionsDropdownMenu
-            menu={<OptionMenu items={filterMenuOptions} />}
-            updateFilters={onApply}
+            menu={
+                <OptionList>
+                    {filterMenuOptions.map((opt) => (
+                        <React.Fragment key={opt.key}>{opt.label}</React.Fragment>
+                    ))}
+                </OptionList>
+            }
             searchQuery={searchQuery || ''}
             updateSearchQuery={setSearchQuery}
             isLoading={aggLoading}
             searchPlaceholder={displayName}
-            type={type}
             className={className}
         />
     );

--- a/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import OptionsDropdownMenu from '@app/searchV2/filters/OptionsDropdownMenu';
 import { mapFilterOption } from '@app/searchV2/filters/mapFilterOption';
 import { EntityFilterField, FilterValue, FilterValueOption } from '@app/searchV2/filters/types';
-import { OptionMenu } from '@app/searchV2/filters/value/styledComponents';
+import { OptionList } from '@app/searchV2/filters/value/styledComponents';
 import {
     deduplicateOptions,
     useFilterOptionsBySearchQuery,
@@ -16,8 +16,6 @@ interface Props {
     values: FilterValue[];
     defaultOptions: FilterValueOption[];
     onChangeValues: (newValues: FilterValue[]) => void;
-    onApply: () => void;
-    type?: 'card' | 'default';
     includeCount?: boolean;
     className?: string;
 }
@@ -26,32 +24,25 @@ export default function EntityValueMenu({
     field,
     values,
     defaultOptions,
-    type = 'card',
     includeCount = false,
     onChangeValues,
-    onApply,
     className,
 }: Props) {
     const entityRegistry = useEntityRegistry();
     const isSearchable = !!field.entityTypes?.length;
     const { displayName } = field;
 
-    // Ideally we would not have staged values, and filters would update automatically.
     const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
 
-    // Here we optionally load the search options, which are the options that are displayed when the user searches.
     const { options: searchOptions, loading: searchLoading } = useLoadSearchOptions(field, searchQuery, !isSearchable);
 
     const localSearchOptions = useFilterOptionsBySearchQuery(defaultOptions, searchQuery);
 
     const finalSearchOptions = [...localSearchOptions, ...deduplicateOptions(localSearchOptions, searchOptions)];
 
-    // Compute the final options to show to the user.
     const finalDefaultOptions = defaultOptions.length ? defaultOptions : searchOptions;
     const finalOptions = searchQuery ? finalSearchOptions : finalDefaultOptions;
 
-    // Finally, create the option set.
-    // TODO: Add an option set for "no x".
     const filterMenuOptions = finalOptions.map((option) =>
         mapFilterOption({
             filterOption: {
@@ -77,13 +68,17 @@ export default function EntityValueMenu({
 
     return (
         <OptionsDropdownMenu
-            menu={<OptionMenu items={filterMenuOptions} />}
-            updateFilters={onApply}
+            menu={
+                <OptionList>
+                    {filterMenuOptions.map((opt) => (
+                        <React.Fragment key={opt.key}>{opt.label}</React.Fragment>
+                    ))}
+                </OptionList>
+            }
             searchQuery={searchQuery || ''}
             updateSearchQuery={setSearchQuery}
             isLoading={searchLoading}
             searchPlaceholder={`Search for ${displayName}`}
-            type={type}
             className={className}
         />
     );

--- a/datahub-web-react/src/app/searchV2/filters/value/EnumValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EnumValueMenu.tsx
@@ -4,7 +4,7 @@ import OptionsDropdownMenu from '@app/searchV2/filters/OptionsDropdownMenu';
 import { mapFilterOption } from '@app/searchV2/filters/mapFilterOption';
 import { FilterField, FilterValue, FilterValueOption } from '@app/searchV2/filters/types';
 import { getFilterDisplayName, useFilterDisplayName } from '@app/searchV2/filters/utils';
-import { OptionMenu } from '@app/searchV2/filters/value/styledComponents';
+import { OptionList } from '@app/searchV2/filters/value/styledComponents';
 import {
     deduplicateOptions,
     useFilterOptionsBySearchQuery,
@@ -18,8 +18,6 @@ interface Props {
     values: FilterValue[];
     defaultOptions: FilterValueOption[];
     onChangeValues: (newValues: FilterValue[]) => void;
-    onApply: () => void;
-    type?: 'card' | 'default';
     includeCount?: boolean;
     className?: string;
     aggregationsEntityTypes?: Array<EntityType>;
@@ -30,19 +28,15 @@ export default function EnumValueMenu({
     values,
     includeCount = false,
     defaultOptions,
-    type = 'card',
     onChangeValues,
-    onApply,
     className,
     aggregationsEntityTypes,
 }: Props) {
     const entityRegistry = useEntityRegistry();
     const displayName = useFilterDisplayName(field);
 
-    // Ideally we would not have staged values, and filters would update automatically.
     const [searchQuery, setSearchQuery] = useState<string | undefined>(undefined);
 
-    // Here we optionally load the aggregation options, which are the options that are displayed by default.
     const { options: aggOptions, loading: aggLoading } = useLoadAggregationOptions({
         field,
         visible: true,
@@ -52,10 +46,9 @@ export default function EnumValueMenu({
 
     const optionsWithAggs = [...defaultOptions, ...deduplicateOptions(defaultOptions, aggOptions)];
 
-    // Do an aggregations query with the given search query as a filter to find any values not in the first set of results
     const { options: searchAggOptions, loading: searchAggsLoading } = useLoadAggregationOptions({
         field,
-        visible: !!searchQuery, // only run this query if there's a search query
+        visible: !!searchQuery,
         includeCounts: includeCount,
         aggregationsEntityTypes,
         extraOrFilters: [{ and: [{ field: field.field, values: [searchQuery || ''] }] }],
@@ -66,7 +59,6 @@ export default function EnumValueMenu({
 
     const localSearchOptions = useFilterOptionsBySearchQuery(allOptions, searchQuery);
 
-    // Compute the final options to show to the user.
     const finalOptions = searchQuery ? localSearchOptions : allOptions;
 
     const filterMenuOptions = finalOptions.map((option) =>
@@ -93,13 +85,17 @@ export default function EnumValueMenu({
 
     return (
         <OptionsDropdownMenu
-            menu={<OptionMenu items={filterMenuOptions} />}
-            updateFilters={onApply}
+            menu={
+                <OptionList>
+                    {filterMenuOptions.map((opt) => (
+                        <React.Fragment key={opt.key}>{opt.label}</React.Fragment>
+                    ))}
+                </OptionList>
+            }
             searchQuery={searchQuery || ''}
             updateSearchQuery={setSearchQuery}
             isLoading={aggLoading || searchAggsLoading}
             searchPlaceholder={displayName}
-            type={type}
             className={className}
         />
     );

--- a/datahub-web-react/src/app/searchV2/filters/value/TextValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/TextValueMenu.tsx
@@ -1,4 +1,3 @@
-import { Button, Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -7,44 +6,36 @@ import TextValueInput from '@app/searchV2/filters/value/TextValueInput';
 
 const Container = styled.div`
     padding: 16px;
-    background-color: #ffffff;
-    box-shadow:
-        0 3px 6px -4px rgba(0, 0, 0, 0.12),
-        0 6px 16px 0 rgba(0, 0, 0, 0.08),
-        0 9px 28px 8px rgba(0, 0, 0, 0.05);
-    border-radius: 8px;
+    background-color: ${(props) => props.theme.colors.bg};
+    box-shadow: ${(props) => props.theme.colors.shadowMd};
+    border-radius: 12px;
 `;
 
-const Title = styled(Typography.Title)`
+const Title = styled.div`
+    font-size: 16px;
+    font-weight: 600;
+    color: ${(props) => props.theme.colors.text};
     padding-bottom: 4px;
-`;
-
-const UpdateButton = styled(Button)`
-    margin-top: 12px;
 `;
 
 interface Props {
     field: FilterField;
     values: FilterValue[];
     onChangeValues: (newValues: FilterValue[]) => void;
-    onApply: () => void;
 }
 
-export default function TextValueMenu({ field, values, onChangeValues, onApply }: Props) {
+export default function TextValueMenu({ field, values, onChangeValues }: Props) {
     const { displayName } = field;
     const value = values.length > 0 ? values[0].displayName || values[0].value : '';
 
     return (
         <Container>
-            <Title level={5}>{`Filter by ${displayName}`}</Title>
+            <Title>{`Filter by ${displayName}`}</Title>
             <TextValueInput
                 name={displayName}
                 value={value}
                 onChangeValue={(v) => onChangeValues([{ value: v, entity: null }])}
             />
-            <UpdateButton type="primary" onClick={onApply}>
-                Apply
-            </UpdateButton>
         </Container>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/value/TimeBucketMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/TimeBucketMenu.tsx
@@ -1,26 +1,22 @@
-import type { ItemType } from 'antd/lib/menu/hooks/useItems';
 import moment from 'moment';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
-import { ANTD_GRAY } from '@app/entity/shared/constants';
 import OptionsDropdownMenu from '@app/searchV2/filters/OptionsDropdownMenu';
 import { FilterValue, TimeBucketFilterField } from '@app/searchV2/filters/types';
-import { OptionMenu } from '@app/searchV2/filters/value/styledComponents';
 
-const FilterOptionWrapper = styled.div`
+const TimeBucketOption = styled.div<{ $isSelected: boolean }>`
     display: flex;
     align-items: center;
-
-    margin: 0 4px;
-    padding: 10px;
-
+    padding: 8px 4px;
     border-radius: 8px;
-
     font-size: 14px;
+    cursor: pointer;
+    color: ${(props) => props.theme.colors.text};
+    background-color: ${(props) => (props.$isSelected ? props.theme.colors.bgSelectedSubtle : 'transparent')};
 
     &:hover {
-        background-color: ${ANTD_GRAY[3]};
+        background-color: ${(props) => props.theme.colors.bgHover};
     }
 `;
 
@@ -28,45 +24,44 @@ interface Props {
     field: TimeBucketFilterField;
     values: FilterValue[];
     onChangeValues: (newValues: FilterValue[]) => void;
-    onApply: () => void;
-    type?: 'card' | 'default';
     className?: string;
 }
 
-export default function TimeBucketMenu({ field, values, type = 'card', onChangeValues, onApply, className }: Props) {
-    const filterMenuOptions = useMemo(
+export default function TimeBucketMenu({ field, values, onChangeValues, className }: Props) {
+    const options = useMemo(
         () =>
-            field.options.map(({ label, startOffsetMillis }): ItemType => {
+            field.options.map(({ label, startOffsetMillis }) => {
                 const timestamp = moment()
                     .subtract(startOffsetMillis, 'milliseconds')
                     .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
                     .valueOf()
                     .toString();
-                return {
-                    key: timestamp,
-                    label: <FilterOptionWrapper>{label}</FilterOptionWrapper>,
-                    onClick: () => onChangeValues([{ value: timestamp, entity: null }]),
-                };
+                return { key: timestamp, label, timestamp };
             }),
-        [field.options, onChangeValues],
+        [field.options],
     );
 
     const selectedKey = useMemo(
-        () => filterMenuOptions.find((option) => values.length && option?.key === values[0].value)?.key,
-        [filterMenuOptions, values],
+        () => options.find((option) => values.length && option.key === values[0].value)?.key,
+        [options, values],
     );
 
     return (
         <OptionsDropdownMenu
             menu={
-                <OptionMenu
-                    items={filterMenuOptions}
-                    selectedKeys={selectedKey ? [selectedKey.toString()] : undefined}
-                />
+                <div>
+                    {options.map((option) => (
+                        <TimeBucketOption
+                            key={option.key}
+                            $isSelected={option.key === selectedKey}
+                            onClick={() => onChangeValues([{ value: option.timestamp, entity: null }])}
+                        >
+                            {option.label}
+                        </TimeBucketOption>
+                    ))}
+                </div>
             }
-            updateFilters={onApply}
             showSearchBar={false}
-            type={type}
             className={className}
         />
     );

--- a/datahub-web-react/src/app/searchV2/filters/value/ValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/ValueMenu.tsx
@@ -19,7 +19,6 @@ interface Props {
     values: FilterValue[];
     defaultOptions: FilterValueOption[];
     onChangeValues: (newValues: FilterValue[]) => void;
-    type?: 'card' | 'default';
     visible: boolean;
     includeCount?: boolean;
     className?: string;
@@ -31,7 +30,6 @@ export default function ValueMenu({
     field,
     values,
     defaultOptions,
-    type = 'card',
     onChangeValues,
     visible,
     includeCount,
@@ -43,10 +41,6 @@ export default function ValueMenu({
     const visibilityRef = useRef<boolean>(visible);
     const isDateRangeFilter = getIsDateRangeFilter(field);
 
-    /**
-     * Synchronize stagedSelectedValues with the values prop
-     * NOTE: Callback with useState not feasible due to its initialization behavior.
-     */
     const previousValues = usePrevious(values);
     useEffect(() => {
         if (!isEqual(values, previousValues)) {
@@ -54,10 +48,6 @@ export default function ValueMenu({
         }
     }, [values, previousValues]);
 
-    /**
-     * If the visibility of the menu changes in the parent component, we can dump off the staged values before closing
-     * to make the UI feel more responsive.
-     */
     useEffect(() => {
         const previouslyVisible = visibilityRef.current;
         visibilityRef.current = visible;
@@ -74,22 +64,15 @@ export default function ValueMenu({
     switch (field.type) {
         case FieldType.TEXT:
             return (
-                <TextValueMenu
-                    field={field}
-                    values={stagedSelectedValues}
-                    onChangeValues={setStagedSelectedValues}
-                    onApply={() => onChangeValues(stagedSelectedValues)}
-                />
+                <TextValueMenu field={field} values={stagedSelectedValues} onChangeValues={setStagedSelectedValues} />
             );
         case FieldType.BOOLEAN:
             return (
                 <BooleanValueMenu
                     field={field}
                     values={stagedSelectedValues}
-                    type={type}
                     className={className}
                     onChangeValues={setStagedSelectedValues}
-                    onApply={() => onChangeValues(stagedSelectedValues)}
                 />
             );
         case FieldType.ENTITY:
@@ -99,10 +82,8 @@ export default function ValueMenu({
                     includeCount={includeCount}
                     values={stagedSelectedValues}
                     defaultOptions={defaultOptions}
-                    type={type}
                     className={className}
                     onChangeValues={setStagedSelectedValues}
-                    onApply={() => onChangeValues(stagedSelectedValues)}
                 />
             );
         case FieldType.NESTED_ENTITY_TYPE:
@@ -112,10 +93,8 @@ export default function ValueMenu({
                     includeCount={includeCount}
                     values={stagedSelectedValues}
                     defaultOptions={defaultOptions}
-                    type={type}
                     className={className}
                     onChangeValues={setStagedSelectedValues}
-                    onApply={() => onChangeValues(stagedSelectedValues)}
                 />
             );
         case FieldType.ENTITY_TYPE:
@@ -125,10 +104,8 @@ export default function ValueMenu({
                     includeCount={includeCount}
                     values={stagedSelectedValues}
                     defaultOptions={defaultOptions}
-                    type={type}
                     className={className}
                     onChangeValues={setStagedSelectedValues}
-                    onApply={() => onChangeValues(stagedSelectedValues)}
                     aggregationsEntityTypes={aggregationsEntityTypes}
                 />
             );
@@ -139,10 +116,8 @@ export default function ValueMenu({
                     includeCount={includeCount}
                     values={stagedSelectedValues}
                     defaultOptions={defaultOptions}
-                    type={type}
                     className={className}
                     onChangeValues={setStagedSelectedValues}
-                    onApply={() => onChangeValues(stagedSelectedValues)}
                     aggregationsEntityTypes={aggregationsEntityTypes}
                 />
             );
@@ -151,10 +126,8 @@ export default function ValueMenu({
                 <TimeBucketMenu
                     field={field}
                     values={stagedSelectedValues}
-                    type={type}
                     className={className}
                     onChangeValues={setStagedSelectedValues}
-                    onApply={() => onChangeValues(stagedSelectedValues)}
                 />
             );
         case FieldType.BROWSE_PATH:

--- a/datahub-web-react/src/app/searchV2/filters/value/ValueName.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/ValueName.tsx
@@ -1,6 +1,6 @@
-import { Typography } from 'antd';
 import moment from 'moment';
 import React from 'react';
+import styled from 'styled-components';
 
 import { getV1FieldPathFromSchemaFieldUrn } from '@app/lineageV2/lineageUtils';
 import { FieldType, FilterField, FilterValue } from '@app/searchV2/filters/types';
@@ -8,6 +8,10 @@ import { getStructuredPropFilterDisplayName } from '@app/searchV2/filters/utils'
 import { getEntityTypeFilterValueDisplayName } from '@app/searchV2/filters/value/utils';
 import { UNIT_SEPARATOR } from '@app/searchV2/utils/constants';
 import { useEntityRegistry } from '@app/useEntityRegistry';
+
+const PathSeparator = styled.span`
+    color: ${(props) => props.theme.colors.textSecondary};
+`;
 
 function getTextFieldName(field: FilterField, value: FilterValue) {
     let textFieldName = value.displayName || value.value;
@@ -38,24 +42,19 @@ export default function ValueName({ field, value }: Props) {
         case FieldType.NESTED_ENTITY_TYPE:
             return <> {getEntityTypeFilterValueDisplayName(value.value, entityRegistry)}</>;
         case FieldType.BROWSE_PATH: {
-            // TODO: Break this into a separate component.
             const pathParts = value.value.split(UNIT_SEPARATOR).filter((part) => part);
             return (
                 <>
                     {pathParts.map((part, index) => (
-                        <>
+                        <React.Fragment key={part}>
                             {part}
-                            {(index < pathParts.length - 1 && (
-                                <Typography.Text type="secondary"> / </Typography.Text>
-                            )) ||
-                                undefined}
-                        </>
+                            {index < pathParts.length - 1 && <PathSeparator> / </PathSeparator>}
+                        </React.Fragment>
                     ))}
                 </>
             );
         }
         case FieldType.BUCKETED_TIMESTAMP:
-            // Note: Currently unused, as SelectedFilter.tsx renders DatePicker instead
             return <>{moment(value.value).format('YYYY-MM-DD')}</>;
         default:
             console.error(`Unknown field type: ${field}`);

--- a/datahub-web-react/src/app/searchV2/filters/value/ValueSelector.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/ValueSelector.tsx
@@ -1,10 +1,23 @@
 /* eslint-disable import/no-cycle */
-import { Dropdown } from 'antd';
-import React, { useState } from 'react';
+import React, { CSSProperties, useCallback, useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import useClickOutside from '@components/components/Utils/ClickOutside/useClickOutside';
 
 import { FilterField, FilterValue, FilterValueOption } from '@app/searchV2/filters/types';
 import ValueMenu from '@app/searchV2/filters/value/ValueMenu';
 import { EntityType, FacetFilterInput } from '@src/types.generated';
+
+const Wrapper = styled.div`
+    position: relative;
+`;
+
+const MenuContainer = styled.div`
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 1050;
+`;
 
 interface Props {
     field: FilterField;
@@ -13,6 +26,7 @@ interface Props {
     onChangeValues: (newValues: FilterValue[]) => void;
     children?: any;
     className?: string;
+    menuStyle?: CSSProperties;
     manuallyUpdateFilters?: (newValues: FacetFilterInput[]) => void;
     aggregationsEntityTypes?: Array<EntityType>;
 }
@@ -24,10 +38,12 @@ export default function ValueSelector({
     onChangeValues,
     children,
     className,
+    menuStyle,
     manuallyUpdateFilters,
     aggregationsEntityTypes,
 }: Props) {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const wrapperRef = useRef<HTMLDivElement>(null);
 
     const onUpdateValues = (newValues: FilterValue[]) => {
         setIsMenuOpen(false);
@@ -39,27 +55,36 @@ export default function ValueSelector({
         manuallyUpdateFilters?.(newValues);
     };
 
+    const handleClickOutside = useCallback(() => setIsMenuOpen(false), []);
+    const clickOutsideOptions = useMemo(() => ({ wrappers: [wrapperRef] }), []);
+    useClickOutside(handleClickOutside, clickOutsideOptions);
+
     return (
-        <Dropdown
-            key={field.field}
-            trigger={['click']}
-            open={isMenuOpen}
-            onOpenChange={setIsMenuOpen}
-            dropdownRender={(_) => (
-                <ValueMenu
-                    field={field}
-                    values={values}
-                    defaultOptions={defaultOptions}
-                    onChangeValues={onUpdateValues}
-                    visible={isMenuOpen}
-                    includeCount
-                    className={className}
-                    manuallyUpdateFilters={onManuallyUpdateFilters}
-                    aggregationsEntityTypes={aggregationsEntityTypes}
-                />
+        <Wrapper ref={wrapperRef} className={className}>
+            <div
+                role="button"
+                tabIndex={0}
+                onClick={() => setIsMenuOpen((prev) => !prev)}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') setIsMenuOpen((prev) => !prev);
+                }}
+            >
+                {children}
+            </div>
+            {isMenuOpen && (
+                <MenuContainer style={menuStyle}>
+                    <ValueMenu
+                        field={field}
+                        values={values}
+                        defaultOptions={defaultOptions}
+                        onChangeValues={onUpdateValues}
+                        visible={isMenuOpen}
+                        includeCount
+                        manuallyUpdateFilters={onManuallyUpdateFilters}
+                        aggregationsEntityTypes={aggregationsEntityTypes}
+                    />
+                </MenuContainer>
             )}
-        >
-            {children}
-        </Dropdown>
+        </Wrapper>
     );
 }

--- a/datahub-web-react/src/app/searchV2/filters/value/styledComponents.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/styledComponents.tsx
@@ -1,15 +1,6 @@
-import { Menu } from 'antd';
 import styled from 'styled-components';
 
-export const OptionMenu = styled(Menu)`
-    &&& .ant-menu-item {
-        height: auto;
-        line-height: 22px;
-        height: auto;
-        padding: 0;
-    }
-
-    &&& .ant-dropdown-menu-item {
-        padding: 0;
-    }
+export const OptionList = styled.div`
+    display: flex;
+    flex-direction: column;
 `;

--- a/datahub-web-react/src/app/searchV2/sorting/SearchSortSelect.tsx
+++ b/datahub-web-react/src/app/searchV2/sorting/SearchSortSelect.tsx
@@ -1,32 +1,8 @@
-import { CaretDownFilled } from '@ant-design/icons';
-import { Tooltip } from '@components';
-import { Select } from 'antd';
+import { SimpleSelect } from '@components';
 import React from 'react';
-import styled from 'styled-components';
 
-import { ANTD_GRAY } from '@app/entity/shared/constants';
 import { DEFAULT_SORT_OPTION } from '@app/searchV2/context/constants';
 import useGetSortOptions from '@app/searchV2/sorting/useGetSortOptions';
-
-const SelectWrapper = styled.span`
-    display: inline-flex;
-    align-items: center;
-    margin-right: 0px;
-    && {
-        padding: 0px;
-        margin: 0px;
-    }
-    .ant-select-selection-item {
-        // !important is necessary because updating Select styles for antd is impossible
-        color: ${ANTD_GRAY[8]} !important;
-        font-weight: 700;
-    }
-
-    .ant-select-selection-placeholder {
-        color: ${ANTD_GRAY[8]};
-        font-weight: 700;
-    }
-`;
 
 type Props = {
     selectedSortOption: string | undefined;
@@ -37,20 +13,20 @@ export default function SearchSortSelect({ selectedSortOption, setSelectedSortOp
     const sortOptions = useGetSortOptions();
     const options = Object.entries(sortOptions).map(([value, option]) => ({ value, label: option.label }));
 
+    const currentValue = selectedSortOption || DEFAULT_SORT_OPTION;
+
     return (
-        <Tooltip title="Sort search results" showArrow={false} placement="left">
-            <SelectWrapper>
-                <Select
-                    placeholder="Sort by"
-                    value={selectedSortOption === DEFAULT_SORT_OPTION ? null : selectedSortOption}
-                    options={options}
-                    bordered={false}
-                    onChange={(option) => setSelectedSortOption(option)}
-                    dropdownStyle={{ minWidth: 'max-content' }}
-                    placement="bottomRight"
-                    suffixIcon={<CaretDownFilled />}
-                />
-            </SelectWrapper>
-        </Tooltip>
+        <SimpleSelect
+            options={options}
+            values={[currentValue]}
+            onUpdate={(values) => {
+                if (values.length > 0) {
+                    setSelectedSortOption(values[0]);
+                }
+            }}
+            showClear={false}
+            width="fit-content"
+            size="md"
+        />
     );
 }

--- a/datahub-web-react/src/app/sharedV2/search/DownloadButton.tsx
+++ b/datahub-web-react/src/app/sharedV2/search/DownloadButton.tsx
@@ -1,10 +1,5 @@
-import { Button, Tooltip, colors } from '@components';
+import { Button, Tooltip } from '@components';
 import React from 'react';
-import styled from 'styled-components';
-
-const StyledButton = styled(Button)`
-    border: 1px solid ${colors.gray[100]};
-`;
 
 type Props = {
     setShowDownloadAsCsvModal: (showDownloadAsCsvModal: boolean) => any;
@@ -15,18 +10,17 @@ type Props = {
 export default function DownloadButton({ setShowDownloadAsCsvModal, isDownloadingCsv, disabled }: Props) {
     return (
         <Tooltip title="Download results..." showArrow={false} placement="top">
-            <StyledButton
+            <Button
                 onClick={() => setShowDownloadAsCsvModal(true)}
                 disabled={isDownloadingCsv || disabled}
-                isCircle
                 icon={{ icon: 'DownloadSimple', source: 'phosphor' }}
                 variant="text"
                 color="gray"
-                size="sm"
+                size="md"
                 data-testid="download-csv-button"
             >
                 {isDownloadingCsv ? 'Downloading...' : null}
-            </StyledButton>
+            </Button>
         </Tooltip>
     );
 }

--- a/datahub-web-react/src/app/sharedV2/search/EditButton.tsx
+++ b/datahub-web-react/src/app/sharedV2/search/EditButton.tsx
@@ -1,10 +1,5 @@
-import { Button, Tooltip, colors } from '@components';
+import { Button, Tooltip } from '@components';
 import React from 'react';
-import styled from 'styled-components';
-
-const StyledButton = styled(Button)`
-    border: 1px solid ${colors.gray[100]};
-`;
 
 type Props = {
     setShowSelectMode: (showSelectMode: boolean) => any;
@@ -14,15 +9,14 @@ type Props = {
 export default function EditButton({ setShowSelectMode, disabled }: Props) {
     return (
         <Tooltip title="Edit..." showArrow={false} placement="top">
-            <StyledButton
+            <Button
                 onClick={() => setShowSelectMode(true)}
                 disabled={disabled}
                 data-testid="search-results-edit-button"
-                isCircle
                 icon={{ icon: 'PencilSimple', source: 'phosphor' }}
                 variant="text"
                 color="gray"
-                size="sm"
+                size="md"
             />
         </Tooltip>
     );


### PR DESCRIPTION
## Summary
- **Replace antd components** (Select, Dropdown, Menu, Checkbox, Typography) with native implementations and alchemy components across all search filter menus
- **Enforce semantic theme colors** (`props.theme.colors.*`) everywhere — removed all hardcoded hex values, `ANTD_GRAY`, `REDESIGN_COLORS`, and raw alchemy color imports
- **Match filter trigger styling** exactly to alchemy `SimpleSelect` (font-weight 400, padding `4px 8px`, min-height 36px, border-radius 8px, matching box-shadow)
- **Replace antd Dropdowns** with native `position: absolute` + `useClickOutside` hook in ValueSelector, MoreFilters, BooleanSearchFilter, BooleanMoreFilter
- **Alchemy component adoption**: `Pill` for filter option counts, `Checkbox` (xs) for selections, `Avatar` for owner filter options
- **Sort by menu**: replaced antd `Select` with alchemy `SimpleSelect`, always shows current selection
- **Download/Edit buttons**: removed circular icon styling, now plain `Button variant="text" color="gray" size="md"`
- **Dead code cleanup**: removed unused `icon` props from boolean filter renderers and their callers
- **Consistent styling**: 14px font-size, 4px checkbox-text gap, 4px menu item padding, 12px border-radius on dropdown panels across all filter menus

## Test plan
- [ ] Verify all filter dropdowns open/close correctly (Platform, Type, Tag, Domain, Owner, Glossary Terms, etc.)
- [ ] Verify the "More" dropdown and its sub-menus render correctly without layout issues
- [ ] Verify sort by select shows "Relevance" by default and changes on selection
- [ ] Verify download and edit buttons are visible and functional
- [ ] Verify filter trigger buttons match SimpleSelect styling (height, font, shadow, border)
- [ ] Verify checkboxes, pills (count), and avatars render correctly in filter options
- [ ] Verify all menus use semantic theme colors (no antd typography/styling leaks)
- [ ] Verify view toggle (full card / compact) still works
- [ ] Test dark mode to ensure semantic color tokens resolve correctly

Made with [Cursor](https://cursor.com)