### PR TITLE
build(gitignore): add Agents Skills to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,10 @@ coverage*.xml
 # Local dev environment overrides (user-specific GMS/Kafka settings)
 docker/profiles/my-settings.env
 
+# Agents Skills
+.agents/
+skills-lock.json
+
 # Claude ignores
 .claude/
 **/.claude/settings.local.json


### PR DESCRIPTION
added Agents Skills to the gitignore to use the new Connector Skills