### PR TITLE
fix(ingest/iceberg): inject S3 credentials alongside Glue during cross-account role assumption

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
@@ -50,6 +50,14 @@ DEFAULT_REST_RETRY_POLICY = {"total": 3, "backoff_factor": 0.1}
 
 GLUE_ROLE_ARN = "glue.role-arn"
 
+# S3 FileIO credential property keys.
+# Defined inline because pyiceberg does not export these as public constants
+# in all versions supported by DataHub.
+S3_ACCESS_KEY_ID = "s3.access-key-id"
+S3_SECRET_ACCESS_KEY = "s3.secret-access-key"
+S3_SESSION_TOKEN = "s3.session-token"
+S3_ROLE_ARN = "s3.role-arn"
+
 
 class TimeoutHTTPAdapter(HTTPAdapter):
     def __init__(self, *args, **kwargs):
@@ -174,7 +182,7 @@ class IcebergSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin)
 
     def _custom_glue_catalog_handling(self, catalog_config: Dict[str, Any]) -> None:
         role_to_assume = get_first_property_value(
-            catalog_config, GLUE_ROLE_ARN, AWS_ROLE_ARN
+            catalog_config, GLUE_ROLE_ARN, AWS_ROLE_ARN, S3_ROLE_ARN
         )
         if role_to_assume:
             logger.debug(
@@ -241,6 +249,29 @@ class IcebergSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin)
                 catalog_config[GLUE_ACCESS_KEY_ID] = creds["AccessKeyId"]
                 catalog_config[GLUE_SECRET_ACCESS_KEY] = creds["SecretAccessKey"]
                 catalog_config[GLUE_SESSION_TOKEN] = creds["SessionToken"]
+
+                # Also inject credentials for S3 FileIO so that cross-account
+                # data/metadata file access works with the same assumed role.
+                # Only set S3 credentials if the user hasn't explicitly configured
+                # separate S3 credentials or a different S3 role.
+                s3_has_own_creds = any(
+                    k in catalog_config
+                    for k in (S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, S3_SESSION_TOKEN)
+                )
+                s3_has_own_role = (
+                    S3_ROLE_ARN in catalog_config
+                    and catalog_config[S3_ROLE_ARN] != role_to_assume
+                )
+                if not s3_has_own_creds and not s3_has_own_role:
+                    catalog_config[S3_ACCESS_KEY_ID] = creds["AccessKeyId"]
+                    catalog_config[S3_SECRET_ACCESS_KEY] = creds["SecretAccessKey"]
+                    catalog_config[S3_SESSION_TOKEN] = creds["SessionToken"]
+                    logger.debug("Also injected assumed-role credentials for S3 FileIO")
+
+            # Remove role-arn keys so pyiceberg doesn't attempt its own
+            # (broken) role assumption on top of our credentials
+            for key in (GLUE_ROLE_ARN, AWS_ROLE_ARN, S3_ROLE_ARN):
+                catalog_config.pop(key, None)
 
     def get_catalog(self) -> Catalog:
         """Returns the Iceberg catalog instance as configured by the `catalog` dictionary.

--- a/metadata-ingestion/tests/unit/test_iceberg.py
+++ b/metadata-ingestion/tests/unit/test_iceberg.py
@@ -2063,3 +2063,230 @@ class TestGlueCatalogRoleAssumption:
             == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYZEXAMPLEKEY2"
         )
         assert updated_config["glue.session-token"] == "FwoGZXIvYXdzEBYaDH2..."
+
+    def test_s3_credentials_injected_alongside_glue(self, mock_boto3_session):
+        """Test that when glue.role-arn is set, both Glue and S3 credentials are injected."""
+        mock_session, mock_sts = mock_boto3_session
+
+        catalog_config = {
+            "test_glue": {
+                "type": "glue",
+                "glue.role-arn": "arn:aws:iam::123456789012:role/TargetRole",
+                "s3.region": "us-west-2",
+            }
+        }
+        config = IcebergSourceConfig(catalog=catalog_config)
+
+        mock_sts.get_caller_identity.return_value = {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/CurrentRole/session",
+            "UserId": "AIDACKCEVSQ6C2EXAMPLE",
+            "Account": "123456789012",
+        }
+
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+                "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYZEXAMPLEKEY",
+                "SessionToken": "FwoGZXIvYXdzEBYaDH...",
+                "Expiration": "2024-01-01T00:00:00Z",
+            },
+            "AssumedRoleUser": {
+                "AssumedRoleId": "AROA3XFRBF535PLBIFPI4:session",
+                "Arn": "arn:aws:sts::123456789012:assumed-role/TargetRole/session",
+            },
+        }
+
+        config.get_catalog()
+
+        updated_config = config.catalog["test_glue"]
+        # Glue credentials should be injected
+        assert updated_config["glue.access-key-id"] == "ASIAIOSFODNN7EXAMPLE"
+        assert (
+            updated_config["glue.secret-access-key"]
+            == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYZEXAMPLEKEY"
+        )
+        assert updated_config["glue.session-token"] == "FwoGZXIvYXdzEBYaDH..."
+        # S3 credentials should also be injected
+        assert updated_config["s3.access-key-id"] == "ASIAIOSFODNN7EXAMPLE"
+        assert (
+            updated_config["s3.secret-access-key"]
+            == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYZEXAMPLEKEY"
+        )
+        assert updated_config["s3.session-token"] == "FwoGZXIvYXdzEBYaDH..."
+
+    def test_s3_credentials_not_overwritten_when_explicit(self, mock_boto3_session):
+        """Test that explicit S3 credentials are not overwritten by role assumption."""
+        mock_session, mock_sts = mock_boto3_session
+
+        catalog_config = {
+            "test_glue": {
+                "type": "glue",
+                "glue.role-arn": "arn:aws:iam::123456789012:role/TargetRole",
+                "s3.region": "us-west-2",
+                "s3.access-key-id": "USER_PROVIDED_KEY",
+                "s3.secret-access-key": "USER_PROVIDED_SECRET",
+                "s3.session-token": "USER_PROVIDED_TOKEN",
+            }
+        }
+        config = IcebergSourceConfig(catalog=catalog_config)
+
+        mock_sts.get_caller_identity.return_value = {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/CurrentRole/session",
+            "UserId": "AIDACKCEVSQ6C2EXAMPLE",
+            "Account": "123456789012",
+        }
+
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+                "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYZEXAMPLEKEY",
+                "SessionToken": "FwoGZXIvYXdzEBYaDH...",
+                "Expiration": "2024-01-01T00:00:00Z",
+            },
+            "AssumedRoleUser": {
+                "AssumedRoleId": "AROA3XFRBF535PLBIFPI4:session",
+                "Arn": "arn:aws:sts::123456789012:assumed-role/TargetRole/session",
+            },
+        }
+
+        config.get_catalog()
+
+        updated_config = config.catalog["test_glue"]
+        # Glue credentials should be injected from assumed role
+        assert updated_config["glue.access-key-id"] == "ASIAIOSFODNN7EXAMPLE"
+        # S3 credentials should NOT be overwritten
+        assert updated_config["s3.access-key-id"] == "USER_PROVIDED_KEY"
+        assert updated_config["s3.secret-access-key"] == "USER_PROVIDED_SECRET"
+        assert updated_config["s3.session-token"] == "USER_PROVIDED_TOKEN"
+
+    def test_s3_credentials_not_overwritten_when_different_s3_role(
+        self, mock_boto3_session
+    ):
+        """Test that S3 credentials are not injected when s3.role-arn differs from assumed role."""
+        mock_session, mock_sts = mock_boto3_session
+
+        catalog_config = {
+            "test_glue": {
+                "type": "glue",
+                "glue.role-arn": "arn:aws:iam::123456789012:role/GlueRole",
+                "s3.role-arn": "arn:aws:iam::999999999999:role/SeparateS3Role",
+                "s3.region": "us-west-2",
+            }
+        }
+        config = IcebergSourceConfig(catalog=catalog_config)
+
+        mock_sts.get_caller_identity.return_value = {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/CurrentRole/session",
+            "UserId": "AIDACKCEVSQ6C2EXAMPLE",
+            "Account": "123456789012",
+        }
+
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+                "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYZEXAMPLEKEY",
+                "SessionToken": "FwoGZXIvYXdzEBYaDH...",
+                "Expiration": "2024-01-01T00:00:00Z",
+            },
+            "AssumedRoleUser": {
+                "AssumedRoleId": "AROA3XFRBF535PLBIFPI4:session",
+                "Arn": "arn:aws:sts::123456789012:assumed-role/GlueRole/session",
+            },
+        }
+
+        config.get_catalog()
+
+        updated_config = config.catalog["test_glue"]
+        # Glue credentials should be injected
+        assert updated_config["glue.access-key-id"] == "ASIAIOSFODNN7EXAMPLE"
+        # S3 credentials should NOT be injected because s3.role-arn is different
+        assert "s3.access-key-id" not in updated_config
+        assert "s3.secret-access-key" not in updated_config
+        assert "s3.session-token" not in updated_config
+
+    def test_role_arn_keys_cleaned_up_after_assumption(self, mock_boto3_session):
+        """Test that role-arn keys are removed after assumption to prevent pyiceberg's broken handling."""
+        mock_session, mock_sts = mock_boto3_session
+
+        catalog_config = {
+            "test_glue": {
+                "type": "glue",
+                "glue.role-arn": "arn:aws:iam::123456789012:role/TargetRole",
+                "s3.region": "us-west-2",
+            }
+        }
+        config = IcebergSourceConfig(catalog=catalog_config)
+
+        mock_sts.get_caller_identity.return_value = {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/CurrentRole/session",
+            "UserId": "AIDACKCEVSQ6C2EXAMPLE",
+            "Account": "123456789012",
+        }
+
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+                "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYZEXAMPLEKEY",
+                "SessionToken": "FwoGZXIvYXdzEBYaDH...",
+                "Expiration": "2024-01-01T00:00:00Z",
+            },
+            "AssumedRoleUser": {
+                "AssumedRoleId": "AROA3XFRBF535PLBIFPI4:session",
+                "Arn": "arn:aws:sts::123456789012:assumed-role/TargetRole/session",
+            },
+        }
+
+        config.get_catalog()
+
+        updated_config = config.catalog["test_glue"]
+        assert "glue.role-arn" not in updated_config
+        assert "client.role-arn" not in updated_config
+        assert "s3.role-arn" not in updated_config
+
+    def test_s3_role_arn_triggers_assumption(self, mock_boto3_session):
+        """Test that s3.role-arn alone can trigger role assumption."""
+        mock_session, mock_sts = mock_boto3_session
+
+        catalog_config = {
+            "test_glue": {
+                "type": "glue",
+                "s3.role-arn": "arn:aws:iam::123456789012:role/S3OnlyRole",
+                "s3.region": "us-west-2",
+            }
+        }
+        config = IcebergSourceConfig(catalog=catalog_config)
+
+        mock_sts.get_caller_identity.return_value = {
+            "Arn": "arn:aws:sts::123456789012:assumed-role/CurrentRole/session",
+            "UserId": "AIDACKCEVSQ6C2EXAMPLE",
+            "Account": "123456789012",
+        }
+
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+                "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYZEXAMPLEKEY",
+                "SessionToken": "FwoGZXIvYXdzEBYaDH...",
+                "Expiration": "2024-01-01T00:00:00Z",
+            },
+            "AssumedRoleUser": {
+                "AssumedRoleId": "AROA3XFRBF535PLBIFPI4:session",
+                "Arn": "arn:aws:sts::123456789012:assumed-role/S3OnlyRole/session",
+            },
+        }
+
+        config.get_catalog()
+
+        mock_sts.assume_role.assert_called_once()
+
+        updated_config = config.catalog["test_glue"]
+        # Both Glue and S3 credentials should be injected
+        assert updated_config["glue.access-key-id"] == "ASIAIOSFODNN7EXAMPLE"
+        assert updated_config["s3.access-key-id"] == "ASIAIOSFODNN7EXAMPLE"
+        assert (
+            updated_config["s3.secret-access-key"]
+            == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYZEXAMPLEKEY"
+        )
+        assert updated_config["s3.session-token"] == "FwoGZXIvYXdzEBYaDH..."
+        # Role ARN keys should be cleaned up
+        assert "s3.role-arn" not in updated_config


### PR DESCRIPTION

The `_custom_glue_catalog_handling()` method performs STS AssumeRole when `glue.role-arn` is configured, but only injected credentials for the Glue client. The S3 FileIO layer still used the executor's default credentials, causing cross-account Iceberg ingestion to fail when reading S3 data/metadata files.

This change:
- Injects assumed-role credentials for S3 FileIO (`s3.access-key-id`, `s3.secret-access-key`, `s3.session-token`) alongside Glue credentials
- Respects user-provided S3 credentials or a separate `s3.role-arn`
- Recognizes `s3.role-arn` as a trigger for role assumption
- Cleans up role-arn keys after assumption to prevent pyiceberg from attempting its own (broken) role assumption

Ref: https://github.com/apache/iceberg-python/issues/2747

🤖 AI Assisted with Claude Code

Co-Authored-By: ai-tools@stepstone.com
