### PR TITLE
Build Python wheels from merge commit

### DIFF
--- a/.github/workflows/python-build-pages.yml
+++ b/.github/workflows/python-build-pages.yml
@@ -46,6 +46,8 @@ jobs:
           java-version: 17
       - uses: gradle/actions/setup-gradle@v4
       - uses: acryldata/sane-checkout-action@v4
+        with:
+          checkout-head-only: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"


### PR DESCRIPTION
## Summary
- Set `checkout-head-only: false` in `python-build-pages.yml` so the PyPI wheel is built from the merge commit (PR branch + master) instead of just the PR branch head
- This ensures connector tests and other consumers test against what will actually land on master, catching conflicts early



## Test plan
- [ ] Verify Python Build workflow still succeeds on a PR
- [ ] Verify the built wheel correctly includes merge commit changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)