### PR TITLE
fix(local-dev): Corrected yarn version in mise.toml to 1.22.22.

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ java = "17"
 node = "22"
 python = "3.11"
 shellcheck = "0.11.0"
-yarn = "4.12.0"
+yarn = "1.22.22"
 
 [tasks.regenerate-pre-commit]
 description = "Regenerate the pre-commit configuration to add new/removed projects"


### PR DESCRIPTION
This version `1.22.22` matches yarnVersion in datahub-web-react/build.gradle .  Version `4.12.0` is not correct, and the `yarn.lock` file checked-in is a v1 lock file.

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
