### PR TITLE
ci(labeler): community-contribution label : replace static user list with author_association check

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -19,62 +19,10 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/pr-labeler-config.yml"
       - uses: actions-ecosystem/action-add-labels@v1.1.3
-        # only add names of DataHub team members here
         if: ${{
-          !contains(
-          fromJson('[
-          "acrylJonny",
-          "AdrianMachado",
-          "Alex23Hub",
-          "alexsku",
-          "alfiyas-datahub",
-          "alokr-dhub",
-          "annadoesdesign",
-          "anshbansal",
-          "asikowitz",
-          "askumar27",
-          "aviraj-gour",
-          "benjiaming",
-          "brock-acryl",
-          "bryanprosser-acryl",
-          "chakru-r",
-          "chriscollins3456",
-          "david-leifker",
-          "deepgarg760",
-          "devashish2203",
-          "dinesh-verma-datahub",
-          "dutt23",
-          "esteban",
-          "gabe-lyons",
-          "jayacryl",
-          "jjoyce0510",
-          "jmacryl",
-          "kardeepak-datahub",
-          "kevinkarchacryl",
-          "kewats",
-          "ksrinath",
-          "kyungsoo-datahub",
-          "ligfx",
-          "maggiehays",
-          "pdruley",
-          "pedro93",
-          "petemango",
-          "purnimagarg1",
-          "rajatoss",
-          "rob-1019",
-          "RyanHolstien",
-          "sakethvarma397",
-          "sgomezvillamor",
-          "shirshanka",
-          "skrydal",
-          "swaroopjagadish",
-          "treff7es",
-          "v-tarasevich-blitz-brain",
-          "yoonhyejin",
-          "gdatahub"
-          ]'),
-          github.actor
-          )
+          github.event.pull_request.author_association != 'MEMBER' &&
+          github.event.pull_request.author_association != 'OWNER' &&
+          github.event.pull_request.author_association != 'COLLABORATOR'
           }}
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
Replace the hardcoded list of team member usernames with a dynamic check on pull_request.author_association. The community-contribution label is now applied when the PR author is not a `MEMBER`, `OWNER`, or `COLLABORATOR` of the repository's organization, eliminating ongoing maintenance of the static list.

My PRs kept being mis-labeled.

Testing - will necessarily need to be on GH itself once merged, but `actionlist` passes cleanly.

There is a slight behavioural difference if a PR is reopened - with this change it will still check the PR author's membership, not the PR reopener's, which seems correct for this label.

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)