### PR TITLE
feat(ingest/mongodb): add pymongo[aws] extra for AWS IAM auth support

### DIFF
--- a/metadata-ingestion/docs/sources/mongodb/mongodb_pre.md
+++ b/metadata-ingestion/docs/sources/mongodb/mongodb_pre.md
@@ -1,4 +1,67 @@
 ## Prerequisites and Permissions
 
-**Important:**  
+**Important:**
 The user account used for MongoDB ingestion must have the `readWrite` role on each database to be ingested. Schema inference and sampling logic executes on system collections (such as `system.profile` and `system.views`), which are not permitted with only `read` or `readAnyDatabase` roles. Without `readWrite`, ingestion will fail with an authorization error.
+
+## Authentication
+
+The `authMechanism` config field maps directly to PyMongo's
+[authentication mechanisms](https://pymongo.readthedocs.io/en/stable/examples/authentication.html).
+Supported values:
+
+| `authMechanism` | Use Case                                                                                                                                                                                 | Required Fields                            |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `DEFAULT`       | SCRAM auth (MongoDB default). Automatically negotiates SCRAM-SHA-256 or SCRAM-SHA-1 based on server version.                                                                             | `username`, `password`                     |
+| `SCRAM-SHA-256` | Explicit SCRAM-SHA-256 (MongoDB 4.0+).                                                                                                                                                   | `username`, `password`                     |
+| `SCRAM-SHA-1`   | Explicit SCRAM-SHA-1.                                                                                                                                                                    | `username`, `password`                     |
+| `MONGODB-AWS`   | AWS IAM authentication for MongoDB Atlas or AWS DocumentDB. Credentials are resolved from the environment (env vars, EC2 instance profile, ECS task role, EKS pod identity) via `boto3`. | See below                                  |
+| `MONGODB-X509`  | X.509 certificate authentication.                                                                                                                                                        | TLS options via `connect_uri` or `options` |
+
+### Username/Password (DEFAULT, SCRAM)
+
+The simplest configuration - supply `username` and `password` directly:
+
+```yaml
+source:
+  type: mongodb
+  config:
+    connect_uri: "mongodb://host:27017"
+    username: "${MONGODB_USER}"
+    password: "${MONGODB_PASSWORD}"
+    authMechanism: "DEFAULT"
+```
+
+### AWS IAM Authentication (MONGODB-AWS)
+
+Set `authMechanism: "MONGODB-AWS"` to authenticate using AWS IAM
+credentials. The connector resolves credentials automatically via
+`boto3`'s standard credential chain:
+
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+   `AWS_SESSION_TOKEN`)
+2. Shared credentials/config files (`~/.aws/credentials`)
+3. EC2 instance metadata / instance profile
+4. ECS container credentials
+5. EKS Pod Identity / IRSA (IAM Roles for Service Accounts)
+
+```yaml
+source:
+  type: mongodb
+  config:
+    connect_uri: "mongodb+srv://cluster.example.mongodb.net"
+    authMechanism: "MONGODB-AWS"
+    hostingEnvironment: "ATLAS" # or "AWS_DOCUMENTDB"
+```
+
+To supply explicit AWS credentials instead of using the credential chain:
+
+```yaml
+source:
+  type: mongodb
+  config:
+    connect_uri: "mongodb://docdb-cluster.region.docdb.amazonaws.com:27017/?tls=true&tlsCAFile=/path/to/rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+    username: "${AWS_ACCESS_KEY_ID}"
+    password: "${AWS_SECRET_ACCESS_KEY}"
+    authMechanism: "MONGODB-AWS"
+    hostingEnvironment: "AWS_DOCUMENTDB"
+```

--- a/metadata-ingestion/docs/sources/mongodb/mongodb_recipe.yml
+++ b/metadata-ingestion/docs/sources/mongodb/mongodb_recipe.yml
@@ -5,8 +5,10 @@ source:
     connect_uri: "mongodb://localhost"
 
     # Credentials
-    username: admin
-    password: password
+    # See the connector docs for all supported authMechanism values,
+    # including MONGODB-AWS for IAM authentication.
+    username: "${MONGODB_USER}"
+    password: "${MONGODB_PASSWORD}"
     authMechanism: "DEFAULT"
 
     # Options

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -662,7 +662,7 @@ plugins: Dict[str, Set[str]] = {
     "datahub-documents": unstructured_lib,
     "mode": {"requests<3.0.0", "python-liquid<2", "tenacity>=8.0.1,<9.0.0"}
     | sqlglot_lib,
-    "mongodb": {"pymongo>=4.8.0,<5.0.0", "packaging<26.0.0"},
+    "mongodb": {"pymongo[aws]>=4.8.0,<5.0.0", "packaging<26.0.0"},
     "mssql": sql_common | mssql_common,
     "mssql-odbc": sql_common | mssql_common | {"pyodbc<6.0.0"},
     "mysql": mysql_common,

--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -101,7 +101,11 @@ class MongoDBConfig(
         default=None, description="MongoDB password."
     )
     authMechanism: Optional[str] = Field(
-        default=None, description="MongoDB authentication mechanism."
+        default=None,
+        description="MongoDB authentication mechanism. Supported values: "
+        "DEFAULT, SCRAM-SHA-1, SCRAM-SHA-256, MONGODB-AWS, MONGODB-X509. "
+        "When using MONGODB-AWS, credentials are resolved via boto3. "
+        "See https://pymongo.readthedocs.io/en/stable/examples/authentication.html",
     )
     options: dict = Field(
         default={}, description="Additional options to pass to `pymongo.MongoClient()`."


### PR DESCRIPTION
Enable MONGODB-AWS authentication mechanism for MongoDB/DocumentDB connectors by including the pymongo-auth-aws dependency.

Updated documentation on authMechanism config.

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)