### PR TITLE
fix(ci): update to new trivy action release to fix breakages

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -378,7 +378,7 @@ jobs:
           echo "docker_image=$(docker images --format '{{.Repository}}:{{.Tag}}'  | grep "${{ needs.setup.outputs.tag }}" )" >> "$GITHUB_OUTPUT"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.34.2
         env:
           TRIVY_OFFLINE_SCAN: true
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2


### PR DESCRIPTION
Trivy broke their previous action version by yanking a release, this needs to be updated to fix the scan failures in CI.

https://github.com/aquasecurity/trivy-action/pull/513

https://github.com/aquasecurity/trivy-action/issues/512#issuecomment-3983599969