### PR TITLE
fix(ui): Fix aspect ratio for lineage platform icons

### DIFF
--- a/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
+++ b/datahub-web-react/src/app/lineageV3/components/LineageCard.tsx
@@ -119,6 +119,7 @@ const ColumnButtonWrapper = styled.div`
 const StyledPlatformIcon = styled.img`
     height: 16px;
     width: 16px;
+    object-fit: contain;
 `;
 
 // Defaults to phosphor icon if the img fails to load for any reason


### PR DESCRIPTION
This fixes the aspect ratio for the platform icons in lineage. It makes sure icons that looks like this:
<img width="544" height="293" alt="Screenshot 2026-03-03 at 5 00 47 PM" src="https://github.com/user-attachments/assets/c193d381-c5e7-4dcf-84bd-e1357fcdcf09" />

now look like this:
<img width="570" height="321" alt="Screenshot 2026-03-03 at 5 01 06 PM" src="https://github.com/user-attachments/assets/61087665-2031-4659-b57b-b772c42ed896" />


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
