### PR TITLE
feat(search): set dynamic on object type fields in ES v2/v3 mapings

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilder.java
@@ -166,7 +166,15 @@ public class V2MappingsBuilder implements MappingsBuilder {
               ((Map<String, Object>) mappings.get(PROPERTIES))
                   .computeIfAbsent(
                       STRUCTURED_PROPERTY_MAPPING_FIELD,
-                      (key) -> new HashMap<>(Map.of(PROPERTIES, new HashMap<>())));
+                      (key) ->
+                          new HashMap<>(
+                              Map.of(
+                                  TYPE,
+                                  ESUtils.OBJECT_FIELD_TYPE,
+                                  "dynamic",
+                                  true,
+                                  PROPERTIES,
+                                  new HashMap<>())));
 
       props.merge(
           PROPERTIES,
@@ -334,6 +342,7 @@ public class V2MappingsBuilder implements MappingsBuilder {
       mappingForField.put(TYPE, ESUtils.DATE_FIELD_TYPE);
     } else if (OBJECT_FIELD_TYPES.contains(fieldType)) {
       mappingForField.put(TYPE, ESUtils.OBJECT_FIELD_TYPE);
+      mappingForField.put("dynamic", true);
     } else if (fieldType == FieldType.DOUBLE) {
       mappingForField.put(TYPE, ESUtils.DOUBLE_FIELD_TYPE);
     } else {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/MultiEntityMappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/MultiEntityMappingsBuilder.java
@@ -838,6 +838,9 @@ public class MultiEntityMappingsBuilder implements MappingsBuilder {
       // Create root field mapping - this is the target field that aspect fields will copy_to
       Map<String, Object> rootFieldMapping = new HashMap<>();
       rootFieldMapping.put(TYPE, resolvedElasticsearchType);
+      if (ESUtils.OBJECT_FIELD_TYPE.equals(resolvedElasticsearchType)) {
+        rootFieldMapping.put("dynamic", true);
+      }
 
       // Check if any of the conflicting fields have eagerGlobalOrdinals set to true
       boolean hasEagerGlobalOrdinals =
@@ -926,8 +929,12 @@ public class MultiEntityMappingsBuilder implements MappingsBuilder {
       log.debug("Creating root alias for _entityName -> _search.entityName");
     } else {
       // Create root field mapping - this is the target field that aspect fields will copy_to
+      String resolvedType = FieldTypeMapper.getElasticsearchTypeForFieldType(fieldType);
       Map<String, Object> rootFieldMapping = new HashMap<>();
-      rootFieldMapping.put(TYPE, FieldTypeMapper.getElasticsearchTypeForFieldType(fieldType));
+      rootFieldMapping.put(TYPE, resolvedType);
+      if (ESUtils.OBJECT_FIELD_TYPE.equals(resolvedType)) {
+        rootFieldMapping.put("dynamic", true);
+      }
 
       // Check if any of the conflicting fields have eagerGlobalOrdinals set to true
       boolean hasEagerGlobalOrdinals =

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v2/V2MappingsBuilderTest.java
@@ -13,6 +13,8 @@ import com.linkedin.metadata.config.search.EntityIndexConfiguration;
 import com.linkedin.metadata.config.search.EntityIndexVersionConfiguration;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.EntitySpecBuilder;
+import com.linkedin.metadata.models.SearchableFieldSpec;
+import com.linkedin.metadata.models.annotation.SearchableAnnotation;
 import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder.IndexMapping;
@@ -283,6 +285,74 @@ public class V2MappingsBuilderTest {
 
     // Results should be the same as with only the related structured property
     assertEquals(resultWithBothStructuredProps.size(), resultWithOnlyRelatedStructuredProp.size());
+  }
+
+  @Test
+  public void testStructuredPropertiesMappingHasDynamicTrue() throws URISyntaxException {
+    when(entityIndexConfiguration.getV2().isCleanup()).thenReturn(true);
+    StructuredPropertyDefinition structPropForThisEntity =
+        new StructuredPropertyDefinition()
+            .setVersion(null, SetMode.REMOVE_IF_NULL)
+            .setQualifiedName("propForThis")
+            .setDisplayName("propForThis")
+            .setEntityTypes(
+                new UrnArray(
+                    Urn.createFromString(ENTITY_TYPE_URN_PREFIX + "dataset"),
+                    Urn.createFromString(ENTITY_TYPE_URN_PREFIX + "testEntity")))
+            .setValueType(Urn.createFromString("urn:li:logicalType:STRING"));
+    Collection<IndexMapping> result =
+        mappingsBuilder.getIndexMappings(
+            operationContext,
+            List.of(
+                Pair.of(
+                    UrnUtils.getUrn("urn:li:structuredProperty:propForThis"),
+                    structPropForThisEntity)));
+    IndexMapping mapping =
+        result.stream()
+            .filter(
+                m ->
+                    ((Map<String, Object>) m.getMappings().get("properties"))
+                        .containsKey(STRUCTURED_PROPERTY_MAPPING_FIELD))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(mapping, "One mapping should include structuredProperties");
+    Map<String, Object> properties = (Map<String, Object>) mapping.getMappings().get("properties");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> structuredPropsMapping =
+        (Map<String, Object>) properties.get(STRUCTURED_PROPERTY_MAPPING_FIELD);
+    assertEquals(
+        structuredPropsMapping.get("type"),
+        "object",
+        "structuredProperties root must be type object");
+    assertEquals(
+        structuredPropsMapping.get("dynamic"),
+        true,
+        "structuredProperties root must have dynamic=true for nested indexing");
+  }
+
+  @Test
+  public void testObjectFieldMappingHasDynamicTrue() {
+    when(entityIndexConfiguration.getV2().isCleanup()).thenReturn(true);
+
+    EntitySpec mockEntitySpec = mock(EntitySpec.class);
+    SearchableFieldSpec objectFieldSpec = mock(SearchableFieldSpec.class);
+    SearchableAnnotation objectAnnotation = mock(SearchableAnnotation.class);
+    when(objectAnnotation.getFieldName()).thenReturn("objectField");
+    when(objectAnnotation.getFieldType()).thenReturn(SearchableAnnotation.FieldType.OBJECT);
+    when(objectFieldSpec.getSearchableAnnotation()).thenReturn(objectAnnotation);
+    when(mockEntitySpec.getSearchableFieldSpecs()).thenReturn(List.of(objectFieldSpec));
+    when(mockEntitySpec.getSearchScoreFieldSpecs()).thenReturn(Collections.emptyList());
+    when(mockEntitySpec.getSearchableRefFieldSpecs()).thenReturn(Collections.emptyList());
+
+    Map<String, Object> result =
+        mappingsBuilder.getIndexMappings(operationContext.getEntityRegistry(), mockEntitySpec);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> props = (Map<String, Object>) result.get("properties");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> objectFieldMapping = (Map<String, Object>) props.get("objectField");
+    assertNotNull(objectFieldMapping, "Object field should have a mapping");
+    assertEquals(objectFieldMapping.get("type"), "object", "Object field must have type object");
+    assertEquals(objectFieldMapping.get("dynamic"), true, "Object field must have dynamic=true");
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/MultiEntityMappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/index/entity/v3/MultiEntityMappingsBuilderTest.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.schema.DataSchema;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.metadata.config.search.EntityIndexConfiguration;
 import com.linkedin.metadata.config.search.EntityIndexVersionConfiguration;
@@ -17,6 +18,7 @@ import com.linkedin.metadata.models.SearchableFieldSpec;
 import com.linkedin.metadata.models.SearchableRefFieldSpec;
 import com.linkedin.metadata.models.annotation.EntityAnnotation;
 import com.linkedin.metadata.models.annotation.SearchableAnnotation;
+import com.linkedin.metadata.models.annotation.SearchableAnnotation.FieldType;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.index.MappingsBuilder.IndexMapping;
 import com.linkedin.structured.StructuredPropertyDefinition;
@@ -306,6 +308,46 @@ public class MultiEntityMappingsBuilderTest {
         "Should have root-level field for conflicted field");
   }
 
+  /**
+   * When a field name alias has type OBJECT and conflicts across entities (same alias, different
+   * aspect paths), the root field mapping must have dynamic=true so Elasticsearch can index nested
+   * properties.
+   */
+  @Test
+  public void testConflictedObjectFieldRootMappingHasDynamicTrue() {
+    EntitySpec entitySpec1 =
+        createMockEntitySpecWithAliasAndAspect(
+            "entity1", "objectField", FieldType.OBJECT, "objectAlias", "datasetProperties");
+    EntitySpec entitySpec2 =
+        createMockEntitySpecWithAliasAndAspect(
+            "entity2", "objectField", FieldType.OBJECT, "objectAlias", "otherProperties");
+
+    when(mockEntityRegistry.getSearchGroups()).thenReturn(Collections.singleton("default"));
+    when(mockEntityRegistry.getEntitySpecsBySearchGroup("default"))
+        .thenReturn(ImmutableMap.of("entity1", entitySpec1, "entity2", entitySpec2));
+
+    Collection<IndexMapping> mappings = mappingsBuilder.getIndexMappings(operationContext);
+
+    assertNotNull(mappings, "Mappings should not be null");
+    assertFalse(mappings.isEmpty(), "Should handle conflicting object field alias");
+
+    IndexMapping mapping = mappings.iterator().next();
+    Map<String, Object> properties = (Map<String, Object>) mapping.getMappings().get("properties");
+    assertTrue(
+        properties.containsKey("objectAlias"),
+        "Should have root-level field for conflicted object field alias");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> objectAliasMapping = (Map<String, Object>) properties.get("objectAlias");
+    assertEquals(
+        objectAliasMapping.get("type"),
+        "object",
+        "Conflicted object field alias root must have type object");
+    assertEquals(
+        objectAliasMapping.get("dynamic"),
+        true,
+        "Conflicted object field alias root must have dynamic=true");
+  }
+
   @Test
   public void testMappingsConsistency() {
     // Setup: V3 enabled
@@ -393,6 +435,26 @@ public class MultiEntityMappingsBuilderTest {
   }
 
   private EntitySpec createMockEntitySpec(String entityName, String fieldName) {
+    return createMockEntitySpec(entityName, fieldName, FieldType.KEYWORD);
+  }
+
+  private EntitySpec createMockEntitySpec(
+      String entityName, String fieldName, FieldType fieldType) {
+    return createMockEntitySpecWithAlias(entityName, fieldName, fieldType, null);
+  }
+
+  private EntitySpec createMockEntitySpecWithAlias(
+      String entityName, String fieldName, FieldType fieldType, String fieldNameAlias) {
+    return createMockEntitySpecWithAliasAndAspect(
+        entityName, fieldName, fieldType, fieldNameAlias, "datasetProperties");
+  }
+
+  private EntitySpec createMockEntitySpecWithAliasAndAspect(
+      String entityName,
+      String fieldName,
+      FieldType fieldType,
+      String fieldNameAlias,
+      String aspectName) {
     EntitySpec entitySpec = mock(EntitySpec.class);
     when(entitySpec.getName()).thenReturn(entityName);
     when(entitySpec.getSearchGroup()).thenReturn("default");
@@ -402,12 +464,14 @@ public class MultiEntityMappingsBuilderTest {
     when(entityAnnotation.getName()).thenReturn(entityName);
     when(entitySpec.getEntityAnnotation()).thenReturn(entityAnnotation);
 
-    // Create aspect specs
-    List<AspectSpec> aspectSpecs = createMockAspectSpecs(fieldName);
+    // Create aspect specs with given aspect name so alias paths differ across entities
+    List<AspectSpec> aspectSpecs =
+        createMockAspectSpecsWithAliasAndAspect(fieldName, fieldType, fieldNameAlias, aspectName);
     when(entitySpec.getAspectSpecs()).thenReturn(aspectSpecs);
 
     // Create searchable field specs
-    List<SearchableFieldSpec> searchableFields = createMockSearchableFieldSpecs(fieldName);
+    List<SearchableFieldSpec> searchableFields =
+        createMockSearchableFieldSpecsWithAlias(fieldName, fieldType, fieldNameAlias);
     when(entitySpec.getSearchableFieldSpecs()).thenReturn(searchableFields);
 
     // Create searchable ref field specs
@@ -418,35 +482,60 @@ public class MultiEntityMappingsBuilderTest {
   }
 
   private List<AspectSpec> createMockAspectSpecs(String fieldName) {
+    return createMockAspectSpecs(fieldName, FieldType.KEYWORD);
+  }
+
+  private List<AspectSpec> createMockAspectSpecs(String fieldName, FieldType fieldType) {
+    return createMockAspectSpecsWithAlias(fieldName, fieldType, null);
+  }
+
+  private List<AspectSpec> createMockAspectSpecsWithAlias(
+      String fieldName, FieldType fieldType, String fieldNameAlias) {
+    return createMockAspectSpecsWithAliasAndAspect(
+        fieldName, fieldType, fieldNameAlias, "datasetProperties");
+  }
+
+  private List<AspectSpec> createMockAspectSpecsWithAliasAndAspect(
+      String fieldName, FieldType fieldType, String fieldNameAlias, String aspectName) {
     List<AspectSpec> aspectSpecs = new ArrayList<>();
 
-    // Create a regular aspect spec
-    AspectSpec regularAspect = mock(AspectSpec.class);
-    when(regularAspect.getName()).thenReturn("datasetProperties");
+    AspectSpec aspectSpec = mock(AspectSpec.class);
+    when(aspectSpec.getName()).thenReturn(aspectName);
 
-    // Create mock searchable field specs for the regular aspect
-    List<SearchableFieldSpec> searchableFields = new ArrayList<>();
-    SearchableFieldSpec fieldSpec = mock(SearchableFieldSpec.class);
-    SearchableAnnotation searchableAnnotation = mock(SearchableAnnotation.class);
-    when(searchableAnnotation.getFieldName()).thenReturn(fieldName);
-    when(searchableAnnotation.getFieldType()).thenReturn(SearchableAnnotation.FieldType.KEYWORD);
-    when(fieldSpec.getSearchableAnnotation()).thenReturn(searchableAnnotation);
-    searchableFields.add(fieldSpec);
-
-    when(regularAspect.getSearchableFieldSpecs()).thenReturn(searchableFields);
-    aspectSpecs.add(regularAspect);
+    // Create mock searchable field specs for the aspect
+    List<SearchableFieldSpec> searchableFields =
+        createMockSearchableFieldSpecsWithAlias(fieldName, fieldType, fieldNameAlias);
+    when(aspectSpec.getSearchableFieldSpecs()).thenReturn(searchableFields);
+    aspectSpecs.add(aspectSpec);
 
     return aspectSpecs;
   }
 
   private List<SearchableFieldSpec> createMockSearchableFieldSpecs(String fieldName) {
+    return createMockSearchableFieldSpecs(fieldName, FieldType.KEYWORD);
+  }
+
+  private List<SearchableFieldSpec> createMockSearchableFieldSpecs(
+      String fieldName, FieldType fieldType) {
+    return createMockSearchableFieldSpecsWithAlias(fieldName, fieldType, null);
+  }
+
+  private List<SearchableFieldSpec> createMockSearchableFieldSpecsWithAlias(
+      String fieldName, FieldType fieldType, String fieldNameAlias) {
     List<SearchableFieldSpec> searchableFields = new ArrayList<>();
 
     SearchableFieldSpec fieldSpec = mock(SearchableFieldSpec.class);
     SearchableAnnotation searchableAnnotation = mock(SearchableAnnotation.class);
     when(searchableAnnotation.getFieldName()).thenReturn(fieldName);
-    when(searchableAnnotation.getFieldType()).thenReturn(SearchableAnnotation.FieldType.KEYWORD);
+    when(searchableAnnotation.getFieldType()).thenReturn(fieldType);
+    when(searchableAnnotation.getFieldNameAliases())
+        .thenReturn(fieldNameAlias != null ? Collections.singletonList(fieldNameAlias) : null);
     when(fieldSpec.getSearchableAnnotation()).thenReturn(searchableAnnotation);
+    if (fieldType == FieldType.OBJECT) {
+      DataSchema mockSchema = mock(DataSchema.class);
+      when(mockSchema.getDereferencedType()).thenReturn(DataSchema.Type.RECORD);
+      when(fieldSpec.getPegasusSchema()).thenReturn(mockSchema);
+    }
     searchableFields.add(fieldSpec);
 
     return searchableFields;


### PR DESCRIPTION
### Summary
Enables dynamic mapping on object-type fields in Elasticsearch index mappings so nested/dynamic properties can be indexed without mapping updates.

### Changes
- **V2MappingsBuilder**: Set `dynamic: true` on (1) the `structuredProperties` root mapping and (2) searchable fields whose type is OBJECT.
- **MultiEntityMappingsBuilder**: Set `dynamic: true` on root field mappings when the resolved type is object, for both conflicted field names and conflicted field-name aliases.

### Testing
- `testStructuredPropertiesMappingHasDynamicTrue`: structuredProperties root has `type: "object"` and `dynamic: true`.
- `testObjectFieldMappingHasDynamicTrue`: OBJECT searchable field mapping includes `dynamic: true`.
- `testConflictedObjectFieldRootMappingHasDynamicTrue`: conflicted OBJECT field-name alias gets a root mapping with `type: "object"` and `dynamic: true`.