### PR TITLE
fix(ingestion/snowplow): add missing cachetools dependency to snowplow connector

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -431,9 +431,9 @@ slack = {
     "tenacity>=8.0.1,<9.0.0",
 }
 
-# Snowplow uses base requirements only (requests, pydantic)
-# No additional dependencies needed
-snowplow = set()
+snowplow = {
+    *cachetools_lib,
+}
 
 databricks_common = {
     # 0.1.11 appears to have authentication issues with azure databricks


### PR DESCRIPTION
## Summary
- The snowplow connector's `CacheManager` imports `cachetools` but it was not listed in the `snowplow` extras in `setup.py`
- This caused `datahub check plugins --source snowplow` to fail with: `snowplow is disabled due to a missing dependency: cachetools`
- Added `cachetools_lib` to the snowplow dependency set

## Test plan
- [x] Verified `datahub check plugins --source snowplow` returns "Source snowplow is enabled" after the fix
- [x] Linting passes