### PR TITLE
refactor(search): relocate runId tracking to MAE-consumer

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
@@ -348,10 +348,6 @@ public class JavaEntityClient implements EntityClient {
     auditStamp.setTime(Clock.systemUTC().millis());
 
     entityService.ingestEntity(opContext, entity, auditStamp, systemMetadata);
-    tryIndexRunId(
-        opContext,
-        com.datahub.util.ModelUtils.getUrnFromSnapshotUnion(entity.getValue()),
-        systemMetadata);
   }
 
   @SneakyThrows
@@ -779,7 +775,6 @@ public class JavaEntityClient implements EntityClient {
 
               List<IngestResult> results =
                   entityService.ingestProposal(opContext, aspectsBatch, async);
-              entitySearchService.appendRunId(opContext, results);
 
               Map<Pair<Urn, String>, List<IngestResult>> resultMap =
                   results.stream()
@@ -806,11 +801,6 @@ public class JavaEntityClient implements EntityClient {
                                     .filter(Objects::nonNull)
                                     .distinct()
                                     .collect(Collectors.toList());
-
-                            // Update runIds
-                            urnsForRequest.forEach(
-                                urn ->
-                                    tryIndexRunId(opContext, urn, requestItem.getSystemMetadata()));
 
                             return urnsForRequest.isEmpty()
                                 ? null
@@ -879,13 +869,6 @@ public class JavaEntityClient implements EntityClient {
       @Nonnull OperationContext opContext, @Nonnull String runId, @Nonnull Authorizer authorizer)
       throws Exception {
     rollbackService.rollbackIngestion(opContext, runId, false, true, authorizer);
-  }
-
-  private void tryIndexRunId(
-      @Nonnull OperationContext opContext, Urn entityUrn, @Nullable SystemMetadata systemMetadata) {
-    if (systemMetadata != null && systemMetadata.hasRunId()) {
-      entitySearchService.appendRunId(opContext, entityUrn, systemMetadata.getRunId());
-    }
   }
 
   protected <T> T withRetry(@Nonnull final Supplier<T> block, @Nullable String counterPrefix) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -310,6 +310,32 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
     }
   }
 
+  /**
+   * Appends a run ID to the runId list on a document in a V3 search group index. Used by
+   * MAE-consumer when updating the search index so runId is written in the same bulk batch as the
+   * document.
+   */
+  public void appendRunIdBySearchGroup(
+      @Nonnull OperationContext opContext,
+      @Nonnull String searchGroup,
+      @Nonnull String docId,
+      @Nonnull Urn urn,
+      @Nullable String runId) {
+    log.debug(
+        "Appending run id for searchGroup '{}', docId='{}', runId='{}'", searchGroup, docId, runId);
+
+    Map<String, Object> upsert = new HashMap<>();
+    upsert.put("urn", urn.toString());
+    upsert.put("runId", Collections.singletonList(runId));
+
+    Map<String, Object> scriptParams = new HashMap<>();
+    scriptParams.put("runId", runId);
+    scriptParams.put("maxRunIds", MAX_RUN_IDS_INDEXED);
+
+    esWriteDAO.applyScriptUpdateBySearchGroup(
+        opContext, searchGroup, docId, SCRIPT_SOURCE, scriptParams, upsert);
+  }
+
   @Nonnull
   @Override
   public SearchResult search(

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
@@ -270,6 +270,27 @@ public class ESWriteDAO {
   }
 
   /**
+   * Applies a script to a particular document in the V3 index for the specified search group.
+   *
+   * @param opContext the operation context
+   * @param searchGroup the search group name
+   * @param docId the document ID
+   * @param scriptSource the script source code
+   * @param scriptParams the script parameters
+   * @param upsert the document to upsert if it doesn't exist
+   */
+  public void applyScriptUpdateBySearchGroup(
+      @Nonnull OperationContext opContext,
+      @Nonnull String searchGroup,
+      @Nonnull String docId,
+      @Nonnull String scriptSource,
+      @Nonnull Map<String, Object> scriptParams,
+      Map<String, Object> upsert) {
+    applyScriptUpdateByIndexName(
+        toIndexNameV3(opContext, searchGroup), docId, scriptSource, scriptParams, upsert);
+  }
+
+  /**
    * Delete the index
    *
    * @param opContext the operation context

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -289,6 +289,11 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
     if (shouldWrite) {
       writeToSemanticIndex(entityName, finalDocument, docId);
     }
+
+    // Append runId to search document so rollback/list runs can find touched URNs (MAE path)
+    if (systemMetadata != null && systemMetadata.hasRunId()) {
+      elasticSearchService.appendRunId(opContext, urn, systemMetadata.getRunId());
+    }
   }
 
   void deleteSearchData(

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV3Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV3Strategy.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -272,6 +273,17 @@ public class UpdateIndicesV3Strategy implements UpdateIndicesStrategy {
         urn,
         searchGroup,
         events.size());
+
+    // Append runIds to search document so rollback/list runs can find touched URNs (MAE path)
+    List<String> distinctRunIds =
+        events.stream()
+            .filter(e -> e.getSystemMetadata() != null && e.getSystemMetadata().hasRunId())
+            .map(e -> e.getSystemMetadata().getRunId())
+            .distinct()
+            .collect(Collectors.toList());
+    for (String runId : distinctRunIds) {
+      elasticSearchService.appendRunIdBySearchGroup(opContext, searchGroup, docId, urn, runId);
+    }
   }
 
   /**

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/ElasticSearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/ElasticSearchServiceTest.java
@@ -303,6 +303,31 @@ public class ElasticSearchServiceTest {
   }
 
   @Test
+  public void testAppendRunIdBySearchGroup() {
+    String searchGroup = "dataset";
+    String runId = "run-v3-123";
+
+    testInstance.appendRunIdBySearchGroup(opContext, searchGroup, TEST_DOC_ID, TEST_URN, runId);
+
+    ArgumentCaptor<Map<String, Object>> scriptParamsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> upsertCaptor = ArgumentCaptor.forClass(Map.class);
+
+    verify(mockEsWriteDAO)
+        .applyScriptUpdateBySearchGroup(
+            eq(opContext),
+            eq(searchGroup),
+            eq(TEST_DOC_ID),
+            eq(ElasticSearchService.SCRIPT_SOURCE),
+            scriptParamsCaptor.capture(),
+            upsertCaptor.capture());
+
+    assertEquals(runId, scriptParamsCaptor.getValue().get("runId"));
+    assertEquals(MAX_RUN_IDS_INDEXED, scriptParamsCaptor.getValue().get("maxRunIds"));
+    assertEquals(Collections.singletonList(runId), upsertCaptor.getValue().get("runId"));
+    assertEquals(TEST_URN.toString(), upsertCaptor.getValue().get("urn"));
+  }
+
+  @Test
   public void testRaw_WithValidUrns() {
     ESSearchDAO mockEsSearchDAO = mock(ESSearchDAO.class);
     testInstance =

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/update/ESWriteDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/update/ESWriteDAOTest.java
@@ -25,6 +25,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -155,6 +156,33 @@ public class ESWriteDAOTest {
     // Verify upsert content
     Map<String, Object> upsertMap = capturedRequest.upsertRequest().sourceAsMap();
     assertEquals("initialValue", upsertMap.get("field"));
+  }
+
+  @Test
+  public void testApplyScriptUpdateBySearchGroup() {
+    String searchGroup = "dataset";
+    String scriptSource = "ctx._source.runId.add(params.runId)";
+    Map<String, Object> scriptParams = new HashMap<>();
+    scriptParams.put("runId", "run-1");
+    scriptParams.put("maxRunIds", 25);
+    Map<String, Object> upsert = new HashMap<>();
+    upsert.put("urn", "urn:li:dataset:(urn:li:dataPlatform:hdfs,Sample,PROD)");
+    upsert.put("runId", Collections.singletonList("run-1"));
+
+    esWriteDAO.applyScriptUpdateBySearchGroup(
+        opContext, searchGroup, TEST_DOC_ID, scriptSource, scriptParams, upsert);
+
+    ArgumentCaptor<UpdateRequest> requestCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+    verify(mockBulkProcessor).add(requestCaptor.capture());
+
+    UpdateRequest capturedRequest = requestCaptor.getValue();
+    assertEquals("datasetindex_v3", capturedRequest.index());
+    assertEquals(TEST_DOC_ID, capturedRequest.id());
+    assertFalse(capturedRequest.detectNoop());
+    assertTrue(capturedRequest.scriptedUpsert());
+    Script script = capturedRequest.script();
+    assertEquals(scriptSource, script.getIdOrCode());
+    assertEquals(scriptParams, script.getParams());
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV2StrategyTest.java
@@ -166,6 +166,39 @@ public class UpdateIndicesV2StrategyTest {
   }
 
   @Test
+  public void testUpdateSearchIndices_CallsAppendRunIdWhenRunIdPresent() throws Exception {
+    when(mockSystemMetadata.hasRunId()).thenReturn(true);
+    when(mockSystemMetadata.getRunId()).thenReturn("run-123");
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            eq(false),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(mockSearchDocument));
+    when(mockSearchDocument.toString()).thenReturn("{\"test\": \"document\"}");
+    when(mockSearchDocument.isEmpty()).thenReturn(false);
+
+    ObjectNode mockPreviousSearchDocument = mock(ObjectNode.class);
+    when(mockPreviousSearchDocument.toString()).thenReturn("{\"previous\": \"document\"}");
+    when(searchDocumentTransformer.transformAspect(
+            eq(operationContext),
+            eq(testUrn),
+            eq(mockPreviousAspect),
+            eq(mockAspectSpec),
+            eq(false),
+            eq(mockAuditStamp)))
+        .thenReturn(Optional.of(mockPreviousSearchDocument));
+
+    strategy.updateSearchIndices(operationContext, Collections.singletonList(mockEvent));
+
+    verify(elasticSearchService)
+        .upsertDocument(eq(operationContext), eq("dataset"), anyString(), anyString());
+    verify(elasticSearchService).appendRunId(eq(operationContext), eq(testUrn), eq("run-123"));
+  }
+
+  @Test
   public void testUpdateSearchIndices_EmptySearchDocument() throws Exception {
     // Setup mocks - return empty search document
     when(searchDocumentTransformer.transformAspect(

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV3StrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesV3StrategyTest.java
@@ -163,6 +163,31 @@ public class UpdateIndicesV3StrategyTest {
             anyString()); // doc id
   }
 
+  @Test
+  public void testProcessBatch_CallsAppendRunIdBySearchGroupWhenRunIdPresent() throws Exception {
+    when(mockSystemMetadata.hasRunId()).thenReturn(true);
+    when(mockSystemMetadata.getRunId()).thenReturn("run-456");
+    when(searchDocumentTransformer.transformAspect(
+            any(OperationContext.class),
+            any(Urn.class),
+            any(RecordTemplate.class),
+            any(AspectSpec.class),
+            anyBoolean(),
+            any(AuditStamp.class)))
+        .thenReturn(Optional.of(mockSearchDocument));
+
+    Map<Urn, List<MCLItem>> groupedEvents =
+        Collections.singletonMap(testUrn, Collections.singletonList(mockEvent));
+
+    strategy.processBatch(operationContext, groupedEvents, true);
+
+    verify(elasticSearchService)
+        .upsertDocumentBySearchGroup(eq(operationContext), eq("dataset"), anyString(), anyString());
+    verify(elasticSearchService)
+        .appendRunIdBySearchGroup(
+            eq(operationContext), eq("dataset"), anyString(), eq(testUrn), eq("run-456"));
+  }
+
   // Note: Key aspect deletion test is complex due to static method calls
   // and would require more sophisticated mocking. Skipping for now.
 

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
@@ -325,7 +325,6 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
 
         List<IngestResult> results =
                 _entityService.ingestProposal(opContext, batch, asyncBool);
-        entitySearchService.appendRunId(opContext, results);
 
             // TODO: We don't actually use this return value anywhere. Maybe we should just stop returning it altogether?
             return RESTLI_SUCCESS;


### PR DESCRIPTION
## Summary

Run ID list updates on entity search documents are now performed in the **MAE-consumer** when it updates the search index, instead of synchronously in GMS or JavaEntityClient after ingest. This aligns with separation of concerns (Elasticsearch document writes happen in MAE) and batches runId script updates with document upserts in the same `ESBulkProcessor`.

## Motivation

- **Separation of concerns**: Elasticsearch index documents are normally updated in the MAE-consumer via `UpdateIndicesHook` → `UpdateIndicesService` → V2/V3 strategies. RunId was previously updated in GMS or the MCE-consumer callers immediately after ingest, which mixed write-path concerns.
- **Batching**: Moving runId updates to MAE allows them to be enqueued in the same bulk request as the document upsert, reducing round-trips and keeping index updates cohesive.

## Changes

### MAE path (new behavior)

- **UpdateIndicesV2Strategy**: After `upsertDocument` and semantic dual-write in `updateSearchIndicesForEvent`, when `systemMetadata != null && systemMetadata.hasRunId()`, calls `elasticSearchService.appendRunId(opContext, urn, systemMetadata.getRunId())`. One script update per document upsert when runId is present.
- **UpdateIndicesV3Strategy**: After `upsertDocumentBySearchGroup` in `processUrnBatch`, collects distinct runIds from the URN’s events (where `systemMetadata.hasRunId()`), then for each calls `elasticSearchService.appendRunIdBySearchGroup(opContext, searchGroup, docId, urn, runId)`.

### New / extended APIs

- **ESWriteDAO**: Added `applyScriptUpdateBySearchGroup(OperationContext, searchGroup, docId, scriptSource, scriptParams, upsert)` to apply a script update to the V3 index for a search group (delegates to `applyScriptUpdateByIndexName` with `toIndexNameV3`).
- **ElasticSearchService**: Added `appendRunIdBySearchGroup(OperationContext, searchGroup, docId, urn, runId)` for the MAE V3 path; uses the same runId script and params as `appendRunId`.

### Removed synchronous runId updates

- **AspectResource**: Removed `entitySearchService.appendRunId(opContext, results)` after `_entityService.ingestProposal(...)`.
- **JavaEntityClient**: Removed `entitySearchService.appendRunId(opContext, results)` after batch `ingestProposal`; removed the `urnsForRequest.forEach(..., tryIndexRunId(...))` block; removed the `tryIndexRunId` call after `ingestEntity`; removed the private method `tryIndexRunId`.

## Behavioral notes

- **Eventual consistency**: RunId in the search index is now updated when MAE processes the MCL (after Kafka + MAE lag). Queries like “URNs touched by run X” may be briefly stale after ingest. SQL will reflect updated runId in system metadata.
- **V2 semantic index**: `appendRunId` still dual-writes to the semantic index when it exists. V3 `appendRunIdBySearchGroup` updates only the primary search-group index.
