### PR TITLE
fix(UI): properly display applications on glossary terms

### DIFF
--- a/datahub-web-react/src/graphql/glossaryTerm.graphql
+++ b/datahub-web-react/src/graphql/glossaryTerm.graphql
@@ -63,6 +63,9 @@ query getGlossaryTerm($urn: String!, $start: Int, $count: Int) {
         domain {
             ...entityDomain
         }
+        applications {
+            ...entityApplication
+        }
         institutionalMemory {
             ...institutionalMemoryFields
         }


### PR DESCRIPTION
Before, the applications aspect would be added to the glossary term but would not appear in the UI. This fixes that:
<img width="524" height="434" alt="image" src="https://github.com/user-attachments/assets/b1b25891-625a-43bc-b881-8ad605c20b70" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
