### PR TITLE
fix(web): clear stale view URN when selected view no longer exists

### DIFF
--- a/datahub-web-react/src/app/entityV2/view/select/ViewSelectContext.tsx
+++ b/datahub-web-react/src/app/entityV2/view/select/ViewSelectContext.tsx
@@ -146,10 +146,8 @@ export default function ViewSelectContextProvider({ isOpen, onOpenChange, childr
         if (isOpen !== undefined) setIsInternalOpen(isOpen);
     }, [isOpen]);
 
-    const localStateRef = useRef(userContext.localState);
-    localStateRef.current = userContext.localState;
-    const updateLocalStateRef = useRef(userContext.updateLocalState);
-    updateLocalStateRef.current = userContext.updateLocalState;
+    const userContextRef = useRef(userContext);
+    userContextRef.current = userContext;
 
     useEffect(() => {
         setSelectedUrn(userContext.localState?.selectedViewUrn || undefined);
@@ -174,7 +172,8 @@ export default function ViewSelectContextProvider({ isOpen, onOpenChange, childr
     // the Apollo cache update propagates to the query hooks.
     useEffect(() => {
         if (!privateViewsData || !publicViewsData) return;
-        const viewUrn = localStateRef.current?.selectedViewUrn;
+        const { localState, updateLocalState } = userContextRef.current;
+        const viewUrn = localState?.selectedViewUrn;
         if (!viewUrn) return;
 
         const viewExists =
@@ -182,8 +181,8 @@ export default function ViewSelectContextProvider({ isOpen, onOpenChange, childr
             publicViewsData.listGlobalViews?.views?.some((v) => v?.urn === viewUrn);
 
         if (!viewExists) {
-            updateLocalStateRef.current({
-                ...localStateRef.current,
+            updateLocalState({
+                ...localState,
                 selectedViewUrn: null,
             });
         }


### PR DESCRIPTION
This pull request improves the robustness of the view selection logic in the `ViewSelectContextProvider` component by ensuring that the selected view is kept in sync with the available views. The main changes focus on clearing out stale selections when a view is deleted or becomes unavailable and on ensuring the latest user context is used in effects.

**View selection consistency improvements:**

* Added a `userContextRef` to always access the latest `userContext` within effects, preventing issues with stale closures.
* Introduced an effect to clear the `selectedViewUrn` from local state when the selected view no longer exists in either private or public views, ensuring the UI does not reference deleted or missing views. This effect is intentionally triggered only on changes to the views data, not on selection changes, to avoid race conditions with Apollo cache updates.