### PR TITLE
fix(python-build): show actual PR commit in wheel build context

### DIFF
--- a/.github/workflows/python-build-pages.yml
+++ b/.github/workflows/python-build-pages.yml
@@ -62,6 +62,7 @@ jobs:
           ./gradlew :python-build:buildSite
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          DATAHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Publish
         id: cloudflare
         uses: cloudflare/pages-action@v1

--- a/python-build/build_site.py
+++ b/python-build/build_site.py
@@ -40,15 +40,46 @@ with contextlib.suppress(Exception):
     context_info["branch"] = branch_info.strip()
 
 # Get commit info.
+# For pull_request events, GitHub Actions checks out a synthetic merge commit
+# (refs/pull/N/merge) that merges the PR branch into the base branch.
+# DATAHUB_HEAD_SHA contains the actual PR HEAD commit.
 with contextlib.suppress(Exception):
-    commit_info = subprocess.check_output(
-        ["git", "log", "-1", "--pretty=%H%n%B"], text=True
-    )
+    head_sha = os.getenv("DATAHUB_HEAD_SHA")
+    if head_sha:
+        commit_info = subprocess.check_output(
+            ["git", "log", "-1", "--pretty=%H%n%B", head_sha], text=True
+        )
+    else:
+        commit_info = subprocess.check_output(
+            ["git", "log", "-1", "--pretty=%H%n%B"], text=True
+        )
     commit_hash, commit_msg = commit_info.strip().split("\n", 1)
     context_info["commit"] = {
         "hash": commit_hash,
         "message": commit_msg.strip(),
     }
+
+# For PR builds, indicate the base branch commit that was merged in.
+# The checked-out code is the result of merging the PR into the base branch,
+# so the wheel contains both PR changes and the latest base branch state.
+with contextlib.suppress(Exception):
+    head_sha = os.getenv("DATAHUB_HEAD_SHA")
+    merge_commit_msg = subprocess.check_output(
+        ["git", "log", "-1", "--pretty=%B"], text=True
+    ).strip()
+    # GitHub's merge ref has message: "Merge <head_sha> into <base_sha>"
+    if head_sha and merge_commit_msg.startswith("Merge "):
+        parts = merge_commit_msg.split()
+        if len(parts) >= 4 and parts[2] == "into":
+            base_sha = parts[3]
+            base_info = subprocess.check_output(
+                ["git", "log", "-1", "--pretty=%H%n%B", base_sha], text=True
+            )
+            base_hash, base_msg = base_info.strip().split("\n", 1)
+            context_info["base"] = {
+                "hash": base_hash,
+                "message": base_msg.strip(),
+            }
 
 # Get PR info.
 with contextlib.suppress(Exception):


### PR DESCRIPTION
## Summary

- Fix wheel build site showing the synthetic GitHub merge commit hash and "Merge X into Y" message instead of the actual PR commit - Change done in #16402 
- Add `base` field to build context showing which master commit was merged in, making it clear the wheel contains both PR changes and latest master state

## Motivation

For `pull_request` events, GitHub Actions checks out `refs/pull/N/merge` — a synthetic merge commit that merges the PR into the base branch. The `build_site.py` script was running `git log -1` which captured this merge commit's info rather than the actual PR commit. This made it hard to identify which PR commit a wheel was built from.

**Before:**
```json
{
  "commit": {
    "hash": "cac13a8637b8d9...",
    "message": "Merge 781a52cd into 23a72adf"
  }
}
```

**After:**
```json
{
  "commit": {
    "hash": "781a52cd2692e1...",
    "message": "fix(powerbi): handle if/then/else expressions in M-Query lineage "
  },
  "base": {
    "hash": "23a72adf1d15cb...",
    "message": "chore(ingestion): urllib3 v2 (#16464)"
  }
}
```