### PR TITLE
fix(versioning): VersionPropertiesSideEffect mutates shared DataMap causing 422 on transaction retry

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionPropertiesSideEffect.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionPropertiesSideEffect.java
@@ -5,6 +5,7 @@ import static com.linkedin.metadata.Constants.*;
 import com.datahub.util.RecordUtils;
 import com.linkedin.common.VersionProperties;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.entity.Aspect;
 import com.linkedin.events.metadata.ChangeType;
@@ -109,8 +110,6 @@ public class VersionPropertiesSideEffect extends MCPSideEffect {
       @Nonnull VersionProperties versionProperties,
       ChangeMCP changeMCP,
       @Nonnull RetrieverContext retrieverContext) {
-    versionProperties.setIsLatest(true);
-
     Urn entityUrn = changeMCP.getUrn();
     Urn versionSetUrn = versionProperties.getVersionSet();
 
@@ -146,7 +145,14 @@ public class VersionPropertiesSideEffect extends MCPSideEffect {
             .systemMetadata(changeMCP.getSystemMetadata())
             .build(retrieverContext.getAspectRetriever());
 
-    return Stream.of(createVersionSetKey, createVersionSetProperties);
+    // Set isLatest=true via a separate ChangeItemImpl rather than mutating versionProperties
+    // in-place. In-place mutation contaminates the shared DataMap on ChangeItemImpl.recordTemplate;
+    // on transaction retry validateProposedAspects re-runs on the same ChangeItemImpl and would
+    // then see isLatest=true and incorrectly reject the proposal.
+    ChangeMCP setIsLatest =
+        buildSetIsLatestChange(entityUrn, versionProperties, changeMCP, retrieverContext);
+
+    return Stream.of(createVersionSetKey, createVersionSetProperties, setIsLatest);
   }
 
   private static Stream<ChangeMCP> updateVersionSetLatest(
@@ -155,8 +161,6 @@ public class VersionPropertiesSideEffect extends MCPSideEffect {
       @Nonnull Urn prevLatest,
       ChangeMCP changeMCP,
       @Nonnull RetrieverContext retrieverContext) {
-    versionProperties.setIsLatest(true);
-
     Urn entityUrn = changeMCP.getUrn();
     Urn versionSetUrn = versionProperties.getVersionSet();
 
@@ -174,8 +178,13 @@ public class VersionPropertiesSideEffect extends MCPSideEffect {
             .systemMetadata(changeMCP.getSystemMetadata())
             .build(retrieverContext.getAspectRetriever());
 
+    // See createVersionSet for why we use a separate ChangeItemImpl rather than mutating
+    // versionProperties in-place.
+    ChangeMCP setIsLatest =
+        buildSetIsLatestChange(entityUrn, versionProperties, changeMCP, retrieverContext);
+
     if (prevLatestVersionProperties == null) {
-      return Stream.of(updateVersionSetProperties);
+      return Stream.of(updateVersionSetProperties, setIsLatest);
     }
 
     EntitySpec entitySpec =
@@ -199,6 +208,28 @@ public class VersionPropertiesSideEffect extends MCPSideEffect {
             .build(retrieverContext.getAspectRetriever().getEntityRegistry())
             .applyPatch(prevLatestVersionProperties, retrieverContext.getAspectRetriever());
 
-    return Stream.of(updateVersionSetProperties, updateOldLatestVersionProperties);
+    return Stream.of(updateVersionSetProperties, updateOldLatestVersionProperties, setIsLatest);
+  }
+
+  /**
+   * Builds a new ChangeItemImpl that writes the entity's versionProperties with isLatest=true,
+   * using a shallow copy of the DataMap so the original ChangeItemImpl.recordTemplate is not
+   * mutated.
+   */
+  private static ChangeMCP buildSetIsLatestChange(
+      @Nonnull Urn entityUrn,
+      @Nonnull VersionProperties versionProperties,
+      @Nonnull ChangeMCP changeMCP,
+      @Nonnull RetrieverContext retrieverContext) {
+    VersionProperties withIsLatest =
+        new VersionProperties(new DataMap(versionProperties.data())).setIsLatest(true);
+    return ChangeItemImpl.builder()
+        .urn(entityUrn)
+        .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
+        .changeType(ChangeType.UPSERT)
+        .recordTemplate(withIsLatest)
+        .auditStamp(changeMCP.getAuditStamp())
+        .systemMetadata(changeMCP.getSystemMetadata())
+        .build(retrieverContext.getAspectRetriever());
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionPropertiesSideEffectTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionPropertiesSideEffectTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -147,9 +148,8 @@ public class VersionPropertiesSideEffectTest {
             .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
             .collect(Collectors.toList());
 
-    // Verify results
-    assert properties.isIsLatest();
-    assertEquals(sideEffectResults.size(), 2, "Expected two mcps: key and set properties");
+    // Verify results: key, set properties, and isLatest=true write for the entity
+    assertEquals(sideEffectResults.size(), 3, "Expected three mcps: key, set properties, isLatest");
 
     MCPItem keyMCP = sideEffectResults.get(0);
     assertEquals(keyMCP.getUrn(), NON_EXISTENT_VERSION_SET_URN);
@@ -165,6 +165,14 @@ public class VersionPropertiesSideEffectTest {
     assertNotNull(versionSetProperties);
     assertEquals(versionSetProperties.getLatest(), ENTITY_URN);
     assertEquals(versionSetProperties.getVersioningScheme(), VersioningScheme.LEXICOGRAPHIC_STRING);
+
+    // isLatest=true is written as a separate ChangeItemImpl targeting the entity, not via
+    // in-place mutation of the incoming recordTemplate.
+    MCPItem setIsLatestMCP = sideEffectResults.get(2);
+    assertEquals(setIsLatestMCP.getUrn(), ENTITY_URN);
+    VersionProperties entityVersionProperties = setIsLatestMCP.getAspect(VersionProperties.class);
+    assertNotNull(entityVersionProperties);
+    assertTrue(entityVersionProperties.isIsLatest());
   }
 
   @Test
@@ -195,12 +203,11 @@ public class VersionPropertiesSideEffectTest {
             .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
             .collect(Collectors.toList());
 
-    // Verify results
-    assert properties.isIsLatest();
+    // Verify results: set properties, old-latest patch, and isLatest=true write for new entity
     assertEquals(
         sideEffectResults.size(),
-        2,
-        "Expected two mcps: set properties and old latest version properties");
+        3,
+        "Expected three mcps: set properties, old latest patch, and isLatest write");
 
     MCPItem setPropertiesMCP = sideEffectResults.get(0);
     assertEquals(setPropertiesMCP.getUrn(), HAS_SET_PROPERTIES_VERSION_SET_URN);
@@ -215,6 +222,12 @@ public class VersionPropertiesSideEffectTest {
     VersionProperties oldLatestVersionProperties = oldLatestMCP.getAspect(VersionProperties.class);
     assertNotNull(oldLatestVersionProperties);
     assertFalse(oldLatestVersionProperties.isIsLatest());
+
+    MCPItem setIsLatestMCP = sideEffectResults.get(2);
+    assertEquals(setIsLatestMCP.getUrn(), ENTITY_URN);
+    VersionProperties entityVersionProperties = setIsLatestMCP.getAspect(VersionProperties.class);
+    assertNotNull(entityVersionProperties);
+    assertTrue(entityVersionProperties.isIsLatest());
   }
 
   @Test
@@ -246,7 +259,7 @@ public class VersionPropertiesSideEffectTest {
             .collect(Collectors.toList());
 
     // Verify results
-    assert !properties.isIsLatest();
+    assertFalse(properties.hasIsLatest(), "Incoming recordTemplate must not be mutated");
     assertEquals(sideEffectResults.size(), 0, "Expected no operations");
   }
 
@@ -278,9 +291,8 @@ public class VersionPropertiesSideEffectTest {
             .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
             .collect(Collectors.toList());
 
-    // Verify results
-    assert properties.isIsLatest();
-    assertEquals(sideEffectResults.size(), 2, "Expected two mcps: key and set properties");
+    // Verify results: key, set properties, and isLatest=true write for the entity
+    assertEquals(sideEffectResults.size(), 3, "Expected three mcps: key, set properties, isLatest");
 
     MCPItem keyMCP = sideEffectResults.get(0);
     assertEquals(keyMCP.getUrn(), MISSING_SET_PROPERTIES_VERSION_SET_URN);
@@ -296,6 +308,12 @@ public class VersionPropertiesSideEffectTest {
     assertNotNull(versionSetProperties);
     assertEquals(versionSetProperties.getLatest(), ML_MODEL_URN);
     assertEquals(versionSetProperties.getVersioningScheme(), VersioningScheme.LEXICOGRAPHIC_STRING);
+
+    MCPItem setIsLatestMCP = sideEffectResults.get(2);
+    assertEquals(setIsLatestMCP.getUrn(), ML_MODEL_URN);
+    VersionProperties entityVersionProperties = setIsLatestMCP.getAspect(VersionProperties.class);
+    assertNotNull(entityVersionProperties);
+    assertTrue(entityVersionProperties.isIsLatest());
   }
 
   @Test
@@ -326,9 +344,8 @@ public class VersionPropertiesSideEffectTest {
             .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
             .collect(Collectors.toList());
 
-    // Verify results
-    assert properties.isIsLatest();
-    assertEquals(sideEffectResults.size(), 1, "Expected one mcps: set properties");
+    // Verify results: set properties and isLatest=true write for the entity
+    assertEquals(sideEffectResults.size(), 2, "Expected two mcps: set properties and isLatest");
 
     MCPItem setPropertiesMCP = sideEffectResults.get(0);
     assertEquals(setPropertiesMCP.getUrn(), INVALID_VERSION_SET_URN);
@@ -336,6 +353,12 @@ public class VersionPropertiesSideEffectTest {
         setPropertiesMCP.getAspect(VersionSetProperties.class);
     assertEquals(versionSetProperties.getLatest(), ENTITY_URN);
     assertEquals(versionSetProperties.getVersioningScheme(), VersioningScheme.LEXICOGRAPHIC_STRING);
+
+    MCPItem setIsLatestMCP = sideEffectResults.get(1);
+    assertEquals(setIsLatestMCP.getUrn(), ENTITY_URN);
+    VersionProperties entityVersionProperties = setIsLatestMCP.getAspect(VersionProperties.class);
+    assertNotNull(entityVersionProperties);
+    assertTrue(entityVersionProperties.isIsLatest());
   }
 
   @Test
@@ -364,5 +387,96 @@ public class VersionPropertiesSideEffectTest {
     // Verify no changes for non-version set properties aspects
     assertEquals(
         sideEffectResults.size(), 0, "Expected no changes for non-version set properties aspect");
+  }
+
+  @Test
+  public void testOriginalRecordTemplateNotMutatedOnCreateVersionSet() {
+    VersionProperties properties =
+        new VersionProperties()
+            .setVersionSet(NON_EXISTENT_VERSION_SET_URN)
+            .setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING)
+            .setVersion(new VersionTag().setVersionTag("v1"))
+            .setSortId("abc");
+
+    EntitySpec entitySpec = TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME);
+    ChangeItemImpl changeItem =
+        ChangeItemImpl.builder()
+            .urn(ENTITY_URN)
+            .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
+            .entitySpec(entitySpec)
+            .aspectSpec(entitySpec.getAspectSpec(VERSION_PROPERTIES_ASPECT_NAME))
+            .recordTemplate(properties)
+            .previousSystemAspect(mock(SystemAspect.class))
+            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+            .build(mockAspectRetriever);
+
+    // First pass (initial transaction attempt)
+    sideEffect
+        .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
+        .collect(Collectors.toList());
+
+    // The incoming recordTemplate must not have isLatest set — if it were mutated here,
+    // validateProposedAspects on a retry would reject it with "IsLatest should not be specified".
+    assertFalse(
+        properties.hasIsLatest(),
+        "Side effect must not mutate the incoming VersionProperties DataMap");
+
+    // Second pass (simulated transaction retry) — must produce the same result without error
+    List<MCPItem> retryResults =
+        sideEffect
+            .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
+            .collect(Collectors.toList());
+
+    assertEquals(retryResults.size(), 3, "Retry must produce the same three MCPs");
+
+    // isLatest=true must still be communicated via the returned ChangeItemImpl, not via mutation
+    Optional<MCPItem> setIsLatestMCP =
+        retryResults.stream().filter(item -> item.getUrn().equals(ENTITY_URN)).findFirst();
+    assertTrue(setIsLatestMCP.isPresent());
+    assertTrue(setIsLatestMCP.get().getAspect(VersionProperties.class).isIsLatest());
+  }
+
+  @Test
+  public void testOriginalRecordTemplateNotMutatedOnUpdateLatest() {
+    VersionProperties properties =
+        new VersionProperties()
+            .setVersionSet(HAS_SET_PROPERTIES_VERSION_SET_URN)
+            .setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING)
+            .setVersion(new VersionTag().setVersionTag("v2"))
+            .setSortId("bbb");
+
+    EntitySpec entitySpec = TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME);
+    ChangeItemImpl changeItem =
+        ChangeItemImpl.builder()
+            .urn(ENTITY_URN)
+            .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
+            .entitySpec(entitySpec)
+            .aspectSpec(entitySpec.getAspectSpec(VERSION_PROPERTIES_ASPECT_NAME))
+            .recordTemplate(properties)
+            .previousSystemAspect(mock(SystemAspect.class))
+            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+            .build(mockAspectRetriever);
+
+    // First pass
+    sideEffect
+        .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
+        .collect(Collectors.toList());
+
+    assertFalse(
+        properties.hasIsLatest(),
+        "Side effect must not mutate the incoming VersionProperties DataMap");
+
+    // Second pass (simulated retry) — must succeed without error
+    List<MCPItem> retryResults =
+        sideEffect
+            .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
+            .collect(Collectors.toList());
+
+    assertEquals(retryResults.size(), 3, "Retry must produce the same three MCPs");
+
+    Optional<MCPItem> setIsLatestMCP =
+        retryResults.stream().filter(item -> item.getUrn().equals(ENTITY_URN)).findFirst();
+    assertTrue(setIsLatestMCP.isPresent());
+    assertTrue(setIsLatestMCP.get().getAspect(VersionProperties.class).isIsLatest());
   }
 }


### PR DESCRIPTION
## Summary

`VersionPropertiesSideEffect` previously set `isLatest=true` by calling `versionProperties.setIsLatest(true)` directly on the object returned by `changeMCP.getAspect(VersionProperties.class)`. Because `ReadItem.getAspect()` passes the underlying `DataMap` by reference, this mutated `ChangeItemImpl.recordTemplate` in-place.

On a database transaction retry, `validateProposedAspects` re-runs on the same (now-mutated) `ChangeItemImpl` instances. It found `isLatest=true` in the record template and correctly rejected the proposal with:
```
ValidationExceptionCollection{... IsLatest should not be specified, this is a computed field.}
```

This caused `422` errors during ingestion of `versionProperties` aspects from any connector (Vertex AI, MLflow, etc.) whenever a transaction retry occurred.

**Fix:** Replace the two in-place mutations in `createVersionSet` and `updateVersionSetLatest` with a new private helper `buildSetIsLatestChange`. This builds a new `ChangeItemImpl` from a shallow `DataMap` copy (`new DataMap(versionProperties.data())`) with `isLatest=true` and appends it to the side-effect output stream. Items returned by side effects go through `validatePreCommit` only — not `validateProposedAspects` — so the `isLatest` field check is never triggered on them. The original `ChangeItemImpl.recordTemplate` is left untouched for the life of the transaction, making retries safe.

The final result stored in the database is identical: the entity's `versionProperties` aspect is written with `isLatest=true`, just via a separate write within the same transaction rather than by mutating the original proposal.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
