### PR TITLE
feat(ui): add Alchemy Alert component

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Alert/Alert.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Alert/Alert.tsx
@@ -1,0 +1,57 @@
+import { CheckCircle, Info, MegaphoneSimple, WarningCircle, X } from '@phosphor-icons/react';
+import React from 'react';
+
+import { AlertActions, AlertContainer, AlertContent, AlertIconWrapper } from '@components/components/Alert/components';
+import { AlertProps, AlertVariant } from '@components/components/Alert/types';
+import { Text } from '@components/components/Text';
+
+const DEFAULT_ICONS: Record<AlertVariant, React.ReactNode> = {
+    success: <CheckCircle size={20} weight="fill" />,
+    error: <WarningCircle size={20} weight="fill" />,
+    warning: <WarningCircle size={20} weight="fill" />,
+    info: <Info size={20} weight="fill" />,
+    brand: <MegaphoneSimple size={20} weight="fill" />,
+};
+
+/**
+ * Inline status banner for success, error, warning, info, and brand messages.
+ * Colors are derived from semantic theme tokens based on the variant.
+ */
+export function Alert({ variant, title, description, icon, onClose, action, className, style }: AlertProps) {
+    const displayIcon = icon ?? DEFAULT_ICONS[variant];
+
+    const hasActions = !!(action || onClose);
+
+    return (
+        <AlertContainer $variant={variant} $hasActions={hasActions} className={className} style={style}>
+            <AlertIconWrapper $variant={variant}>{displayIcon}</AlertIconWrapper>
+            <AlertContent>
+                <Text weight="semiBold" size="sm">
+                    {title}
+                </Text>
+                {description && <Text size="sm">{description}</Text>}
+            </AlertContent>
+            {(action || onClose) && (
+                <AlertActions>
+                    {action}
+                    {onClose && (
+                        <button
+                            type="button"
+                            aria-label="close"
+                            onClick={onClose}
+                            style={{
+                                all: 'unset',
+                                cursor: 'pointer',
+                                display: 'flex',
+                                alignItems: 'center',
+                                opacity: 0.7,
+                            }}
+                        >
+                            <X size={16} weight="bold" />
+                        </button>
+                    )}
+                </AlertActions>
+            )}
+        </AlertContainer>
+    );
+}

--- a/datahub-web-react/src/alchemy-components/components/Alert/__tests__/Alert.test.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Alert/__tests__/Alert.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Alert } from '@components/components/Alert/Alert';
+import { AlertProps, AlertVariant } from '@components/components/Alert/types';
+
+import themeV2 from '@conf/theme/themeV2';
+
+function renderAlert(props: Partial<AlertProps> & { variant?: AlertVariant; title?: string } = {}) {
+    const defaultProps: AlertProps = {
+        variant: 'success',
+        title: 'Test title',
+        ...props,
+    };
+
+    return render(
+        <ThemeProvider theme={themeV2}>
+            <Alert {...defaultProps} />
+        </ThemeProvider>,
+    );
+}
+
+describe('Alert', () => {
+    it('should render the title', () => {
+        renderAlert({ title: 'Operation complete' });
+
+        expect(screen.getByText('Operation complete')).toBeInTheDocument();
+    });
+
+    it('should render the description when provided', () => {
+        renderAlert({ title: 'Done', description: 'All changes saved.' });
+
+        expect(screen.getByText('Done')).toBeInTheDocument();
+        expect(screen.getByText('All changes saved.')).toBeInTheDocument();
+    });
+
+    it('should not render a description when omitted', () => {
+        renderAlert({ title: 'Title only' });
+
+        expect(screen.getByText('Title only')).toBeInTheDocument();
+        expect(screen.queryByText('All changes saved.')).not.toBeInTheDocument();
+    });
+
+    it('should render an action element when provided', () => {
+        renderAlert({
+            title: 'Error',
+            variant: 'error',
+            action: <button type="button">Retry</button>,
+        });
+
+        expect(screen.getByText('Retry')).toBeInTheDocument();
+    });
+
+    it('should render a close button when onClose is provided', () => {
+        const onClose = vi.fn();
+        renderAlert({ title: 'Dismissable', onClose });
+
+        const closeButton = screen.getByRole('button', { name: /close/i });
+        expect(closeButton).toBeInTheDocument();
+
+        fireEvent.click(closeButton);
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('should not render close button when onClose is omitted', () => {
+        renderAlert({ title: 'No close' });
+
+        expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+    });
+
+    it.each<AlertVariant>(['success', 'error', 'warning', 'info', 'brand'])(
+        'should render without errors for variant "%s"',
+        (variant) => {
+            const { container } = renderAlert({ variant, title: `${variant} alert` });
+
+            expect(screen.getByText(`${variant} alert`)).toBeInTheDocument();
+            expect(container.firstChild).toBeInTheDocument();
+        },
+    );
+
+    it('should apply className and style props', () => {
+        const { container } = renderAlert({
+            title: 'Styled',
+            className: 'custom-class',
+            style: { marginTop: 12 },
+        });
+
+        const alertEl = container.firstChild as HTMLElement;
+        expect(alertEl.classList.contains('custom-class')).toBe(true);
+        expect(alertEl.style.marginTop).toBe('12px');
+    });
+});

--- a/datahub-web-react/src/alchemy-components/components/Alert/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Alert/components.ts
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+import { AlertVariant } from '@components/components/Alert/types';
+
+import { radius, spacing } from '@src/alchemy-components/theme';
+
+const VARIANT_THEME_MAP: Record<AlertVariant, { bg: string; text: string; icon: string }> = {
+    success: { bg: 'bgSurfaceSuccess', text: 'textSuccess', icon: 'iconSuccess' },
+    error: { bg: 'bgSurfaceError', text: 'textError', icon: 'iconError' },
+    warning: { bg: 'bgSurfaceWarning', text: 'textWarning', icon: 'iconWarning' },
+    info: { bg: 'bgSurfaceInfo', text: 'textInformation', icon: 'iconInformation' },
+    brand: { bg: 'bgSurfaceBrand', text: 'textBrand', icon: 'iconBrand' },
+};
+
+export const AlertContainer = styled.div<{ $variant: AlertVariant; $hasActions?: boolean }>(
+    ({ $variant, $hasActions, theme }) => {
+        const tokens = VARIANT_THEME_MAP[$variant];
+        return {
+            display: 'flex',
+            alignItems: 'center',
+            gap: spacing.xsm,
+            padding: `${spacing.sm} ${$hasActions ? spacing.xxsm : spacing.md} ${spacing.sm} ${spacing.md}`,
+            borderRadius: radius.lg,
+            backgroundColor: theme.colors[tokens.bg],
+            color: theme.colors[tokens.text],
+        };
+    },
+);
+
+export const AlertIconWrapper = styled.span<{ $variant: AlertVariant }>(({ $variant, theme }) => {
+    const tokens = VARIANT_THEME_MAP[$variant];
+    return {
+        display: 'inline-flex',
+        alignItems: 'center',
+        flexShrink: 0,
+        color: theme.colors[tokens.icon],
+    };
+});
+
+export const AlertContent = styled.div({
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minWidth: 0,
+});
+
+export const AlertActions = styled.div({
+    display: 'flex',
+    alignItems: 'center',
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
+});

--- a/datahub-web-react/src/alchemy-components/components/Alert/index.ts
+++ b/datahub-web-react/src/alchemy-components/components/Alert/index.ts
@@ -1,0 +1,2 @@
+export { Alert } from './Alert';
+export type { AlertProps, AlertVariant } from './types';

--- a/datahub-web-react/src/alchemy-components/components/Alert/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Alert/types.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+
+/** Supported visual variants for the Alert component */
+export type AlertVariant = 'success' | 'error' | 'warning' | 'info' | 'brand';
+
+export interface AlertProps {
+    /** Visual style variant determining colors and default icon */
+    variant: AlertVariant;
+    /** Primary message */
+    title: string | React.ReactNode;
+    /** Optional secondary message */
+    description?: string | React.ReactNode;
+    /** Override the default icon for the variant */
+    icon?: React.ReactNode;
+    /** Show a close/dismiss button */
+    onClose?: () => void;
+    /** Additional action element rendered on the right */
+    action?: React.ReactNode;
+    /** Additional CSS class */
+    className?: string;
+    /** Inline styles */
+    style?: React.CSSProperties;
+}

--- a/datahub-web-react/src/alchemy-components/index.ts
+++ b/datahub-web-react/src/alchemy-components/index.ts
@@ -3,6 +3,7 @@ export * from './theme';
 
 // example usage: import { Button } from '@components';
 export * from './components/ActionsBar';
+export * from './components/Alert';
 export * from './components/AutoComplete';
 export * from './components/Avatar';
 export * from './components/Badge';


### PR DESCRIPTION
## Summary
- Backport reusable `Alert` component from SaaS (PR [acryldata/datahub-fork#8482](https://github.com/acryldata/datahub-fork/pull/8482)) to OSS alchemy-components library
- Supports `success`, `error`, `warning`, `info`, and `brand` variants with semantic theme tokens
- Includes optional close button, action slot, custom icon override, and className/style passthrough
- Comprehensive test coverage for all variants, actions, dismissal, and prop forwarding

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly PR Title Format)
- [x] Tests for the changes have been added/updated
- [x] `yarn prettier` and `yarn lint` pass with zero errors


Made with [Cursor](https://cursor.com)