### PR TITLE
fix(ingest/glue): allow generating fine-grained lineage without a graph

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -951,14 +951,15 @@ class GlueSource(StatefulIngestionSourceBase):
                     s3_dataset_urn = make_s3_urn_for_lineage(
                         location, self.source_config.env
                     )
-                    if self.ctx.graph:
-                        schema_metadata_for_s3 = self.ctx.graph.get_schema_metadata(
-                            s3_dataset_urn
-                        )
-                    else:
-                        schema_metadata_for_s3 = None
 
                     if self.source_config.glue_s3_lineage_direction == "upstream":
+                        if self.ctx.graph:
+                            schema_metadata_for_s3 = self.ctx.graph.get_schema_metadata(
+                                s3_dataset_urn
+                            )
+                        else:
+                            schema_metadata_for_s3 = None
+
                         fine_grained_lineages = None
                         if (
                             self.source_config.include_column_lineage


### PR DESCRIPTION
- fix(ingest/glue): allow generating fine-grained lineage without a graph
- fix(ingest/glue): only use graph when needed (for upstream lineage)
