### PR TITLE
feat(ingestion): pass MCP headers through to OpenAPI request payload

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/request_helper.py
+++ b/metadata-ingestion/src/datahub/emitter/request_helper.py
@@ -83,8 +83,10 @@ class OpenApiRequest:
             url = f"{gms_server}/openapi/v3/entity/{mcp.entityType}/{mcp.entityUrn}"
         else:
             if mcp.aspect:
-                mcp_headers = {}
-
+                mcp_headers: Dict[str, str] = {}
+                headers = getattr(mcp, "headers", None)
+                if headers:
+                    mcp_headers.update(headers)
                 if not async_flag and search_sync_flag:
                     mcp_headers["X-DataHub-Sync-Index-Update"] = "true"
 

--- a/metadata-ingestion/tests/unit/datahub/emitter/test_request_helper.py
+++ b/metadata-ingestion/tests/unit/datahub/emitter/test_request_helper.py
@@ -290,3 +290,36 @@ def test_from_mcp_search_sync_flag():
     assert request.method == "delete"
     # For DELETE, there's no payload so no headers
     assert len(request.payload) == 0
+
+
+def test_from_mcp_upsert_with_mcp_headers():
+    """Test that MCP headers (e.g. If-Version-Match) are passed through to the request payload."""
+    mcp = MetadataChangeProposalWrapper(
+        entityUrn="urn:li:chart:(test,test)",
+        aspect=CHART_INFO,
+        headers={"If-Version-Match": "42"},
+    )
+
+    request = OpenApiRequest.from_mcp(mcp, GMS_SERVER)
+
+    assert request is not None
+    assert request.payload[0]["chartInfo"]["headers"] == {"If-Version-Match": "42"}
+
+
+def test_from_mcp_upsert_mcp_headers_merged_with_search_sync():
+    """Test that MCP headers and search_sync_flag header are merged in payload."""
+    mcp = MetadataChangeProposalWrapper(
+        entityUrn="urn:li:chart:(test,test)",
+        aspect=CHART_INFO,
+        headers={"If-Version-Match": "3"},
+    )
+
+    request = OpenApiRequest.from_mcp(
+        mcp, GMS_SERVER, async_flag=False, search_sync_flag=True
+    )
+
+    assert request is not None
+    assert request.payload[0]["chartInfo"]["headers"] == {
+        "If-Version-Match": "3",
+        "X-DataHub-Sync-Index-Update": "true",
+    }


### PR DESCRIPTION
Forward mcp.headers (e.g. If-Version-Match) into mcp_headers when building OpenApiRequest.from_mcp, so async ingest with version match works. Add unit tests for MCP headers and merge with search_sync header.

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
