### PR TITLE
feat(docker): add slim-mode PySpark check in bundled venv builder

### DIFF
--- a/docker/snippets/ingestion/build_bundled_venvs_unified.py
+++ b/docker/snippets/ingestion/build_bundled_venvs_unified.py
@@ -90,6 +90,18 @@ def create_venv(plugin: str, venv_name: str, bundled_cli_version: str, venv_base
             install_cmd = f'source {venv_path}/bin/activate && uv pip install "{datahub_package}" --constraints {constraints_path}'
         subprocess.run(['bash', '-c', install_cmd], check=True, capture_output=True)
 
+        # Defense-in-depth: in slim mode, verify PySpark was not pulled in transitively
+        if slim_mode:
+            python_exe = os.path.join(venv_path, "bin", "python")
+            result = subprocess.run(
+                [python_exe, "-c", "import pyspark"],
+                capture_output=True,
+            )
+            if result.returncode == 0:
+                print(f"  ❌ FAIL: PySpark found in {venv_name} (slim mode requires no PySpark)")
+                return False
+            print(f"  → Verified: No PySpark in {venv_name}")
+
         print(f"  ✅ Successfully created {venv_name}")
         return True
 


### PR DESCRIPTION
Defense-in-depth: in slim mode, verify no venv has PySpark pulled in transitively after install. On failure, print clear message and return False.

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
