### PR TITLE
fix(ingestion): fix navigating to source from executions

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/IngestionSourceList.tsx
@@ -167,22 +167,23 @@ export const IngestionSourceList = ({
         [createdOrUpdatedSourceUrnFromLocation],
     );
 
+    const handleSearchInputChange = (value: string) => {
+        setSearchInput(value);
+    };
+
+    const { page, setPage, start, count: pageSize } = useUrlParamsPagination(DEFAULT_PAGE_SIZE);
+
     // Initialize search input from URL parameter
     useEffect(() => {
         if (searchQueryFromUrl?.length) {
+            setPage(1);
             setQuery(searchQueryFromUrl);
             setSearchInput(searchQueryFromUrl);
             setTimeout(() => {
                 searchInputRef.current?.focus?.();
             }, 0);
         }
-    }, [searchQueryFromUrl]);
-
-    const handleSearchInputChange = (value: string) => {
-        setSearchInput(value);
-    };
-
-    const { page, setPage, start, count: pageSize } = useUrlParamsPagination(DEFAULT_PAGE_SIZE);
+    }, [searchQueryFromUrl, setPage]);
 
     const [isViewingRecipe, setIsViewingRecipe] = useState<boolean>(false);
     const [focusSourceUrn, setFocusSourceUrn] = useState<undefined | string>(undefined);


### PR DESCRIPTION
Linear: https://linear.app/acryl-data/issue/CAT-1495/search-results-are-not-correct-when-navigating-back-from-run-history

Fixed navigating back to source from executions tab. The problem was reproducible when initially an user was on the second and further page. The page number was saved in state and after navigating from run to source wasn't reset.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
