### PR TITLE
docs(mcp): add Claude Code setup instructions

### DIFF
--- a/docs/features/feature-guides/mcp.md
+++ b/docs/features/feature-guides/mcp.md
@@ -186,6 +186,19 @@ For on-premises DataHub Cloud, replace `<tenant>.acryl.io` with your DataHub FQD
 </details>
 
 <details>
+  <summary>Claude Code</summary>
+
+Claude Code natively supports streamable HTTP, so no proxy or additional dependencies are needed.
+
+Run the following command, replacing `<tenant>` and `<token>` with your own values:
+
+```bash
+claude mcp add --transport http datahub-cloud "https://<tenant>.acryl.io/integrations/ai/mcp/?token=<token>"
+```
+
+</details>
+
+<details>
   <summary>Cursor</summary>
 
 1. Make sure you're using Cursor v1.1 or newer.
@@ -273,6 +286,20 @@ These are passed to the `mcp-server-datahub` process at startup (see configurati
     }
   }
 }
+```
+
+</details>
+
+<details>
+  <summary>Claude Code</summary>
+
+Run the following command, replacing the placeholder values:
+
+```bash
+claude mcp add datahub \
+  -e DATAHUB_GMS_URL="<your-datahub-url>" \
+  -e DATAHUB_GMS_TOKEN="<your-datahub-token>" \
+  -- uvx mcp-server-datahub@latest
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- Adds Claude Code configuration examples to both the Managed and Self-Hosted MCP Server "Configure" sections
- For the managed server, Claude Code natively supports streamable HTTP transport, so setup is a single command with no need for `mcp-remote` or Node.js
- For the self-hosted server, shows the `claude mcp add` command with environment variables for authentication

## Context
Customer reported connection timeout errors when using the `mcp-remote` approach with Claude Code. The root cause was `npx` downloading `mcp-remote` on each startup, exceeding Claude Code's default 30-second MCP connection timeout. Since Claude Code supports streamable HTTP natively, documenting the direct setup avoids this issue entirely.

## Test plan
- [ ] Verify the managed server command works: `claude mcp add --transport http datahub-cloud "https://<tenant>.acryl.io/integrations/ai/mcp/?token=<token>"`
- [ ] Verify the self-hosted command works: `claude mcp add datahub -e DATAHUB_GMS_URL="<url>" -e DATAHUB_GMS_TOKEN="<token>" -- uvx mcp-server-datahub@latest`
- [ ] Confirm docs-website renders the new collapsible sections correctly