### PR TITLE
fix(test): fix flaky TestIsolatedClassLoader by cleaning up SecurityManager

### DIFF
--- a/metadata-service/plugin/build.gradle
+++ b/metadata-service/plugin/build.gradle
@@ -37,6 +37,9 @@ test {
   systemProperty 'datahub.gms.home', file("$projectDir").absolutePath
   systemProperty 'java.security.policy', file("../war/src/main/resources/security.policy").absolutePath
   systemProperty 'datahub.project.root.dir', "$rootDir" // used in security.policy
+  // Required for Java 17+ where System.setSecurityManager() is deprecated
+  // and disabled by default in Java 18+
+  jvmArgs '-Djava.security.manager=allow'
 }
 
 processTestResources.dependsOn(":metadata-service:plugin:src:test:sample-test-plugins:copyJar")

--- a/metadata-service/plugin/src/test/java/com/datahub/plugins/auth/TestIsolatedClassLoader.java
+++ b/metadata-service/plugin/src/test/java/com/datahub/plugins/auth/TestIsolatedClassLoader.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -63,6 +64,11 @@ class TestIsolatedClassLoader {
   @BeforeClass
   public void setSecurityManager() {
     System.setSecurityManager(new SecurityManager());
+  }
+
+  @AfterClass
+  public void clearSecurityManager() {
+    System.setSecurityManager(null);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Add `@AfterClass clearSecurityManager()` to restore `System.setSecurityManager(null)` after the test class completes, preventing the installed SecurityManager from leaking into other test classes running in the same JVM worker
- Add `-Djava.security.manager=allow` JVM arg to `build.gradle` so the SecurityManager can be set on Java 17+ where it is disabled by default (and throws `UnsupportedOperationException` on Java 18+)

The flake occurred because the SecurityManager is JVM-global state. When Gradle's test workers ran multiple test classes in the same JVM process, the SecurityManager installed by `@BeforeClass` persisted into subsequent classes. Depending on execution order, later classes would hit permission denials, or `@BeforeClass` itself would fail if a prior SecurityManager was already installed that didn't grant `RuntimePermission("setSecurityManager")`.

Closes PFP-2875

## Test plan

- [x] Ran `TestIsolatedClassLoader` 10 consecutive times with `--rerun-tasks` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)