### PR TITLE
fix(ui/ingestion): fix not able to switch back to form tab in edit source

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/RecipeSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/RecipeSection.tsx
@@ -54,7 +54,7 @@ export function RecipeSection({ state, displayRecipe, sourceConfigs, setStagedRe
                 if (
                     parsedYaml &&
                     !!existingIngestionSource &&
-                    parsedYaml?.source?.config?.type !== existingIngestionSource.type
+                    parsedYaml?.source?.type !== existingIngestionSource.type
                 ) {
                     throw new Error("It's not possible to change source type for existing ingestion source");
                 }


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-1492/not-able-to-switch-tab-from-yaml-to-form-in-ingestion-source-update

**Description:**

This fixes the bug that prevented us from switching back to form tab from yaml tab in edit ingestion source flow

Brings back [this](https://github.com/acryldata/datahub-fork/pull/8556) PR to OSS


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
