### PR TITLE
fix(ece): directly use event producer for ece

### DIFF
--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
@@ -215,7 +215,8 @@ public class EntityChangeEventGeneratorHook implements MetadataChangeLogHook {
 
   private void emitPlatformEvent(
       @Nonnull final PlatformEvent event, @Nonnull final String partitioningKey) throws Exception {
-    eventProducer.producePlatformEvent(Constants.CHANGE_EVENT_PLATFORM_EVENT_NAME, partitioningKey, event);
+    eventProducer.producePlatformEvent(
+        Constants.CHANGE_EVENT_PLATFORM_EVENT_NAME, partitioningKey, event);
   }
 
   private PlatformEvent buildPlatformEvent(final ChangeEvent rawChangeEvent) {

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
@@ -1198,8 +1198,8 @@ public class EntityChangeEventGeneratorHookTest {
     return TestOperationContexts.systemContextNoSearchAuthorization(registry);
   }
 
-  private void verifyProducePlatformEvent(
-      EventProducer eventProducer, PlatformEvent platformEvent) throws Exception {
+  private void verifyProducePlatformEvent(EventProducer eventProducer, PlatformEvent platformEvent)
+      throws Exception {
     verifyProducePlatformEvent(eventProducer, platformEvent, true);
   }
 


### PR DESCRIPTION
This avoids an extra round trip on the ECE consumer side to produce Kafka events using GMS instead of just directly producing them.