### PR TITLE
(fix: datahub-web-react) glossary-term-hover-crashes-summary-panel

### DIFF
--- a/datahub-web-react/src/app/sharedV2/propagation/HoverCardAttributionDetails.tsx
+++ b/datahub-web-react/src/app/sharedV2/propagation/HoverCardAttributionDetails.tsx
@@ -19,7 +19,14 @@ interface Props {
 
 export default function HoverCardAttributionDetails({ propagationDetails, addMargin }: Props) {
     const sourceDetail = usePropagationDetails(propagationDetails?.attribution?.sourceDetail);
-    const context = propagationDetails?.context ? (JSON.parse(propagationDetails.context) as PropagationContext) : null;
+    let context: PropagationContext | null = null;
+    if (propagationDetails?.context) {
+        try {
+            context = JSON.parse(propagationDetails.context) as PropagationContext;
+        } catch (e) {
+            console.warn('Failed to parse propagation context as JSON:', propagationDetails.context, e);
+        }
+    }
     const contextEntities = usePropagationContextEntities(context);
     const isPropagated = sourceDetail.isPropagated || context?.propagated;
 

--- a/datahub-web-react/src/app/sharedV2/propagation/LabelPropagationDetails.tsx
+++ b/datahub-web-react/src/app/sharedV2/propagation/LabelPropagationDetails.tsx
@@ -1,6 +1,6 @@
 import { Popover } from '@components';
 import React from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import PropagationEntityLink from '@app/sharedV2/propagation/PropagationEntityLink';
 import { PropagateThunderbolt, PropagateThunderboltFilled } from '@app/sharedV2/propagation/PropagationIcon';
@@ -17,13 +17,13 @@ const PopoverTitle = styled.div`
     font-weight: bold;
     font-size: 14px;
     padding: 6px 0px;
-    color: #eeecfa;
+    color: ${(props) => props.theme.colors.textOnFillDefault};
 `;
 
 const PopoverDescription = styled.div`
     max-width: 340px;
     font-size: 14px;
-    color: #eeecfa;
+    color: ${(props) => props.theme.colors.textOnFillDefault};
     display: inline;
     padding: 0px 0px 8px 0px;
 `;
@@ -39,7 +39,7 @@ const PopoverAttribute = styled.div`
 
 const PopoverAttributeTitle = styled.div`
     font-size: 14px;
-    color: #eeecfa;
+    color: ${(props) => props.theme.colors.textOnFillDefault};
     font-weight: bold;
     margin: 8px 0px;
     overflow: hidden;
@@ -52,7 +52,15 @@ interface Props {
 }
 
 export default function LabelPropagationDetails({ entityType, context }: Props) {
-    const contextObj = context ? (JSON.parse(context) as PropagationContext) : null;
+    const theme = useTheme();
+    let contextObj: PropagationContext | null = null;
+    if (context) {
+        try {
+            contextObj = JSON.parse(context) as PropagationContext;
+        } catch (e) {
+            console.warn('Failed to parse propagation context as JSON:', context, e);
+        }
+    }
     const isPropagated = contextObj?.propagated;
     const { originEntity } = usePropagationContextEntities(contextObj);
     const isSiblingsRelationship = contextObj?.relationship === PropagationRelationshipType.SIBLINGS;
@@ -79,7 +87,7 @@ export default function LabelPropagationDetails({ entityType, context }: Props) 
 
     return (
         <Popover
-            overlayInnerStyle={{ backgroundColor: '#272D48' }}
+            overlayInnerStyle={{ backgroundColor: theme.colors.bgTooltip }}
             showArrow={false}
             title={
                 <PopoverTitle>


### PR DESCRIPTION
This change serves as a defensive mechanism to handle invalid custom types for hover cards in summary panel.
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
