### PR TITLE
fix(gms): align MySQL schema with mysql-setup to prevent getNextVersi…

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
@@ -110,7 +110,7 @@ public class MySqlDatabaseOperations implements DatabaseOperations {
           INDEX urnIndex (urn),
           INDEX aspectIndex (aspect),
           INDEX versionIndex (version)
-        );
+        ) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
         """);
   }
 
@@ -124,8 +124,13 @@ public class MySqlDatabaseOperations implements DatabaseOperations {
       stmt.setString(1, databaseName);
       try (ResultSet result = stmt.executeQuery()) {
         if (!result.next()) {
-          // Create database using PreparedStatement
-          String createDbSql = "CREATE DATABASE `" + databaseName + "`";
+          // Create database with charset/collation matching docker/mysql-setup/init.sql to avoid
+          // case/encoding mismatches (e.g. utf8mb4_ci vs utf8mb4_bin) that can cause NPE in
+          // EbeanAspectDao.getNextVersions when DB-returned URN strings don't match request keys.
+          String createDbSql =
+              "CREATE DATABASE "
+                  + escapeMysqlIdentifier(databaseName)
+                  + " CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
           try (PreparedStatement createStmt = connection.prepareStatement(createDbSql)) {
             createStmt.executeUpdate();
             log.info("Created MySQL database: {}", databaseName);
@@ -137,8 +142,11 @@ public class MySqlDatabaseOperations implements DatabaseOperations {
     } catch (Exception e) {
       log.debug("MySQL database check failed, attempting to create: {}", e.getMessage());
       // Fallback: try to create database directly
-      try (PreparedStatement createStmt =
-          connection.prepareStatement("CREATE DATABASE `" + databaseName + "`")) {
+      String createDbSql =
+          "CREATE DATABASE "
+              + escapeMysqlIdentifier(databaseName)
+              + " CHARACTER SET utf8mb4 COLLATE utf8mb4_bin";
+      try (PreparedStatement createStmt = connection.prepareStatement(createDbSql)) {
         createStmt.executeUpdate();
         log.info("Created MySQL database: {}", databaseName);
       }

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperationsTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperationsTest.java
@@ -153,6 +153,19 @@ public class DatabaseOperationsTest {
   }
 
   @Test
+  public void testMysqlCreateTableSqlStatementsMatchesMysqlSetupCharsetAndCollation() {
+    java.util.List<String> statements = mysqlOps.createTableSqlStatements();
+    assertNotNull(statements);
+    String ddl = statements.get(0);
+    assertTrue(
+        ddl.contains("CHARACTER SET utf8mb4"),
+        "Table DDL should match docker/mysql-setup/init.sql charset to avoid case/encoding regression");
+    assertTrue(
+        ddl.contains("COLLATE utf8mb4_bin"),
+        "Table DDL should match docker/mysql-setup/init.sql collation (case-sensitive)");
+  }
+
+  @Test
   public void testPostgresModifyJdbcUrl() {
     String originalUrl = "jdbc:postgresql://localhost:5432/testdb";
     String result = postgresOps.modifyJdbcUrl(originalUrl, true);

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -931,13 +931,34 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
 
     List<EbeanAspectV2.PrimaryKey> dbResults = exp.endOr().findIds();
 
-    for (EbeanAspectV2.PrimaryKey key : dbResults) {
-      if (result.get(key.getUrn()).get(key.getAspect()) <= key.getVersion()) {
-        result.get(key.getUrn()).put(key.getAspect(), key.getVersion() + 1L);
-      }
-    }
+    mergeNextVersionsFromDb(result, dbResults);
 
     return result;
+  }
+
+  /**
+   * Merges DB max-version results into the request-keyed result map. Package-private for testing.
+   */
+  static void mergeNextVersionsFromDb(
+      Map<String, Map<String, Long>> result, List<EbeanAspectV2.PrimaryKey> dbResults) {
+    for (EbeanAspectV2.PrimaryKey key : dbResults) {
+      try {
+        if (result.get(key.getUrn()).get(key.getAspect()) <= key.getVersion()) {
+          result.get(key.getUrn()).put(key.getAspect(), key.getVersion() + 1L);
+        }
+      } catch (NullPointerException e) {
+        throw new IllegalStateException(
+            "URN or aspect from database did not match request keys (urn=\""
+                + key.getUrn()
+                + "\", aspect=\""
+                + key.getAspect()
+                + "\"). "
+                + "Possible cause: MySQL database/table created with different charset or collation "
+                + "than mysql-setup (ensure CHARACTER SET utf8mb4 COLLATE utf8mb4_bin). "
+                + "Create schema via docker/mysql-setup or datahub-upgrade SqlSetup with aligned DDL.",
+            e);
+      }
+    }
   }
 
   @Nonnull

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/ebean/EbeanAspectDaoTest.java
@@ -34,6 +34,7 @@ import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.ebean.Database;
 import io.ebean.test.LoggedSql;
 import java.sql.Timestamp;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -69,6 +70,29 @@ public class EbeanAspectDaoTest {
       {true, "Writable"}, // canWrite = true, description
       {false, "ReadOnly"} // canWrite = false, description
     };
+  }
+
+  @Test
+  public void testGetNextVersionsThrowsIllegalStateWhenDbKeyNotInRequest() {
+    Map<String, Map<String, Long>> result = new HashMap<>();
+    result.put("urn:li:corpuser:requested", new HashMap<>(Map.of("status", 0L)));
+    List<EbeanAspectV2.PrimaryKey> dbResults =
+        List.of(
+            new EbeanAspectV2.PrimaryKey("urn:li:corpuser:from-db-not-in-request", "status", 0));
+
+    try {
+      EbeanAspectDao.mergeNextVersionsFromDb(result, dbResults);
+      throw new AssertionError("Expected IllegalStateException");
+    } catch (IllegalStateException e) {
+      assertTrue(
+          e.getMessage().contains("urn:li:corpuser:from-db-not-in-request"),
+          "Message should include failing URN");
+      assertTrue(e.getMessage().contains("status"), "Message should include failing aspect");
+      assertTrue(
+          e.getMessage().contains("utf8mb4_bin"), "Message should hint at charset/collation fix");
+      assertNotNull(e.getCause(), "Cause should be set");
+      assertTrue(e.getCause() instanceof NullPointerException);
+    }
   }
 
   @Test(dataProvider = "writabilityConfig")


### PR DESCRIPTION
…ons NPE

When the schema is created via system update instead of mysql-setup, the database and table can get default collation (e.g. utf8mb4_ci) instead of utf8mb4_bin. That causes URN/aspect string mismatch between request keys and DB-returned keys, leading to NPE in EbeanAspectDao.getNextVersions.

- MySqlDatabaseOperations: create database and metadata_aspect_v2 table with CHARACTER SET utf8mb4 COLLATE utf8mb4_bin to match docker/mysql-setup/init.sql.
- Add unit test: DatabaseOperationsTest (charset/collation in DDL).

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
