### PR TITLE
test(ingest/glue): set an explicit runId for test_glue_stateful

### DIFF
--- a/metadata-ingestion/tests/unit/glue/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source.py
@@ -387,6 +387,7 @@ def test_glue_stateful(pytestconfig, tmp_path, mock_time, mock_datahub_graph):
             "type": "console"
         },
         "pipeline_name": "statefulpipeline",
+        "run_id": "glue-2020_04_14-07_00_00-xds5dj",
     }
 
     with patch(


### PR DESCRIPTION
It would dynamically change, introducing spurious diffs when running --update-golden-files.