### PR TITLE
feat(summaryTab): hide visible properties from menu (#8577)

### DIFF
--- a/datahub-web-react/src/app/entityV2/summary/properties/menuAddProperty/hooks/__tests__/useAddPropertyMenuItems.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/properties/menuAddProperty/hooks/__tests__/useAddPropertyMenuItems.test.ts
@@ -7,17 +7,21 @@ import { sortMenuItems } from '@components/components/Menu/utils';
 import useBasicAssetProperties from '@app/entityV2/summary/properties/hooks/useBasicAssetProperties';
 import useAddPropertyMenuItems from '@app/entityV2/summary/properties/menuAddProperty/hooks/useAddPropertyMenuItems';
 import useStructuredPropertiesMenuItems from '@app/entityV2/summary/properties/menuAddProperty/hooks/useStructuredPropertiesMenuItems';
-import { PropertyType } from '@app/entityV2/summary/properties/types';
+import { AssetProperty } from '@app/entityV2/summary/properties/types';
+import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
+
+import { SummaryElementType } from '@types';
 
 vi.mock('@app/entityV2/summary/properties/hooks/useBasicAssetProperties');
 vi.mock('@app/entityV2/summary/properties/menuAddProperty/hooks/useStructuredPropertiesMenuItems');
+vi.mock('@app/homeV3/context/PageTemplateContext');
 vi.mock('@components/components/Menu/utils', () => ({
     sortMenuItems: vi.fn((items) => items),
 }));
 
-const mockBasicProperties = [
-    { name: 'Tags', type: PropertyType.Tags },
-    { name: 'Owners', type: PropertyType.Owners },
+const mockBasicProperties: AssetProperty[] = [
+    { name: 'Tags', type: SummaryElementType.Tags },
+    { name: 'Owners', type: SummaryElementType.Owners },
 ];
 
 const mockStructuredPropertiesMenuItems = [{ type: 'item', key: 'structured1', title: 'Structured Prop 1' }];
@@ -25,6 +29,7 @@ const mockStructuredPropertiesMenuItems = [{ type: 'item', key: 'structured1', t
 describe('useAddPropertyMenuItems', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        (usePageTemplateContext as any).mockReturnValue({ summaryElements: [] });
     });
 
     it('should return only basic properties when no structured properties are available', () => {
@@ -61,5 +66,59 @@ describe('useAddPropertyMenuItems', () => {
         (useStructuredPropertiesMenuItems as any).mockReturnValue([]);
         renderHook(() => useAddPropertyMenuItems(vi.fn()));
         expect(sortMenuItems).toHaveBeenCalled();
+    });
+
+    it('should filter out basic properties that are already visible in summaryElements', () => {
+        (usePageTemplateContext as any).mockReturnValue({
+            summaryElements: [{ type: SummaryElementType.Tags }],
+        });
+        (useBasicAssetProperties as any).mockReturnValue(mockBasicProperties);
+        (useStructuredPropertiesMenuItems as any).mockReturnValue([]);
+        const { result } = renderHook(() => useAddPropertyMenuItems(vi.fn()));
+        expect(result.current).toHaveLength(1);
+        expect((result.current[0] as MenuItemType).title).toBe('Owners');
+    });
+
+    it('should filter out structured properties that are already visible in summaryElements', () => {
+        const visibleStructuredProperty: AssetProperty = {
+            name: 'Visible Prop',
+            type: SummaryElementType.StructuredProperty,
+            key: 'visible',
+            structuredProperty: { urn: 'urn:li:structuredProperty:visible' } as any,
+        };
+        const nonVisibleStructuredProperty: AssetProperty = {
+            name: 'Non Visible Prop',
+            type: SummaryElementType.StructuredProperty,
+            key: 'nonVisible',
+            structuredProperty: { urn: 'urn:li:structuredProperty:nonVisible' } as any,
+        };
+        (usePageTemplateContext as any).mockReturnValue({
+            summaryElements: [{ structuredProperty: { urn: 'urn:li:structuredProperty:visible' } }],
+        });
+        (useBasicAssetProperties as any).mockReturnValue([visibleStructuredProperty, nonVisibleStructuredProperty]);
+        (useStructuredPropertiesMenuItems as any).mockReturnValue([]);
+        const { result } = renderHook(() => useAddPropertyMenuItems(vi.fn()));
+        expect(result.current).toHaveLength(1);
+        expect((result.current[0] as MenuItemType).title).toBe('Non Visible Prop');
+    });
+
+    it('should update menu items when summaryElements changes', () => {
+        const { result, rerender } = renderHook(() => useAddPropertyMenuItems(vi.fn()), {
+            initialProps: { summaryElements: [] },
+        });
+        (useBasicAssetProperties as any).mockReturnValue(mockBasicProperties);
+        (useStructuredPropertiesMenuItems as any).mockReturnValue([]);
+
+        // Initial render with no visible elements
+        (usePageTemplateContext as any).mockReturnValue({ summaryElements: [] });
+        rerender();
+        expect(result.current).toHaveLength(2);
+
+        // After adding Tags to summary
+        (usePageTemplateContext as any).mockReturnValue({
+            summaryElements: [{ type: SummaryElementType.Tags }],
+        });
+        rerender();
+        expect(result.current).toHaveLength(1);
     });
 });

--- a/datahub-web-react/src/app/entityV2/summary/properties/menuAddProperty/hooks/__tests__/useStructuredPropertiesMenuItems.test.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/properties/menuAddProperty/hooks/__tests__/useStructuredPropertiesMenuItems.test.tsx
@@ -6,9 +6,13 @@ import { MenuItemType } from '@components/components/Menu/types';
 
 import useStructuredPropertiesV2 from '@app/entityV2/summary/properties/hooks/useStructuredProperties';
 import useStructuredPropertiesMenuItems from '@app/entityV2/summary/properties/menuAddProperty/hooks/useStructuredPropertiesMenuItems';
-import { PropertyType } from '@app/entityV2/summary/properties/types';
+import { AssetProperty } from '@app/entityV2/summary/properties/types';
+import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
+
+import { SummaryElementType } from '@types';
 
 vi.mock('@app/entityV2/summary/properties/hooks/useStructuredProperties');
+vi.mock('@app/homeV3/context/PageTemplateContext');
 vi.mock('@components/components/Menu/utils', () => ({
     sortMenuItems: vi.fn((items) => items),
 }));
@@ -22,14 +26,16 @@ vi.mock('@app/entityV2/summary/properties/menuAddProperty/components/MenuSearchB
     default: () => <div />,
 }));
 
-const mockStructuredProperties = [
-    { name: 'Prop 1', type: PropertyType.StructuredProperty, key: 'prop1' },
-    { name: 'Prop 2', type: PropertyType.StructuredProperty, key: 'prop2' },
+const mockStructuredProperties: AssetProperty[] = [
+    { name: 'Prop 1', type: SummaryElementType.StructuredProperty, key: 'prop1' },
+    { name: 'Prop 2', type: SummaryElementType.StructuredProperty, key: 'prop2' },
 ];
 
 describe('useStructuredPropertiesMenuItems', () => {
     beforeEach(() => {
         vi.useFakeTimers();
+        vi.clearAllMocks();
+        (usePageTemplateContext as any).mockReturnValue({ summaryElements: [] });
     });
 
     afterEach(() => {
@@ -106,5 +112,89 @@ describe('useStructuredPropertiesMenuItems', () => {
         rerender();
 
         expect(result.current.some((item) => item.key === 'noResults')).toBe(true);
+    });
+
+    it('should filter out structured properties that are already visible in summaryElements', () => {
+        const visibleProperty: AssetProperty = {
+            name: 'Visible Prop',
+            type: SummaryElementType.StructuredProperty,
+            key: 'visible',
+            structuredProperty: { urn: 'urn:li:structuredProperty:visible' } as any,
+        };
+        const nonVisibleProperty: AssetProperty = {
+            name: 'Non Visible Prop',
+            type: SummaryElementType.StructuredProperty,
+            key: 'nonVisible',
+            structuredProperty: { urn: 'urn:li:structuredProperty:nonVisible' } as any,
+        };
+        (usePageTemplateContext as any).mockReturnValue({
+            summaryElements: [{ structuredProperty: { urn: 'urn:li:structuredProperty:visible' } }],
+        });
+        (useStructuredPropertiesV2 as any).mockReturnValue({
+            structuredProperties: [visibleProperty, nonVisibleProperty],
+            loading: false,
+        });
+        const { result } = renderHook(() => useStructuredPropertiesMenuItems(vi.fn()));
+        // Should only show non-visible property (plus search bar)
+        expect(result.current.length).toBe(2);
+        expect(result.current[1].key).toBe('nonVisible');
+    });
+
+    it('should reset query and hasAnyStructuredProperties when summaryElements changes', () => {
+        (useStructuredPropertiesV2 as any).mockReturnValue({
+            structuredProperties: mockStructuredProperties,
+            loading: false,
+        });
+        const { rerender } = renderHook(() => useStructuredPropertiesMenuItems(vi.fn()));
+
+        // Initial render with empty summaryElements
+        (usePageTemplateContext as any).mockReturnValue({ summaryElements: [] });
+        rerender();
+
+        // Change summaryElements - this should trigger reset of query and hasAnyStructuredProperties
+        (usePageTemplateContext as any).mockReturnValue({
+            summaryElements: [{ type: SummaryElementType.Tags }],
+        });
+        rerender();
+
+        // Verify hasAnyStructuredProperties was reset by checking menu items are rebuilt
+        const { result } = renderHook(() => useStructuredPropertiesMenuItems(vi.fn()));
+        // After reset, the menu should still have search bar as first item
+        expect(result.current[0].key).toBe('search');
+    });
+
+    it('should update filtered properties when summaryElements changes', () => {
+        const property1: AssetProperty = {
+            name: 'Prop 1',
+            type: SummaryElementType.StructuredProperty,
+            key: 'prop1',
+            structuredProperty: { urn: 'urn:li:structuredProperty:1' } as any,
+        };
+        const property2: AssetProperty = {
+            name: 'Prop 2',
+            type: SummaryElementType.StructuredProperty,
+            key: 'prop2',
+            structuredProperty: { urn: 'urn:li:structuredProperty:2' } as any,
+        };
+
+        (useStructuredPropertiesV2 as any).mockReturnValue({
+            structuredProperties: [property1, property2],
+            loading: false,
+        });
+
+        const { result, rerender } = renderHook(() => useStructuredPropertiesMenuItems(vi.fn()));
+
+        // Initially no visible elements
+        (usePageTemplateContext as any).mockReturnValue({ summaryElements: [] });
+        rerender();
+        expect(result.current.length).toBe(3); // search bar + 2 properties
+
+        // Add property1 to summary
+        (usePageTemplateContext as any).mockReturnValue({
+            summaryElements: [{ structuredProperty: { urn: 'urn:li:structuredProperty:1' } }],
+        });
+        rerender();
+        expect(result.current.length).toBe(2); // search bar + 1 property
+        expect(result.current[1].key).toBe('prop2');
     });
 });

--- a/datahub-web-react/src/app/entityV2/summary/properties/menuAddProperty/hooks/useAddPropertyMenuItems.ts
+++ b/datahub-web-react/src/app/entityV2/summary/properties/menuAddProperty/hooks/useAddPropertyMenuItems.ts
@@ -7,13 +7,33 @@ import useBasicAssetProperties from '@app/entityV2/summary/properties/hooks/useB
 import useStructuredPropertiesMenuItems from '@app/entityV2/summary/properties/menuAddProperty/hooks/useStructuredPropertiesMenuItems';
 import { AssetProperty } from '@app/entityV2/summary/properties/types';
 import { assetPropertyToMenuItem } from '@app/entityV2/summary/properties/utils';
+import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
 
 export default function useAddPropertyMenuItems(onClick: (property: AssetProperty) => void): ItemType[] {
     const basicAssetProperties = useBasicAssetProperties();
+    const { summaryElements } = usePageTemplateContext();
     const structuredPropertiesMenuItems = useStructuredPropertiesMenuItems(onClick);
 
     const menuItems: ItemType[] = useMemo(() => {
-        const items = basicAssetProperties.map((assetProperty) => assetPropertyToMenuItem(assetProperty, onClick));
+        const visiblePropertyTypes = new Set(summaryElements?.map((el) => el.type) ?? []);
+        const visibleStructuredPropertyUrns = new Set(
+            summaryElements
+                ?.filter((el) => el.structuredProperty)
+                .map((el) => el.structuredProperty?.urn)
+                .filter((urn): urn is string => urn !== undefined) ?? [],
+        );
+
+        const items = basicAssetProperties
+            .filter((assetProperty) => {
+                if (visiblePropertyTypes.has(assetProperty.type)) {
+                    return false;
+                }
+                if (assetProperty.structuredProperty) {
+                    return !visibleStructuredPropertyUrns.has(assetProperty.structuredProperty.urn);
+                }
+                return true;
+            })
+            .map((assetProperty) => assetPropertyToMenuItem(assetProperty, onClick));
 
         if (structuredPropertiesMenuItems.length > 0) {
             items.push({
@@ -26,7 +46,7 @@ export default function useAddPropertyMenuItems(onClick: (property: AssetPropert
         }
 
         return sortMenuItems(items);
-    }, [onClick, basicAssetProperties, structuredPropertiesMenuItems]);
+    }, [onClick, basicAssetProperties, structuredPropertiesMenuItems, summaryElements]);
 
     return menuItems;
 }

--- a/datahub-web-react/src/app/entityV2/summary/properties/menuAddProperty/hooks/useStructuredPropertiesMenuItems.tsx
+++ b/datahub-web-react/src/app/entityV2/summary/properties/menuAddProperty/hooks/useStructuredPropertiesMenuItems.tsx
@@ -10,9 +10,11 @@ import MenuNoResultsFound from '@app/entityV2/summary/properties/menuAddProperty
 import MenuSearchBar from '@app/entityV2/summary/properties/menuAddProperty/components/MenuSearchBar';
 import { AssetProperty } from '@app/entityV2/summary/properties/types';
 import { assetPropertyToMenuItem } from '@app/entityV2/summary/properties/utils';
+import { usePageTemplateContext } from '@app/homeV3/context/PageTemplateContext';
 import { DEBOUNCE_SEARCH_MS } from '@app/shared/constants';
 
 export default function useStructuredPropertiesMenuItems(onClick: (property: AssetProperty) => void) {
+    const { summaryElements } = usePageTemplateContext();
     const [query, setQuery] = useState<string>('');
     const [debouncedQuery, setDebouncedQuery] = useState<string>('');
     // The flag used to return empty menu if an asset have no any structured properties
@@ -30,11 +32,40 @@ export default function useStructuredPropertiesMenuItems(onClick: (property: Ass
         [onClick],
     );
 
+    const visibleStructuredPropertyUrns = useMemo(
+        () =>
+            new Set(
+                summaryElements
+                    ?.filter((el) => el.structuredProperty)
+                    .map((el) => el.structuredProperty?.urn)
+                    .filter((urn): urn is string => urn !== undefined) ?? [],
+            ),
+        [summaryElements],
+    );
+
+    const filteredProperties = useMemo(
+        () =>
+            structuredProperties.filter((assetProperty) => {
+                if (assetProperty.structuredProperty) {
+                    return !visibleStructuredPropertyUrns.has(assetProperty.structuredProperty.urn);
+                }
+                return true;
+            }),
+        [structuredProperties, visibleStructuredPropertyUrns],
+    );
+
+    // Reset `hasAnyStructuredProperties` and `query` to recompute `hasAnyStructuredProperties`
+    // after updating of structured properties
     useEffect(() => {
-        if (!hasAnyStructuredProperties && structuredProperties.length > 0) {
+        setHasAnyStructuredProperties(false);
+        setQuery('');
+    }, [visibleStructuredPropertyUrns]);
+
+    useEffect(() => {
+        if (!hasAnyStructuredProperties && filteredProperties.length > 0) {
             setHasAnyStructuredProperties(true);
         }
-    }, [structuredProperties, hasAnyStructuredProperties]);
+    }, [filteredProperties, hasAnyStructuredProperties]);
 
     const noResultsFoundItem: ItemType = useMemo(
         () => ({
@@ -48,8 +79,8 @@ export default function useStructuredPropertiesMenuItems(onClick: (property: Ass
     );
 
     const shouldShowNoResultsFound = useMemo(
-        () => !!query && structuredProperties.length === 0,
-        [query, structuredProperties],
+        () => !!query && filteredProperties.length === 0,
+        [query, filteredProperties],
     );
 
     const searchBarItem: ItemType = useMemo(
@@ -79,11 +110,13 @@ export default function useStructuredPropertiesMenuItems(onClick: (property: Ass
         [],
     );
 
-    const structuredPropertyMenuItems = useMemo(() => {
-        return sortMenuItems(
-            structuredProperties.map((assetProperty) => assetPropertyToMenuItem(assetProperty, onMenuItemClick)),
-        );
-    }, [structuredProperties, onMenuItemClick]);
+    const structuredPropertyMenuItems = useMemo(
+        () =>
+            sortMenuItems(
+                filteredProperties.map((assetProperty) => assetPropertyToMenuItem(assetProperty, onMenuItemClick)),
+            ),
+        [filteredProperties, onMenuItemClick],
+    );
 
     const shouldShowLoading = useMemo(
         () => loading && structuredProperties.length === 0,

--- a/datahub-web-react/src/app/entityV2/summary/properties/menuProperty/__tests__/usePropertyMenuItems.test.ts
+++ b/datahub-web-react/src/app/entityV2/summary/properties/menuProperty/__tests__/usePropertyMenuItems.test.ts
@@ -58,4 +58,23 @@ describe('usePropertyMenuItems', () => {
             currentElementType: SummaryElementType.Created,
         });
     });
+
+    it('should only show remove item when addPropertyMenuItems is empty', () => {
+        (useAddPropertyMenuItems as any).mockReturnValue([]);
+        const { result } = renderHook(() => usePropertyMenuItems(0, SummaryElementType.Created));
+        expect(result.current).toHaveLength(1);
+        const removeItem = result.current[0] as MenuItemType;
+        expect(removeItem.key).toBe('remove');
+        expect(result.current.some((item) => item.key === 'replace')).toBe(false);
+    });
+
+    it('should show replace item at the beginning when addPropertyMenuItems is not empty', () => {
+        (useAddPropertyMenuItems as any).mockReturnValue(mockAddPropertyMenuItems);
+        const { result } = renderHook(() => usePropertyMenuItems(0, SummaryElementType.Created));
+        expect(result.current).toHaveLength(2);
+        const replaceItem = result.current[0] as MenuItemType;
+        expect(replaceItem.key).toBe('replace');
+        const removeItem = result.current[1] as MenuItemType;
+        expect(removeItem.key).toBe('remove');
+    });
 });

--- a/datahub-web-react/src/app/entityV2/summary/properties/menuProperty/usePropertyMenuItems.ts
+++ b/datahub-web-react/src/app/entityV2/summary/properties/menuProperty/usePropertyMenuItems.ts
@@ -32,18 +32,22 @@ export default function usePropertyMenuItems(position: number, elementType: Summ
         const items: ItemType[] = [
             {
                 type: 'item',
-                key: 'replace',
-                title: 'Replace Property',
-                children: addPropertyMenuItems,
-            },
-            {
-                type: 'item',
                 key: 'remove',
                 title: 'Remove',
                 onClick: onRemove,
                 danger: true,
             },
         ];
+
+        if (addPropertyMenuItems.length > 0) {
+            // add to the beginning
+            items.unshift({
+                type: 'item',
+                key: 'replace',
+                title: 'Replace Property',
+                children: addPropertyMenuItems,
+            });
+        }
 
         return items;
     }, [addPropertyMenuItems, onRemove]);


### PR DESCRIPTION
Linear: https://linear.app/acryl-data/issue/CAT-1502/duplicate-properties-can-be-added-to-domain-summary-due-to-missing

This PR hides already visible properties from Add Property and Replace Property menus

Ported from SaaS - https://github.com/acryldata/datahub-fork/pull/8577

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
