### PR TITLE
fix(analytics): strip URN prefix from platform name in daily report

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/telemetry/DailyReport.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/telemetry/DailyReport.java
@@ -4,6 +4,7 @@ import static com.linkedin.gms.factory.telemetry.TelemetryUtils.*;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.datahub.graphql.analytics.service.AnalyticsService;
 import com.linkedin.datahub.graphql.generated.DateRange;
 import com.linkedin.datahub.graphql.generated.EntityType;
@@ -18,6 +19,7 @@ import com.mixpanel.mixpanelapi.MixpanelAPI;
 import io.datahubproject.metadata.context.OperationContext;
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -356,7 +358,7 @@ public class DailyReport {
 
       // Add platform distribution as flattened properties
       for (NamedBar bar : platformBars) {
-        String platformName = bar.getName();
+        String platformName = extractPlatformName(bar.getName());
 
         // Add null/bounds check
         if (bar.getSegments() == null || bar.getSegments().isEmpty()) {
@@ -375,6 +377,22 @@ public class DailyReport {
     } catch (Exception e) {
       log.warn("Failed to collect platform statistics: {}", e.getMessage());
       report.put("platform_count", 0);
+    }
+  }
+
+  /**
+   * Extracts the platform name from a DataPlatform URN. Uses DataPlatformUrn for proper parsing,
+   * falling back to the raw value if the URN is malformed — this is telemetry code so we'd rather
+   * report a degraded name than lose the data point entirely.
+   */
+  private String extractPlatformName(String platformValue) {
+    if (platformValue == null) {
+      return null;
+    }
+    try {
+      return DataPlatformUrn.createFromString(platformValue).getPlatformNameEntity();
+    } catch (URISyntaxException e) {
+      return platformValue;
     }
   }
 

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/telemetry/DailyReportTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/telemetry/DailyReportTest.java
@@ -327,6 +327,40 @@ public class DailyReportTest {
             input, expectedOutput, result));
   }
 
+  @DataProvider(name = "extractPlatformNameTestCases")
+  public Object[][] extractPlatformNameTestCases() {
+    return new Object[][] {
+      // Valid URNs should return just the platform name
+      {"urn:li:dataPlatform:snowflake", "snowflake"},
+      {"urn:li:dataPlatform:bigquery", "bigquery"},
+      {"urn:li:dataPlatform:mysql", "mysql"},
+      {"urn:li:dataPlatform:custom-platform", "custom-platform"},
+      // Malformed URNs should fall back to the raw value
+      {"not-a-urn", "not-a-urn"},
+      {"urn:li:dataset:foo", "urn:li:dataset:foo"},
+      {"", ""},
+      // Null should return null
+      {null, null},
+    };
+  }
+
+  @Test(dataProvider = "extractPlatformNameTestCases")
+  public void testExtractPlatformName(String input, String expected) throws Exception {
+    DailyReport dailyReport = createDailyReportForTesting();
+
+    java.lang.reflect.Method method =
+        DailyReport.class.getDeclaredMethod("extractPlatformName", String.class);
+    method.setAccessible(true);
+
+    String result = (String) method.invoke(dailyReport, input);
+    assertEquals(
+        result,
+        expected,
+        String.format(
+            "extractPlatformName(\"%s\") should return \"%s\" but got \"%s\"",
+            input, expected, result));
+  }
+
   @Test
   public void testAnonymizeToBucketBoundaries() throws Exception {
     DailyReport dailyReport = createDailyReportForTesting();


### PR DESCRIPTION
## Summary
- The `platform.keyword` field from ES contains full URNs (e.g. `urn:li:dataPlatform:snowflake`), so the platform name was never being used correctly since the URN prefix consumed the useful portion of the string
- Now extracts the platform name via `DataPlatformUrn` before use, with a graceful fallback for malformed URNs
- Added unit tests for `extractPlatformName`

## Test plan
- [x] Unit tests pass (`DailyReportTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)