### PR TITLE
fix(docker): remove UV_CONSTRAINT from datahub-ingestion Dockerfile

### DIFF
--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -179,7 +179,6 @@ RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_u
 FROM add-code-slim AS final-slim
 
 ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
-ENV UV_CONSTRAINT=/metadata-ingestion/constraints.txt
 
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \
     UV_LINK_MODE=copy uv pip install -e "/metadata-ingestion/[base,datahub-rest,datahub-kafka,snowflake,bigquery,redshift,mysql,postgres,s3-slim,gcs-slim,abs-slim,clickhouse,glue,dbt,looker,lookml,tableau,powerbi,superset,datahub-business-glossary]" && \
@@ -188,7 +187,6 @@ RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private 
 FROM add-code-full AS final-full
 
 ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
-ENV UV_CONSTRAINT=/metadata-ingestion/constraints.txt
 
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \
     UV_LINK_MODE=copy uv pip install \
@@ -198,7 +196,6 @@ RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private 
 FROM add-code-locked AS final-locked
 
 ENV UV_BUILD_CONSTRAINT=/metadata-ingestion/build-constraints.txt
-ENV UV_CONSTRAINT=/metadata-ingestion/constraints.txt
 
 # Locked variant: minimal install with s3-slim, network will be blocked
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,sharing=private \


### PR DESCRIPTION
Version-matched constraints are now fetched at runtime from GitHub per CLI version in acryl-executor's runner.py. ENV UV_CONSTRAINT in the Dockerfile is no longer needed.

Reverts #16498.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
