### PR TITLE
feat: Entity Change Event Generator for structured properties

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/StructuredPropertyChangeEvent.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/StructuredPropertyChangeEvent.java
@@ -1,0 +1,41 @@
+package com.linkedin.metadata.timeline.data.entity;
+
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.timeline.data.ChangeCategory;
+import com.linkedin.metadata.timeline.data.ChangeEvent;
+import com.linkedin.metadata.timeline.data.ChangeOperation;
+import com.linkedin.metadata.timeline.data.SemanticChangeType;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+
+@EqualsAndHashCode(callSuper = true)
+@Value
+@NonFinal
+@Getter
+public class StructuredPropertyChangeEvent extends ChangeEvent {
+  @Builder(builderMethodName = "entityStructuredPropertyChangeEventBuilder")
+  public StructuredPropertyChangeEvent(
+      String entityUrn,
+      ChangeCategory category,
+      ChangeOperation operation,
+      String modifier,
+      AuditStamp auditStamp,
+      SemanticChangeType semVerChange,
+      String description,
+      Urn propertyUrn) {
+    super(
+        entityUrn,
+        category,
+        operation,
+        modifier,
+        ImmutableMap.of("propertyUrn", propertyUrn.toString()),
+        auditStamp,
+        semVerChange,
+        description);
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/StructuredPropertiesChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/StructuredPropertiesChangeEventGenerator.java
@@ -1,0 +1,139 @@
+package com.linkedin.metadata.timeline.eventgenerator;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.timeline.data.ChangeCategory;
+import com.linkedin.metadata.timeline.data.ChangeEvent;
+import com.linkedin.metadata.timeline.data.ChangeOperation;
+import com.linkedin.metadata.timeline.data.SemanticChangeType;
+import com.linkedin.metadata.timeline.data.entity.StructuredPropertyChangeEvent;
+import com.linkedin.structured.PrimitivePropertyValue;
+import com.linkedin.structured.StructuredProperties;
+import com.linkedin.structured.StructuredPropertyValueAssignment;
+import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+public class StructuredPropertiesChangeEventGenerator
+    extends EntityChangeEventGenerator<StructuredProperties> {
+
+  private static final String PROPERTY_VALUE_ADDED_FORMAT =
+      "Structured property '%s' value added on entity '%s'.";
+  private static final String PROPERTY_VALUE_REMOVED_FORMAT =
+      "Structured property '%s' value removed from entity '%s'.";
+
+  public static List<ChangeEvent> computeDiffs(
+      StructuredProperties baseProps,
+      StructuredProperties targetProps,
+      String entityUrn,
+      AuditStamp auditStamp) {
+    Map<String, StructuredPropertyValueAssignment> baseMap =
+        toMap(
+            baseProps != null
+                ? baseProps.getProperties()
+                : new StructuredPropertyValueAssignmentArray());
+    Map<String, StructuredPropertyValueAssignment> targetMap =
+        toMap(
+            targetProps != null
+                ? targetProps.getProperties()
+                : new StructuredPropertyValueAssignmentArray());
+
+    List<ChangeEvent> changeEvents = new ArrayList<>();
+
+    // Properties present in target (added or value-changed)
+    for (Map.Entry<String, StructuredPropertyValueAssignment> entry : targetMap.entrySet()) {
+      StructuredPropertyValueAssignment target = entry.getValue();
+      StructuredPropertyValueAssignment base = baseMap.get(entry.getKey());
+
+      Set<PrimitivePropertyValue> baseValues =
+          base != null ? new HashSet<>(base.getValues()) : new HashSet<>();
+      Set<PrimitivePropertyValue> targetValues = new HashSet<>(target.getValues());
+
+      // Emit ADD for each value that is new
+      for (PrimitivePropertyValue value : targetValues) {
+        if (!baseValues.contains(value)) {
+          changeEvents.add(
+              buildEvent(
+                  target.getPropertyUrn(),
+                  entityUrn,
+                  ChangeOperation.ADD,
+                  PROPERTY_VALUE_ADDED_FORMAT,
+                  auditStamp));
+          break; // one event per property per operation direction is sufficient
+        }
+      }
+
+      // Emit REMOVE for each value that was dropped
+      for (PrimitivePropertyValue value : baseValues) {
+        if (!targetValues.contains(value)) {
+          changeEvents.add(
+              buildEvent(
+                  target.getPropertyUrn(),
+                  entityUrn,
+                  ChangeOperation.REMOVE,
+                  PROPERTY_VALUE_REMOVED_FORMAT,
+                  auditStamp));
+          break;
+        }
+      }
+    }
+
+    // Properties fully removed
+    for (Map.Entry<String, StructuredPropertyValueAssignment> entry : baseMap.entrySet()) {
+      if (!targetMap.containsKey(entry.getKey())) {
+        changeEvents.add(
+            buildEvent(
+                entry.getValue().getPropertyUrn(),
+                entityUrn,
+                ChangeOperation.REMOVE,
+                PROPERTY_VALUE_REMOVED_FORMAT,
+                auditStamp));
+      }
+    }
+
+    return changeEvents;
+  }
+
+  private static Map<String, StructuredPropertyValueAssignment> toMap(
+      StructuredPropertyValueAssignmentArray assignments) {
+    Map<String, StructuredPropertyValueAssignment> map = new HashMap<>();
+    for (StructuredPropertyValueAssignment a : assignments) {
+      map.put(a.getPropertyUrn().toString(), a);
+    }
+    return map;
+  }
+
+  private static ChangeEvent buildEvent(
+      Urn propertyUrn,
+      String entityUrn,
+      ChangeOperation operation,
+      String format,
+      AuditStamp auditStamp) {
+    return StructuredPropertyChangeEvent.entityStructuredPropertyChangeEventBuilder()
+        .modifier(propertyUrn.toString())
+        .entityUrn(entityUrn)
+        .category(ChangeCategory.STRUCTURED_PROPERTY)
+        .operation(operation)
+        .semVerChange(SemanticChangeType.MINOR)
+        .description(String.format(format, propertyUrn.getId(), entityUrn))
+        .propertyUrn(propertyUrn)
+        .auditStamp(auditStamp)
+        .build();
+  }
+
+  @Override
+  public List<ChangeEvent> getChangeEvents(
+      @Nonnull Urn urn,
+      @Nonnull String entity,
+      @Nonnull String aspect,
+      @Nonnull Aspect<StructuredProperties> from,
+      @Nonnull Aspect<StructuredProperties> to,
+      @Nonnull AuditStamp auditStamp) {
+    return computeDiffs(from.getValue(), to.getValue(), urn.toString(), auditStamp);
+  }
+}

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
@@ -65,6 +65,7 @@ public class EntityChangeEventGeneratorHook implements MetadataChangeLogHook {
           Constants.DATA_PROCESS_INSTANCE_RUN_EVENT_ASPECT_NAME,
           Constants.BUSINESS_ATTRIBUTE_INFO_ASPECT_NAME,
           Constants.BUSINESS_ATTRIBUTE_ASPECT,
+          Constants.STRUCTURED_PROPERTIES_ASPECT_NAME,
 
           // Entity Lifecycle Event
           Constants.DATASET_KEY_ASPECT_NAME,

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
@@ -60,6 +60,11 @@ import com.linkedin.mxe.PlatformEventHeader;
 import com.linkedin.platform.event.v1.EntityChangeEvent;
 import com.linkedin.platform.event.v1.Parameters;
 import com.linkedin.schema.*;
+import com.linkedin.structured.PrimitivePropertyValue;
+import com.linkedin.structured.PrimitivePropertyValueArray;
+import com.linkedin.structured.StructuredProperties;
+import com.linkedin.structured.StructuredPropertyValueAssignment;
+import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.net.URISyntaxException;
@@ -675,6 +680,151 @@ public class EntityChangeEventGeneratorHookTest {
   }
 
   @Test
+  public void testInvokeStructuredPropertyAdd() throws Exception {
+    final Urn propertyUrn = Urn.createFromString("urn:li:structuredProperty:io.acryl.testProperty");
+
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setAspectName(STRUCTURED_PROPERTIES_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+    event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    PrimitivePropertyValue value = new PrimitivePropertyValue();
+    value.setString("testValue");
+    StructuredPropertyValueAssignment assignment =
+        new StructuredPropertyValueAssignment()
+            .setPropertyUrn(propertyUrn)
+            .setValues(new PrimitivePropertyValueArray(ImmutableList.of(value)));
+    StructuredProperties newProps =
+        new StructuredProperties()
+            .setProperties(
+                new StructuredPropertyValueAssignmentArray(ImmutableList.of(assignment)));
+
+    event.setAspect(GenericRecordUtils.serializeAspect(newProps));
+    // No previous aspect — first time property is set
+
+    _entityChangeEventHook.invoke(event);
+
+    PlatformEvent platformEvent =
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.STRUCTURED_PROPERTY,
+            ChangeOperation.ADD,
+            propertyUrn.toString(),
+            ImmutableMap.of("propertyUrn", propertyUrn.toString()),
+            actorUrn);
+
+    verifyProducePlatformEvent(_mockClient, platformEvent);
+  }
+
+  @Test
+  public void testInvokeStructuredPropertyRemove() throws Exception {
+    final Urn propertyUrn = Urn.createFromString("urn:li:structuredProperty:io.acryl.testProperty");
+
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setAspectName(STRUCTURED_PROPERTIES_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+    event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    PrimitivePropertyValue value = new PrimitivePropertyValue();
+    value.setString("testValue");
+    StructuredPropertyValueAssignment assignment =
+        new StructuredPropertyValueAssignment()
+            .setPropertyUrn(propertyUrn)
+            .setValues(new PrimitivePropertyValueArray(ImmutableList.of(value)));
+    StructuredProperties prevProps =
+        new StructuredProperties()
+            .setProperties(
+                new StructuredPropertyValueAssignmentArray(ImmutableList.of(assignment)));
+    StructuredProperties newProps =
+        new StructuredProperties().setProperties(new StructuredPropertyValueAssignmentArray());
+
+    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(prevProps));
+    event.setAspect(GenericRecordUtils.serializeAspect(newProps));
+
+    _entityChangeEventHook.invoke(event);
+
+    PlatformEvent platformEvent =
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.STRUCTURED_PROPERTY,
+            ChangeOperation.REMOVE,
+            propertyUrn.toString(),
+            ImmutableMap.of("propertyUrn", propertyUrn.toString()),
+            actorUrn);
+
+    verifyProducePlatformEvent(_mockClient, platformEvent);
+  }
+
+  @Test
+  public void testInvokeStructuredPropertyUpsert() throws Exception {
+    final Urn propertyUrn = Urn.createFromString("urn:li:structuredProperty:io.acryl.testProperty");
+
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setAspectName(STRUCTURED_PROPERTIES_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+    event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    PrimitivePropertyValue oldValue = new PrimitivePropertyValue();
+    oldValue.setString("oldValue");
+    PrimitivePropertyValue newValue = new PrimitivePropertyValue();
+    newValue.setString("newValue");
+
+    StructuredPropertyValueAssignment prevAssignment =
+        new StructuredPropertyValueAssignment()
+            .setPropertyUrn(propertyUrn)
+            .setValues(new PrimitivePropertyValueArray(ImmutableList.of(oldValue)));
+    StructuredPropertyValueAssignment newAssignment =
+        new StructuredPropertyValueAssignment()
+            .setPropertyUrn(propertyUrn)
+            .setValues(new PrimitivePropertyValueArray(ImmutableList.of(newValue)));
+
+    StructuredProperties prevProps =
+        new StructuredProperties()
+            .setProperties(
+                new StructuredPropertyValueAssignmentArray(ImmutableList.of(prevAssignment)));
+    StructuredProperties newProps =
+        new StructuredProperties()
+            .setProperties(
+                new StructuredPropertyValueAssignmentArray(ImmutableList.of(newAssignment)));
+
+    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(prevProps));
+    event.setAspect(GenericRecordUtils.serializeAspect(newProps));
+
+    _entityChangeEventHook.invoke(event);
+
+    // Value changed: expect both a REMOVE (old value dropped) and an ADD (new value added)
+    PlatformEvent addEvent =
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.STRUCTURED_PROPERTY,
+            ChangeOperation.ADD,
+            propertyUrn.toString(),
+            ImmutableMap.of("propertyUrn", propertyUrn.toString()),
+            actorUrn);
+    verifyProducePlatformEvent(_mockClient, addEvent, false);
+
+    PlatformEvent removeEvent =
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.STRUCTURED_PROPERTY,
+            ChangeOperation.REMOVE,
+            propertyUrn.toString(),
+            ImmutableMap.of("propertyUrn", propertyUrn.toString()),
+            actorUrn);
+    verifyProducePlatformEvent(_mockClient, removeEvent, true);
+  }
+
+  @Test
   public void testInvokeIneligibleAspect() throws Exception {
     MetadataChangeLog event = new MetadataChangeLog();
     event.setEntityType(DATASET_ENTITY_NAME);
@@ -1127,6 +1277,10 @@ public class EntityChangeEventGeneratorHookTest {
         DATA_PROCESS_INSTANCE_RUN_EVENT_ASPECT_NAME,
         new DataProcessInstanceRunEventChangeEventGenerator(
             mock(OperationContext.class), entityClient));
+
+    // Structured property change event generators
+    registry.register(
+        STRUCTURED_PROPERTIES_ASPECT_NAME, new StructuredPropertiesChangeEventGenerator());
     return registry;
   }
 
@@ -1173,6 +1327,10 @@ public class EntityChangeEventGeneratorHookTest {
     AspectSpec mockEditableSchemaMetadata = createMockAspectSpec(EditableSchemaMetadata.class);
     Mockito.when(datasetSpec.getAspectSpec(eq(EDITABLE_SCHEMA_METADATA_ASPECT_NAME)))
         .thenReturn(mockEditableSchemaMetadata);
+
+    AspectSpec mockStructuredProperties = createMockAspectSpec(StructuredProperties.class);
+    Mockito.when(datasetSpec.getAspectSpec(eq(STRUCTURED_PROPERTIES_ASPECT_NAME)))
+        .thenReturn(mockStructuredProperties);
 
     Mockito.when(registry.getEntitySpec(eq(DATASET_ENTITY_NAME))).thenReturn(datasetSpec);
 

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/timeline/eventgenerator/EntityChangeEventGeneratorRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/timeline/eventgenerator/EntityChangeEventGeneratorRegistryFactory.java
@@ -22,6 +22,7 @@ import com.linkedin.metadata.timeline.eventgenerator.OwnershipChangeEventGenerat
 import com.linkedin.metadata.timeline.eventgenerator.SchemaMetadataChangeEventGenerator;
 import com.linkedin.metadata.timeline.eventgenerator.SingleDomainChangeEventGenerator;
 import com.linkedin.metadata.timeline.eventgenerator.StatusChangeEventGenerator;
+import com.linkedin.metadata.timeline.eventgenerator.StructuredPropertiesChangeEventGenerator;
 import io.datahubproject.metadata.context.OperationContext;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,6 +62,8 @@ public class EntityChangeEventGeneratorRegistryFactory {
     registry.register(
         BUSINESS_ATTRIBUTE_ASSOCIATION, new BusinessAttributeAssociationChangeEventGenerator());
     registry.register(BUSINESS_ATTRIBUTE_ASPECT, new BusinessAttributesChangeEventGenerator());
+    registry.register(
+        STRUCTURED_PROPERTIES_ASPECT_NAME, new StructuredPropertiesChangeEventGenerator());
 
     // Entity Lifecycle Differs
     registry.register(DATASET_KEY_ASPECT_NAME, new EntityKeyChangeEventGenerator<>());

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/data/ChangeCategory.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/timeline/data/ChangeCategory.java
@@ -27,6 +27,8 @@ public enum ChangeCategory {
 
   BUSINESS_ATTRIBUTE,
   // Parent relationship changes (for hierarchical entities like documents)
+  // Add or remove a structured property value on an entity
+  STRUCTURED_PROPERTY,
   PARENT,
   // Related entities changes (Currently used for document related assets, related documents, etc.)
   RELATED_ENTITIES;


### PR DESCRIPTION
Modifying structured properties wasn't producing change events, which are crucial for audit purposes.
This feature implements change events so that every Upsert or Removal of structured properties from assets generates ADD and/or REMOVE events according to the diff of the change.
