### PR TITLE
fix(ui/entity-header): Fix context path overflow on entity header

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/header/DefaultEntityHeader.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/header/DefaultEntityHeader.tsx
@@ -24,7 +24,7 @@ import { useEntityRegistry } from '@app/useEntityRegistry';
 import { DataPlatform, DisplayProperties, Domain, EntityType, Post } from '@types';
 
 export const TitleWrapper = styled.div`
-    max-width: 100%;
+    min-width: 0;
 
     display: flex;
     align-items: center;


### PR DESCRIPTION
We added the `<EntityBackButton />` to the parent of `TitleWrapper` which makes `max-width: 100%` incorrect. I think this was initially put in just to ensure `TitleWrapper` would properly shrink beyond its `flex-basis`, so `min-width: 0` should do the trick.

<img width="751" height="82" alt="Screenshot 2026-03-13 at 9 21 57 AM" src="https://github.com/user-attachments/assets/42c11c7d-e1e3-4225-871f-156a97d5518c" />
<img width="744" height="83" alt="Screenshot 2026-03-13 at 9 24 31 AM" src="https://github.com/user-attachments/assets/b52a64a4-6326-488a-bc5f-75ac31108b6e" />

Note that in the pics above, everything is also shifted to the right. That's because we also are removing overflow on the left side.



<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
