### PR TITLE
fix(ingestion/rdf): regenerate pyproject.toml and update lock files to include rdf plugin

### DIFF
--- a/metadata-ingestion/constraints.txt
+++ b/metadata-ingestion/constraints.txt
@@ -651,11 +651,12 @@ ipython==8.38.0
     #   ipywidgets
 ipywidgets==8.1.8
     # via acryl-great-expectations
-isodate==0.7.2
+isodate==0.6.1
     # via
     #   azure-mgmt-datafactory
     #   azure-storage-blob
     #   azure-storage-file-datalake
+    #   rdflib
     #   tableschema
     #   zeep
 isoduration==20.11.0
@@ -1220,6 +1221,7 @@ pyparsing==3.3.2
     # via
     #   acryl-great-expectations
     #   pyiceberg
+    #   rdflib
 pypdf==6.8.0
     # via unstructured-client
 pypdfium2==5.6.0
@@ -1349,6 +1351,8 @@ pyzmq==27.1.0
     #   jupyter-server
 rapidfuzz==3.14.3
     # via unstructured
+rdflib==6.3.2
+    # via acryl-datahub
 readme-renderer==44.0
     # via twine
 redash-toolbelt==0.1.9
@@ -1514,6 +1518,7 @@ six==1.17.0
     #   dataflows-tabulator
     #   ecdsa
     #   html5lib
+    #   isodate
     #   langdetect
     #   linear-tsv
     #   python-dateutil

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -1011,17 +1011,17 @@ qlik-sense = [
     "websocket-client<2.0.0",
 ]
 
+rdf = [
+    "rdflib==6.3.2",
+    "requests==2.32.5",
+    "requests_file==3.0.1",
+]
+
 redash = [
     "patchy==2.8.0",
     "redash-toolbelt<0.2.0",
     "sql-metadata<3.0.0",
     "sqlglot[c]==29.0.1",
-]
-
-rdf = [
-    "rdflib==6.3.2",
-    "requests==2.32.5",
-    "requests_file==3.0.1",
 ]
 
 redshift = [
@@ -1450,12 +1450,11 @@ all = [
     "pyspark~=3.5.6,<4.0.0",
     "python-ldap>=2.4,<4.0.0",
     "python-liquid<2",
-    "redash-toolbelt<0.2.0",
     "rdflib==6.3.2",
+    "redash-toolbelt<0.2.0",
     "redshift-connector>=2.1.5,<3.0.0",
     "requests-gssapi<2.0.0",
-    "requests>=2.28.0,<3.0.0",
-    "requests==2.32.5",
+    "requests>=2.28.0,==2.32.5,<3.0.0",
     "requests_file==3.0.1",
     "requests_ntlm<2.0.0",
     "schwifty<2026.0.0",
@@ -1618,15 +1617,13 @@ dev = [
     "python-ldap>=2.4,<4.0.0",
     "python-liquid<2",
     "PyYAML<7.0.0",
-    "redash-toolbelt<0.2.0",
     "rdflib==6.3.2",
+    "redash-toolbelt<0.2.0",
     "redshift-connector>=2.1.5,<3.0.0",
     "requests-gssapi<2.0.0",
     "requests-mock<2.0.0",
-    "requests<3.0.0",
-    "requests==2.32.5",
-    "requests_file<4.0.0",
-    "requests_file==3.0.1",
+    "requests==2.32.5,<3.0.0",
+    "requests_file==3.0.1,<4.0.0",
     "requests_ntlm<2.0.0",
     "ruamel.yaml<0.19.0",
     "ruff==0.11.7",
@@ -1812,15 +1809,13 @@ docs = [
     "python-ldap>=2.4,<4.0.0",
     "python-liquid<2",
     "PyYAML<7.0.0",
-    "redash-toolbelt<0.2.0",
     "rdflib==6.3.2",
+    "redash-toolbelt<0.2.0",
     "redshift-connector>=2.1.5,<3.0.0",
     "requests-gssapi<2.0.0",
     "requests-mock<2.0.0",
-    "requests<3.0.0",
-    "requests==2.32.5",
-    "requests_file<4.0.0",
-    "requests_file==3.0.1",
+    "requests==2.32.5,<3.0.0",
+    "requests_file==3.0.1,<4.0.0",
     "requests_ntlm<2.0.0",
     "ruamel.yaml<0.19.0",
     "ruff==0.11.7",
@@ -1947,10 +1942,9 @@ integration-tests = [
     "pyspark~=3.5.6,<4.0.0",
     "python-ldap>=2.4,<4.0.0",
     "pyzipper>=0.3.6,<1.0",
-    "redash-toolbelt<0.2.0",
     "rdflib==6.3.2",
-    "requests>=2.28.0,<3.0.0",
-    "requests==2.32.5",
+    "redash-toolbelt<0.2.0",
+    "requests>=2.28.0,==2.32.5,<3.0.0",
     "requests_file==3.0.1",
     "responses>=0.25.0,<1.0",
     "schwifty<2026.0.0",
@@ -2042,8 +2036,8 @@ doris = "datahub.ingestion.source.sql.doris.doris_source:DorisSource"
 okta = "datahub.ingestion.source.identity.okta:OktaSource"
 oracle = "datahub.ingestion.source.sql.oracle:OracleSource"
 postgres = "datahub.ingestion.source.sql.postgres:PostgresSource"
-redash = "datahub.ingestion.source.redash:RedashSource"
 rdf = "datahub.ingestion.source.rdf.ingestion.rdf_source:RDFSource"
+redash = "datahub.ingestion.source.redash:RedashSource"
 redshift = "datahub.ingestion.source.redshift.redshift:RedshiftSource"
 slack = "datahub.ingestion.source.slack.slack:SlackSource"
 snowflake = "datahub.ingestion.source.snowflake.snowflake_v2:SnowflakeV2Source"

--- a/metadata-ingestion/uv.lock
+++ b/metadata-ingestion/uv.lock
@@ -171,9 +171,11 @@ all = [
     { name = "pyspark" },
     { name = "python-ldap" },
     { name = "python-liquid" },
+    { name = "rdflib" },
     { name = "redash-toolbelt" },
     { name = "redshift-connector" },
     { name = "requests" },
+    { name = "requests-file" },
     { name = "requests-gssapi" },
     { name = "requests-ntlm" },
     { name = "schwifty" },
@@ -645,6 +647,7 @@ dev = [
     { name = "python-ldap" },
     { name = "python-liquid" },
     { name = "pyyaml" },
+    { name = "rdflib" },
     { name = "redash-toolbelt" },
     { name = "redshift-connector" },
     { name = "requests" },
@@ -835,6 +838,7 @@ docs = [
     { name = "python-ldap" },
     { name = "python-liquid" },
     { name = "pyyaml" },
+    { name = "rdflib" },
     { name = "redash-toolbelt" },
     { name = "redshift-connector" },
     { name = "requests" },
@@ -1199,8 +1203,10 @@ integration-tests = [
     { name = "pyspark" },
     { name = "python-ldap" },
     { name = "pyzipper" },
+    { name = "rdflib" },
     { name = "redash-toolbelt" },
     { name = "requests" },
+    { name = "requests-file" },
     { name = "responses" },
     { name = "schwifty" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1518,6 +1524,11 @@ qlik-sense = [
     { name = "requests" },
     { name = "sqlglot", extra = ["c"] },
     { name = "websocket-client" },
+]
+rdf = [
+    { name = "rdflib" },
+    { name = "requests" },
+    { name = "requests-file" },
 ]
 redash = [
     { name = "patchy" },
@@ -2872,6 +2883,11 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'testing-utils'", specifier = "<7.0.0" },
     { name = "pyzipper", marker = "extra == 'debug-recording'", specifier = ">=0.3.6,<1.0" },
     { name = "pyzipper", marker = "extra == 'integration-tests'", specifier = ">=0.3.6,<1.0" },
+    { name = "rdflib", marker = "extra == 'all'", specifier = "==6.3.2" },
+    { name = "rdflib", marker = "extra == 'dev'", specifier = "==6.3.2" },
+    { name = "rdflib", marker = "extra == 'docs'", specifier = "==6.3.2" },
+    { name = "rdflib", marker = "extra == 'integration-tests'", specifier = "==6.3.2" },
+    { name = "rdflib", marker = "extra == 'rdf'", specifier = "==6.3.2" },
     { name = "redash-toolbelt", marker = "extra == 'all'", specifier = "<0.2.0" },
     { name = "redash-toolbelt", marker = "extra == 'dev'", specifier = "<0.2.0" },
     { name = "redash-toolbelt", marker = "extra == 'docs'", specifier = "<0.2.0" },
@@ -2881,18 +2897,18 @@ requires-dist = [
     { name = "redshift-connector", marker = "extra == 'dev'", specifier = ">=2.1.5,<3.0.0" },
     { name = "redshift-connector", marker = "extra == 'docs'", specifier = ">=2.1.5,<3.0.0" },
     { name = "redshift-connector", marker = "extra == 'redshift'", specifier = ">=2.1.5,<3.0.0" },
-    { name = "requests", marker = "extra == 'all'", specifier = ">=2.28.0,<3.0.0" },
+    { name = "requests", marker = "extra == 'all'", specifier = ">=2.28.0,==2.32.5,<3.0.0" },
     { name = "requests", marker = "extra == 'databricks'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'datahub-debug'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'datahub-rest'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'dbt'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'dbt-cloud'", specifier = "<3.0.0" },
-    { name = "requests", marker = "extra == 'dev'", specifier = "<3.0.0" },
-    { name = "requests", marker = "extra == 'docs'", specifier = "<3.0.0" },
+    { name = "requests", marker = "extra == 'dev'", specifier = "==2.32.5,<3.0.0" },
+    { name = "requests", marker = "extra == 'docs'", specifier = "==2.32.5,<3.0.0" },
     { name = "requests", marker = "extra == 'dremio'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'fabric-onelake'", specifier = ">=2.28.0,<3.0" },
     { name = "requests", marker = "extra == 'grafana'", specifier = "<3.0.0" },
-    { name = "requests", marker = "extra == 'integration-tests'", specifier = ">=2.28.0,<3.0.0" },
+    { name = "requests", marker = "extra == 'integration-tests'", specifier = ">=2.28.0,==2.32.5,<3.0.0" },
     { name = "requests", marker = "extra == 'json-schema'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'kafka-connect'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'metabase'", specifier = "<3.0.0" },
@@ -2902,13 +2918,17 @@ requires-dist = [
     { name = "requests", marker = "extra == 'preset'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'pulsar'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'qlik-sense'", specifier = "<3.0.0" },
+    { name = "requests", marker = "extra == 'rdf'", specifier = "==2.32.5" },
     { name = "requests", marker = "extra == 'sac'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'sigma'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'superset'", specifier = "<3.0.0" },
     { name = "requests", marker = "extra == 'unity-catalog'", specifier = "<3.0.0" },
     { name = "requests-file", specifier = "<4.0.0" },
-    { name = "requests-file", marker = "extra == 'dev'", specifier = "<4.0.0" },
-    { name = "requests-file", marker = "extra == 'docs'", specifier = "<4.0.0" },
+    { name = "requests-file", marker = "extra == 'all'", specifier = "==3.0.1" },
+    { name = "requests-file", marker = "extra == 'dev'", specifier = "==3.0.1,<4.0.0" },
+    { name = "requests-file", marker = "extra == 'docs'", specifier = "==3.0.1,<4.0.0" },
+    { name = "requests-file", marker = "extra == 'integration-tests'", specifier = "==3.0.1" },
+    { name = "requests-file", marker = "extra == 'rdf'", specifier = "==3.0.1" },
     { name = "requests-gssapi", marker = "extra == 'all'", specifier = "<2.0.0" },
     { name = "requests-gssapi", marker = "extra == 'dev'", specifier = "<2.0.0" },
     { name = "requests-gssapi", marker = "extra == 'docs'", specifier = "<2.0.0" },
@@ -3440,7 +3460,7 @@ requires-dist = [
     { name = "zstd", marker = "extra == 'docs'", specifier = "<1.5.6.8" },
     { name = "zstd", marker = "extra == 'integration-tests'", specifier = "<1.5.6.8" },
 ]
-provides-extras = ["base", "abs", "abs-slim", "athena", "azure-ad", "azure-data-factory", "bigquery", "bigquery-queries", "bigquery-slim", "cassandra", "circuit-breaker", "clickhouse", "clickhouse-usage", "cockroachdb", "confluence", "databricks", "datahub", "datahub-business-glossary", "datahub-debug", "datahub-documents", "datahub-kafka", "datahub-lineage-file", "datahub-lite", "datahub-rest", "dataplex", "db2", "dbt", "dbt-cloud", "debug-recording", "delta-lake", "doris", "dremio", "druid", "dynamodb", "elasticsearch", "excel", "fabric-onelake", "feast", "fivetran", "gcs", "gcs-slim", "glue", "grafana", "hana", "hive", "hive-metastore", "iceberg", "iceberg-catalog", "json-schema", "kafka", "kafka-connect", "ldap", "looker", "lookml", "mariadb", "metabase", "mlflow", "mode", "mongodb", "mssql", "mssql-odbc", "mysql", "neo4j", "nifi", "notion", "okta", "oracle", "postgres", "powerbi", "powerbi-report-server", "preset", "presto", "presto-on-hive", "pulsar", "qlik-sense", "redash", "redshift", "s3", "s3-slim", "sac", "sagemaker", "salesforce", "sigma", "slack", "snaplogic", "snowflake", "snowflake-queries", "snowflake-slim", "snowflake-summary", "snowplow", "sql-parser", "sql-queries", "sqlalchemy", "starburst-trino-usage", "superset", "sync-file-emitter", "tableau", "teradata", "trino", "unity-catalog", "unstructured", "vertexai", "vertica", "all", "cloud", "dev", "docs", "lint", "testing-utils", "integration-tests", "debug"]
+provides-extras = ["base", "abs", "abs-slim", "athena", "azure-ad", "azure-data-factory", "bigquery", "bigquery-queries", "bigquery-slim", "cassandra", "circuit-breaker", "clickhouse", "clickhouse-usage", "cockroachdb", "confluence", "databricks", "datahub", "datahub-business-glossary", "datahub-debug", "datahub-documents", "datahub-kafka", "datahub-lineage-file", "datahub-lite", "datahub-rest", "dataplex", "db2", "dbt", "dbt-cloud", "debug-recording", "delta-lake", "doris", "dremio", "druid", "dynamodb", "elasticsearch", "excel", "fabric-onelake", "feast", "fivetran", "gcs", "gcs-slim", "glue", "grafana", "hana", "hive", "hive-metastore", "iceberg", "iceberg-catalog", "json-schema", "kafka", "kafka-connect", "ldap", "looker", "lookml", "mariadb", "metabase", "mlflow", "mode", "mongodb", "mssql", "mssql-odbc", "mysql", "neo4j", "nifi", "notion", "okta", "oracle", "postgres", "powerbi", "powerbi-report-server", "preset", "presto", "presto-on-hive", "pulsar", "qlik-sense", "rdf", "redash", "redshift", "s3", "s3-slim", "sac", "sagemaker", "salesforce", "sigma", "slack", "snaplogic", "snowflake", "snowflake-queries", "snowflake-slim", "snowflake-summary", "snowplow", "sql-parser", "sql-queries", "sqlalchemy", "starburst-trino-usage", "superset", "sync-file-emitter", "tableau", "teradata", "trino", "unity-catalog", "unstructured", "vertexai", "vertica", "all", "cloud", "dev", "docs", "lint", "testing-utils", "integration-tests", "debug"]
 
 [[package]]
 name = "acryl-datahub-classify"
@@ -7143,11 +7163,14 @@ wheels = [
 
 [[package]]
 name = "isodate"
-version = "0.7.2"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/7a/c0a56c7d56c7fa723988f122fa1f1ccf8c5c4ccc48efad0d214b49e5b1af/isodate-0.6.1.tar.gz", hash = "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9", size = 28443, upload-time = "2021-12-13T20:28:31.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/85/7882d311924cbcfc70b1890780763e36ff0b140c7e51c110fc59a532f087/isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96", size = 41722, upload-time = "2021-12-13T20:28:29.073Z" },
 ]
 
 [[package]]
@@ -11014,6 +11037,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/33/cd87d92b23f0b06e8914a61cea6850c6d495ca027f669fab7a379041827a/rapidfuzz-3.14.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1faa0f8f76ba75fd7b142c984947c280ef6558b5067af2ae9b8729b0a0f99ede", size = 1352187, upload-time = "2025-11-01T11:54:45.518Z" },
     { url = "https://files.pythonhosted.org/packages/22/20/9d30b4a1ab26aac22fff17d21dec7e9089ccddfe25151d0a8bb57001dc3d/rapidfuzz-3.14.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e6eefec45625c634926a9fd46c9e4f31118ac8f3156fff9494422cee45207e6", size = 3101472, upload-time = "2025-11-01T11:54:47.255Z" },
     { url = "https://files.pythonhosted.org/packages/b1/ad/fa2d3e5c29a04ead7eaa731c7cd1f30f9ec3c77b3a578fdf90280797cbcb/rapidfuzz-3.14.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56fefb4382bb12250f164250240b9dd7772e41c5c8ae976fd598a32292449cc5", size = 1511361, upload-time = "2025-11-01T11:54:49.057Z" },
+]
+
+[[package]]
+name = "rdflib"
+version = "6.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/28/4d1f27c5d73f58e567ca1a14a4eab7d7978a09c4e117687f9f6c216d3366/rdflib-6.3.2.tar.gz", hash = "sha256:72af591ff704f4caacea7ecc0c5a9056b8553e0489dd4f35a9bc52dbd41522e0", size = 4749592, upload-time = "2023-03-26T11:52:54.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/92/d7fb1d7fb70c9f7003fa50b7a3880ebcb311cc3f8552b3595e7c8f75aeeb/rdflib-6.3.2-py3-none-any.whl", hash = "sha256:36b4e74a32aa1e4fa7b8719876fb192f19ecd45ff932ea5ebbd2e417a0247e63", size = 528122, upload-time = "2023-03-26T11:52:52.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The `rdf` ingestion plugin was correctly defined in `setup.py` (deps, entry
point, and inclusion in dev/integration-test extras) but `pyproject.toml`,
`uv.lock`, and `constraints.txt` had never been regenerated to reflect it.
This caused `checkLockFile` to fail in CI.

## Changes

- Ran `./gradlew :metadata-ingestion:updateLockFile` to regenerate all three
  derived files from `setup.py`:
  - `pyproject.toml` — now includes the `rdf` extra and its entry point
  - `uv.lock` — now resolves `rdflib==6.3.2` and its transitive dependencies
  - `constraints.txt` — updated to match

## Test plan

- [x] `./gradlew :metadata-ingestion:checkLockFile` passes with 123/123 checks

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
