### PR TITLE
fix(build): exclude docs/generated from prettier markdown check

### DIFF
--- a/datahub-web-react/.prettierignore
+++ b/datahub-web-react/.prettierignore
@@ -1,4 +1,5 @@
 ../docs-website
+../docs/generated
 **/.venv
 **/venv
 **/.tox


### PR DESCRIPTION
## Summary
- Adds `../docs/generated` to `datahub-web-react/.prettierignore`
- The `docs/generated/` directory is gitignored and populated by `docGen`. When developers run `docGen` locally before `mdPrettierCheck`, the generated markdown files can cause spurious formatting failures. This prevents that.

## Test plan
- [x] Ran `docGen` locally to populate `docs/generated/`
- [x] Verified `mdPrettierCheck` passes with generated files present
- [x] Verified `mdPrettierCheck` still catches real formatting issues in tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)