### PR TITLE
feat(snowflake): add Cortex Analyst natural language query tracking

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -122,6 +122,13 @@ class SemanticViewsConfig(ConfigModel):
         "Only applicable when include_queries is True.",
     )
 
+    include_cortex_analyst_queries: bool = Field(
+        default=False,
+        description="If enabled, collect natural language questions and generated SQL from "
+        "Cortex Analyst via SNOWFLAKE.LOCAL.CORTEX_ANALYST_REQUESTS_V. "
+        "Requires SELECT privilege on that view. Emitted as Query entities accessible via API.",
+    )
+
     @model_validator(mode="after")
     def validate_column_lineage_requires_enabled(self) -> "SemanticViewsConfig":
         if self.column_lineage and not self.enabled:
@@ -142,6 +149,11 @@ class SemanticViewsConfig(ConfigModel):
             logger.warning(
                 "semantic_views.include_queries is set to True but semantic_views.enabled is False. "
                 "Query entities will not be generated. Set semantic_views.enabled to True to enable query tracking."
+            )
+        if self.include_cortex_analyst_queries and not self.enabled:
+            logger.warning(
+                "semantic_views.include_cortex_analyst_queries is set to True but semantic_views.enabled is False. "
+                "Cortex Analyst queries will not be collected. Set semantic_views.enabled to True first."
             )
         return self
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -1630,3 +1630,28 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
             AND sv.NAME = tc.semantic_view_name
         ORDER BY sv.SCHEMA, sv.NAME
         """
+
+    @staticmethod
+    def semantic_view_cortex_analyst_requests(
+        start_time_millis: int,
+        end_time_millis: int,
+        max_requests: int = 1000,
+    ) -> str:
+        """Query CORTEX_ANALYST_REQUESTS_V for natural language questions and generated SQL.
+
+        This view provides structured data about Cortex Analyst interactions,
+        including the original natural language question and the SQL it generated.
+        """
+        return f"""
+        SELECT
+            latest_question AS "QUESTION",
+            generated_sql AS "GENERATED_SQL",
+            semantic_model_name AS "SEMANTIC_MODEL_NAME",
+            user_id AS "USER_NAME",
+            timestamp AS "REQUEST_TIMESTAMP"
+        FROM snowflake.local.cortex_analyst_requests_v
+        WHERE timestamp >= to_timestamp_ltz({start_time_millis}, 3)
+            AND timestamp < to_timestamp_ltz({end_time_millis}, 3)
+        ORDER BY timestamp DESC
+        LIMIT {max_requests}
+        """

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -291,6 +291,17 @@ class SemanticViewQuery:
 
 
 @dataclass
+class CortexAnalystQuery:
+    """A natural language query made via Cortex Analyst against a semantic view."""
+
+    question: str
+    generated_sql: str
+    semantic_view_name: str
+    user_name: str
+    timestamp: datetime
+
+
+@dataclass
 class SemanticViewProfileCounts:
     """Profile counts for a semantic view (dimensions, facts, metrics)."""
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_semantic_view_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_semantic_view_usage.py
@@ -22,6 +22,7 @@ from datahub.ingestion.source.snowflake.snowflake_connection import SnowflakeCon
 from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
 from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
 from datahub.ingestion.source.snowflake.snowflake_schema import (
+    CortexAnalystQuery,
     SemanticViewQuery,
     SemanticViewUsageRecord,
     UserQueryCount,
@@ -386,3 +387,138 @@ class SemanticViewUsageExtractor:
         if len(query_text) > max_length:
             return query_text[: max_length - 3] + "..."
         return query_text
+
+    def get_cortex_analyst_query_workunits(
+        self,
+        discovered_semantic_views: Set[str],
+    ) -> Iterable[MetadataWorkUnit]:
+        """Extract Cortex Analyst natural language queries from CORTEX_ANALYST_REQUESTS_V.
+
+        Emits Query entities with the original NL question in customProperties
+        and the generated SQL as the QueryStatement.
+
+        Args:
+            discovered_semantic_views: Set of discovered semantic view identifiers
+        """
+        if not self.config.semantic_views.include_cortex_analyst_queries:
+            return
+
+        if not discovered_semantic_views:
+            return
+
+        logger.info("Extracting Cortex Analyst queries for semantic views")
+
+        try:
+            start_time_millis = int(self.config.start_time.timestamp() * 1000)
+            end_time_millis = int(self.config.end_time.timestamp() * 1000)
+
+            results = self.connection.query(
+                SnowflakeQuery.semantic_view_cortex_analyst_requests(
+                    start_time_millis=start_time_millis,
+                    end_time_millis=end_time_millis,
+                    max_requests=self.config.semantic_views.max_queries_per_view
+                    * len(discovered_semantic_views),
+                )
+            )
+
+            queries_by_view: Dict[str, List[CortexAnalystQuery]] = {}
+            max_per_view = self.config.semantic_views.max_queries_per_view
+
+            for row in results:
+                semantic_model_name = row.get("SEMANTIC_MODEL_NAME")
+                if not semantic_model_name:
+                    continue
+
+                normalized_name = self._normalize_semantic_view_name(
+                    semantic_model_name
+                )
+                if normalized_name not in discovered_semantic_views:
+                    continue
+
+                if (
+                    normalized_name in queries_by_view
+                    and len(queries_by_view[normalized_name]) >= max_per_view
+                ):
+                    continue
+
+                question = row.get("QUESTION") or ""
+                generated_sql = row.get("GENERATED_SQL") or ""
+                if not question and not generated_sql:
+                    continue
+
+                query = CortexAnalystQuery(
+                    question=question,
+                    generated_sql=generated_sql,
+                    semantic_view_name=semantic_model_name,
+                    user_name=row.get("USER_NAME") or "",
+                    timestamp=row["REQUEST_TIMESTAMP"].astimezone(tz=timezone.utc),
+                )
+
+                if normalized_name not in queries_by_view:
+                    queries_by_view[normalized_name] = []
+                queries_by_view[normalized_name].append(query)
+
+            for view_name, queries in queries_by_view.items():
+                logger.debug(
+                    f"Emitting {len(queries)} Cortex Analyst query entities for {view_name}"
+                )
+                for query in queries:
+                    yield from self._build_cortex_analyst_query_workunits(
+                        query, view_name
+                    )
+
+        except Exception as e:
+            logger.warning(
+                f"Failed to extract Cortex Analyst queries: {e}", exc_info=True
+            )
+            self.report.warning(
+                "cortex-analyst-queries",
+                f"Failed to extract Cortex Analyst queries: {e}",
+            )
+
+    def _build_cortex_analyst_query_workunits(
+        self, query: CortexAnalystQuery, dataset_identifier: str
+    ) -> Iterable[MetadataWorkUnit]:
+        """Build Query entity workunits for a Cortex Analyst query."""
+        # Use question hash as stable query ID since CORTEX_ANALYST_REQUESTS_V has no query_id
+        query_id = f"cortex_analyst_{hash((query.question, query.generated_sql, str(query.timestamp)))}"
+        query_urn = QueryUrn(query_id).urn()
+        dataset_urn = self.identifiers.gen_dataset_urn(dataset_identifier)
+        user_urn, _ = self._get_user_urn_and_email(query.user_name)
+        timestamp_millis = int(query.timestamp.timestamp() * 1000)
+
+        query_properties = QueryProperties(
+            statement=QueryStatement(
+                value=query.generated_sql,
+                language=QueryLanguage.SQL,
+            ),
+            source=QuerySource.SYSTEM,
+            name=self._generate_cortex_analyst_query_name(query.question),
+            description="Cortex Analyst natural language query",
+            created=AuditStampClass(time=timestamp_millis, actor=user_urn),
+            lastModified=AuditStampClass(time=timestamp_millis, actor=user_urn),
+            customProperties={
+                "natural_language_question": query.question,
+                "query_source": "CORTEX_ANALYST",
+            },
+        )
+
+        yield MetadataChangeProposalWrapper(
+            entityUrn=query_urn,
+            aspect=query_properties,
+        ).as_workunit()
+
+        yield MetadataChangeProposalWrapper(
+            entityUrn=query_urn,
+            aspect=QuerySubjects(subjects=[QuerySubject(entity=dataset_urn)]),
+        ).as_workunit()
+
+    def _generate_cortex_analyst_query_name(
+        self, question: str, max_length: int = 72
+    ) -> str:
+        """Generate a readable name from a natural language question."""
+        if not question:
+            return "Cortex Analyst query"
+        if len(question) <= max_length:
+            return question
+        return question[: max_length - 3] + "..."

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -258,9 +258,9 @@ class SnowflakeV2Source(
 
         # Semantic view usage extractor (separate from main usage due to different data source)
         self.semantic_view_usage_extractor: Optional[SemanticViewUsageExtractor] = None
-        if (
-            self.config.semantic_views.enabled
-            and self.config.semantic_views.include_usage
+        if self.config.semantic_views.enabled and (
+            self.config.semantic_views.include_usage
+            or self.config.semantic_views.include_cortex_analyst_queries
         ):
             self.semantic_view_usage_extractor = SemanticViewUsageExtractor(
                 config=config,
@@ -696,6 +696,9 @@ class SnowflakeV2Source(
                 discovered_semantic_views_set
             )
             yield from self.semantic_view_usage_extractor.get_semantic_view_query_workunits(
+                discovered_semantic_views_set
+            )
+            yield from self.semantic_view_usage_extractor.get_cortex_analyst_query_workunits(
                 discovered_semantic_views_set
             )
 

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_semantic_view_usage.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_semantic_view_usage.py
@@ -27,6 +27,7 @@ from datahub.ingestion.source.snowflake.snowflake_utils import (
     SnowflakeIdentifierBuilder,
 )
 from datahub.metadata.com.linkedin.pegasus2avro.dataset import DatasetUsageStatistics
+from datahub.metadata.com.linkedin.pegasus2avro.query import QueryProperties
 
 
 class TestSemanticViewsConfig:
@@ -467,3 +468,181 @@ class TestSemanticViewUsageIntegration:
             "SELECT * FROM SEMANTIC_VIEW(test_db.public.sales_view)"
             in usage_stats.topSqlQueries
         )
+
+
+class TestCortexAnalystConfig:
+    """Tests for Cortex Analyst config validation."""
+
+    def test_warning_cortex_analyst_without_enabled(self):
+        with patch(
+            "datahub.ingestion.source.snowflake.snowflake_config.logger"
+        ) as mock_logger:
+            SemanticViewsConfig(
+                enabled=False,
+                include_cortex_analyst_queries=True,
+            )
+            mock_logger.warning.assert_called()
+
+
+class TestCortexAnalystSqlQuery:
+    """Tests for Cortex Analyst SQL query generation."""
+
+    def test_cortex_analyst_requests_query(self):
+        query = SnowflakeQuery.semantic_view_cortex_analyst_requests(
+            start_time_millis=1704067200000,
+            end_time_millis=1704153600000,
+            max_requests=500,
+        )
+
+        assert "cortex_analyst_requests_v" in query.lower()
+        assert "latest_question" in query.lower()
+        assert "generated_sql" in query.lower()
+        assert "semantic_model_name" in query.lower()
+        assert "LIMIT 500" in query
+
+
+class TestCortexAnalystExtraction:
+    """Tests for Cortex Analyst query extraction."""
+
+    @pytest.fixture
+    def extractor(self) -> SemanticViewUsageExtractor:
+        config = MagicMock(spec=SnowflakeV2Config)
+        config.semantic_views = SemanticViewsConfig(
+            enabled=True,
+            include_cortex_analyst_queries=True,
+            max_queries_per_view=100,
+        )
+        config.start_time = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+        config.end_time = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+        config.email_domain = "test.com"
+
+        connection = MagicMock()
+        identifiers = MagicMock(spec=SnowflakeIdentifierBuilder)
+        identifiers.gen_dataset_urn.return_value = (
+            "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.sales_view,PROD)"
+        )
+        identifiers.get_user_identifier.return_value = "analyst@test.com"
+
+        report = SnowflakeV2Report()
+        extractor = SemanticViewUsageExtractor(
+            config=config,
+            report=report,
+            connection=connection,
+            identifiers=identifiers,
+        )
+        return extractor
+
+    def test_cortex_analyst_extraction_end_to_end(
+        self, extractor: SemanticViewUsageExtractor
+    ):
+        """Test full extraction: query -> parse -> emit Query entities."""
+        extractor.connection.query.return_value = [
+            {
+                "QUESTION": "What were total sales last quarter?",
+                "GENERATED_SQL": "SELECT SUM(amount) FROM sales WHERE quarter = 'Q4'",
+                "SEMANTIC_MODEL_NAME": "db.schema.sales_view",
+                "USER_NAME": "analyst",
+                "REQUEST_TIMESTAMP": datetime.datetime(
+                    2024, 1, 1, 10, 0, tzinfo=datetime.timezone.utc
+                ),
+            },
+            {
+                "QUESTION": "Show me top customers by revenue",
+                "GENERATED_SQL": "SELECT customer, SUM(revenue) FROM sales GROUP BY 1 ORDER BY 2 DESC",
+                "SEMANTIC_MODEL_NAME": "db.schema.sales_view",
+                "USER_NAME": "manager",
+                "REQUEST_TIMESTAMP": datetime.datetime(
+                    2024, 1, 1, 11, 0, tzinfo=datetime.timezone.utc
+                ),
+            },
+        ]
+
+        discovered = {"db.schema.sales_view"}
+        workunits = list(extractor.get_cortex_analyst_query_workunits(discovered))
+
+        # 2 queries * 2 aspects (QueryProperties + QuerySubjects) = 4
+        assert len(workunits) == 4
+
+        # Verify first query's properties
+        props_wu = workunits[0]
+        assert isinstance(props_wu.metadata, MetadataChangeProposalWrapper)
+        query_props = props_wu.metadata.aspect
+        assert isinstance(query_props, QueryProperties)
+        assert (
+            query_props.customProperties["natural_language_question"]
+            == "What were total sales last quarter?"
+        )
+        assert query_props.customProperties["query_source"] == "CORTEX_ANALYST"
+        assert (
+            query_props.statement.value
+            == "SELECT SUM(amount) FROM sales WHERE quarter = 'Q4'"
+        )
+
+    def test_cortex_analyst_skips_undiscovered_views(
+        self, extractor: SemanticViewUsageExtractor
+    ):
+        """Test that queries for undiscovered views are skipped."""
+        extractor.connection.query.return_value = [
+            {
+                "QUESTION": "What is revenue?",
+                "GENERATED_SQL": "SELECT revenue FROM sales",
+                "SEMANTIC_MODEL_NAME": "db.schema.unknown_view",
+                "USER_NAME": "analyst",
+                "REQUEST_TIMESTAMP": datetime.datetime(
+                    2024, 1, 1, 10, 0, tzinfo=datetime.timezone.utc
+                ),
+            },
+        ]
+
+        discovered = {"db.schema.sales_view"}
+        workunits = list(extractor.get_cortex_analyst_query_workunits(discovered))
+
+        assert len(workunits) == 0
+
+    def test_cortex_analyst_disabled_emits_nothing(
+        self, extractor: SemanticViewUsageExtractor
+    ):
+        extractor.config.semantic_views.include_cortex_analyst_queries = False
+        workunits = list(
+            extractor.get_cortex_analyst_query_workunits({"db.schema.sales_view"})
+        )
+        assert len(workunits) == 0
+
+    def test_cortex_analyst_handles_privilege_error(
+        self, extractor: SemanticViewUsageExtractor
+    ):
+        """Test graceful handling when user lacks SELECT on CORTEX_ANALYST_REQUESTS_V."""
+        extractor.connection.query.side_effect = Exception(
+            "Insufficient privileges to operate on view 'CORTEX_ANALYST_REQUESTS_V'"
+        )
+
+        discovered = {"db.schema.sales_view"}
+        workunits = list(extractor.get_cortex_analyst_query_workunits(discovered))
+
+        assert len(workunits) == 0
+        # Should have reported a warning
+        assert len(extractor.report.warnings) > 0
+
+    def test_cortex_analyst_respects_max_queries_per_view(
+        self, extractor: SemanticViewUsageExtractor
+    ):
+        """Test that per-view limit is respected."""
+        extractor.config.semantic_views.max_queries_per_view = 2
+
+        base_time = datetime.datetime(2024, 1, 1, 10, 0, tzinfo=datetime.timezone.utc)
+        extractor.connection.query.return_value = [
+            {
+                "QUESTION": f"Question {i}",
+                "GENERATED_SQL": f"SELECT {i}",
+                "SEMANTIC_MODEL_NAME": "db.schema.sales_view",
+                "USER_NAME": "analyst",
+                "REQUEST_TIMESTAMP": base_time + datetime.timedelta(minutes=i),
+            }
+            for i in range(10)
+        ]
+
+        discovered = {"db.schema.sales_view"}
+        workunits = list(extractor.get_cortex_analyst_query_workunits(discovered))
+
+        # 2 queries * 2 aspects = 4
+        assert len(workunits) == 4

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_semantic_view_usage.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_semantic_view_usage.py
@@ -505,7 +505,11 @@ class TestCortexAnalystExtraction:
     """Tests for Cortex Analyst query extraction."""
 
     @pytest.fixture
-    def extractor(self) -> SemanticViewUsageExtractor:
+    def mock_connection(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def extractor(self, mock_connection: MagicMock) -> SemanticViewUsageExtractor:
         config = MagicMock(spec=SnowflakeV2Config)
         config.semantic_views = SemanticViewsConfig(
             enabled=True,
@@ -516,7 +520,6 @@ class TestCortexAnalystExtraction:
         config.end_time = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
         config.email_domain = "test.com"
 
-        connection = MagicMock()
         identifiers = MagicMock(spec=SnowflakeIdentifierBuilder)
         identifiers.gen_dataset_urn.return_value = (
             "urn:li:dataset:(urn:li:dataPlatform:snowflake,db.schema.sales_view,PROD)"
@@ -524,19 +527,18 @@ class TestCortexAnalystExtraction:
         identifiers.get_user_identifier.return_value = "analyst@test.com"
 
         report = SnowflakeV2Report()
-        extractor = SemanticViewUsageExtractor(
+        return SemanticViewUsageExtractor(
             config=config,
             report=report,
-            connection=connection,
+            connection=mock_connection,
             identifiers=identifiers,
         )
-        return extractor
 
     def test_cortex_analyst_extraction_end_to_end(
-        self, extractor: SemanticViewUsageExtractor
-    ):
+        self, extractor: SemanticViewUsageExtractor, mock_connection: MagicMock
+    ) -> None:
         """Test full extraction: query -> parse -> emit Query entities."""
-        extractor.connection.query.return_value = [
+        mock_connection.query.return_value = [
             {
                 "QUESTION": "What were total sales last quarter?",
                 "GENERATED_SQL": "SELECT SUM(amount) FROM sales WHERE quarter = 'Q4'",
@@ -579,10 +581,10 @@ class TestCortexAnalystExtraction:
         )
 
     def test_cortex_analyst_skips_undiscovered_views(
-        self, extractor: SemanticViewUsageExtractor
-    ):
+        self, extractor: SemanticViewUsageExtractor, mock_connection: MagicMock
+    ) -> None:
         """Test that queries for undiscovered views are skipped."""
-        extractor.connection.query.return_value = [
+        mock_connection.query.return_value = [
             {
                 "QUESTION": "What is revenue?",
                 "GENERATED_SQL": "SELECT revenue FROM sales",
@@ -601,7 +603,7 @@ class TestCortexAnalystExtraction:
 
     def test_cortex_analyst_disabled_emits_nothing(
         self, extractor: SemanticViewUsageExtractor
-    ):
+    ) -> None:
         extractor.config.semantic_views.include_cortex_analyst_queries = False
         workunits = list(
             extractor.get_cortex_analyst_query_workunits({"db.schema.sales_view"})
@@ -609,10 +611,10 @@ class TestCortexAnalystExtraction:
         assert len(workunits) == 0
 
     def test_cortex_analyst_handles_privilege_error(
-        self, extractor: SemanticViewUsageExtractor
-    ):
+        self, extractor: SemanticViewUsageExtractor, mock_connection: MagicMock
+    ) -> None:
         """Test graceful handling when user lacks SELECT on CORTEX_ANALYST_REQUESTS_V."""
-        extractor.connection.query.side_effect = Exception(
+        mock_connection.query.side_effect = Exception(
             "Insufficient privileges to operate on view 'CORTEX_ANALYST_REQUESTS_V'"
         )
 
@@ -624,13 +626,13 @@ class TestCortexAnalystExtraction:
         assert len(extractor.report.warnings) > 0
 
     def test_cortex_analyst_respects_max_queries_per_view(
-        self, extractor: SemanticViewUsageExtractor
-    ):
+        self, extractor: SemanticViewUsageExtractor, mock_connection: MagicMock
+    ) -> None:
         """Test that per-view limit is respected."""
         extractor.config.semantic_views.max_queries_per_view = 2
 
         base_time = datetime.datetime(2024, 1, 1, 10, 0, tzinfo=datetime.timezone.utc)
-        extractor.connection.query.return_value = [
+        mock_connection.query.return_value = [
             {
                 "QUESTION": f"Question {i}",
                 "GENERATED_SQL": f"SELECT {i}",


### PR DESCRIPTION
Query SNOWFLAKE.LOCAL.CORTEX_ANALYST_REQUESTS_V to capture NL questions and generated SQL from Cortex Analyst, emitted as Query entities with the original question in customProperties. Disabled by default via include_cortex_analyst_queries config flag.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
