### PR TITLE
fix(bigquery): use SchemaResolverProvider directly to avoid module-level caching in _init_schema_resolver

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -62,7 +62,7 @@ from datahub.ingestion.source.state.stateful_ingestion_base import (
 )
 from datahub.ingestion.source_report.ingestion_stage import QUERIES_EXTRACTION
 from datahub.sql_parsing.schema_resolver import SchemaResolver
-from datahub.sql_parsing.schema_resolver_provider import provide_schema_resolver
+from datahub.sql_parsing.schema_resolver_provider import SchemaResolverProvider
 from datahub.utilities.registries.domain_registry import DomainRegistry
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -245,19 +245,26 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         if schema_resolution_required and not schema_ingestion_enabled:
             if self.ctx.graph:
                 try:
-                    return provide_schema_resolver(
+                    return SchemaResolverProvider(
                         graph=self.ctx.graph,
+                        batch_size=self.config.schema_resolution_batch_size,
+                    ).get(
                         platform=self.platform,
                         platform_instance=self.config.platform_instance,
                         env=self.config.env,
-                        batch_size=self.config.schema_resolution_batch_size,
                     )
                 except Exception as e:
                     self.report.report_warning(
                         message="Failed to bulk-load schemas from DataHub for SQL lineage. "
-                        "Lineage resolution will proceed with an empty schema resolver.",
+                        "Lineage resolution will proceed with lazy-loading schema resolver.",
                         context=str(e),
                         exc=e,
+                    )
+                    return SchemaResolver(
+                        platform=self.platform,
+                        platform_instance=self.config.platform_instance,
+                        env=self.config.env,
+                        graph=self.ctx.graph,
                     )
             else:
                 logger.warning(


### PR DESCRIPTION
The previous change in #16499 introduced a module-level lru_cache for
provide_schema_resolver, which could cause subtle issues in connector test
environments. Using SchemaResolverProvider directly ensures a fresh bulk
fetch per source instance, matching the original behavior of
initialize_schema_resolver_from_datahub.

Additionally, improve the error fallback to use lazy-loading
(graph=self.ctx.graph) instead of an empty resolver without any
schema source, and include platform_instance in the fallback resolver
for correctness.

https://claude.ai/code/session_01LbGYSUcdihjouXmV74wNmC