### PR TITLE
Increase search filter dropdown width

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/FilterOption.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/FilterOption.tsx
@@ -112,7 +112,7 @@ const ArrowButton = styled(Button)<{ isOpen: boolean }>`
 `;
 
 const ParentWrapper = styled.div`
-    max-width: 220px;
+    max-width: 500px;
     font-size: 12px;
 `;
 
@@ -200,7 +200,7 @@ export default function FilterOption({
                                             overlayInnerStyle: { color: colors.gray[1700] },
                                         },
                                     }}
-                                    style={{ maxWidth: 150 }}
+                                    style={{ maxWidth: 500 }}
                                 >
                                     {isSubTypeFilter ? capitalizeFirstLetterOnly(label as string) : label}
                                 </Label>

--- a/datahub-web-react/src/app/searchV2/filters/OptionsDropdownMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/OptionsDropdownMenu.tsx
@@ -39,7 +39,6 @@ export const DropdownMenu = styled.div<{ type: 'card' | 'default' }>`
 const ScrollableContent = styled.div`
     max-height: 380px;
     overflow: auto;
-    min-width: 260px;
 `;
 
 const LoadingWrapper = styled.div`

--- a/datahub-web-react/src/app/searchV2/filters/SearchFilterOptions.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/SearchFilterOptions.tsx
@@ -22,6 +22,7 @@ export const FlexWrapper = styled.div`
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    gap: 6px;
 `;
 
 export const FlexSpacer = styled.div`


### PR DESCRIPTION
Increases the maximum width of the search filter dropdowns when the content is longer.
In our case we have some very long Glossary Terms and they were very heavily truncated in the current implementation.
<img width="1076" height="341" alt="image (7)" src="https://github.com/user-attachments/assets/6a965727-c316-4471-813c-c70a71b5a072" />

Shorter content keeps its current behavior
<img width="454" height="483" alt="image (8)" src="https://github.com/user-attachments/assets/d8e9bc73-7692-4143-bdd5-b58aa4f1e300" />

Also fixes a small visual bug where the grey border click effect of filters was showing up behind the next filter's box, being cut. Increased the gap between filters to circumvent this.
<img width="460" height="182" alt="Screenshot__4_" src="https://github.com/user-attachments/assets/111e36db-8e32-46f8-ab30-97e8956bd48c" />
