### PR TITLE
ci: update build job names to be unique to avoid conflicting checks in Mergeable

### DIFF
--- a/.github/workflows/agent-context.yml
+++ b/.github/workflows/agent-context.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-datahub-agent-context:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: ./.github/actions/ci-optimization
         id: ci-optimize
 
-  build:
+  build-and-test:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/metadata-io.yml
+++ b/.github/workflows/metadata-io.yml
@@ -50,7 +50,7 @@ jobs:
           checkout-head-only: false
       - uses: ./.github/actions/ci-optimization
         id: ci-optimize
-  build:
+  build-metadata-io:
     runs-on: ${{ vars.DEPOT_PROJECT_ID != '' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     timeout-minutes: 60
     needs: setup


### PR DESCRIPTION
## Summary

When Mergeable gets check updates for a PR, it uses a deduplication logic that relies on the check run name. When multiple jobs across different workflows share the same name, the deduplication logic treats them as the same check and only reports the status of the latest one.

This renames the `build` jobs in three workflows to be unique:
- `agent-context.yml`: `build` → `build-datahub-agent-context`
- `build-and-test.yml`: `build` → `build-and-test`
- `metadata-io.yml`: `build` → `build-metadata-io`

refs PFP-2543

## Test plan
- [ ] Verify CI passes with renamed job keys
- [ ] Confirm Mergeable correctly distinguishes checks after rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)