### PR TITLE
docs(ingestion): add request-connector page to fix dead link on Integrations page

### DIFF
--- a/metadata-ingestion/request-connector.md
+++ b/metadata-ingestion/request-connector.md
@@ -1,0 +1,29 @@
+---
+title: Request a Connector
+---
+
+# Request a Connector
+
+Looking for a DataHub connector that doesn't exist yet? Here's how to get started.
+
+## Search Existing Requests
+
+Before submitting a new request, check if someone has already asked for it. Upvoting existing requests helps us prioritize.
+
+- **[Feature Request Portal →](https://feature-requests.datahubproject.io/b/feedback)** — search and upvote on FeatureOS
+- **[GitHub Issues →](https://github.com/datahub-project/datahub/issues?q=is%3Aissue+label%3Aingestion+label%3Afeature-request)** — browse connector requests on GitHub
+
+## Submit a New Request
+
+If your connector isn't already requested, submit a new one so the community and maintainers can track demand.
+
+- **[Feature Request Portal →](https://feature-requests.datahubproject.io/b/feedback)** — submit and track on FeatureOS
+- **[Open a GitHub Issue →](https://github.com/datahub-project/datahub/issues/new?labels=ingestion,feature-request&title=%5BConnector+Request%5D+)** — file a request on GitHub
+
+## Build It Yourself
+
+Want to build the connector yourself? The [Adding a Source](adding-source.md) guide walks you through creating a full ingestion plugin — with configuration, profiling, lineage, and more.
+
+**[Build a Source Plugin →](adding-source.md)**
+
+To speed things up, install **[DataHub Skills](datahub-skills.md)** — a Claude Code plugin that handles planning, scaffolding, and code review so you can focus on the integration logic.


### PR DESCRIPTION
## Summary
- Adds `metadata-ingestion/request-connector.md` which was referenced by the Integrations page (`FilterPage/index.jsx`) but never checked in
- The page links to the FeatureOS feature request portal, GitHub issues, and the source plugin guide

## Test plan
- [ ] Verify the link at the bottom of the Integrations page (`/docs/metadata-ingestion/request-connector`) resolves after docgen

🤖 Generated with [Claude Code](https://claude.com/claude-code)