### PR TITLE
fix(frontend): replace deprecated ANTD_GRAY with semantic theme token in sources.tsx

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/conf/sources.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/conf/sources.tsx
@@ -1,7 +1,7 @@
 import { FormOutlined } from '@ant-design/icons';
 import React from 'react';
+import { useTheme } from 'styled-components';
 
-import { ANTD_GRAY } from '@app/entity/shared/constants';
 import azureAdConfig from '@app/ingestV2/source/conf/azure/azure';
 import bigqueryConfig from '@app/ingestV2/source/conf/bigquery/bigquery';
 import csvConfig from '@app/ingestV2/source/conf/csv/csv';
@@ -19,6 +19,11 @@ import sacConfig from '@app/ingestV2/source/conf/sac/sac';
 import snowflakeConfig from '@app/ingestV2/source/conf/snowflake/snowflake';
 import tableauConfig from '@app/ingestV2/source/conf/tableau/tableau';
 import { SourceConfig } from '@app/ingestV2/source/conf/types';
+
+function CustomConnectorIcon() {
+    const theme = useTheme();
+    return <FormOutlined style={{ color: theme.colors.icon, fontSize: 28 }} />;
+}
 
 const baseUrl = window.location.origin;
 
@@ -56,6 +61,6 @@ export const SOURCE_TEMPLATE_CONFIGS: Array<SourceConfig> = [
         placeholderRecipe: DEFAULT_PLACEHOLDER_RECIPE,
         displayName: 'Other',
         docsUrl: 'https://docs.datahub.com/docs/metadata-ingestion/',
-        logoComponent: <FormOutlined style={{ color: ANTD_GRAY[8], fontSize: 28 }} />,
+        logoComponent: <CustomConnectorIcon />,
     },
 ];


### PR DESCRIPTION
Uses useTheme() via a small wrapper component to access theme.colors.icon, fixing a pre-existing no-restricted-imports lint violation.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
