### PR TITLE
fix(): remove pydantic from constraints for datahub-actions bundled images

### DIFF
--- a/docker/snippets/ingestion/constraints.txt
+++ b/docker/snippets/ingestion/constraints.txt
@@ -1,4 +1,3 @@
-pydantic_core!=2.41.3
 cmdstanpy>=1.3.0,<2.0.0
 # GHSA-58pv-8j8x-9vj2: Path traversal vulnerability in jaraco.context <6.1.0
 # Note: Airflow 2.9.x constraints pin jaraco.context==5.3.0, creating a conflict


### PR DESCRIPTION
his was caught when running the file-bundled source in datahub-actions. 

# The Issue

Was QAing the ingestion bundled venvs, and saw this when running ingestion:

```
    from datahub.configuration.common import (
  File "/opt/datahub/venvs/file-bundled/lib/python3.11/site-packages/datahub/configuration/common.py", line 23, in <module>
    import pydantic
  File "/opt/datahub/venvs/file-bundled/lib/python3.11/site-packages/pydantic/__init__.py", line 8, in <module>
    _ensure_pydantic_core_version()
  File "/opt/datahub/venvs/file-bundled/lib/python3.11/site-packages/pydantic/version.py", line 94, in _ensure_pydantic_core_version
    raise SystemError(
SystemError: The installed pydantic-core version (2.42.0) is incompatible with the current pydantic version, which requires 2.41.5. If you encounter this error, make sure that you haven't upgraded pydantic-core manually.
```

# Root Cause

The constraints.txt file used in building the datahub-actions image (docker/snippets/ingestion/build_bundled_venvs_unified.py) serves double duty as both --constraint and --overrides in the uv pip install commands (lines 95, 104, 107). This is intentional for the security floor constraints (like jaraco.context>=6.1.0 which need to override packages that pin older vulnerable versions), but pydantic_core!=2.41.3 should NOT be an override.

When pydantic_core!=2.41.3 is applied as an --overrides entry, it replaces pydantic's internal requirement of pydantic-core==2.41.5 with just !=2.41.3, allowing uv to freely resolve the latest pydantic-core (2.42.0) which is incompatible.
The exclusion is already correctly declared in metadata-ingestion/setup.py line 33 ("pydantic_core!=2.41.3,<3.0.0"), so it's redundant in constraints.txt — and actively harmful when that file is used as --overrides.
Fix

Remove the pydantic_core line from constraints.txt. The exclusion is already enforced by the package's own dependency metadata in setup.py, and having it in the overrides file is what causes uv to break pydantic's version pin.

To summarize:

What broke: pydantic-core 2.42.0 got installed into the file-bundled venv, but the installed pydantic version requires exactly pydantic-core==2.41.5.

Why: build_bundled_venvs_unified.py passes constraints.txt as both --constraint and --overrides to uv pip install. The pydantic_core!=2.41.3 entry, when used as an override, replaces pydantic's own strict pin (==2.41.5) with a loose !=2.41.3, letting uv resolve to the latest 2.42.0.

Fix: Remove pydantic_core!=2.41.3 from constraints.txt. The exclusion is already declared in setup.py as a normal dependency, which pip/uv will correctly AND with pydantic's own pin without overriding it.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
