### PR TITLE
fix(search): reduce logging and cache index existence check for semantic dual-write

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -3,6 +3,8 @@ package com.linkedin.metadata.search.elasticsearch;
 import static com.linkedin.metadata.search.utils.SearchUtils.applyDefaultSearchFlags;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.browse.BrowseResultV2;
@@ -29,6 +31,7 @@ import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -58,6 +61,15 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
           .setIncludeRestricted(false);
 
   private static final int MAX_RUN_IDS_INDEXED = 25; // Save the previous 25 run ids in the index.
+  private static final long SEMANTIC_INDEX_CACHE_TTL_MINUTES = 5;
+
+  // Cache for semantic index existence checks to avoid repeated HEAD requests to OpenSearch
+  private final Cache<String, Boolean> semanticIndexExistsCache =
+      CacheBuilder.newBuilder()
+          .expireAfterWrite(SEMANTIC_INDEX_CACHE_TTL_MINUTES, TimeUnit.MINUTES)
+          .maximumSize(150)
+          .build();
+
   public static final String SCRIPT_SOURCE =
       "if (ctx._source.containsKey('runId')) { "
           + "if (!ctx._source.runId.contains(params.runId)) { "
@@ -267,7 +279,7 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
     final String entityName = urn.getEntityType();
     final String docId = opContext.getSearchContext().getIndexConvention().getEntityDocumentId(urn);
 
-    log.info("Appending run id for entity '{}', docId='{}', runId='{}'", entityName, docId, runId);
+    log.debug("Appending run id for entity '{}', docId='{}', runId='{}'", entityName, docId, runId);
 
     // Create an upsert document that will be used if the document doesn't exist
     Map<String, Object> upsert = new HashMap<>();
@@ -292,11 +304,16 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
         scriptParams,
         upsert);
 
-    // Dual-write to semantic index if it exists
+    // Dual-write to semantic index if it exists (with caching to avoid repeated HEAD requests)
     String semanticIndexName =
         opContext.getSearchContext().getIndexConvention().getEntityIndexNameSemantic(entityName);
-    if (indexExists(semanticIndexName)) {
-      log.info(
+    Boolean semanticExists = semanticIndexExistsCache.getIfPresent(semanticIndexName);
+    if (semanticExists == null) {
+      semanticExists = indexExists(semanticIndexName);
+      semanticIndexExistsCache.put(semanticIndexName, semanticExists);
+    }
+    if (semanticExists) {
+      log.debug(
           "Semantic dual-write: APPEND_RUNID to '{}' for entity '{}', docId='{}', runId='{}'",
           semanticIndexName,
           entityName,
@@ -304,7 +321,7 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
           runId);
       applyScriptUpdateByIndexName(semanticIndexName, docId, SCRIPT_SOURCE, scriptParams, upsert);
     } else {
-      log.info(
+      log.debug(
           "Semantic dual-write: SKIP - index '{}' does not exist for runId update",
           semanticIndexName);
     }

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/UpdateIndicesV2Strategy.java
@@ -114,7 +114,7 @@ public class UpdateIndicesV2Strategy implements UpdateIndicesStrategy {
     this.semanticIndexExistsCache =
         CacheBuilder.newBuilder()
             .expireAfterWrite(SEMANTIC_INDEX_CACHE_TTL_MINUTES, TimeUnit.MINUTES)
-            .maximumSize(100)
+            .maximumSize(150)
             .build();
 
     // Log semantic search configuration at initialization


### PR DESCRIPTION
The semantic dual-write path in `appendRunId` was making a HEAD request to OpenSearch on every write to check if the semantic index exists, and logging at INFO level for each call. This adds a Guava cache (5-min TTL, max 150 entries) for the index existence check so we only hit OpenSearch once per index name, and lowers the log statements to DEBUG to reduce noise during ingestion. Also aligns the cache max size to 150 in `UpdateIndicesV2Strategy` for consistency.