### PR TITLE
fix(): v2 indices clean-up default config

### DIFF
--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -380,7 +380,7 @@ elasticsearch:
   entityIndex:
     v2:
       enabled: ${ELASTICSEARCH_ENTITY_INDEX_V2_ENABLED:true}
-      cleanup: ${ELASTICSEARCH_ENTITY_INDEX_V2_CLEANUP:false}
+      cleanup: ${ELASTICSEARCH_ENTITY_INDEX_V2_CLEANUP:true}
     v3:
       enabled: ${ELASTICSEARCH_ENTITY_INDEX_V3_ENABLED:false}
       cleanup: ${ELASTICSEARCH_ENTITY_INDEX_V3_CLEANUP:false}


### PR DESCRIPTION
## Rationale

- **V2 is still the primary entity search layout today.** When operators run flows that call **`EntitySearchService.clear()`** (**`RestoreIndices -a clean`**, **`RestoreBackup`**), search should be reset in a predictable way: **including V2 indices** unless there is a deliberate reason not to.
- **Default `false`** makes “clear search” **skip V2 indices**, which is easy to misread as “restore/reindex finished” while **stale V2 data** remains—surprising when V2 is still the default index mode.
- **`true` until V3 is ready** keeps OSS and single-version deployments **consistent**: clear means clear. The **`false`** default is mainly valuable when **V3 is in play** and you must **preserve V2 indices** across clears (cutover, dual indexing, or migration windows)—at that point operators can set **`ELASTICSEARCH_ENTITY_INDEX_V2_CLEANUP=false`** explicitly.

## Behavior (unchanged semantics)

- Flag still only affects **whether V2 patterns are deleted in `clear()`**; it does **not** change normal indexing.
- **V3** remains governed by **`ELASTICSEARCH_ENTITY_INDEX_V3_CLEANUP`** separately.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
