### PR TITLE
fix(ingest/snowflake): exclude private_key from config serialization

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
@@ -86,6 +86,7 @@ class SnowflakeConnectionConfig(ConfigModel):
     )
     private_key: Optional[TransparentSecretStr] = pydantic.Field(
         default=None,
+        exclude=True,
         description="Private key in a form of '-----BEGIN PRIVATE KEY-----\\nprivate-key\\n-----END PRIVATE KEY-----\\n' if using key pair authentication. Encrypted version of private key will be in a form of '-----BEGIN ENCRYPTED PRIVATE KEY-----\\nencrypted-private-key\\n-----END ENCRYPTED PRIVATE KEY-----\\n' See: https://docs.snowflake.com/en/user-guide/key-pair-auth.html",
     )
 

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
@@ -369,6 +369,31 @@ def test_private_key_set_but_auth_not_changed():
         )
 
 
+def test_snowflake_connection_config_excludes_secrets_from_serialization():
+    """Ensure secret fields are excluded from model_dump() to prevent leaking
+    credentials in logs, reports, or the system info endpoint."""
+    from datahub.ingestion.source.snowflake.snowflake_connection import (
+        SnowflakeConnectionConfig,
+    )
+
+    config = SnowflakeConnectionConfig.model_validate(
+        {
+            "account_id": "acctname",
+            "username": "user",
+            "password": "hunter2",
+            "private_key": "-----BEGIN PRIVATE KEY-----\nfakekey\n-----END PRIVATE KEY-----\n",
+            "private_key_password": "keypassword",
+            "authentication_type": "KEY_PAIR_AUTHENTICATOR",
+        }
+    )
+
+    dumped = config.model_dump()
+    assert "password" not in dumped
+    assert "private_key" not in dumped
+    assert "private_key_password" not in dumped
+    assert dumped["username"] == "user"  # non-secret field still present
+
+
 def test_snowflake_config_with_connect_args_overrides_base_connect_args():
     config_dict = default_config_dict.copy()
     config_dict["connect_args"] = {


### PR DESCRIPTION
private_key was missing exclude=True despite holding PEM-encoded key material, unlike password and private_key_password which were already excluded. Without this, the raw private key content could appear in serialized config output (logs, reports, system info endpoint).

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)