### PR TITLE
fix(docs): remove stale mock server reference from datahub-web-react README

### DIFF
--- a/datahub-web-react/README.md
+++ b/datahub-web-react/README.md
@@ -46,8 +46,6 @@ can run the following in this directory:
 which will start a forwarding server at `localhost:3000`. Note that to fetch real data, `datahub-frontend` server will also
 need to be deployed, still at `http://localhost:9002`, to service GraphQL API requests.
 
-Optionally you could also start the app with the mock server without running the docker containers by executing `yarn start:mock`. See [here](src/graphql-mock/fixtures/searchResult/userSearchResult.ts#L6) for available login users.
-
 ### Testing your customizations
 
 There is two options to test your customizations:


### PR DESCRIPTION
## Summary

- The `graphql-mock` directory was deleted in #16680 (dead code removal after v1 UI removal)
- `datahub-web-react/README.md` still referenced `src/graphql-mock/fixtures/searchResult/userSearchResult.ts#L6`, breaking the docs build with: `Error: broken github repo link to datahub-web-react/src/graphql-mock/fixtures/searchResult/userSearchResult.ts#L6 in datahub-web-react/README.md`
- Removes the stale sentence about `yarn start:mock` and mock login users — the mock server no longer exists

Fixes:

```
$ ts-node -O '{ "lib": ["es2020"], "target": "es6" }' generateDocsDir.ts
/vercel/path0/docs-website/generateDocsDir.ts:408
      throw new Error(
            ^
Error: broken github repo link to datahub-web-react/src/graphql-mock/fixtures/searchResult/userSearchResult.ts#L6 in datahub-web-react/README.md
    at new_url (/vercel/path0/docs-website/generateDocsDir.ts:408:13)
    at /vercel/path0/docs-website/generateDocsDir.ts:444:25
    at String.replace (<anonymous>)
    at markdown_rewrite_urls (/vercel/path0/docs-website/generateDocsDir.ts:437:6)
    at /vercel/path0/docs-website/generateDocsDir.ts:691:5
    at Generator.next (<anonymous>)
    at /vercel/path0/docs-website/generateDocsDir.ts:31:71
    at new Promise (<anonymous>)
    at __awaiter (/vercel/path0/docs-website/generateDocsDir.ts:27:12)
    at main (/vercel/path0/docs-website/generateDocsDir.ts:554:12)
error Command failed with exit code 1.
error Command failed with exit code 1.
error Command failed with exit code 1.
```

## Test plan

- [ ] Docs build completes without the broken link error

🤖 Generated with [Claude Code](https://claude.com/claude-code)