### PR TITLE
perf(ui): Drop react-phosphor v1 and migrate to v2

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -77,7 +77,6 @@
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.35",
         "monaco-editor": "^0.28.1",
-        "phosphor-react": "^1.4.1",
         "prosemirror-autocomplete": "^0.4.3",
         "query-string": "^6.13.8",
         "rc-table": "^7.13.1",

--- a/datahub-web-react/src/alchemy-components/components/DatePicker/variants/dateSwitcher/components.tsx
+++ b/datahub-web-react/src/alchemy-components/components/DatePicker/variants/dateSwitcher/components.tsx
@@ -1,5 +1,6 @@
 import { colors } from '@components';
-import { CaretLeft, CaretRight } from 'phosphor-react';
+import { CaretLeft } from '@phosphor-icons/react/dist/csr/CaretLeft';
+import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
 import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/alchemy-components/components/Editor/toolbar/FileUploadButton.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Editor/toolbar/FileUploadButton.tsx
@@ -1,6 +1,6 @@
 import { Dropdown, Tooltip, colors } from '@components';
+import { FileArrowUp } from '@phosphor-icons/react/dist/csr/FileArrowUp';
 import { useRemirrorContext } from '@remirror/react';
-import { FileArrowUp } from 'phosphor-react';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/alchemy-components/components/Table/Table.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Table/Table.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable rulesdir/no-hardcoded-colors */
 import { LoadingOutlined } from '@ant-design/icons';
 import { Text } from '@components';
+import { CaretDown } from '@phosphor-icons/react/dist/csr/CaretDown';
 import { CaretLeft } from '@phosphor-icons/react/dist/csr/CaretLeft';
 import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
-import { CaretDown, CaretUp } from 'phosphor-react';
+import { CaretUp } from '@phosphor-icons/react/dist/csr/CaretUp';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/app/entityV2/glossaryNode/ChildrenTab.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryNode/ChildrenTab.tsx
@@ -1,4 +1,4 @@
-import { Plus } from 'phosphor-react';
+import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer.tsx
@@ -1,6 +1,6 @@
 import { Tooltip } from '@components';
+import { Info } from '@phosphor-icons/react/dist/csr/Info';
 import { Typography } from 'antd';
-import { Info } from 'phosphor-react';
 import React from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/AssertionList/Tags/AcrylAssertionTagColumn.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/AssertionList/Tags/AcrylAssertionTagColumn.tsx
@@ -1,5 +1,5 @@
+import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import { message } from 'antd';
-import { Plus } from 'phosphor-react';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/actions/AssertionListItemActions.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/assertion/profile/actions/AssertionListItemActions.tsx
@@ -1,5 +1,5 @@
+import { DotsThreeVertical } from '@phosphor-icons/react/dist/csr/DotsThreeVertical';
 import { Dropdown, Menu } from 'antd';
-import { DotsThreeVertical } from 'phosphor-react';
 import React from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/app/ingest/secret/SecretsList.tsx
+++ b/datahub-web-react/src/app/ingest/secret/SecretsList.tsx
@@ -1,6 +1,7 @@
 import { SearchBar } from '@components';
+import { PencilSimpleLine } from '@phosphor-icons/react/dist/csr/PencilSimpleLine';
+import { Trash } from '@phosphor-icons/react/dist/csr/Trash';
 import { Empty, Modal, Typography, message } from 'antd';
-import { PencilSimpleLine, Trash } from 'phosphor-react';
 import * as QueryString from 'query-string';
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router';

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
@@ -1,6 +1,6 @@
 import { Button, SearchBar, SimpleSelect } from '@components';
+import { ArrowClockwise } from '@phosphor-icons/react/dist/csr/ArrowClockwise';
 import { Modal, Pagination, message } from 'antd';
-import { ArrowClockwise } from 'phosphor-react';
 import * as QueryString from 'query-string';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router';

--- a/datahub-web-react/src/app/ingest/source/utils.ts
+++ b/datahub-web-react/src/app/ingest/source/utils.ts
@@ -1,13 +1,11 @@
 import { colors } from '@components';
-import {
-    ArrowCounterClockwise,
-    ArrowsCounterClockwise,
-    Checks,
-    ClockClockwise,
-    Prohibit,
-    Spinner,
-    X,
-} from 'phosphor-react';
+import { ArrowCounterClockwise } from '@phosphor-icons/react/dist/csr/ArrowCounterClockwise';
+import { ArrowsCounterClockwise } from '@phosphor-icons/react/dist/csr/ArrowsCounterClockwise';
+import { Checks } from '@phosphor-icons/react/dist/csr/Checks';
+import { ClockClockwise } from '@phosphor-icons/react/dist/csr/ClockClockwise';
+import { Prohibit } from '@phosphor-icons/react/dist/csr/Prohibit';
+import { Spinner } from '@phosphor-icons/react/dist/csr/Spinner';
+import { X } from '@phosphor-icons/react/dist/csr/X';
 import YAML from 'yamljs';
 
 import EntityRegistry from '@app/entity/EntityRegistry';

--- a/datahub-web-react/src/app/previewV2/HealthIcon.tsx
+++ b/datahub-web-react/src/app/previewV2/HealthIcon.tsx
@@ -1,5 +1,6 @@
 import { Popover, colors } from '@components';
-import { CheckCircle, WarningCircle } from 'phosphor-react';
+import { CheckCircle } from '@phosphor-icons/react/dist/csr/CheckCircle';
+import { WarningCircle } from '@phosphor-icons/react/dist/csr/WarningCircle';
 import React from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/app/search/filters/ParentEntities.tsx
+++ b/datahub-web-react/src/app/search/filters/ParentEntities.tsx
@@ -1,6 +1,6 @@
 import { FolderOpenOutlined } from '@ant-design/icons';
+import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
 import { Tooltip, Typography } from 'antd';
-import { CaretRight } from 'phosphor-react';
 import React from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/app/searchV2/searchBarV2/components/AutocompleteFooter.tsx
+++ b/datahub-web-react/src/app/searchV2/searchBarV2/components/AutocompleteFooter.tsx
@@ -1,4 +1,6 @@
-import { ArrowDown, ArrowElbowDownLeft, ArrowUp } from 'phosphor-react';
+import { ArrowDown } from '@phosphor-icons/react/dist/csr/ArrowDown';
+import { ArrowElbowDownLeft } from '@phosphor-icons/react/dist/csr/ArrowElbowDownLeft';
+import { ArrowUp } from '@phosphor-icons/react/dist/csr/ArrowUp';
 import React from 'react';
 import styled from 'styled-components';
 

--- a/datahub-web-react/src/app/shared/sidebar/components.tsx
+++ b/datahub-web-react/src/app/shared/sidebar/components.tsx
@@ -1,4 +1,4 @@
-import { CaretRight } from 'phosphor-react';
+import { CaretRight } from '@phosphor-icons/react/dist/csr/CaretRight';
 import React from 'react';
 
 import { RotatingButton } from '@app/shared/components';

--- a/datahub-web-react/yarn.lock
+++ b/datahub-web-react/yarn.lock
@@ -10770,11 +10770,6 @@ peek-readable@^4.1.0:
   resolved "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz"
   integrity sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==
 
-phosphor-react@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/phosphor-react/-/phosphor-react-1.4.1.tgz"
-  integrity sha512-gO5j7U0xZrdglTAYDYPACU4xDOFBTJmptrrB/GeR+tHhCZF3nUMyGmV/0hnloKjuTrOmpSFlbfOY78H39rgjUQ==
-
 picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"


### PR DESCRIPTION
### Summary
Migrating left over phosphor v1 icons to v2. Decreasing bundle size by 50kB.

Meticulous is reporting a regression (health check not showing up). Confirmed that this still works:

<img width="336" height="216" alt="Screenshot 2026-03-20 at 7 03 06 PM" src="https://github.com/user-attachments/assets/312bcde4-ca23-4470-beb0-dafd8d8d5ba3" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://

github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
