### PR TITLE
fix(build/spark): include jackson dependencies and relocate antlr package

### DIFF
--- a/metadata-integration/java/acryl-spark-lineage/build.gradle
+++ b/metadata-integration/java/acryl-spark-lineage/build.gradle
@@ -180,7 +180,7 @@ scalaVersions.each { sv ->
 
     dependencies {
       exclude(dependency {
-        exclude_modules.contains(it.name)
+        exclude_modules.contains(it.name) && !it.name.startsWith("com.fasterxml.jackson")
       })
       exclude(dependency("org.slf4j::"))
       exclude(dependency("ch.qos.logback:"))
@@ -225,6 +225,7 @@ scalaVersions.each { sv ->
     relocate 'org.checkerframework', 'io.acryl.shaded.org.checkerframework'
     relocate 'com.google.errorprone', 'io.acryl.shaded.com.google.errorprone'
     relocate 'com.sun.jna', 'io.acryl.shaded.com.sun.jna'
+    relocate 'org.antlr', 'datahub.shaded.org.antlr'
 
     // Debug output to verify we're using the right dependency
     doFirst {


### PR DESCRIPTION
Fix `acryl-spark-lineage` dependency conflict issues

Closes #16722 #16724

After this fix, I was able to successfully run `select 1` and I didn't see any exceptions in spark driver logs.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
