### PR TITLE
fix: Use the proper name for Fabric

### DIFF
--- a/metadata-service/configuration/src/main/resources/product-update-saas.json
+++ b/metadata-service/configuration/src/main/resources/product-update-saas.json
@@ -4,7 +4,7 @@
   "requiredVersion": null,
   "header": null,
   "title": "DataHub Cloud March Updates",
-  "description": "Cross-platform context, now including Fabric",
+  "description": "Cross-platform context, now including Microsoft Fabric",
   "image": "https://raw.githubusercontent.com/datahub-project/datahub/master/datahub-web-react/src/images/in-product-release-mar2026.png",
   "ctaText": "Learn more",
   "ctaLink": "https://datahub.com/blog/datahub-cloud-v0-3-17",


### PR DESCRIPTION
Product Toast for 0.3.17 should show now show "Microsoft Fabric" instead of just "Fabric".

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
