### PR TITLE
fix(docker): ship metadata-ingestion in locked datahub-actions image

### DIFF
--- a/docker/datahub-actions/Dockerfile
+++ b/docker/datahub-actions/Dockerfile
@@ -402,10 +402,12 @@ RUN chmod a+x /start_datahub_actions.sh && \
     mkdir -p /tmp/datahub/logs/actions/system && \
     chown -R datahub:datahub /etc/datahub /tmp/datahub
 
-# NO metadata-ingestion install in locked variant - only bundled venvs available
-# This ensures complete isolation and prevents any package installations
+# Bundled venvs under /opt/datahub/venvs are built with editable installs against
+# /metadata-ingestion. Ship that tree so subprocess ingestion can import datahub;
+# the default app venv still does not pip-install metadata-ingestion (PyPI blocked below).
+COPY --chown=datahub:datahub ./metadata-ingestion /metadata-ingestion
 
-# Copy only datahub-actions code (not metadata-ingestion)
+# Copy only datahub-actions code for the actions framework venv (not a pip install of metadata-ingestion)
 COPY --chown=datahub:datahub ./datahub-actions/setup.py /datahub-actions/
 COPY --chown=datahub:datahub ./datahub-actions/src/datahub_actions/_version.py /datahub-actions/src/datahub_actions/
 COPY --chown=datahub:datahub ./datahub-actions/README.md /datahub-actions/
@@ -423,13 +425,14 @@ USER datahub
 ARG RELEASE_VERSION
 RUN test -n "$RELEASE_VERSION"
 RUN --mount=type=bind,source=./python-build/version_updater.py,target=/version_updater.py \
+    python /version_updater.py --directory /metadata-ingestion/ --version "$RELEASE_VERSION" --expected-update-count 1 && \
     python /version_updater.py --directory /datahub-actions/ --version "$RELEASE_VERSION" --expected-update-count 1
 
-# Install ONLY datahub-actions (not metadata-ingestion)
+# Install ONLY datahub-actions into the default venv (not metadata-ingestion)
 RUN --mount=type=cache,target=$HOME/.cache/uv,uid=1000,gid=1000,id=datahub-actions,sharing=private \
   uv pip install -e '/datahub-actions/[all]'
 
-# Block network access to PyPI - locked variant only uses bundled venvs
+# Block network access to PyPI - locked variant has no runtime pip installs for ingestion CLI
 ENV UV_INDEX_URL=http://127.0.0.1:1/simple
 ENV PIP_INDEX_URL=http://127.0.0.1:1/simple
 


### PR DESCRIPTION
Bundled venvs are built with editable installs against /metadata-ingestion. final-locked omitted that tree, breaking datahub imports in *-bundled venvs.

Copy the full metadata-ingestion source and align versions with RELEASE_VERSION via version_updater, matching slim/full. Default venv still only installs datahub-actions; PyPI remains blocked for runtime installs.

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
