### PR TITLE
perf(frontend): reduce Monaco Editor static assets from 23 MB to 3 MB

### DIFF
--- a/datahub-web-react/.eslintrc.js
+++ b/datahub-web-react/.eslintrc.js
@@ -119,6 +119,11 @@ module.exports = {
                             'Import Phosphor icons from their individual CSR paths: @phosphor-icons/react/dist/csr/IconName.',
                         allowTypeImports: true,
                     },
+                    {
+                        name: '@monaco-editor/react',
+                        importNames: ['loader'],
+                        message: "Configure Monaco's loader path via `import '@conf/monaco'` instead of calling loader.config() directly.",
+                    },
                 ],
             },
         ],

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/QueryBuilderForm.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/QueryBuilderForm.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import { ANTD_GRAY } from '@app/entityV2/shared/constants';
 import { QueryBuilderState } from '@app/entityV2/shared/tabs/Dataset/Queries/types';
+import '@conf/monaco';
 import { Editor as MarkdownEditor } from '@src/alchemy-components';
 
 const EditorWrapper = styled.div`

--- a/datahub-web-react/src/app/ingest/source/RecipeViewerModal.tsx
+++ b/datahub-web-react/src/app/ingest/source/RecipeViewerModal.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from 'styled-components/macro';
 
 import { jsonToYaml } from '@app/ingest/source/utils';
+import '@conf/monaco';
 
 const YamlWrapper = styled.div`
     padding: 24px;

--- a/datahub-web-react/src/app/ingest/source/builder/YamlEditor.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/YamlEditor.tsx
@@ -1,13 +1,7 @@
-import Editor, { loader } from '@monaco-editor/react';
+import Editor from '@monaco-editor/react';
 import React from 'react';
 
-import { resolveRuntimePath } from '@utils/runtimeBasePath';
-
-loader.config({
-    paths: {
-        vs: resolveRuntimePath('/node_modules/monaco-editor/min/vs'),
-    },
-});
+import '@conf/monaco';
 
 type Props = {
     initialText: string;

--- a/datahub-web-react/src/app/ingestV2/source/RecipeViewerModal.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/RecipeViewerModal.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from 'styled-components/macro';
 
 import { jsonToYaml } from '@app/ingestV2/source/utils';
+import '@conf/monaco';
 
 const YamlWrapper = styled.div`
     padding: 24px;

--- a/datahub-web-react/src/app/ingestV2/source/builder/YamlEditor.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/builder/YamlEditor.tsx
@@ -1,13 +1,7 @@
-import Editor, { loader } from '@monaco-editor/react';
+import Editor from '@monaco-editor/react';
 import React from 'react';
 
-import { resolveRuntimePath } from '@utils/runtimeBasePath';
-
-loader.config({
-    paths: {
-        vs: resolveRuntimePath('/node_modules/monaco-editor/min/vs'),
-    },
-});
+import '@conf/monaco';
 
 type Props = {
     initialText: string;

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/YamlEditor.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/YamlEditor.tsx
@@ -1,5 +1,5 @@
 import { Button, Icon, Text, borders, colors, radius, spacing, typography } from '@components';
-import Editor, { loader } from '@monaco-editor/react';
+import Editor from '@monaco-editor/react';
 import { ArrowsInLineVertical } from '@phosphor-icons/react/dist/csr/ArrowsInLineVertical';
 import { ArrowsOutLineVertical } from '@phosphor-icons/react/dist/csr/ArrowsOutLineVertical';
 import { Copy } from '@phosphor-icons/react/dist/csr/Copy';
@@ -7,13 +7,7 @@ import { message } from 'antd';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
-import { resolveRuntimePath } from '@utils/runtimeBasePath';
-
-loader.config({
-    paths: {
-        vs: resolveRuntimePath('/node_modules/monaco-editor/min/vs'),
-    },
-});
+import '@conf/monaco';
 
 const Container = styled.div`
     display: flex;

--- a/datahub-web-react/src/conf/monaco.ts
+++ b/datahub-web-react/src/conf/monaco.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { loader } from '@monaco-editor/react';
+
+import { resolveRuntimePath } from '@utils/runtimeBasePath';
+
+loader.config({
+    paths: {
+        vs: resolveRuntimePath('/node_modules/monaco-editor/min/vs'),
+    },
+});

--- a/datahub-web-react/vite.config.ts
+++ b/datahub-web-react/vite.config.ts
@@ -123,21 +123,29 @@ export default defineConfig(async ({ mode }) => {
             }),
             viteStaticCopy({
                 targets: [
-                    // Copy monaco-editor files to the build directory
-                    // Because of the structured option, specifying dest .
-                    // means that it will mirror the node_modules/... structure
-                    // in the build directory.
+                    // Selective Monaco Editor files — only what DataHub actually uses (YAML + SQL).
+                    // structured: true mirrors the node_modules/... path into the build directory,
+                    // so Monaco's AMD loader can find files at /node_modules/monaco-editor/min/vs/*.
+                    // The language/ directory (TS/CSS/HTML/JSON IntelliSense, ~7 MB) and min-maps/
+                    // (~11 MB) are intentionally excluded — they are never requested at runtime.
+                    { src: 'node_modules/monaco-editor/min/vs/loader.js', dest: '.' },
                     {
-                        src: 'node_modules/monaco-editor/min/vs/',
+                        src: [
+                            'node_modules/monaco-editor/min/vs/editor/editor.main.js',
+                            'node_modules/monaco-editor/min/vs/editor/editor.main.css',
+                            'node_modules/monaco-editor/min/vs/editor/editor.main.nls.js',
+                        ],
                         dest: '.',
                     },
+                    // base/ contains workerMain.js and the codicon font — required by the editor core.
+                    { src: 'node_modules/monaco-editor/min/vs/base/', dest: '.' },
+                    // Only the two language tokenizers DataHub uses.
                     {
-                        src: 'node_modules/monaco-editor/min-maps/vs/',
+                        src: [
+                            'node_modules/monaco-editor/min/vs/basic-languages/yaml/',
+                            'node_modules/monaco-editor/min/vs/basic-languages/sql/',
+                        ],
                         dest: '.',
-                        rename: (name, ext, fullPath) => {
-                            console.log(name, ext, fullPath);
-                            return name;
-                        },
                     },
                 ],
                 structured: true,


### PR DESCRIPTION
### Summary
Monaco Editor's full `min/vs/` directory (12 MB) and source maps `min-maps/vs/` (11 MB) were
being copied into every production build via `vite-plugin-static-copy`, even though DataHub only
uses Monaco for YAML and SQL editing. This PR replaces the blanket copy with a selective list of
only the files Monaco actually needs at runtime.


| | Before | After |
|---|---|---|
| Monaco in `dist/` | 23 MB | 3 MB |
| Total `dist/` size | 58 MB | 39 MB |
| Docker image | 568.1 MB | 564.1 MB |
| Files copied at build | 193+ | 8 |


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
