### PR TITLE
fix(ui): Disable schedule by default in ingestion form

### DIFF
--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/IngestionSourceCreatePage.tsx
@@ -14,7 +14,6 @@ import { SelectSourceStep } from '@app/ingestV2/source/multiStepBuilder/steps/st
 import SelectSourceSubtitle from '@app/ingestV2/source/multiStepBuilder/steps/step1SelectSource/SelectSourceSubtitle';
 import { ConnectionDetailsStep } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/ConnectionDetailsStep';
 import { ConnectionDetailsSubTitle } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/ConnectionDetailsSubTitle';
-import { DAILY_MIDNIGHT_CRON_INTERVAL } from '@app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/syncScheduleSection/constants';
 import {
     IngestionSourceFormStep,
     MultiStepSourceBuilderState,
@@ -59,11 +58,7 @@ export function IngestionSourceCreatePage() {
 
     const { defaultOwnershipType } = useOwnershipTypes();
 
-    const initialState = {
-        schedule: {
-            interval: DAILY_MIDNIGHT_CRON_INTERVAL,
-        },
-    };
+    const initialState = {};
 
     const onSubmit = useCallback(
         async (data: MultiStepSourceBuilderState | undefined, options: SubmitOptions | undefined) => {

--- a/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/syncScheduleSection/ScheduleSection.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/multiStepBuilder/steps/step2ConnectionDetails/sections/recipeSection/sections/syncScheduleSection/ScheduleSection.tsx
@@ -120,6 +120,7 @@ export function ScheduleSection() {
                 checked={scheduleEnabled}
                 onChange={(e) => setScheduleEnabled(e.target.checked)}
                 labelPosition="right"
+                data-testid="schedule-enabled-switch"
             />
             {!scheduleEnabled && (
                 <WarningContainer>

--- a/datahub-web-react/src/providers/hooks/__tests__/useHasSeenEducationStep.test.tsx
+++ b/datahub-web-react/src/providers/hooks/__tests__/useHasSeenEducationStep.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
 
 import { useUserContext } from '@app/context/useUserContext';
+import useShouldSkipOnboardingTour from '@app/onboarding/useShouldSkipOnboardingTour';
 import { EducationStepsContext } from '@providers/EducationStepsContext';
 import useHasSeenEducationStep from '@providers/hooks/useHasSeenEducationStep';
 
@@ -16,7 +17,12 @@ vi.mock('@app/onboarding/utils', () => ({
     convertStepId: vi.fn((stepId: string, userUrn: string) => `${userUrn}-${stepId}`),
 }));
 
+vi.mock('@app/onboarding/useShouldSkipOnboardingTour', () => ({
+    default: vi.fn(),
+}));
+
 const mockUseUserContext = useUserContext as ReturnType<typeof vi.fn>;
+const mockUseShouldSkipOnboardingTour = useShouldSkipOnboardingTour as ReturnType<typeof vi.fn>;
 
 describe('useHasSeenEducationStep', () => {
     const mockSetEducationSteps = vi.fn();
@@ -26,6 +32,55 @@ describe('useHasSeenEducationStep', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockUseShouldSkipOnboardingTour.mockReturnValue(false);
+    });
+
+    describe('when shouldSkip is true', () => {
+        beforeEach(() => {
+            mockUseShouldSkipOnboardingTour.mockReturnValue(true);
+        });
+
+        it('should return true even when step has not been seen', () => {
+            mockUseUserContext.mockReturnValue({ user: { urn: testUserUrn } });
+            const educationSteps: StepStateResult[] = [{ id: `${testUserUrn}-other-step`, properties: [] }];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: mockSetEducationStepIdsAllowlist,
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useHasSeenEducationStep(testStepId), { wrapper });
+
+            expect(result.current).toBe(true);
+        });
+
+        it('should return true even when educationSteps is empty', () => {
+            mockUseUserContext.mockReturnValue({ user: { urn: testUserUrn } });
+            const educationSteps: StepStateResult[] = [];
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <EducationStepsContext.Provider
+                    value={{
+                        educationSteps,
+                        setEducationSteps: mockSetEducationSteps,
+                        educationStepIdsAllowlist: new Set(),
+                        setEducationStepIdsAllowlist: mockSetEducationStepIdsAllowlist,
+                    }}
+                >
+                    {children}
+                </EducationStepsContext.Provider>
+            );
+
+            const { result } = renderHook(() => useHasSeenEducationStep(testStepId), { wrapper });
+
+            expect(result.current).toBe(true);
+        });
     });
 
     describe('when user is not loaded', () => {

--- a/datahub-web-react/src/providers/hooks/useHasSeenEducationStep.ts
+++ b/datahub-web-react/src/providers/hooks/useHasSeenEducationStep.ts
@@ -1,12 +1,18 @@
 import { useContext } from 'react';
 
 import { useUserContext } from '@app/context/useUserContext';
+import useShouldSkipOnboardingTour from '@app/onboarding/useShouldSkipOnboardingTour';
 import { convertStepId } from '@app/onboarding/utils';
 import { EducationStepsContext } from '@providers/EducationStepsContext';
 
 export default function useHasSeenEducationStep(stepId: string, isForUser = true) {
     const { educationSteps } = useContext(EducationStepsContext);
     const { user } = useUserContext();
+
+    const shouldSkip = useShouldSkipOnboardingTour();
+
+    // if skipping, return that they have seen it
+    if (shouldSkip) return true;
 
     if (isForUser && !user?.urn) {
         // assume they have seen the step while user loads

--- a/smoke-test/tests/cypress/cypress/e2e/ingestionV3/sources_v2.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ingestionV3/sources_v2.js
@@ -45,7 +45,7 @@ describe("ingestion sources", () => {
     const sourceName = "ingestion source";
     const updatedSourceName = "updated ingestion source";
     createIngestionSource(sourceName);
-    verifyScheduleIsAppliedOnTable(sourceName, "12:00 am"); // the default schedule
+    verifyScheduleIsAppliedOnTable(sourceName, "-"); // the default schedule
     updateIngestionSource(sourceName, updatedSourceName, {
       schedule: { hour: "01" },
     });

--- a/smoke-test/tests/cypress/cypress/e2e/ingestionV3/utils.js
+++ b/smoke-test/tests/cypress/cypress/e2e/ingestionV3/utils.js
@@ -141,6 +141,7 @@ export const createIngestionSource = (sourceName, options = undefined) => {
   // Finish creating source
   cy.contains("Sync Schedule").scrollIntoView().should("be.visible");
   if (options?.schedule) {
+    cy.get('[data-testid="schedule-enabled-switch"]').click();
     changeSchedule(options?.schedule);
   }
 
@@ -169,6 +170,7 @@ export const updateIngestionSource = (
     .type(`{selectall}{backspace}${updatedSourceName}`);
   cy.contains("Sync Schedule").scrollIntoView().should("be.visible");
   if (options?.schedule) {
+    cy.get('[data-testid="schedule-enabled-switch"]').click();
     changeSchedule(options?.schedule);
   }
 


### PR DESCRIPTION
With the change to sync schedule, we want to disable schedule by default so people don't add a schedule without meaning to.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
