### PR TITLE
fix(ui): Add glossary section to policy view only modal

### DIFF
--- a/datahub-web-react/src/app/permissions/policy/PolicyDetailsModal.tsx
+++ b/datahub-web-react/src/app/permissions/policy/PolicyDetailsModal.tsx
@@ -11,6 +11,7 @@ import {
     getFieldValues,
     mapResourceTypeToDisplayName,
 } from '@app/permissions/policy/policyUtils';
+import { useIsGlossaryBasedPoliciesEnabled } from '@app/shared/hooks/useIsGlossaryBasedPoliciesEnabled';
 import { useAppConfig } from '@app/useAppConfig';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
@@ -70,6 +71,7 @@ const Privileges = styled.div`
  */
 export default function PolicyDetailsModal({ policy, open, onClose, privileges }: Props) {
     const entityRegistry = useEntityRegistry();
+    const isGlossaryBasedPoliciesEnabled = useIsGlossaryBasedPoliciesEnabled();
 
     const isActive = policy?.state === PolicyState.Active;
     const isMetadataPolicy = policy?.type === PolicyType.Metadata;
@@ -82,6 +84,7 @@ export default function PolicyDetailsModal({ policy, open, onClose, privileges }
         getFieldCondition(resources?.filter, URN, RESOURCE_URN) || PolicyMatchCondition.Equals;
     const domains = getFieldValues(resources?.filter, 'DOMAIN') || [];
     const containers = getFieldValues(resources?.filter, 'CONTAINER') || [];
+    const glossaryEntities = getFieldValues(resources?.filter, 'GLOSSARY') || [];
 
     const {
         config: { policiesConfig },
@@ -225,6 +228,21 @@ export default function PolicyDetailsModal({ policy, open, onClose, privileges }
                                     );
                                 })) || <PoliciesTag>All</PoliciesTag>}
                         </div>
+                        {isGlossaryBasedPoliciesEnabled && (
+                            <div>
+                                <Typography.Title level={5}>Glossary Terms & Term Groups</Typography.Title>
+                                <ThinDivider />
+                                {(glossaryEntities?.length &&
+                                    glossaryEntities.map((value, key) => {
+                                        return (
+                                            // eslint-disable-next-line react/no-array-index-key
+                                            <PoliciesTag key={`glossary-${value.value}-${key}`}>
+                                                {getEntityTag(value)}
+                                            </PoliciesTag>
+                                        );
+                                    })) || <PoliciesTag>None</PoliciesTag>}
+                            </div>
+                        )}
                     </>
                 )}
                 <Privileges>

--- a/datahub-web-react/src/app/permissions/policy/_tests_/PolicyDetailsModal.test.tsx
+++ b/datahub-web-react/src/app/permissions/policy/_tests_/PolicyDetailsModal.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@app/useAppConfig', () => ({
                     },
                 ],
             },
+            featureFlags: { glossaryBasedPoliciesEnabled: true },
         },
     }),
 }));


### PR DESCRIPTION
This section was forgotten where you can review a policy without editing it in a "read only" state - we just need to list the selected terms and groups if the flag is enabled.

<img width="1726" height="910" alt="Screenshot 2026-03-05 at 5 42 54 PM" src="https://github.com/user-attachments/assets/deb55946-329e-4641-9e51-0dfed97814e5" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
