### PR TITLE
chore: add chore to allowed PR title types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Before you submit your PR, please go through the checklist below:
 - [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
 
 
-Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_
+Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_
 
 
 -->

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -27,6 +27,7 @@ jobs:
             style
             build
             ci
+            chore
           requireScope: false
       - if: always() && steps.lint_pr_title.outputs.error_message != null
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,7 +418,7 @@ When creating PRs, follow the template in `.github/pull_request_template.md`:
 <type>[optional scope]: <description>
 ```
 
-Types: `feat`, `fix`, `refactor`, `docs`, `test`, `perf`, `style`, `build`, `ci`
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `perf`, `style`, `build`, `ci`, `chore`
 
 Example: `feat(parser): add ability to parse arrays`
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -60,3 +60,4 @@ Must be one of the following:
 - _style_: Changes that do not affect the meaning of the code (whitespace, formatting, missing semicolons, etc.)
 - _build_: Changes that affect the build system or external dependencies
 - _ci_: Changes to our CI configuration files and scripts
+- _chore_: Maintenance tasks (dependency bumps, tooling, etc.)


### PR DESCRIPTION
## Summary

- Adds `chore` as an allowed PR title type across all 4 locations where types are defined
- Fixes CI failures for PRs with `chore(...)` titles (e.g. dependency bumps, tooling updates)