### PR TITLE
fix(ci): add import check to validate-plugin-deps workflow

### DIFF
--- a/.github/workflows/metadata-ingestion.yml
+++ b/.github/workflows/metadata-ingestion.yml
@@ -223,12 +223,18 @@ jobs:
             uv venv "$PLUGIN_VENV"
             
             # Install the plugin in its venv using system uv command
-            if uv pip install -e ".[${plugin}]" --python "$PLUGIN_VENV/bin/python"; then
-              echo "✅ Plugin '$plugin' installed successfully with all dependencies"
-              SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
-            else
+            if ! uv pip install -e ".[${plugin}]" --python "$PLUGIN_VENV/bin/python"; then
               echo "❌ Plugin '$plugin' failed to install"
               FAILED_PLUGINS+=("$plugin")
+            # Verify the plugin is actually importable in the isolated venv.
+            # This catches dependencies used in code but missing from declared extras
+            # (e.g. a package imported at module level but not listed in setup.py).
+            elif ! "$PLUGIN_VENV/bin/datahub" check plugins --source "$plugin"; then
+              echo "❌ Plugin '$plugin' installed but failed to import (missing dependency?)"
+              FAILED_PLUGINS+=("$plugin")
+            else
+              echo "✅ Plugin '$plugin' installed and importable"
+              SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
             fi
             
             # Clean up venv to save space


### PR DESCRIPTION
## 📋 Summary
Add a plugin importability check to the `validate-plugin-deps` CI job so that undeclared runtime dependencies are caught at PR time.

## 🎯 Motivation
The `validate-plugin-deps` workflow failed to catch a missing `tenacity` dependency in the Flink source. Even though `tenacity` was imported at module level in the Flink source code, it wasn't declared in the `flink` extras in `setup.py`. The workflow reported success because it only verified that `pip install` exited 0 — which it does regardless of whether all code-level imports are satisfied.

This was discovered after the Flink PR merged and connector tests failed with `ModuleNotFoundError: No module named 'tenacity'`.

## 🔧 Changes Overview

**Bug Fix:**
- After installing each plugin's extras in its isolated venv, the workflow now runs `datahub check plugins --source <plugin>` to verify the plugin is actually importable
- If any module-level import fails (e.g. a missing transitive dep not declared in extras), the plugin is marked as failed and the job exits non-zero

## 🏗️ Architecture/Design Notes
- The `connector-tests` repo's `validate_connector_deps` workflow already follows this exact pattern: install deps, then run `datahub check plugins --source <plugin>`. This change brings the OSS workflow in line with that approach.
- The only intentional difference between the two workflows remains: OSS validates the local editable source (`-e ".[plugin]"`), while connector-tests validates the published PyPI package — appropriate for their respective purposes.

## 🧪 Testing
- The fix would have caught the missing `tenacity` dep on the original Flink PR: `pip install` would have succeeded, but `datahub check plugins --source flink` would have failed with an import error.

## 🔗 References
- Root cause fix (added tenacity to flink extras): #16741