### PR TITLE
fix(build): skip non-numeric PyPI versions in resolveDefaultCliVersion

### DIFF
--- a/gradle/versioning/cliVersion.gradle
+++ b/gradle/versioning/cliVersion.gradle
@@ -4,5 +4,5 @@ ext {
     //
     // To automatically update this to the latest CLI version prior to release, run the following command:
     // ./gradlew resolveDefaultCliVersion
-    cliVersion = "1.4.0.3"
+    cliVersion = "1.5.0"
 }

--- a/gradle/versioning/resolveDefaultCliVersion.gradle
+++ b/gradle/versioning/resolveDefaultCliVersion.gradle
@@ -22,16 +22,19 @@ ext.resolveDefaultCliVersion = {
         // Get all releases
         def releases = data.releases
         
-        // Filter out RC versions and yanked releases
+        // Filter out RC versions, post/dev/local releases, and yanked releases.
+        // PyPI keys like 1.2.0.6.post1 are not dot-separated integers; they broke the
+        // legacy comparator and are not appropriate defaults (use the base release, e.g. 1.5.0).
         def validReleases = releases.findAll { version, releaseFiles ->
-            // Skip RC versions
             if (version.toLowerCase().contains("rc")) {
                 return false
             }
-            
-            // Skip if all files are yanked
-            def allYanked = releaseFiles.every { file -> 
-                file.yanked == true 
+            def parts = version.tokenize('.')
+            if (!parts.every { part -> part.isInteger() }) {
+                return false
+            }
+            def allYanked = releaseFiles.every { file ->
+                file.yanked == true
             }
             return !allYanked
         }


### PR DESCRIPTION
Filter release keys to dot-separated integers only so .postN segments no longer break sorting. Update default cliVersion to 1.5.0.

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_


-->
