### PR TITLE
fix(vertica): remove accidental pytest import from source file

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import pydantic
-import pytest
 from pydantic import field_validator
 from vertica_sqlalchemy_dialect.base import VerticaInspector
 
@@ -57,7 +56,6 @@ from datahub.utilities import config_clean
 if TYPE_CHECKING:
     from datahub.ingestion.source.ge_data_profiler import GEProfilerRequest
 
-pytestmark = pytest.mark.integration_batch_4
 logger: logging.Logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## 📋 Summary
Remove `import pytest` and `pytestmark` that were accidentally placed in the Vertica source file instead of the test file.

## 🎯 Motivation
The `validate-plugin-deps` CI job installs each plugin in an isolated venv and then verifies it is importable via `datahub check plugins --source <plugin>`. The Vertica plugin was failing this check because `vertica.py` imports `pytest` at module level — a test-only dependency that is not (and should not be) declared in the `vertica` extras.

This was a latent bug that went undetected until the import-check step was added to CI (#16749).

## 🔧 Changes Overview

**Bug Fix:**
- Removed `import pytest` from `vertica.py` (line 7)
- Removed `pytestmark = pytest.mark.integration_batch_4` from `vertica.py` (line 60)

The `pytestmark` marker belongs in test files, not source files. It was already correctly defined in `tests/integration/vertica/test_vertica.py`, making the entry in the source file both redundant and harmful.

## 📊 Impact Assessment
- **Affected Components:** `metadata-ingestion` — Vertica source plugin only
- **Breaking Changes:** None — removing a misplaced test marker has no effect on source behavior or test execution
- **Risk Level:** Low — two-line deletion of code that should never have been in a source file

## 🔗 References
- Related: #16749 (added the import-check step that surfaced this bug)