### PR TITLE
feat(cli): add --context / -C flag for passing context in event properties

### DIFF
--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -82,15 +82,34 @@ if sys.version_info >= (3, 12):
     default=None,
     help="Write debug-level logs to a file.",
 )
+@click.option(
+    "--context",
+    "-C",
+    "context_pairs",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Additional context as key=value pairs (can be repeated).",
+)
 @click.version_option(
     version=datahub_version.nice_version_name(),
     prog_name=datahub_version.__package_name__,
 )
+@click.pass_context
 def datahub(
+    ctx: click.Context,
     debug: bool,
     log_file: Optional[str],
+    context_pairs: tuple,
 ) -> None:
     debug = debug or get_boolean_env_variable("DATAHUB_DEBUG", False)
+
+    # Parse --context key=value pairs and store on Click context for telemetry.
+    ctx.ensure_object(dict)
+    ctx.obj["context"] = {}
+    for pair in context_pairs:
+        if "=" in pair:
+            k, v = pair.split("=", 1)
+            ctx.obj["context"][k] = v
 
     # Note that we're purposely leaking the context manager here.
     # Technically we should wrap this with ctx.with_resource(). However, we have

--- a/metadata-ingestion/src/datahub/telemetry/telemetry.py
+++ b/metadata-ingestion/src/datahub/telemetry/telemetry.py
@@ -417,6 +417,19 @@ _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
 
+def _get_cli_context() -> Dict[str, str]:
+    """Read --context key=value pairs from the Click context, if available."""
+    try:
+        import click
+
+        ctx = click.get_current_context(silent=True)
+        if ctx and ctx.obj and isinstance(ctx.obj, dict):
+            return {f"ctx_{k}": v for k, v in ctx.obj.get("context", {}).items()}
+    except Exception:
+        pass
+    return {}
+
+
 def with_telemetry(
     *, capture_kwargs: Optional[List[str]] = None
 ) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
@@ -431,6 +444,7 @@ def with_telemetry(
             telemetry_instance.init_capture_exception()
 
             call_props: Dict[str, Any] = {"function": function}
+            call_props.update(_get_cli_context())
             for kwarg in kwargs_to_track:
                 call_props[f"arg_{kwarg}"] = kwargs.get(kwarg)
 

--- a/metadata-ingestion/tests/unit/telemetry/test_env_context.py
+++ b/metadata-ingestion/tests/unit/telemetry/test_env_context.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock, patch
+
+from datahub.telemetry.telemetry import _get_cli_context
+
+
+class TestGetCliContext:
+    def test_reads_context_from_click(self):
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {"context": {"skill": "datahub-audit", "run_id": "abc123"}}
+        with patch("click.get_current_context", return_value=mock_ctx):
+            result = _get_cli_context()
+        assert result == {"ctx_skill": "datahub-audit", "ctx_run_id": "abc123"}
+
+    def test_returns_empty_when_no_click_context(self):
+        with patch("click.get_current_context", return_value=None):
+            result = _get_cli_context()
+        assert result == {}
+
+    def test_returns_empty_when_no_context_key(self):
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {}
+        with patch("click.get_current_context", return_value=mock_ctx):
+            result = _get_cli_context()
+        assert result == {}
+
+    def test_returns_empty_on_exception(self):
+        with patch("click.get_current_context", side_effect=RuntimeError):
+            result = _get_cli_context()
+        assert result == {}


### PR DESCRIPTION
## Summary

- Add `--context` / `-C` option on the root `datahub` command that accepts `key=value` pairs
- Can be repeated: `datahub -C skill=audit -C caller=claude search "..."`
- Values are included in event properties prefixed with `ctx_`

## Test plan

- [x] Unit tests for context parsing and propagation
- [ ] CI passes