### PR TITLE
fix(ingest/dataplex): preserve upstream platform in cross-platform lineage URNs

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dataplex/dataplex_lineage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import collections
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Set
@@ -394,6 +395,10 @@ class DataplexLineageExtractor:
                 if platform not in ["bigquery", "gcs", "dataplex"]:
                     logger.warning(f"Unexpected platform '{platform}' in FQN: {fqn}")
 
+                # Normalize GCS entry IDs to match DataHub GCS source URN format
+                if platform == "gcs":
+                    entry_part = self._normalize_gcs_entry_id(entry_part)
+
                 return (platform, entry_part)
             else:
                 # No platform prefix, return as-is (shouldn't happen in practice)
@@ -409,6 +414,31 @@ class DataplexLineageExtractor:
         if result is None:
             return None
         return result[1]
+
+    def _normalize_gcs_entry_id(self, entry_id: str) -> str:
+        """Normalize a GCS entry ID from Data Lineage API format to DataHub URN format.
+
+        The GCP Data Lineage API uses: bucket.`path/to/files/*.csv`
+        DataHub GCS source uses:       bucket/path/to/files
+
+        Transformations:
+        1. Strip backticks
+        2. Replace first dot (bucket.path separator) with slash
+        3. Remove trailing glob patterns (/*.csv, /*.parquet, etc.)
+        """
+        # Strip backticks
+        normalized = entry_id.replace("`", "")
+        # Replace first dot with slash (bucket.path -> bucket/path)
+        # The Data Lineage API uses dot as bucket/path separator.
+        # Only replace if the dot comes before the first slash (or there is no slash),
+        # to avoid double-normalizing already-slash-separated paths.
+        dot_pos = normalized.find(".")
+        slash_pos = normalized.find("/")
+        if dot_pos != -1 and (slash_pos == -1 or dot_pos < slash_pos):
+            normalized = normalized[:dot_pos] + "/" + normalized[dot_pos + 1 :]
+        # Remove trailing glob pattern (e.g. /*.csv, /*.parquet, /*)
+        normalized = re.sub(r"/\*(\.\w+)?$", "", normalized)
+        return normalized
 
     def get_lineage_for_table(
         self, dataset_id: str, dataset_urn: str, platform: str

--- a/metadata-ingestion/tests/unit/dataplex/test_dataplex_lineage.py
+++ b/metadata-ingestion/tests/unit/dataplex/test_dataplex_lineage.py
@@ -1210,3 +1210,110 @@ def test_cross_platform_lineage_preserves_upstream_platform() -> None:
         f"Upstream URN should NOT use 'bigquery' platform for GCS source, "
         f"but got: {upstream_urn}"
     )
+
+
+def test_normalize_gcs_entry_id(
+    lineage_extractor: DataplexLineageExtractor,
+) -> None:
+    """Test GCS entry ID normalization from Data Lineage API format to DataHub format.
+
+    The GCP Data Lineage API uses: bucket.`path/to/files/*.csv`
+    DataHub GCS source uses:       bucket/path/to/files
+    """
+    normalize = lineage_extractor._normalize_gcs_entry_id
+
+    # Standard case: backtick-wrapped path with glob
+    assert normalize("my-bucket.`raw/thelook/order_items/*.csv`") == (
+        "my-bucket/raw/thelook/order_items"
+    )
+
+    # Different glob extension
+    assert normalize("my-bucket.`data/files/*.parquet`") == ("my-bucket/data/files")
+
+    # Bare glob (no extension)
+    assert normalize("my-bucket.`data/files/*`") == "my-bucket/data/files"
+
+    # No glob - concrete file path with backticks
+    assert normalize("my-bucket.`raw/data/file.csv`") == ("my-bucket/raw/data/file.csv")
+
+    # No backticks (just dot separator)
+    assert normalize("my-bucket.raw/data") == "my-bucket/raw/data"
+
+    # Bucket only - no change
+    assert normalize("my-bucket") == "my-bucket"
+
+    # Already slash-separated - no change
+    assert normalize("my-bucket/raw/data") == "my-bucket/raw/data"
+
+
+def test_gcs_entry_id_normalized_to_datahub_format() -> None:
+    """End-to-end test: GCS upstream URN name matches DataHub GCS source format.
+
+    Verifies that the full pipeline (build_lineage_map -> get_lineage_for_table)
+    produces a GCS upstream URN with the normalized entry ID format that the
+    DataHub GCS ingestion source would create.
+
+    Data Lineage API FQN: gcs:my-bucket.`raw/thelook/order_items/*.csv`
+    Expected URN name:    my-bucket/raw/thelook/order_items
+    """
+    config = DataplexConfig(
+        project_ids=["test-project"],
+        entries_location="us",
+        include_lineage=True,
+    )
+    report = DataplexReport()
+    mock_client = MagicMock()
+
+    def mock_search_links(request):
+        target_fqn = getattr(
+            getattr(request, "target", None), "fully_qualified_name", ""
+        )
+        if target_fqn and "ext_thelook_order_items" in target_fqn:
+            mock_link = MagicMock()
+            mock_link.source.fully_qualified_name = (
+                "gcs:my-bucket.`raw/thelook/order_items/*.csv`"
+            )
+            return [mock_link]
+        return []
+
+    mock_client.search_links.side_effect = mock_search_links
+
+    extractor = DataplexLineageExtractor(
+        config=config, report=report, lineage_client=mock_client
+    )
+
+    bq_entry = EntryDataTuple(
+        entry_id="ext_thelook_order_items",
+        source_platform="bigquery",
+        dataset_id="test-project.datahub_demo_raw.ext_thelook_order_items",
+    )
+
+    extractor.build_lineage_map("test-project", [bq_entry])
+
+    dataset_urn = (
+        "urn:li:dataset:(urn:li:dataPlatform:bigquery,"
+        "test-project.datahub_demo_raw.ext_thelook_order_items,PROD)"
+    )
+    result = extractor.get_lineage_for_table(
+        "test-project.datahub_demo_raw.ext_thelook_order_items",
+        dataset_urn,
+        "bigquery",
+    )
+
+    assert result is not None
+    assert len(result.upstreams) == 1
+
+    upstream_urn = result.upstreams[0].dataset
+
+    # URN should be: urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/raw/thelook/order_items,PROD)
+    expected_name = "my-bucket/raw/thelook/order_items"
+    assert expected_name in upstream_urn, (
+        f"Upstream URN name should be '{expected_name}' "
+        f"(slash-separated, no backticks, no glob), but got: {upstream_urn}"
+    )
+    assert "`" not in upstream_urn, (
+        f"Upstream URN should not contain backticks, but got: {upstream_urn}"
+    )
+    assert "*" not in upstream_urn, (
+        f"Upstream URN should not contain glob patterns, but got: {upstream_urn}"
+    )


### PR DESCRIPTION
## Summary

Fixes the Dataplex lineage connector generating incorrect upstream URNs when the GCP Data Lineage API reports cross-platform relationships (e.g. GCS file -> BigQuery external table). Two issues fixed:

- **Wrong platform (commit 1):** `get_lineage_for_table()` used the **target** entry's platform for all upstream URNs, so a GCS upstream got `dataPlatform:bigquery` instead of `dataPlatform:gcs`. Fixed by adding `platform` field to `LineageEdge` and preserving the upstream's platform from the FQN.

- **Wrong entry ID format (commit 2):** The GCP Data Lineage API returns GCS FQNs as ``bucket.`path/*.csv` `` but DataHub's GCS source creates URNs with `bucket/path` (slash-separated, no backticks, no glob). Added `_normalize_gcs_entry_id()` to transform the format so upstream URNs resolve to real GCS-ingested entities.

## Changes

### Commit 1: Platform fix
- Add `platform` field to `LineageEdge` dataclass
- Rename `_extract_entry_id_from_fqn()` to `_extract_platform_and_entry_id_from_fqn()` returning `(platform, entry_id)` tuple (old name kept as backward-compatible wrapper)
- Update `build_lineage_map()` to extract and store the upstream platform from the FQN
- Update `get_lineage_for_table()` to use `lineage_edge.platform` instead of the target's platform parameter

### Commit 2: GCS entry ID normalization
- Add `_normalize_gcs_entry_id()` method: strips backticks, replaces dot bucket separator with slash, removes trailing glob patterns
- Call it from `_extract_platform_and_entry_id_from_fqn()` when platform is `gcs`

## Test plan

- [x] `test_cross_platform_lineage_preserves_upstream_platform` - verifies GCS upstream gets `dataPlatform:gcs` URN (commit 1)
- [x] `test_normalize_gcs_entry_id` - unit tests for normalization edge cases: backtick+glob, no glob, no backticks, bucket only, already normalized (commit 2)
- [x] `test_gcs_entry_id_normalized_to_datahub_format` - end-to-end test through full pipeline verifying URN name matches DataHub GCS source format (commit 2)
- [x] All 37 existing + new dataplex lineage tests pass
- [ ] Verify with real GCP Data Lineage API data (GCS -> BigQuery external table lineage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)