### PR TITLE
feat(ui): Configurable summary section on search results

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -219,6 +219,8 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
 
     final SearchCardConfig searchCardConfig = new SearchCardConfig();
     searchCardConfig.setShowDescription(_searchCardConfig.getShowDescription());
+    searchCardConfig.setSummarySourceUrn(_searchCardConfig.getSummarySourceUrn());
+    searchCardConfig.setSummaryLabel(_searchCardConfig.getSummaryLabel());
     appConfig.setSearchCardConfig(searchCardConfig);
 
     final SearchFlagsConfig searchFlagsConfig = new SearchFlagsConfig();

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -241,6 +241,8 @@ type SearchCardConfig {
   Whether the search card should show description
   """
   showDescription: Boolean!
+  summarySourceUrn: String
+  summaryLabel: String!
 }
 
 """

--- a/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
@@ -23,6 +23,7 @@ import { CompactView } from '@app/previewV2/CompactView';
 import ContextPath from '@app/previewV2/ContextPath';
 import DefaultPreviewCardFooter from '@app/previewV2/DefaultPreviewCardFooter';
 import EntityHeader from '@app/previewV2/EntityHeader';
+import SummarySection from '@app/previewV2/SearchCardSummarySection';
 import { ActionsAndStatusSection } from '@app/previewV2/shared';
 import {
     useRemoveApplicationAssets,
@@ -387,6 +388,7 @@ export default function DefaultPreviewCard({
                     browsePaths={browsePaths}
                 />
             )}
+            <SummarySection data={data} />
             <DefaultPreviewCardFooter
                 glossaryTerms={glossaryTerms}
                 tags={tags}

--- a/datahub-web-react/src/app/previewV2/SearchCardSummarySection.tsx
+++ b/datahub-web-react/src/app/previewV2/SearchCardSummarySection.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { Divider } from 'antd';
+import styled from 'styled-components';
+
+import { Pill } from '@src/alchemy-components';
+import { REDESIGN_COLORS } from '@app/entityV2/shared/constants';
+import { GenericEntityProperties } from '@app/entity/shared/types';
+import { getSearchSummarySourceUrn, getSearchSummaryLabel } from '@src/app/useAppConfig';
+import { StringValue } from '@types';
+
+const Container = styled.div<{ expanded: boolean }>`
+    display: flex;
+    align-items: ${(p) => (p.expanded ? 'flex-start' : 'center')};
+    gap: 8px;
+    margin-top: 8px;
+    width: 100%;
+`;
+
+const DescriptionWrapper = styled.div`
+    flex: 1;
+    min-width: 0;
+`;
+
+const Description = styled.div`
+    font-size: 12px;
+    color: #5f6685;
+    line-height: 18px;
+`;
+
+const ReadMoreButton = styled.button`
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 12px;
+    color: ${REDESIGN_COLORS.BLUE};
+    cursor: pointer;
+    display: inline;
+
+    &:hover {
+        text-decoration: underline;
+    }
+`;
+
+const HorizontalDivider = styled(Divider)`
+    color: ${REDESIGN_COLORS.FOUNDATION_BLUE_2};
+    margin-top: 14px;
+    margin-bottom: 8px;
+    width: calc(100% + 40px) !important;
+    margin-left: -20px;
+`;
+
+const CHAR_THRESHOLD = 120;
+
+interface Props {
+    data: GenericEntityProperties | null;
+}
+
+export default function SummarySection({ data }: Props) {
+    const [expanded, setExpanded] = useState(false);
+
+    const summaryPropertyUrn = getSearchSummarySourceUrn();
+    const summaryLabel = getSearchSummaryLabel();
+    const summary = summaryPropertyUrn
+        ? (data?.structuredProperties?.properties
+              ?.find((p) => p.structuredProperty.urn === summaryPropertyUrn)
+              ?.values?.[0] as StringValue)?.stringValue
+        : undefined;
+
+    if (!summary) return null;
+
+    const isLong = summary.length > CHAR_THRESHOLD;
+
+    let content: React.ReactNode;
+    if (isLong && !expanded) {
+        content = <>{summary.slice(0, CHAR_THRESHOLD)}&hellip;{' '}<ReadMoreButton onClick={() => setExpanded(true)}>Read more</ReadMoreButton></>;
+    } else if (isLong) {
+        content = <>{summary}{' '}<ReadMoreButton onClick={() => setExpanded(false)}>Show less</ReadMoreButton></>;
+    } else {
+        content = summary;
+    }
+
+    return (
+        <>
+            <HorizontalDivider />
+            <Container expanded={expanded}>
+                <Pill label={summaryLabel} size="sm" color="violet" leftIcon="Sparkle" iconSource="phosphor" clickable={false} showLabel/>
+                <DescriptionWrapper>
+                    <Description>{content}</Description>
+                </DescriptionWrapper>
+            </Container>
+        </>
+    );
+}

--- a/datahub-web-react/src/app/useAppConfig.ts
+++ b/datahub-web-react/src/app/useAppConfig.ts
@@ -51,6 +51,16 @@ export function useIsContextDocumentsEnabled(): boolean {
     return appConfig.config.featureFlags.contextDocumentsEnabled;
 }
 
+export function getSearchSummarySourceUrn(): string | null | undefined {
+    const appConfig = useAppConfig();
+    return appConfig.config.searchCardConfig.summarySourceUrn;
+}
+
+export function getSearchSummaryLabel(): string {
+    const appConfig = useAppConfig();
+    return appConfig.config.searchCardConfig.summaryLabel;
+}
+
 function useFlagWithLocalStorageSync(key: string, f: (appConfig: AppConfig) => boolean) {
     const { config, loaded } = useAppConfig();
     const flagValue = f(config);

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -49,6 +49,8 @@ export const DEFAULT_APP_CONFIG = {
     },
     searchCardConfig: {
         showDescription: false,
+        summarySourceUrn: null,
+        summaryLabel: 'Summary'
     },
     searchFlagsConfig: {
         defaultSkipHighlighting: false,

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -71,6 +71,8 @@ query appConfig {
         }
         searchCardConfig {
             showDescription
+            summarySourceUrn
+            summaryLabel
         }
         searchFlagsConfig {
             defaultSkipHighlighting

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/SearchCardConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/SearchCardConfiguration.java
@@ -7,4 +7,10 @@ import lombok.Data;
 public class SearchCardConfiguration {
   /** If turned on, show the description in search card */
   public Boolean showDescription;
+
+  /** Structured property URN used as the AI summary source on search cards */
+  public String summarySourceUrn;
+
+  /** Label displayed on the summary pill in search cards. Defaults to "AI Summary". */
+  public String summaryLabel;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1090,6 +1090,8 @@ searchBar:
 
 searchCard:
   showDescription: ${SEARCH_CARD_SHOW_DESCRIPTION:false}
+  summarySourceUrn: ${SEARCH_CARD_SUMMARY_SOURCE_URN:}
+  summaryLabel: ${SEARCH_CARD_SUMMARY_LABEL:Summary}
 
 searchFlags:
   defaultSkipHighlighting: ${DEFAULT_SKIP_HIGHLIGHTING:false}


### PR DESCRIPTION
Our users requested more information on the search result cards of asset, so they don't have to click each result individually to open the Summary side panel.
This feature proposes a configurable field that appears in the search card, for which the description comes from a structured property. Both the label of this summary section and the structured property urn from which to fetch the data are configurable. We chose a structured property so that both users and possibly external tools can populate this field.

<img width="2265" height="615" alt="image" src="https://github.com/user-attachments/assets/c9a3612f-09aa-4411-8894-fde9d90bc609" />

<img width="2275" height="730" alt="image" src="https://github.com/user-attachments/assets/5bf9c5de-a42a-44d6-8455-9cf9112da132" />
