### PR TITLE
fix(ui): Fix toolbar focus bug and allow file uploads in summary page widgets

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Editor/toolbar/Toolbar.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Editor/toolbar/Toolbar.tsx
@@ -9,7 +9,7 @@ import { TextStrikethrough } from '@phosphor-icons/react/dist/csr/TextStrikethro
 import { TextUnderline } from '@phosphor-icons/react/dist/csr/TextUnderline';
 import { useActive, useCommands, useRemirrorContext } from '@remirror/react';
 import { Divider } from 'antd';
-import React, { useCallback } from 'react';
+import React from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import { FileDragDropExtension } from '@components/components/Editor/extensions/fileDragDrop';
@@ -28,7 +28,7 @@ const Container = styled.div<{ $fixedBottom?: boolean }>`
     ${(props) => (props.$fixedBottom ? 'bottom: 48px;' : 'top: 0;')}
     ${(props) =>
         props.$fixedBottom
-            ? 'left: 50%; transform: translateX(-50%); max-width: 800px; width: fit-content;'
+            ? 'left: 50%; transform: translateX(-50%); max-width: 800px; width: max-content;'
             : 'width: 100%;'}
     z-index: ${(props) => (props.$fixedBottom ? '1000' : '99')};
     background-color: ${(props) => props.theme.colors.bg};
@@ -73,12 +73,8 @@ export const Toolbar = ({ styles, fixedBottom }: Props) => {
 
     const shouldShowImageButtonV2 = documentationFileUploadV1 && fileExtension.options.uploadFileProps?.onFileUpload;
 
-    const handleMouseDown = useCallback((e: React.MouseEvent) => {
-        e.preventDefault();
-    }, []);
-
     return (
-        <Container style={styles} $fixedBottom={fixedBottom} onMouseDown={handleMouseDown}>
+        <Container style={styles} $fixedBottom={fixedBottom}>
             <InnerContainer>
                 <FontSizeSelect />
                 <HeadingMenu />

--- a/datahub-web-react/src/app/auth/shared/ModalHeader.tsx
+++ b/datahub-web-react/src/app/auth/shared/ModalHeader.tsx
@@ -7,7 +7,7 @@ const HeaderContainer = styled.div`
     display: flex;
     gap: 13px;
     align-items: center;
-    padding: 28px 20px 0 20px;
+    padding: 8px 20px 4px 20px;
 `;
 
 const LogoImage = styled(Image)`

--- a/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
+++ b/datahub-web-react/src/app/homeV3/modules/documentation/RichTextContent.tsx
@@ -3,7 +3,12 @@ import { Form, FormInstance } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 
+import { useEntityData } from '@app/entity/shared/EntityContext';
+import useFileUpload from '@app/shared/hooks/useFileUpload';
+import useFileUploadAnalyticsCallbacks from '@app/shared/hooks/useFileUploadAnalyticsCallbacks';
 import { Editor } from '@src/alchemy-components/components/Editor/Editor';
+
+import { UploadDownloadScenario } from '@types';
 
 const EditorContainer = styled.div`
     height: 300px;
@@ -18,6 +23,13 @@ type Props = {
 };
 
 const RichTextContent = ({ content, form }: Props) => {
+    const { urn: assetUrn } = useEntityData();
+    const uploadFileAnalyticsCallbacks = useFileUploadAnalyticsCallbacks({
+        scenario: UploadDownloadScenario.AssetDocumentation,
+        assetUrn,
+    });
+    const { uploadFile } = useFileUpload({ scenario: UploadDownloadScenario.AssetDocumentation, assetUrn });
+
     return (
         <Form form={form} initialValues={{ content }}>
             <Form.Item name="content">
@@ -28,6 +40,14 @@ const RichTextContent = ({ content, form }: Props) => {
                         hideBorder
                         dataTestId="rich-text-documentation"
                         onChange={(newContent) => form.setFieldValue('content', newContent)}
+                        uploadFileProps={
+                            assetUrn // only support file upload on profile pages for now due to permissions
+                                ? {
+                                      onFileUpload: uploadFile,
+                                      ...uploadFileAnalyticsCallbacks,
+                                  }
+                                : undefined
+                        }
                     />
                 </EditorContainer>
             </Form.Item>


### PR DESCRIPTION
This PR fixes 2 bugs and fixes styling in 2 places.

Bugs:
1. we [recently introduced a bug ](https://github.com/datahub-project/datahub/pull/16334)where we were trying to fix a problem where clicking on font size dropdowns would un-focus the floating toolbar when editing context documents. This made it impossible for us to focus on input elements like when trying to add a link or fill out the URL for an image we wanted to upload.

**Fix:** Remove the unnecessary preventDefault. I double checked this is not necessary when fixing the original bug.

2. People were unable to upload files to the documentation widget on asset profile pages because we weren't handling it appropriately. Now I simply add the handler to treat this as it really is - updating asset documentation.


Then there were two minor styling fixes:
1. Update the spacing on the sign up and sign in page headers
<img width="941" height="572" alt="Screenshot 2026-03-24 at 10 28 16 AM" src="https://github.com/user-attachments/assets/9249a6c7-cb9e-457e-91de-d0d002a4754a" />

2. Allow the floating toolbar on the documentation page to be wide enough to fit all of the toolbar options instead of breaking into new lines.
<img width="1727" height="906" alt="Screenshot 2026-03-24 at 10 28 42 AM" src="https://github.com/user-attachments/assets/97e2d2c2-a421-40de-8429-adcee9f46aff" />

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
