### PR TITLE
feat(openapi): Add generic relationships scroll endpoint

### DIFF
--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v3/models/ScrollRelationshipsRequestBody.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v3/models/ScrollRelationshipsRequestBody.java
@@ -1,0 +1,15 @@
+package io.datahubproject.openapi.v3.models;
+
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Jacksonized
+@Builder
+public class ScrollRelationshipsRequestBody {
+  @Nullable private Filter sourceFilter;
+  @Nullable private Filter destinationFilter;
+  @Nullable private Filter edgeFilter;
+}

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericRelationshipController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericRelationshipController.java
@@ -16,7 +16,6 @@ import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.SliceOptions;
-import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.search.utils.QueryUtils;
 import io.datahubproject.metadata.context.OperationContext;
@@ -24,13 +23,16 @@ import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.openapi.exception.UnauthorizedException;
 import io.datahubproject.openapi.models.GenericScrollResult;
 import io.datahubproject.openapi.v2.models.GenericRelationship;
+import io.datahubproject.openapi.v3.models.ScrollRelationshipsRequestBody;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
@@ -271,28 +273,25 @@ public abstract class GenericRelationshipController {
   }
 
   /**
-   * Scrolls relationships with configurable filters on source/destination entity types and URNs.
+   * Scrolls relationships with configurable filters on source/destination entity types and edges.
    *
    * @param relationshipTypes relationship types to filter on (default all)
    * @param sourceTypes entity types to filter on for source
    * @param destinationTypes entity types to filter on for destination
-   * @param sourceUrns URNs to filter on for source (OR logic)
-   * @param destinationUrns URNs to filter on for destination (OR logic)
    * @param count number of results
    * @param scrollId scrolling id
+   * @param body request body containing sourceFilter, destinationFilter, and edgeFilter
    * @return list of relation edges
    */
-  @GetMapping(value = "/scroll", produces = MediaType.APPLICATION_JSON_VALUE)
+  @PostMapping(value = "/scroll", produces = MediaType.APPLICATION_JSON_VALUE)
   @Operation(
       summary =
-          "Scroll relationships with configurable filters on source/destination types and URNs.")
+          "Scroll relationships with configurable filters on source/destination types and edges.")
   public ResponseEntity<GenericScrollResult<GenericRelationship>> scrollRelationships(
       HttpServletRequest request,
       @RequestParam(value = "relationshipTypes", required = false) String[] relationshipTypes,
       @RequestParam(value = "sourceTypes", required = false) String[] sourceTypes,
       @RequestParam(value = "destinationTypes", required = false) String[] destinationTypes,
-      @RequestParam(value = "sourceUrns", required = false) String[] sourceUrns,
-      @RequestParam(value = "destinationUrns", required = false) String[] destinationUrns,
       @RequestParam(value = "count", defaultValue = "10") Integer count,
       @RequestParam(value = "scrollId", required = false) String scrollId,
       @RequestParam(value = "includeSoftDelete", required = false, defaultValue = "false")
@@ -300,7 +299,8 @@ public abstract class GenericRelationshipController {
       @RequestParam(value = "sliceId", required = false) Integer sliceId,
       @RequestParam(value = "sliceMax", required = false) Integer sliceMax,
       @RequestParam(value = "pitKeepAlive", required = false, defaultValue = "5m")
-          String pitKeepAlive) {
+          String pitKeepAlive,
+      @RequestBody @Nonnull ScrollRelationshipsRequestBody body) {
 
     Authentication authentication = AuthenticationContext.getAuthentication();
     OperationContext opContext =
@@ -342,14 +342,18 @@ public abstract class GenericRelationshipController {
             ? Arrays.stream(destinationTypes).collect(Collectors.toSet())
             : null;
 
-    Filter sourceEntityFilter =
-        sourceUrns != null && sourceUrns.length > 0
-            ? QueryUtils.newFilter(QueryUtils.newCriterion("urn", Arrays.asList(sourceUrns)))
-            : QueryUtils.EMPTY_FILTER;
-    Filter destinationEntityFilter =
-        destinationUrns != null && destinationUrns.length > 0
-            ? QueryUtils.newFilter(QueryUtils.newCriterion("urn", Arrays.asList(destinationUrns)))
-            : QueryUtils.EMPTY_FILTER;
+    com.linkedin.metadata.query.filter.Filter sourceEntityFilter =
+        Optional.ofNullable(body.getSourceFilter())
+            .map(io.datahubproject.openapi.v3.models.Filter::toRecordTemplate)
+            .orElse(QueryUtils.EMPTY_FILTER);
+    com.linkedin.metadata.query.filter.Filter destinationEntityFilter =
+        Optional.ofNullable(body.getDestinationFilter())
+            .map(io.datahubproject.openapi.v3.models.Filter::toRecordTemplate)
+            .orElse(QueryUtils.EMPTY_FILTER);
+    com.linkedin.metadata.query.filter.Filter edgeFilter =
+        Optional.ofNullable(body.getEdgeFilter())
+            .map(io.datahubproject.openapi.v3.models.Filter::toRecordTemplate)
+            .orElse(QueryUtils.EMPTY_FILTER);
 
     RelatedEntitiesScrollResult result =
         graphService.scrollRelatedEntities(
@@ -361,8 +365,7 @@ public abstract class GenericRelationshipController {
             relationshipTypes != null
                 ? Arrays.stream(relationshipTypes).collect(Collectors.toSet())
                 : Set.of(),
-            QueryUtils.newRelationshipFilter(
-                QueryUtils.EMPTY_FILTER, RelationshipDirection.UNDIRECTED),
+            QueryUtils.newRelationshipFilter(edgeFilter, RelationshipDirection.UNDIRECTED),
             Edge.EDGE_SORT_CRITERION,
             scrollId,
             pitKeepAlive != null && pitKeepAlive.isEmpty() ? null : pitKeepAlive,

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/RelationshipControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/controller/RelationshipControllerTest.java
@@ -18,13 +18,18 @@ import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.RelationshipFilter;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.openapi.config.GlobalControllerExceptionHandler;
 import io.datahubproject.openapi.config.SpringWebConfig;
 import io.datahubproject.openapi.config.TracingInterceptor;
+import io.datahubproject.openapi.v3.models.ConjunctiveCriterion;
+import io.datahubproject.openapi.v3.models.Criterion;
+import io.datahubproject.openapi.v3.models.ScrollRelationshipsRequestBody;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,6 +64,7 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
   @Autowired private RelationshipController relationshipController;
   @Autowired private MockMvc mockMvc;
   @Autowired private GraphService mockGraphService;
+  @Autowired private ObjectMapper objectMapper;
 
   @BeforeMethod
   public void setup() {
@@ -805,6 +811,9 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
   // scrollRelationships tests
   // -------------------------------------------------------------------------
 
+  private static final ScrollRelationshipsRequestBody EMPTY_SCROLL_BODY =
+      ScrollRelationshipsRequestBody.builder().build();
+
   @Test
   public void testScrollRelationshipsDefaults() throws Exception {
     RelatedEntitiesScrollResult expectedResult =
@@ -834,7 +843,9 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/openapi/v3/relationship/scroll")
+            MockMvcRequestBuilders.post("/openapi/v3/relationship/scroll")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful())
         .andExpect(jsonPath("$.scrollId").value("scroll-1"));
@@ -844,7 +855,7 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     // No sourceType / destinationType → null passed through
     assertNull(sourceTypesCaptor.getValue());
     assertNull(destTypesCaptor.getValue());
-    // No URN filters → EMPTY_FILTER (no criteria)
+    // No filters in body → EMPTY_FILTER (no criteria)
     assertTrue(
         sourceFilterCaptor.getValue().getOr().isEmpty()
             || sourceFilterCaptor.getValue().getOr().stream()
@@ -879,9 +890,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/openapi/v3/relationship/scroll")
+            MockMvcRequestBuilders.post("/openapi/v3/relationship/scroll")
                 .param("relationshipTypes", "DownstreamOf")
                 .param("relationshipTypes", "Consumes")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
@@ -917,10 +930,12 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/openapi/v3/relationship/scroll")
+            MockMvcRequestBuilders.post("/openapi/v3/relationship/scroll")
                 .param("sourceTypes", "dataset")
                 .param("destinationTypes", "chart")
                 .param("destinationTypes", "dashboard")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
@@ -962,12 +977,46 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
             isNull()))
         .thenReturn(expectedResult);
 
+    io.datahubproject.openapi.v3.models.Filter sourceFilter =
+        io.datahubproject.openapi.v3.models.Filter.builder()
+            .and(
+                List.of(
+                    ConjunctiveCriterion.builder()
+                        .criteria(
+                            List.of(
+                                Criterion.builder()
+                                    .field("urn")
+                                    .values(List.of(sourceUrn))
+                                    .condition(Criterion.Condition.EQUAL)
+                                    .build()))
+                        .build()))
+            .build();
+    io.datahubproject.openapi.v3.models.Filter destFilter =
+        io.datahubproject.openapi.v3.models.Filter.builder()
+            .and(
+                List.of(
+                    ConjunctiveCriterion.builder()
+                        .criteria(
+                            List.of(
+                                Criterion.builder()
+                                    .field("urn")
+                                    .values(List.of(destUrn1, destUrn2))
+                                    .condition(Criterion.Condition.EQUAL)
+                                    .build()))
+                        .build()))
+            .build();
+
+    ScrollRelationshipsRequestBody body =
+        ScrollRelationshipsRequestBody.builder()
+            .sourceFilter(sourceFilter)
+            .destinationFilter(destFilter)
+            .build();
+
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/openapi/v3/relationship/scroll")
-                .param("sourceUrns", sourceUrn)
-                .param("destinationUrns", destUrn1)
-                .param("destinationUrns", destUrn2)
+            MockMvcRequestBuilders.post("/openapi/v3/relationship/scroll")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
@@ -978,12 +1027,12 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     assertEquals("urn", capturedSrcFilter.getOr().get(0).getAnd().get(0).getField());
     assertFalse(capturedSrcFilter.getOr().get(0).getAnd().get(0).getValues().isEmpty());
 
-    // Destination filter should have a non-empty criterion on the "urn" field
+    // Destination filter should have a non-empty criterion on the "urn" field with both URNs
     Filter capturedDstFilter = destFilterCaptor.getValue();
     assertNotNull(capturedDstFilter);
     assertFalse(capturedDstFilter.getOr().isEmpty());
     assertEquals("urn", capturedDstFilter.getOr().get(0).getAnd().get(0).getField());
-    assertFalse(capturedDstFilter.getOr().get(0).getAnd().get(0).getValues().isEmpty());
+    assertEquals(2, capturedDstFilter.getOr().get(0).getAnd().get(0).getValues().size());
   }
 
   @Test
@@ -1012,9 +1061,11 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/openapi/v3/relationship/scroll")
+            MockMvcRequestBuilders.post("/openapi/v3/relationship/scroll")
                 .param("sliceId", "1")
                 .param("sliceMax", "4")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(EMPTY_SCROLL_BODY))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful());
 
@@ -1048,6 +1099,8 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     ArgumentCaptor<Set> destTypesCaptor = ArgumentCaptor.forClass(Set.class);
     ArgumentCaptor<Filter> destFilterCaptor = ArgumentCaptor.forClass(Filter.class);
     ArgumentCaptor<Set> relTypesCaptor = ArgumentCaptor.forClass(Set.class);
+    ArgumentCaptor<RelationshipFilter> relFilterCaptor =
+        ArgumentCaptor.forClass(RelationshipFilter.class);
     ArgumentCaptor<String> scrollIdCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> pitCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Integer> countCaptor = ArgumentCaptor.forClass(Integer.class);
@@ -1059,7 +1112,7 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
             destTypesCaptor.capture(),
             destFilterCaptor.capture(),
             relTypesCaptor.capture(),
-            any(),
+            relFilterCaptor.capture(),
             any(),
             scrollIdCaptor.capture(),
             pitCaptor.capture(),
@@ -1068,20 +1121,70 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
             isNull()))
         .thenReturn(expectedResult);
 
+    io.datahubproject.openapi.v3.models.Filter sourceFilter =
+        io.datahubproject.openapi.v3.models.Filter.builder()
+            .and(
+                List.of(
+                    ConjunctiveCriterion.builder()
+                        .criteria(
+                            List.of(
+                                Criterion.builder()
+                                    .field("urn")
+                                    .values(List.of(sourceUrn))
+                                    .condition(Criterion.Condition.EQUAL)
+                                    .build()))
+                        .build()))
+            .build();
+    io.datahubproject.openapi.v3.models.Filter destFilter =
+        io.datahubproject.openapi.v3.models.Filter.builder()
+            .and(
+                List.of(
+                    ConjunctiveCriterion.builder()
+                        .criteria(
+                            List.of(
+                                Criterion.builder()
+                                    .field("urn")
+                                    .values(List.of(destUrn))
+                                    .condition(Criterion.Condition.EQUAL)
+                                    .build()))
+                        .build()))
+            .build();
+    io.datahubproject.openapi.v3.models.Filter edgeFilter =
+        io.datahubproject.openapi.v3.models.Filter.builder()
+            .and(
+                List.of(
+                    ConjunctiveCriterion.builder()
+                        .criteria(
+                            List.of(
+                                Criterion.builder()
+                                    .field("relationshipType")
+                                    .values(List.of("DownstreamOf"))
+                                    .condition(Criterion.Condition.EQUAL)
+                                    .build()))
+                        .build()))
+            .build();
+
+    ScrollRelationshipsRequestBody body =
+        ScrollRelationshipsRequestBody.builder()
+            .sourceFilter(sourceFilter)
+            .destinationFilter(destFilter)
+            .edgeFilter(edgeFilter)
+            .build();
+
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/openapi/v3/relationship/scroll")
+            MockMvcRequestBuilders.post("/openapi/v3/relationship/scroll")
                 .param("relationshipTypes", "DownstreamOf")
                 .param("sourceTypes", "dataset")
                 .param("destinationTypes", "chart")
-                .param("sourceUrns", sourceUrn)
-                .param("destinationUrns", destUrn)
                 .param("count", "20")
                 .param("scrollId", "prev-scroll")
                 .param("pitKeepAlive", "10m")
                 .param("sliceId", "0")
                 .param("sliceMax", "3")
                 .param("includeSoftDelete", "true")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(body))
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful())
         .andExpect(jsonPath("$.scrollId").value("next-scroll"));
@@ -1096,9 +1199,15 @@ public class RelationshipControllerTest extends AbstractTestNGSpringContextTests
     assertEquals(1, destTypesCaptor.getValue().size());
     assertTrue(destTypesCaptor.getValue().contains("chart"));
 
-    // Verify URN filters
+    // Verify URN filters from request body
     assertFalse(sourceFilterCaptor.getValue().getOr().isEmpty());
     assertFalse(destFilterCaptor.getValue().getOr().isEmpty());
+
+    // Verify edge filter was embedded in the RelationshipFilter
+    RelationshipFilter capturedRelFilter = relFilterCaptor.getValue();
+    assertNotNull(capturedRelFilter);
+    assertFalse(capturedRelFilter.getOr().isEmpty());
+    assertEquals("relationshipType", capturedRelFilter.getOr().get(0).getAnd().get(0).getField());
 
     // Verify pagination parameters
     assertEquals("prev-scroll", scrollIdCaptor.getValue());


### PR DESCRIPTION
We currently only have endpoints to scroll a single relationship, + that one doesn't support source and destination filters. We already support this at the service level so this is just exposing that via openapi.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
