### PR TITLE
feat(actions): Support batch-processing actions

### DIFF
--- a/datahub-actions/src/datahub_actions/action/action.py
+++ b/datahub-actions/src/datahub_actions/action/action.py
@@ -36,6 +36,17 @@ class Action(Closeable, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def act(self, event: EventEnvelope) -> None:
-        """Take Action on DataHub events, provided an instance of a DataHub event."""
+    def act(self, event: EventEnvelope) -> bool | None:
+        """Take Action on DataHub events, provided an instance of a DataHub event.
+
+        Returns:
+            Whether to immediately commit the event as processed successfully.
+            Return False if the event has been recorded but should not be acknowledged
+            until some later time, e.g. due to batch or asynchronous processing.
+
+            Returning None is equivalent to returning True, i.e. it assumes the event was processed successfully.
+
+        Raises:
+            Exception: To indicate the event was not processed successfully and to retry processing the same event.
+        """
         pass

--- a/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
+++ b/datahub-actions/src/datahub_actions/plugin/source/kafka/kafka_event_source.py
@@ -329,6 +329,6 @@ class KafkaEventSource(EventSource):
                 self._commit_offsets,
                 event,
             )
-        else:
-            # Otherwise store offset for periodic autocommit
+        elif self.source_config.async_commit_enabled:
+            # Store offset for periodic autocommit
             self._store_offsets(event)


### PR DESCRIPTION
We were already reading the return value of `act` to determine whether to ack:

```
        for enveloped_event in enveloped_events:
            # Then, process the event.
            retval = self._process_event(enveloped_event)

            # For legacy users w/o selective ack support, convert
            # None to True, i.e. always commit.
            if retval is None:
                retval = True

            # Finally, ack the event.
            self._ack_event(enveloped_event, retval)
```
in `pipeline.py`.

This changes the function signature to reflect that behavior. That way, a batch-processing action can decide not to ack right away.
Also, I think we had a small bug -- it only makes sense to `store_offsets` if we're in async commit mode

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
