### PR TITLE
fix(github actions): fix JSON formatting for smoke_test matrix

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -413,7 +413,7 @@ jobs:
           elif [[ "${{ needs.setup.outputs.ingestion_only }}" == 'true' ]]; then
             includes="$python_matrix"
           fi
-          echo "matrix={\"include\":[$includes] }" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"include\":[$includes]}" >> "$GITHUB_OUTPUT"
 
   smoke_test:
     name: Run Smoke Tests (${{ matrix.test_strategy }}, Batch ${{ matrix.batch }}/${{ matrix.batch_count }})


### PR DESCRIPTION
Solves the error message:

```
[Docker Build, Scan, Test](https://github.com/datahub-project/datahub/actions/runs/23565752321/workflow)
Error when evaluating 'strategy' for job 'smoke_test'. .github/workflows/docker-unified.yml (Line: 424, Col: 15): matrix must define at least one vector
```