### PR TITLE
docs: add v_0_3_17 to sidebar and document release note process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,17 @@ See `docs-website/AGENTS.md` for full pipeline details.
 
 If `sidebars.js` is missing the entry, the build will warn about an unaccounted file.
 
+### Adding a DataHub Cloud release note
+
+Release notes live in `docs/managed-datahub/release-notes/` and follow the naming convention `v_0_3_<N>.md`.
+
+**CRITICAL**: Adding the markdown file alone is not enough — you must also add it to `sidebars.js`:
+
+1. Create `docs/managed-datahub/release-notes/v_0_3_<N>.md`
+2. Add `"docs/managed-datahub/release-notes/v_0_3_<N>"` as the **first entry** under `"DataHub Cloud Release History"` in `docs-website/sidebars.js` (newer releases go at the top)
+
+Forgetting step 2 means the release note is published but never appears in the sidebar navigation.
+
 ## Code Standards
 
 ### General Principles

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -625,6 +625,7 @@ module.exports = {
     },
     {
       "DataHub Cloud Release History": [
+        "docs/managed-datahub/release-notes/v_0_3_17",
         "docs/managed-datahub/release-notes/v_0_3_16",
         "docs/managed-datahub/release-notes/v_0_3_15",
         "docs/managed-datahub/release-notes/v_0_3_14",


### PR DESCRIPTION
## Summary

- Add missing `v_0_3_17` entry to the **DataHub Cloud Release History** section in `sidebars.js` — the release note was published in #16759 but never appeared in the sidebar navigation
- Add explicit step-by-step instructions in `AGENTS.md` for adding new release notes to `sidebars.js`, preventing agents (and humans) from hitting this same omission again

## Test plan

- [ ] Verify `v_0_3_17` appears in the sidebar under DataHub Cloud Release History
- [ ] Verify the new AGENTS.md section accurately describes the release note workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)