### PR TITLE
feat(data-factory): support linkedService typeProperties for OneLake lineage resolution

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/fabric/data_factory/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fabric/data_factory/lineage.py
@@ -228,11 +228,16 @@ class CopyActivityLineageExtractor:
         conn_type_props = (dataset_settings.get("connectionSettings") or {}).get(
             "properties", {}
         ).get("typeProperties") or {}
+        ls_type_props = (dataset_settings.get("linkedService") or {}).get(
+            "properties", {}
+        ).get("typeProperties") or {}
         ds_type_props = dataset_settings.get("typeProperties") or {}
 
-        artifact_id: Optional[str] = conn_type_props.get(
-            "artifactId"
-        ) or ds_type_props.get("artifactId")
+        artifact_id: Optional[str] = (
+            conn_type_props.get("artifactId")
+            or ls_type_props.get("artifactId")
+            or ds_type_props.get("artifactId")
+        )
         if not artifact_id:
             logger.debug(
                 "No artifactId found in OneLake datasetSettings for activity '%s'",
@@ -242,6 +247,7 @@ class CopyActivityLineageExtractor:
 
         resolved_workspace_id: str = (
             conn_type_props.get("workspaceId")
+            or ls_type_props.get("workspaceId")
             or ds_type_props.get("workspaceId")
             or pipeline_workspace_id
         )

--- a/metadata-ingestion/tests/unit/fabric_data_factory/test_lineage.py
+++ b/metadata-ingestion/tests/unit/fabric_data_factory/test_lineage.py
@@ -312,6 +312,29 @@ class TestResolveOnelakeUrn:
         assert result is not None
         assert pipeline_ws in result
 
+    def test_linked_service_type_properties(self) -> None:
+        """linkedService.properties.typeProperties provides artifactId and workspaceId."""
+        ds = {
+            "linkedService": {
+                "name": "ConnectorTestLakehouse",
+                "properties": {
+                    "type": "Lakehouse",
+                    "typeProperties": {
+                        "workspaceId": WS_ID,
+                        "artifactId": ARTIFACT_ID,
+                        "rootFolder": "Tables",
+                    },
+                },
+            },
+            "typeProperties": {"schema": "dbo", "table": "Employee"},
+        }
+        result = self.extractor._resolve_onelake_urn(
+            ds, _make_activity(), "fallback-ws"
+        )
+        assert result is not None
+        assert "fabric-onelake" in result
+        assert f"{WS_ID}.{ARTIFACT_ID}.dbo.Employee" in result
+
 
 class TestCopyExtractLineage:
     """End-to-end tests for CopyActivityLineageExtractor.extract_lineage."""


### PR DESCRIPTION
## Summary
- Fix OneLake URN resolution to check `linkedService.properties.typeProperties` for `artifactId` and `workspaceId`, handling the common Fabric payload shape where connection info comes via linkedService rather than connectionSettings
