### PR TITLE
fix(ui): enable lint rule on colors for diff files

### DIFF
--- a/datahub-web-react/.eslintrc.js
+++ b/datahub-web-react/.eslintrc.js
@@ -217,14 +217,14 @@ module.exports = {
             rules: { 'import/no-relative-packages': 'off', 'import-alias/import-alias': 'off' },
         },
         // Semantic color enforcement — only on files changed in the current branch
-        // ...(changedTsFiles.length > 0
-        //     ? [
-        //           {
-        //               files: changedTsFiles,
-        //               excludedFiles: COLOR_RULE_EXCLUDED_FILES,
-        //               rules: COLOR_ENFORCEMENT_RULES,
-        //           },
-        //       ]
-        //     : []),
+        ...(changedTsFiles.length > 0
+            ? [
+                  {
+                      files: changedTsFiles,
+                      excludedFiles: COLOR_RULE_EXCLUDED_FILES,
+                      rules: COLOR_ENFORCEMENT_RULES,
+                  },
+              ]
+            : []),
     ],
 };


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-1649/enable-lint-rule-for-colors-on-diff-files

**Description:**

Uncommenting the lint rule for colors so that changed files/ diff have to follow them

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
