### PR TITLE
feat(sqlsetup): add schemaVersionIndex on metadata_aspect_v2 for Postgres

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStep.java
@@ -74,9 +74,16 @@ public class CreateTablesStep implements UpgradeStep {
     }
 
     // Create metadata_aspect_v2 table and indexes
-    java.util.List<String> createTableStatements = dbOps.createTableSqlStatements();
+    java.util.List<String> createTableStatements =
+        dbOps.createTableSqlStatements(args.createSchemaVersionIndex());
     for (String sql : createTableStatements) {
       server.sqlUpdate(sql).execute();
+    }
+
+    if (args.createSchemaVersionIndex()) {
+      try (Connection connection = server.dataSource().getConnection()) {
+        dbOps.postSetup(connection);
+      }
     }
     result.setTablesCreated(1);
 

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperations.java
@@ -101,9 +101,19 @@ public interface DatabaseOperations {
    * Generate SQL statements for creating the metadata_aspect_v2 table and its indexes. Returns a
    * list of individual SQL statements that can be executed separately.
    *
+   * @param createSchemaVersionIndex whether to include the schemaVersionIndex (controlled by
+   *     featureFlags.zduStage10)
    * @return list of SQL statements to create the table and indexes
    */
-  java.util.List<String> createTableSqlStatements();
+  java.util.List<String> createTableSqlStatements(boolean createSchemaVersionIndex);
+
+  /**
+   * Called after table creation to create any indexes that must run outside a transaction (e.g.
+   * CONCURRENTLY). Defaults to a no-op.
+   *
+   * @param connection open JDBC connection to the target database
+   */
+  default void postSetup(Connection connection) throws SQLException {}
 
   /**
    * Create a database if it doesn't exist.

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/MySqlDatabaseOperations.java
@@ -93,7 +93,11 @@ public class MySqlDatabaseOperations implements DatabaseOperations {
   }
 
   @Override
-  public java.util.List<String> createTableSqlStatements() {
+  public java.util.List<String> createTableSqlStatements(boolean createSchemaVersionIndex) {
+    // schemaVersionIndex is intentionally not created for MySQL: MySQL's query optimizer typically
+    // uses only one index per table scan, so an additional index on schemaVersion rarely helps and
+    // adds write overhead. This query only helps during the upgrade process during background
+    // migration.
     return java.util.Arrays.asList(
         """
         CREATE TABLE IF NOT EXISTS metadata_aspect_v2 (

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/PostgresDatabaseOperations.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/PostgresDatabaseOperations.java
@@ -126,7 +126,7 @@ public class PostgresDatabaseOperations implements DatabaseOperations {
   }
 
   @Override
-  public java.util.List<String> createTableSqlStatements() {
+  public java.util.List<String> createTableSqlStatements(boolean createSchemaVersionIndex) {
     return java.util.Arrays.asList(
         """
         CREATE TABLE IF NOT EXISTS metadata_aspect_v2 (
@@ -145,6 +145,47 @@ public class PostgresDatabaseOperations implements DatabaseOperations {
         "CREATE INDEX IF NOT EXISTS urnIndex ON metadata_aspect_v2 (urn);",
         "CREATE INDEX IF NOT EXISTS aspectIndex ON metadata_aspect_v2 (aspect);",
         "CREATE INDEX IF NOT EXISTS versionIndex ON metadata_aspect_v2 (version);");
+  }
+
+  @Override
+  public void postSetup(Connection connection) throws SQLException {
+    // Drop the index if it exists but is invalid (e.g. a previous CONCURRENTLY run was
+    // interrupted). IF NOT EXISTS on the CREATE below would otherwise leave the invalid index
+    // in place and skip re-creation on retries.
+
+    // Unquoted index names are awlays stored in lower case by postgres.
+    String checkSql =
+        """
+        SELECT i.relname
+        FROM pg_index ix
+        JOIN pg_class i ON i.oid = ix.indexrelid
+        JOIN pg_class t ON t.oid = ix.indrelid
+        WHERE t.relname = 'metadata_aspect_v2'
+          AND i.relname = 'schemaversionindex'
+          AND NOT ix.indisvalid
+        """;
+    try (PreparedStatement stmt = connection.prepareStatement(checkSql);
+        ResultSet rs = stmt.executeQuery()) {
+      if (rs.next()) {
+        log.info("Dropping invalid schemaVersionIndex to allow re-creation");
+        boolean prevAutoCommit = connection.getAutoCommit();
+        connection.setAutoCommit(true);
+        try (java.sql.Statement dropStmt = connection.createStatement()) {
+          dropStmt.execute("DROP INDEX CONCURRENTLY schemaversionindex");
+        } finally {
+          connection.setAutoCommit(prevAutoCommit);
+        }
+      }
+    }
+    // CREATE INDEX CONCURRENTLY cannot run inside a transaction block; autoCommit must be true.
+    boolean prevAutoCommit = connection.getAutoCommit();
+    connection.setAutoCommit(true);
+    try (java.sql.Statement stmt = connection.createStatement()) {
+      stmt.execute(
+          "CREATE INDEX CONCURRENTLY IF NOT EXISTS schemaVersionIndex ON metadata_aspect_v2 ((systemmetadata::jsonb ->> 'schemaVersion'));");
+    } finally {
+      connection.setAutoCommit(prevAutoCommit);
+    }
   }
 
   @Override

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupArgs.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupArgs.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.upgrade.sqlsetup;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.ToString;
 import lombok.Value;
 
@@ -21,4 +22,11 @@ public class SqlSetupArgs {
   String host;
   int port;
   String databaseName;
+
+  @Getter(lombok.AccessLevel.NONE)
+  boolean createSchemaVersionIndex;
+
+  public boolean createSchemaVersionIndex() {
+    return createSchemaVersionIndex;
+  }
 }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/config/SqlSetupConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/sqlsetup/config/SqlSetupConfig.java
@@ -33,6 +33,9 @@ public class SqlSetupConfig {
   @Getter
   private String ebeanUrl;
 
+  @Value("${featureFlags.zduStage10:false}")
+  private boolean createSchemaVersionIndex;
+
   /**
    * Provides a no-op MetricUtils for SqlSetup context to avoid dependency on system telemetry. This
    * allows LocalEbeanConfigFactory to work without requiring the full metrics infrastructure.
@@ -113,7 +116,8 @@ public class SqlSetupConfig {
             createUserPassword,
             host,
             port,
-            databaseName);
+            databaseName,
+            createSchemaVersionIndex);
 
     // Validate authentication configuration
     validateAuthenticationConfig(args);

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateCdcUserStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateCdcUserStepTest.java
@@ -52,7 +52,8 @@ public class CreateCdcUserStepTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "testdb" // databaseName
+            "testdb", // databaseName
+            false // createSchemaVersionIndex
             );
     createCdcUserStep = new CreateCdcUserStep(mockDatabase, defaultSetupArgs);
     when(mockUpgradeContext.report()).thenReturn(mockUpgradeReport);
@@ -114,7 +115,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     CreateCdcUserStep disabledCdcStep = new CreateCdcUserStep(mockDatabase, disabledCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = disabledCdcStep.executable();
@@ -147,7 +149,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     CreateCdcUserStep mysqlCdcStep = new CreateCdcUserStep(mockDatabase, mysqlCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = mysqlCdcStep.executable();
@@ -181,7 +184,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             5432,
-            "testdb");
+            "testdb",
+            false);
     CreateCdcUserStep postgresCdcStep = new CreateCdcUserStep(mockDatabase, postgresCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = postgresCdcStep.executable();
@@ -269,7 +273,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             5432,
-            "custom_db");
+            "custom_db",
+            false);
     CreateCdcUserStep customCdcStep = new CreateCdcUserStep(mockDatabase, customCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = customCdcStep.executable();
@@ -302,7 +307,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     CreateCdcUserStep defaultCdcStep = new CreateCdcUserStep(mockDatabase, defaultCdcArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = defaultCdcStep.executable();
@@ -334,7 +340,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             5432,
-            "testdb");
+            "testdb",
+            false);
     CreateCdcUserStep postgresStep = new CreateCdcUserStep(mockDatabase, postgresArgs);
 
     // This test is now covered by DatabaseOperationsTest
@@ -360,7 +367,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     CreateCdcUserStep mysqlStep = new CreateCdcUserStep(mockDatabase, mysqlArgs);
 
     // This test is now covered by DatabaseOperationsTest
@@ -386,7 +394,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             5432,
-            "testdb");
+            "testdb",
+            false);
     CreateCdcUserStep postgresStep = new CreateCdcUserStep(mockDatabase, postgresArgs);
 
     // This test is now covered by DatabaseOperationsTest
@@ -412,7 +421,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     CreateCdcUserStep mysqlStep = new CreateCdcUserStep(mockDatabase, mysqlArgs);
 
     // This test is now covered by DatabaseOperationsTest
@@ -444,7 +454,8 @@ public class CreateCdcUserStepTest {
               null,
               "localhost",
               3306,
-              "testdb");
+              "testdb",
+              false);
       createCdcUserStep.createCdcUser(testArgs);
       assertTrue(false, "Expected RuntimeException to be thrown");
     } catch (Exception e) {
@@ -471,7 +482,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     SqlSetupResult result = createCdcUserStep.createCdcUser(testArgs);
 
     assertNotNull(result);
@@ -503,7 +515,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     SqlSetupResult result = createCdcUserStep.createCdcUser(testArgs);
 
     assertNotNull(result);
@@ -529,7 +542,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     SqlSetupResult result = createCdcUserStep.createCdcUser(testArgs);
 
     assertNotNull(result);
@@ -559,7 +573,8 @@ public class CreateCdcUserStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     SqlSetupResult result = createCdcUserStep.createCdcUser(testArgs);
 
     assertNotNull(result);

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateTablesStepTest.java
@@ -52,7 +52,8 @@ public class CreateTablesStepTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "testdb" // databaseName
+            "testdb", // databaseName
+            false // createSchemaVersionIndex
             );
     createTablesStep = new CreateTablesStep(mockDatabase, defaultSetupArgs);
     when(mockUpgradeContext.report()).thenReturn(mockUpgradeReport);
@@ -115,7 +116,8 @@ public class CreateTablesStepTest {
             null, // createUserPassword
             "localhost", // host
             5432, // port
-            "testdb" // databaseName
+            "testdb", // databaseName
+            false // createSchemaVersionIndex
             );
     CreateTablesStep postgresStep = new CreateTablesStep(mockDatabase, postgresSetupArgs);
     when(mockDatabase.dataSource()).thenReturn(mockDataSource);
@@ -313,7 +315,8 @@ public class CreateTablesStepTest {
             null,
             "localhost",
             5432,
-            "testdb");
+            "testdb",
+            false);
     CreateTablesStep postgresStep = new CreateTablesStep(mockDatabase, postgresArgs);
 
     // Mock that database exists (ResultSet.next() returns true)
@@ -361,7 +364,8 @@ public class CreateTablesStepTest {
             null,
             "localhost",
             5432,
-            "testdb");
+            "testdb",
+            false);
     CreateTablesStep postgresStep = new CreateTablesStep(mockDatabase, postgresArgs);
 
     // Mock database check failure - PreparedStatement throws exception

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateUsersStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/CreateUsersStepTest.java
@@ -52,7 +52,8 @@ public class CreateUsersStepTest {
             "testpass", // createUserPassword
             "localhost", // host
             3306, // port
-            "testdb" // databaseName
+            "testdb", // databaseName
+            false // createSchemaVersionIndex
             );
     createUsersStep = new CreateUsersStep(mockDatabase, defaultSetupArgs);
     when(mockUpgradeContext.report()).thenReturn(mockUpgradeReport);
@@ -114,7 +115,8 @@ public class CreateUsersStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     CreateUsersStep disabledUserStep = new CreateUsersStep(mockDatabase, disabledUserArgs);
 
     Function<UpgradeContext, UpgradeStepResult> executable = disabledUserStep.executable();
@@ -250,7 +252,8 @@ public class CreateUsersStepTest {
             null,
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     createUsersStep.createIamUser(testArgs, result);
 
     assertEquals(result.getUsersCreated(), 1);
@@ -279,7 +282,8 @@ public class CreateUsersStepTest {
             "testpass",
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     createUsersStep.createTraditionalUser(testArgs, result);
 
     assertEquals(result.getUsersCreated(), 1);
@@ -366,7 +370,8 @@ public class CreateUsersStepTest {
             "testpass",
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     SqlSetupResult result = createUsersStep.createUsers(testArgs);
 
     assertNotNull(result);
@@ -391,7 +396,8 @@ public class CreateUsersStepTest {
             "testpass",
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     SqlSetupResult result = createUsersStep.createUsers(testArgs);
 
     assertNotNull(result);
@@ -416,7 +422,8 @@ public class CreateUsersStepTest {
             "testpass",
             "localhost",
             3306,
-            "testdb");
+            "testdb",
+            false);
     SqlSetupResult result = createUsersStep.createUsers(testArgs);
 
     assertNotNull(result);
@@ -446,7 +453,8 @@ public class CreateUsersStepTest {
               null,
               "localhost",
               3306,
-              "testdb");
+              "testdb",
+              false);
       createUsersStep.createIamUser(testArgs, result);
       assertTrue(false, "Expected SQLException to be thrown");
     } catch (Exception e) {
@@ -476,7 +484,8 @@ public class CreateUsersStepTest {
               "testpass",
               "localhost",
               3306,
-              "testdb");
+              "testdb",
+              false);
       createUsersStep.createTraditionalUser(testArgs, result);
       assertTrue(false, "Expected SQLException to be thrown");
     } catch (Exception e) {

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperationsTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/DatabaseOperationsTest.java
@@ -1,5 +1,8 @@
 package com.linkedin.datahub.upgrade.sqlsetup;
 
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -136,16 +139,58 @@ public class DatabaseOperationsTest {
 
   @Test
   public void testPostgresCreateTableSqlStatements() {
-    java.util.List<String> statements = postgresOps.createTableSqlStatements();
+    java.util.List<String> statements = postgresOps.createTableSqlStatements(false);
     assertNotNull(statements);
     assertTrue(statements.size() >= 2); // At least table creation + one index
     assertTrue(statements.get(0).contains("CREATE TABLE IF NOT EXISTS metadata_aspect_v2"));
     assertTrue(statements.get(1).contains("CREATE INDEX IF NOT EXISTS timeIndex"));
+    assertTrue(statements.stream().noneMatch(s -> s.contains("schemaVersionIndex")));
+  }
+
+  @Test
+  public void testPostgresCreateTableSqlStatementsWithSchemaVersionIndex() {
+    // schemaVersionIndex is created via postSetup, not in the statement list
+    java.util.List<String> statements = postgresOps.createTableSqlStatements(true);
+    assertTrue(statements.stream().noneMatch(s -> s.contains("schemaVersionIndex")));
+  }
+
+  @Test
+  public void testPostgresPostSetupDropsInvalidIndexThenCreates() throws SQLException {
+    // Simulate pg_index returning a row (invalid index exists)
+    when(mockConnection.prepareStatement(org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(true);
+    when(mockConnection.createStatement()).thenReturn(mockPreparedStatement);
+
+    postgresOps.postSetup(mockConnection);
+
+    verify(mockPreparedStatement).execute("DROP INDEX CONCURRENTLY schemaversionindex");
+    verify(mockPreparedStatement)
+        .execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS schemaVersionIndex ON metadata_aspect_v2 ((systemmetadata::jsonb ->> 'schemaVersion'));");
+  }
+
+  @Test
+  public void testPostgresPostSetupCreatesIndexWhenNoneInvalid() throws SQLException {
+    // Simulate pg_index returning no rows (no invalid index)
+    when(mockConnection.prepareStatement(org.mockito.ArgumentMatchers.anyString()))
+        .thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+    when(mockResultSet.next()).thenReturn(false);
+    when(mockConnection.createStatement()).thenReturn(mockPreparedStatement);
+
+    postgresOps.postSetup(mockConnection);
+
+    verify(mockPreparedStatement, never()).execute("DROP INDEX CONCURRENTLY schemaVersionIndex");
+    verify(mockPreparedStatement)
+        .execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS schemaVersionIndex ON metadata_aspect_v2 ((systemmetadata::jsonb ->> 'schemaVersion'));");
   }
 
   @Test
   public void testMysqlCreateTableSqlStatements() {
-    java.util.List<String> statements = mysqlOps.createTableSqlStatements();
+    java.util.List<String> statements = mysqlOps.createTableSqlStatements(false);
     assertNotNull(statements);
     assertEquals(statements.size(), 1); // MySQL creates table with indexes in one statement
     assertTrue(statements.get(0).contains("CREATE TABLE IF NOT EXISTS metadata_aspect_v2"));
@@ -154,7 +199,7 @@ public class DatabaseOperationsTest {
 
   @Test
   public void testMysqlCreateTableSqlStatementsMatchesMysqlSetupCharsetAndCollation() {
-    java.util.List<String> statements = mysqlOps.createTableSqlStatements();
+    java.util.List<String> statements = mysqlOps.createTableSqlStatements(false);
     assertNotNull(statements);
     String ddl = statements.get(0);
     assertTrue(

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/SqlSetupTest.java
@@ -40,7 +40,8 @@ public class SqlSetupTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);
 
@@ -66,7 +67,8 @@ public class SqlSetupTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
     sqlSetup = new SqlSetup(null, setupArgs);
 
@@ -112,7 +114,8 @@ public class SqlSetupTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);
@@ -138,7 +141,8 @@ public class SqlSetupTest {
             "testpass", // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);
@@ -165,7 +169,8 @@ public class SqlSetupTest {
             null, // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);
@@ -192,7 +197,8 @@ public class SqlSetupTest {
             "testpass", // createUserPassword
             "localhost", // host
             3306, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     sqlSetup = new SqlSetup(mockDatabase, setupArgs);

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/config/SqlSetupConfigTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/sqlsetup/config/SqlSetupConfigTest.java
@@ -178,7 +178,8 @@ public class SqlSetupConfigTest {
             null, // createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     SqlSetup sqlSetup = sqlSetupConfig.createInstance(mockDatabase, setupArgs);
@@ -234,7 +235,8 @@ public class SqlSetupConfigTest {
             null, // createUserPassword - no password means IAM auth
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     // Should not throw exception - IAM auth is valid without role
@@ -257,7 +259,8 @@ public class SqlSetupConfigTest {
             null, // createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     sqlSetupConfig.validateAuthenticationConfig(args);
@@ -279,7 +282,8 @@ public class SqlSetupConfigTest {
             "testpass", // createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     try {
@@ -306,7 +310,8 @@ public class SqlSetupConfigTest {
             null, // createUserPassword - Missing createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     try {
@@ -333,7 +338,8 @@ public class SqlSetupConfigTest {
             null, // createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     // Should not throw exception
@@ -356,7 +362,8 @@ public class SqlSetupConfigTest {
             "testpass", // createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     // Should not throw exception
@@ -449,7 +456,8 @@ public class SqlSetupConfigTest {
             null, // createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     // Test IAM auth without password is valid (no exception expected)
@@ -470,7 +478,8 @@ public class SqlSetupConfigTest {
             null, // createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     // Test IAM auth without password is valid (no exception expected)
@@ -491,7 +500,8 @@ public class SqlSetupConfigTest {
             "testpass", // createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     try {
@@ -516,7 +526,8 @@ public class SqlSetupConfigTest {
             "   ", // createUserPassword - Whitespace-only createUserPassword
             "localhost", // host
             0, // port
-            "datahub" // databaseName
+            "datahub", // databaseName
+            false // createSchemaVersionIndex
             );
 
     try {

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -59,4 +59,5 @@ public class FeatureFlags {
   private boolean hideLineageInSearchCards = false;
   private boolean contextDocumentsEnabled = false;
   private boolean glossaryBasedPoliciesEnabled = false;
+  private boolean zduStage10 = false;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1076,6 +1076,7 @@ featureFlags:
   contextDocumentsEnabled: ${CONTEXT_DOCUMENTS_ENABLED:true} # Enables the context documents feature in the sidebar
   multipleDataProductsPerAsset: ${MULTIPLE_DATA_PRODUCTS_PER_ASSET:true} # Enables assets to belong to multiple data products simultaneously
   glossaryBasedPoliciesEnabled: ${GLOSSARY_BASED_POLICIES_ENABLED:false} # Enables glossary-based policies to be created
+  zduStage10: ${ZDU_STAGE_10:false} # // ZDU rollout stage — numbered by 10s to allow future stages to be inserted between existing ones
 
 entityChangeEvents:
   enabled: ${ENABLE_ENTITY_CHANGE_EVENTS_HOOK:true}


### PR DESCRIPTION
Creates a CONCURRENTLY-built expression index on systemmetadata::jsonb ->> 'schemaVersion' for Postgres only.
Not creating the index for mysql since mysql rarely uses more than one index (we already have indices for aspect and version). Its easy to add it, but given this is only during upgrade, skipping this for now. 
The index creation is gated on featureFlags.zduStage10. Before creating, any invalid index left by a previously interrupted CONCURRENTLY run is dropped to allow clean re-creation.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
