### PR TITLE
feat(ingest/git): allow empty url_templates, use repo as default repo_ssh_locator, sanitize external URLs

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/git.py
+++ b/metadata-ingestion/src/datahub/configuration/git.py
@@ -13,6 +13,7 @@ from pydantic import (
 from datahub.configuration.common import ConfigModel
 from datahub.configuration.validate_field_rename import pydantic_renamed_field
 from datahub.configuration.validate_multiline_string import pydantic_multiline_string
+from datahub.utilities.global_warning_util import add_global_warning
 
 _GITHUB_PREFIX = "https://github.com/"
 _GITLAB_PREFIX = "https://gitlab.com/"
@@ -38,8 +39,8 @@ class GitReference(ConfigModel):
     )
     url_template: Optional[str] = Field(
         None,
-        description=f"Template for generating a URL to a file in the repo e.g. '{_GITHUB_URL_TEMPLATE}'. We can infer this for GitHub and GitLab repos, and it is otherwise required."
-        "It supports the following variables: {repo_url}, {branch}, {file_path}",
+        description=f"Template for generating an external URL to a file in the repo, e.g. '{_GITHUB_URL_TEMPLATE}'. We can infer this for GitHub and GitLab repos."
+        "It supports the following variables: {repo_url}, {branch}, {file_path}.",
     )
 
     _deprecated_base_url = pydantic_renamed_field(
@@ -71,14 +72,15 @@ class GitReference(ConfigModel):
         elif self.repo.startswith(_GITLAB_PREFIX):
             self.url_template = _GITLAB_URL_TEMPLATE
         else:
-            raise ValueError(
-                "Unable to infer URL template from repo. Please set url_template manually."
+            add_global_warning(
+                "Unable to infer URL template from `repo`. Please set `url_template` manually."
             )
 
         return self
 
-    def get_url_for_file_path(self, file_path: str) -> str:
-        assert self.url_template
+    def get_url_for_file_path(self, file_path: str) -> Optional[str]:
+        if not self.url_template:
+            return None
         if self.url_subdir:
             file_path = f"{self.url_subdir}/{file_path}"
         return self.url_template.format(

--- a/metadata-ingestion/src/datahub/configuration/git.py
+++ b/metadata-ingestion/src/datahub/configuration/git.py
@@ -104,7 +104,7 @@ class GitInfo(GitReference):
 
     repo_ssh_locator: Optional[str] = Field(
         None,
-        description="The url to call `git clone` on. We infer this for github and gitlab repos, but it is required for other hosts.",
+        description="The URL to call `git clone` on. By default, for GitHub and GitLab repos, we infer the SSH URL. For other hosts, this defaults to the value of `repo`",
     )
 
     _fix_deploy_key_newlines = pydantic_multiline_string("deploy_key")
@@ -140,9 +140,7 @@ class GitInfo(GitReference):
                 f"git@gitlab.com:{self.repo[len(_GITLAB_PREFIX) :]}.git"
             )
         else:
-            raise ValueError(
-                "Unable to infer repo_ssh_locator from repo. Please set repo_ssh_locator manually."
-            )
+            self.repo_ssh_locator = self.repo
 
         return self
 

--- a/metadata-ingestion/src/datahub/configuration/git.py
+++ b/metadata-ingestion/src/datahub/configuration/git.py
@@ -1,4 +1,5 @@
 import pathlib
+import urllib.parse
 from copy import deepcopy
 from typing import Any, Optional, Union
 
@@ -67,9 +68,9 @@ class GitReference(ConfigModel):
         if self.url_template is not None:
             return self
 
-        if self.repo.startswith(_GITHUB_PREFIX):
+        if _remove_url_basic_auth(self.repo).startswith(_GITHUB_PREFIX):
             self.url_template = _GITHUB_URL_TEMPLATE
-        elif self.repo.startswith(_GITLAB_PREFIX):
+        elif _remove_url_basic_auth(self.repo).startswith(_GITLAB_PREFIX):
             self.url_template = _GITLAB_URL_TEMPLATE
         else:
             add_global_warning(
@@ -83,8 +84,11 @@ class GitReference(ConfigModel):
             return None
         if self.url_subdir:
             file_path = f"{self.url_subdir}/{file_path}"
+
         return self.url_template.format(
-            repo_url=self.repo, branch=self.branch, file_path=file_path
+            repo_url=_remove_url_basic_auth(self.repo),
+            branch=self.branch,
+            file_path=file_path,
         )
 
 
@@ -177,3 +181,10 @@ class GitInfo(GitReference):
         )
 
         return checkout_dir
+
+
+def _remove_url_basic_auth(url: str) -> str:
+    parsed_url = urllib.parse.urlsplit(url)
+    return urllib.parse.urlunsplit(
+        parsed_url._replace(netloc=parsed_url.netloc.split("@")[-1])
+    )

--- a/metadata-ingestion/tests/integration/git/test_git_clone.py
+++ b/metadata-ingestion/tests/integration/git/test_git_clone.py
@@ -60,13 +60,13 @@ def test_base_url_guessing() -> None:
     )
     assert config.repo_ssh_locator == "https://gitea.com/gitea/tea.git"
 
-    # Empty url_template and no guess.
+    # Empty url_template and repo_ssh_locator and no guess.
     config = GitInfo(
         repo="https://my.git.internal/myproject",
-        repo_ssh_locator="https://my.git.internal/myproject",
         branch="main",
     )
     assert config.get_url_for_file_path("README.md") is None
+    assert config.repo_ssh_locator == "https://my.git.internal/myproject"
 
     # Deprecated: base_url.
     with pytest.warns(ConfigurationWarning, match="base_url is deprecated"):

--- a/metadata-ingestion/tests/integration/git/test_git_clone.py
+++ b/metadata-ingestion/tests/integration/git/test_git_clone.py
@@ -68,6 +68,27 @@ def test_base_url_guessing() -> None:
     assert config.get_url_for_file_path("README.md") is None
     assert config.repo_ssh_locator == "https://my.git.internal/myproject"
 
+    # GitHub with personal access token
+    config = GitInfo(
+        repo="https://mytoken@github.com/myorg/myproject",
+    )
+    assert (
+        config.get_url_for_file_path("README.md")
+        == "https://github.com/myorg/myproject/blob/main/README.md"
+    )
+    assert config.repo_ssh_locator == "https://mytoken@github.com/myorg/myproject"
+
+    # Sanitize file path
+    config = GitInfo(
+        repo="https://mytoken@my.git.internal/myproject",
+        url_template="{repo_url}/blob/{branch}/{file_path}",
+        branch="main",
+    )
+    assert (
+        config.get_url_for_file_path("README.md")
+        == "https://my.git.internal/myproject/blob/main/README.md"
+    )
+
     # Deprecated: base_url.
     with pytest.warns(ConfigurationWarning, match="base_url is deprecated"):
         config = GitInfo.model_validate(

--- a/metadata-ingestion/tests/integration/git/test_git_clone.py
+++ b/metadata-ingestion/tests/integration/git/test_git_clone.py
@@ -60,6 +60,14 @@ def test_base_url_guessing() -> None:
     )
     assert config.repo_ssh_locator == "https://gitea.com/gitea/tea.git"
 
+    # Empty url_template and no guess.
+    config = GitInfo(
+        repo="https://my.git.internal/myproject",
+        repo_ssh_locator="https://my.git.internal/myproject",
+        branch="main",
+    )
+    assert config.get_url_for_file_path("README.md") is None
+
     # Deprecated: base_url.
     with pytest.warns(ConfigurationWarning, match="base_url is deprecated"):
         config = GitInfo.model_validate(


### PR DESCRIPTION
This makes the connectors that use Git (LookML, dbt) work more easily with a broader range of Git configurations, such as:
- internally-hosted repos
- Azure DevOps
- GitHub using Personal Access Token authorization over HTTPS
