### PR TITLE
feat(platform-events): compute relationship-change aspect set dynamically from entity registry

### DIFF
--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
@@ -57,12 +57,19 @@ import org.springframework.stereotype.Component;
 public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
 
   /**
-   * Computed at startup from the entity registry: all aspects with at least one {@code isLineage:
-   * true} relationship field spec, plus {@code logicalParent} explicitly (its PhysicalInstanceOf
-   * relationship lacks the flag but must still trigger RCEs). Adding a new lineage relationship
-   * type to a PDL file automatically includes it here without code changes.
+   * Aspects that carry non-lineage relationships which must still trigger RCEs. These are added
+   * explicitly because their PDL {@code @Relationship} annotations lack {@code "isLineage": true},
+   * so the registry scan would otherwise miss them.
    */
-  private final Set<String> relationshipChangeSupportedAspectNames;
+  private static final Set<String> NON_LINEAGE_RELATIONSHIP_ASPECTS =
+      ImmutableSet.of(Constants.LOGICAL_PARENT_ASPECT_NAME);
+
+  /**
+   * Computed at startup from the entity registry: all aspects with at least one {@code isLineage:
+   * true} relationship field spec, plus {@link #NON_LINEAGE_RELATIONSHIP_ASPECTS}. Adding a new
+   * lineage relationship type to a PDL file automatically includes it here without code changes.
+   */
+  @Getter private final Set<String> relationshipChangeSupportedAspectNames;
 
   /** The list of aspects that are supported for generating semantic change events. */
   private static final Set<String> ENTITY_CHANGE_SUPPORTED_ASPECT_NAMES =
@@ -148,9 +155,7 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
                         .anyMatch(RelationshipFieldSpec::isLineageRelationship))
             .map(AspectSpec::getName)
             .collect(Collectors.toSet());
-    // logicalParent's PhysicalInstanceOf relationship lacks isLineage=true in its PDL
-    // but must still trigger RCEs so downstream services can react to new physical-logical links.
-    aspects.add(Constants.LOGICAL_PARENT_ASPECT_NAME);
+    aspects.addAll(NON_LINEAGE_RELATIONSHIP_ASPECTS);
     return ImmutableSet.copyOf(aspects);
   }
 
@@ -173,11 +178,6 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
   @Override
   public boolean isEnabled() {
     return isEnabled;
-  }
-
-  @VisibleForTesting
-  Set<String> getRelationshipChangeSupportedAspectNames() {
-    return relationshipChangeSupportedAspectNames;
   }
 
   private List<ChangeEvent> getChangeEvents(MetadataChangeLog logEvent) {

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHook.java
@@ -16,6 +16,7 @@ import com.linkedin.metadata.event.EventProducer;
 import com.linkedin.metadata.graph.EdgeDiff;
 import com.linkedin.metadata.kafka.hook.MetadataChangeLogHook;
 import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.RelationshipFieldSpec;
 import com.linkedin.metadata.timeline.data.ChangeEvent;
 import com.linkedin.metadata.timeline.eventgenerator.Aspect;
 import com.linkedin.metadata.timeline.eventgenerator.ChangeEventGeneratorUtils;
@@ -54,6 +55,14 @@ import org.springframework.stereotype.Component;
 @Component
 @Import({EntityRegistryFactory.class})
 public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
+
+  /**
+   * Computed at startup from the entity registry: all aspects with at least one {@code isLineage:
+   * true} relationship field spec, plus {@code logicalParent} explicitly (its PhysicalInstanceOf
+   * relationship lacks the flag but must still trigger RCEs). Adding a new lineage relationship
+   * type to a PDL file automatically includes it here without code changes.
+   */
+  private final Set<String> relationshipChangeSupportedAspectNames;
 
   /** The list of aspects that are supported for generating semantic change events. */
   private static final Set<String> ENTITY_CHANGE_SUPPORTED_ASPECT_NAMES =
@@ -124,6 +133,25 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
     this.consumerGroupSuffix = consumerGroupSuffix;
     this.entityExclusions = entityExclusions;
     this.fineGrainedLineageNotAllowedForPlatforms = fineGrainedLineageNotAllowedForPlatforms;
+    this.relationshipChangeSupportedAspectNames =
+        computeRelationshipChangeSupportedAspects(systemOperationContext);
+  }
+
+  private static Set<String> computeRelationshipChangeSupportedAspects(
+      @Nonnull OperationContext systemOperationContext) {
+    Set<String> aspects =
+        systemOperationContext.getEntityRegistry().getEntitySpecs().values().stream()
+            .flatMap(entitySpec -> entitySpec.getAspectSpecs().stream())
+            .filter(
+                aspectSpec ->
+                    aspectSpec.getRelationshipFieldSpecs().stream()
+                        .anyMatch(RelationshipFieldSpec::isLineageRelationship))
+            .map(AspectSpec::getName)
+            .collect(Collectors.toSet());
+    // logicalParent's PhysicalInstanceOf relationship lacks isLineage=true in its PDL
+    // but must still trigger RCEs so downstream services can react to new physical-logical links.
+    aspects.add(Constants.LOGICAL_PARENT_ASPECT_NAME);
+    return ImmutableSet.copyOf(aspects);
   }
 
   @VisibleForTesting
@@ -145,6 +173,11 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
   @Override
   public boolean isEnabled() {
     return isEnabled;
+  }
+
+  @VisibleForTesting
+  Set<String> getRelationshipChangeSupportedAspectNames() {
+    return relationshipChangeSupportedAspectNames;
   }
 
   private List<ChangeEvent> getChangeEvents(MetadataChangeLog logEvent) {
@@ -231,11 +264,13 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
       processChangeEvent(logEvent);
     }
 
-    // Steps:
-    // 1. Parse the old and new aspect.
-    // 2. Find and invoke a EntityChangeEventGenerator.
-    // 3. Sink the output of the EntityChangeEventGenerator to a specific PDL change event.
-    processRelationshipChangeEvent(logEvent);
+    if (isEligibleForRelationshipChangeEventProcessing(logEvent)) {
+      // Steps:
+      // 1. Parse the old and new aspect.
+      // 2. Find and invoke a EntityChangeEventGenerator.
+      // 3. Sink the output of the EntityChangeEventGenerator to a specific PDL change event.
+      processRelationshipChangeEvent(logEvent);
+    }
   }
 
   private <T extends RecordTemplate> List<ChangeEvent> generateChangeEvents(
@@ -262,6 +297,11 @@ public class PlatformEventGeneratorHook implements MetadataChangeLogHook {
   private boolean isEligibleForChangeEventProcessing(final MetadataChangeLog log) {
     return CHANGE_EVENT_SUPPORTED_OPERATIONS.contains(log.getChangeType().toString())
         && ENTITY_CHANGE_SUPPORTED_ASPECT_NAMES.contains(log.getAspectName())
+        && !entityExclusions.contains(log.getEntityType());
+  }
+
+  private boolean isEligibleForRelationshipChangeEventProcessing(final MetadataChangeLog log) {
+    return relationshipChangeSupportedAspectNames.contains(log.getAspectName())
         && !entityExclusions.contains(log.getEntityType());
   }
 

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/LogicalParentRCETest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/LogicalParentRCETest.java
@@ -1,0 +1,210 @@
+package com.linkedin.metadata.kafka.hook.event;
+
+import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Edge;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.logical.LogicalParent;
+import com.linkedin.metadata.event.EventProducer;
+import com.linkedin.metadata.timeline.eventgenerator.EntityChangeEventGeneratorRegistry;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeLog;
+import com.linkedin.mxe.PlatformEvent;
+import com.linkedin.platform.event.v1.RelationshipChangeEvent;
+import com.linkedin.platform.event.v1.RelationshipChangeOperation;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.net.URISyntaxException;
+import java.util.Set;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.collections.Sets;
+
+/**
+ * Regression tests for PhysicalInstanceOf RelationshipChangeEvent emission.
+ *
+ * <p>Background: When a physical dataset is linked to a logical dataset via the logicalParent
+ * aspect, a PhysicalInstanceOf RelationshipChangeEvent (RCE) should be emitted by
+ * PlatformEventGeneratorHook. The integrations service depends on this RCE to trigger SP
+ * propagation in the parent-then-child ingestion order (logical SP set before the physical is
+ * linked).
+ *
+ * <p>Two ingestion orderings are tested:
+ *
+ * <ul>
+ *   <li>child-then-parent: physical linked first (logicalParent set), then SP set on logical.
+ *       Propagation works via the ECE path — SP ECE fires against an already-indexed edge.
+ *   <li>parent-then-child: SP set on logical first, then physical linked (logicalParent set).
+ *       Propagation must work via the RCE path — the new edge RCE must trigger SP propagation.
+ * </ul>
+ *
+ * <p>These unit tests assert that PlatformEventGeneratorHook correctly emits a PhysicalInstanceOf
+ * RCE when a logicalParent MCL is processed, which is the prerequisite for the parent-then-child
+ * path to work.
+ *
+ * <p>NOTE: These tests use the real entity registry (loaded from entity-registry.yml) rather than
+ * the mocked registry used in PlatformEventGeneratorHookTest. The mocked registry does not register
+ * logicalParent, so getAspectSpec("logicalParent") returns null there, causing
+ * buildRelationshipChangeEvents to short-circuit early with an empty result. The real registry
+ * contains the @Relationship annotation on LogicalParent.pdl and is required for these tests to
+ * exercise the actual code path.
+ */
+public class LogicalParentRCETest {
+
+  private static final long EVENT_TIME = 123L;
+
+  private static final String PHYSICAL_DATASET_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:snowflake,physical_dataset,PROD)";
+  private static final String LOGICAL_DATASET_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:snowflake,logical_dataset,PROD)";
+  private static final String TEST_ACTOR_URN = "urn:li:corpuser:test";
+
+  private EventProducer mockProducer;
+  private PlatformEventGeneratorHook hook;
+  private Urn actorUrn;
+
+  @BeforeMethod
+  public void setup() throws URISyntaxException {
+    actorUrn = Urn.createFromString(TEST_ACTOR_URN);
+    mockProducer = Mockito.mock(EventProducer.class);
+
+    OperationContext realOpContext = TestOperationContexts.systemContextNoSearchAuthorization();
+
+    hook =
+        new PlatformEventGeneratorHook(
+            realOpContext, new EntityChangeEventGeneratorRegistry(), mockProducer, true);
+  }
+
+  /**
+   * Asserts that processing a logicalParent MCL (physical linked to logical for the first time)
+   * emits a PhysicalInstanceOf ADD RelationshipChangeEvent on the PlatformEvent_v1 topic.
+   *
+   * <p>This is the core prerequisite for the parent-then-child propagation path. If no RCE is
+   * emitted here, the integrations service never learns about the new physical-to-logical
+   * relationship and cannot propagate SPs that were set on the logical before the link existed.
+   */
+  @Test
+  public void testLogicalParentMCLEmitsPhysicalInstanceOfAddRCE() throws Exception {
+    Urn physicalUrn = UrnUtils.getUrn(PHYSICAL_DATASET_URN);
+    Urn logicalUrn = UrnUtils.getUrn(LOGICAL_DATASET_URN);
+
+    // Build the logicalParent aspect: physical -> logical
+    LogicalParent logicalParent = new LogicalParent();
+    Edge parentEdge = new Edge();
+    parentEdge.setDestinationUrn(logicalUrn);
+    logicalParent.setParent(parentEdge);
+
+    // MCL: new logicalParent on the physical dataset (no previous value — first-time link)
+    MetadataChangeLog mcl = new MetadataChangeLog();
+    mcl.setEntityType(DATASET_ENTITY_NAME);
+    mcl.setEntityUrn(physicalUrn);
+    mcl.setAspectName(LOGICAL_PARENT_ASPECT_NAME);
+    mcl.setChangeType(ChangeType.UPSERT);
+    mcl.setAspect(GenericRecordUtils.serializeAspect(logicalParent));
+    mcl.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    hook.invoke(mcl);
+
+    // Verify a RelationshipChangeEvent was produced with the expected fields.
+    verify(mockProducer, times(1))
+        .producePlatformEvent(
+            eq(RELATIONSHIP_PLATFORM_EVENT_NAME),
+            anyString(),
+            argThat(
+                (PlatformEvent event) -> {
+                  if (!RELATIONSHIP_PLATFORM_EVENT_NAME.equals(event.getName())) return false;
+                  RelationshipChangeEvent rce =
+                      GenericRecordUtils.deserializePayload(
+                          event.getPayload().getValue(), RelationshipChangeEvent.class);
+                  return "PhysicalInstanceOf".equals(rce.getRelationshipType())
+                      && RelationshipChangeOperation.ADD.equals(rce.getOperation())
+                      && physicalUrn.equals(rce.getSourceUrn())
+                      && logicalUrn.equals(rce.getDestinationUrn());
+                }));
+  }
+
+  /**
+   * Asserts that removing a logicalParent link emits a PhysicalInstanceOf REMOVE
+   * RelationshipChangeEvent.
+   *
+   * <p>Companion to the ADD test — ensures both sides of the edge lifecycle emit RCEs.
+   */
+  @Test
+  public void testLogicalParentRemovedEmitsPhysicalInstanceOfRemoveRCE() throws Exception {
+    Urn physicalUrn = UrnUtils.getUrn(PHYSICAL_DATASET_URN);
+    Urn logicalUrn = UrnUtils.getUrn(LOGICAL_DATASET_URN);
+
+    // Previous aspect had a parent edge; new aspect has no parent (link removed)
+    LogicalParent previousLogicalParent = new LogicalParent();
+    Edge parentEdge = new Edge();
+    parentEdge.setDestinationUrn(logicalUrn);
+    previousLogicalParent.setParent(parentEdge);
+
+    // new aspect: parent field absent — link removed
+    LogicalParent newLogicalParent = new LogicalParent();
+
+    MetadataChangeLog mcl = new MetadataChangeLog();
+    mcl.setEntityType(DATASET_ENTITY_NAME);
+    mcl.setEntityUrn(physicalUrn);
+    mcl.setAspectName(LOGICAL_PARENT_ASPECT_NAME);
+    mcl.setChangeType(ChangeType.UPSERT);
+    mcl.setPreviousAspectValue(GenericRecordUtils.serializeAspect(previousLogicalParent));
+    mcl.setAspect(GenericRecordUtils.serializeAspect(newLogicalParent));
+    mcl.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    hook.invoke(mcl);
+
+    verify(mockProducer, times(1))
+        .producePlatformEvent(
+            eq(RELATIONSHIP_PLATFORM_EVENT_NAME),
+            anyString(),
+            argThat(
+                (PlatformEvent event) -> {
+                  if (!RELATIONSHIP_PLATFORM_EVENT_NAME.equals(event.getName())) return false;
+                  RelationshipChangeEvent rce =
+                      GenericRecordUtils.deserializePayload(
+                          event.getPayload().getValue(), RelationshipChangeEvent.class);
+                  return "PhysicalInstanceOf".equals(rce.getRelationshipType())
+                      && RelationshipChangeOperation.REMOVE.equals(rce.getOperation())
+                      && physicalUrn.equals(rce.getSourceUrn())
+                      && logicalUrn.equals(rce.getDestinationUrn());
+                }));
+  }
+
+  /**
+   * Contract test: asserts the computed relationship-change supported aspect names exactly match
+   * the hardcoded expected set. If this test fails, a PDL-defined lineage relationship type was
+   * added or removed — update the expected set and confirm the change is intentional.
+   */
+  @Test
+  public void testRelationshipChangeSupportedAspectNamesMatchExpectedSet() {
+    Set<String> expected =
+        Sets.newHashSet(
+            // All discovered via isLineage=true relationship annotations in PDL files
+            UPSTREAM_LINEAGE_ASPECT_NAME,
+            DATA_JOB_INPUT_OUTPUT_ASPECT_NAME,
+            "dataProcessInfo",
+            "dataProcessInstanceInput",
+            "dataProcessInstanceOutput",
+            "chartInfo",
+            "dashboardInfo",
+            "mlModelProperties",
+            "mlModelGroupProperties",
+            "mlFeatureProperties",
+            "mlPrimaryKeyProperties",
+            // Explicit: PhysicalInstanceOf lacks isLineage=true but must trigger RCEs
+            LOGICAL_PARENT_ASPECT_NAME);
+
+    Assert.assertEquals(
+        hook.getRelationshipChangeSupportedAspectNames(),
+        expected,
+        "Lineage aspect set changed — update this list and verify the change is intentional");
+  }
+}

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/PlatformEventGeneratorHookTest.java
@@ -55,6 +55,7 @@ import com.linkedin.metadata.event.EventProducer;
 import com.linkedin.metadata.key.DatasetKey;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.RelationshipFieldSpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeOperation;
@@ -76,6 +77,7 @@ import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.Map;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
@@ -105,6 +107,10 @@ public class PlatformEventGeneratorHookTest {
   private EventProducer mockProducer;
   private SystemEntityClient mockProcessInstanceEntityClient;
   private PlatformEventGeneratorHook _entityChangeEventHook;
+  // Saved by createMockOperationContext() so we can add getEntitySpecs() stub after
+  // TestOperationContexts has finished processing the registry (adding it before caused a
+  // duplicate-key crash inside TestOperationContexts).
+  private EntityRegistry _mockRegistry;
 
   @BeforeMethod
   public void setupTest() throws URISyntaxException {
@@ -113,9 +119,42 @@ public class PlatformEventGeneratorHookTest {
     mockProcessInstanceEntityClient = Mockito.mock(SystemEntityClient.class);
     EntityChangeEventGeneratorRegistry entityChangeEventGeneratorRegistry =
         createEntityChangeEventGeneratorRegistry(mockProcessInstanceEntityClient);
+
+    OperationContext opContext = createMockOperationContext();
+
+    // Stub getEntitySpecs() NOW — after TestOperationContexts is done — so that the hook's
+    // dynamic computation of relationshipChangeSupportedAspectNames includes upstreamLineage
+    // and dataJobInputOutput without re-entering TestOperationContexts.
+    RelationshipFieldSpec mockLineageSpec = Mockito.mock(RelationshipFieldSpec.class);
+    Mockito.when(mockLineageSpec.isLineageRelationship()).thenReturn(true);
+
+    AspectSpec upstreamLineageSpec = Mockito.mock(AspectSpec.class);
+    Mockito.when(upstreamLineageSpec.getName()).thenReturn(UPSTREAM_LINEAGE_ASPECT_NAME);
+    Mockito.when(upstreamLineageSpec.getRelationshipFieldSpecs())
+        .thenReturn(Collections.singletonList(mockLineageSpec));
+
+    AspectSpec dataJobInputOutputSpec = Mockito.mock(AspectSpec.class);
+    Mockito.when(dataJobInputOutputSpec.getName()).thenReturn(DATA_JOB_INPUT_OUTPUT_ASPECT_NAME);
+    Mockito.when(dataJobInputOutputSpec.getRelationshipFieldSpecs())
+        .thenReturn(Collections.singletonList(mockLineageSpec));
+
+    EntitySpec lineageDatasetSpec = Mockito.mock(EntitySpec.class);
+    Mockito.when(lineageDatasetSpec.getAspectSpecs())
+        .thenReturn(Collections.singletonList(upstreamLineageSpec));
+
+    EntitySpec lineageDataJobSpec = Mockito.mock(EntitySpec.class);
+    Mockito.when(lineageDataJobSpec.getAspectSpecs())
+        .thenReturn(Collections.singletonList(dataJobInputOutputSpec));
+
+    Mockito.when(_mockRegistry.getEntitySpecs())
+        .thenReturn(
+            ImmutableMap.of(
+                DATASET_ENTITY_NAME, lineageDatasetSpec,
+                DATA_JOB_ENTITY_NAME, lineageDataJobSpec));
+
     _entityChangeEventHook =
         new PlatformEventGeneratorHook(
-            createMockOperationContext(), entityChangeEventGeneratorRegistry, mockProducer, true);
+            opContext, entityChangeEventGeneratorRegistry, mockProducer, true);
   }
 
   @Test
@@ -2074,6 +2113,7 @@ public class PlatformEventGeneratorHookTest {
 
   private OperationContext createMockOperationContext() {
     EntityRegistry registry = Mockito.mock(EntityRegistry.class);
+    _mockRegistry = registry; // saved so setupTest() can add getEntitySpecs() stub afterwards
     // Build Dataset Entity Spec
     EntitySpec datasetSpec = Mockito.mock(EntitySpec.class);
 


### PR DESCRIPTION
## Summary

- Replaces the unconditional call to `processRelationshipChangeEvent()` with a guard that skips it for aspects carrying no lineage relationships, avoiding unnecessary work on every MCL.
- The eligible aspect set is computed at hook startup by scanning all registered `EntitySpec`s for aspects with at least one `isLineage: true` relationship field. New lineage relationship types added to PDL files are automatically included without code changes.
- Adds `NON_LINEAGE_RELATIONSHIP_ASPECTS` — a named constant for aspects whose `@Relationship` annotations intentionally lack `isLineage: true` but must still trigger RCEs (currently: `logicalParent` / `PhysicalInstanceOf`).
- Fixes a bug where `logicalParent` MCLs did not emit `PhysicalInstanceOf` `RelationshipChangeEvent`s, breaking the parent-then-child structured property propagation path.

## Test plan

- [ ] `LogicalParentRCETest#testLogicalParentMCLEmitsPhysicalInstanceOfAddRCE` — ADD RCE emitted for new physical→logical link
- [ ] `LogicalParentRCETest#testLogicalParentRemovedEmitsPhysicalInstanceOfRemoveRCE` — REMOVE RCE emitted when link is dropped
- [ ] `LogicalParentRCETest#testRelationshipChangeSupportedAspectNamesMatchExpectedSet` — contract test pinning the exact computed set; fails explicitly if PDL changes affect lineage aspects

🤖 Generated with [Claude Code](https://claude.com/claude-code)