### PR TITLE
fix(ui): Fix broken frontend test with timezones

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Loader/Loader.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Loader/Loader.tsx
@@ -24,7 +24,7 @@ export function Loader({
             $alignItems={alignItems || 'none'}
             $padding={padding}
         >
-            <StyledSpinner $height={loaderSize} />
+            <StyledSpinner $height={loaderSize} aria-label="loading" />
         </LoaderWrapper>
     );
 }

--- a/datahub-web-react/src/app/ingestV2/source/__tests__/tests_utils.test.tsx
+++ b/datahub-web-react/src/app/ingestV2/source/__tests__/tests_utils.test.tsx
@@ -570,7 +570,7 @@ describe('formatTimezone', () => {
         expect(['EST', 'EDT']).toContain(nycAbbr);
 
         const londonAbbr = formatTimezone('Europe/London');
-        expect(['GMT', 'BST']).toContain(londonAbbr);
+        expect(['GMT+1', 'BST', 'GMT']).toContain(londonAbbr);
 
         // Tokyo doesn't observe DST, so it's always GMT+9
         expect(formatTimezone('Asia/Tokyo')).toBe('GMT+9');


### PR DESCRIPTION
There was a recent break in a UI test this is a quick fix for. plus adds an aria-label to an alchemy component we have in our saas repo to make sure they're consistent.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
