### PR TITLE
build(ui): Fix colors lint rule diff calculation

### DIFF
--- a/datahub-web-react/.eslintrc.js
+++ b/datahub-web-react/.eslintrc.js
@@ -26,7 +26,7 @@ try {
     }
 
     const raw = execSync(
-        `git diff --diff-filter=d --name-only ${baseBranch} -- "datahub-web-react/src/**/*.ts" "datahub-web-react/src/**/*.tsx"`,
+        `git diff --diff-filter=d --name-only ${baseBranch}...HEAD -- "datahub-web-react/src/**/*.ts" "datahub-web-react/src/**/*.tsx"`,
         { encoding: 'utf-8', cwd: repoRoot, stdio: 'pipe' },
     );
     changedTsFiles = raw


### PR DESCRIPTION
A..B (Double-dot): Shows the difference between the tips of the two specified references, A and B. This is exactly the same as simply running git diff A B.
A...B (Triple-dot): Shows the difference between the merge base of A and B and the tip of B. This effectively shows only the changes unique to branch B since it diverged from A, ignoring changes made on branch A in the meantime. This is often the most useful comparison when reviewing a feature branch against a main branch. 

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
