### PR TITLE
fix(system source): fix default CLI version for system sources on man…

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
@@ -122,14 +122,12 @@ public class CreateIngestionExecutionRequestResolver
               recipe = injectRunId(recipe, executionRequestUrn.toString());
               recipe = IngestionUtils.injectPipelineName(recipe, ingestionSourceUrn.toString());
               arguments.put(RECIPE_ARG_NAME, recipe);
+              String version = ingestionSourceInfo.getConfig().getVersion();
               arguments.put(
                   VERSION_ARG_NAME,
-                  ingestionSourceInfo.getConfig().hasVersion()
-                      ? ingestionSourceInfo.getConfig().getVersion()
+                  version != null && !version.isEmpty()
+                      ? version
                       : _ingestionConfiguration.getDefaultCliVersion());
-              if (ingestionSourceInfo.getConfig().hasVersion()) {
-                arguments.put(VERSION_ARG_NAME, ingestionSourceInfo.getConfig().getVersion());
-              }
               String debugMode = "false";
               if (ingestionSourceInfo.getConfig().hasDebugMode()) {
                 debugMode = ingestionSourceInfo.getConfig().isDebugMode() ? "true" : "false";

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolverTest.java
@@ -14,12 +14,17 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.execution.ExecutionRequestInput;
+import com.linkedin.ingestion.DataHubIngestionSourceConfig;
+import com.linkedin.ingestion.DataHubIngestionSourceInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.config.IngestionConfiguration;
+import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.HashSet;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -106,5 +111,94 @@ public class CreateIngestionExecutionRequestResolverTest {
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(RuntimeException.class, () -> resolver.get(mockEnv).join());
+  }
+
+  @Test
+  public void testVersionUsesExplicitVersion() throws Exception {
+    String expectedVersion = "0.10.5";
+    String capturedVersion = executeAndCaptureVersion(buildSourceInfoWithVersion(expectedVersion));
+    assertEquals(capturedVersion, expectedVersion);
+  }
+
+  @Test
+  public void testVersionFallsBackWhenEmpty() throws Exception {
+    // This is the bug scenario: bootstrap YAML renders an empty string for version
+    String capturedVersion = executeAndCaptureVersion(buildSourceInfoWithVersion(""));
+    assertEquals(capturedVersion, DEFAULT_CLI_VERSION);
+  }
+
+  @Test
+  public void testVersionFallsBackWhenNull() throws Exception {
+    // Version field not set at all
+    DataHubIngestionSourceInfo info = new DataHubIngestionSourceInfo();
+    info.setName("My Test Source");
+    info.setType("mysql");
+    info.setConfig(new DataHubIngestionSourceConfig().setRecipe("{}").setExecutorId("executor id"));
+    // Note: no setVersion call
+
+    String capturedVersion = executeAndCaptureVersion(info);
+    assertEquals(capturedVersion, DEFAULT_CLI_VERSION);
+  }
+
+  private static final String DEFAULT_CLI_VERSION = "default";
+
+  private static DataHubIngestionSourceInfo buildSourceInfoWithVersion(String version) {
+    DataHubIngestionSourceInfo info = new DataHubIngestionSourceInfo();
+    info.setName("My Test Source");
+    info.setType("mysql");
+    info.setConfig(
+        new DataHubIngestionSourceConfig()
+            .setVersion(version)
+            .setRecipe("{}")
+            .setExecutorId("executor id"));
+    return info;
+  }
+
+  /**
+   * Executes the resolver with the given ingestion source info and captures the version argument
+   * from the ingested MetadataChangeProposal.
+   */
+  private String executeAndCaptureVersion(DataHubIngestionSourceInfo sourceInfo) throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.batchGetV2(
+                any(),
+                Mockito.eq(Constants.INGESTION_SOURCE_ENTITY_NAME),
+                Mockito.eq(new HashSet<>(ImmutableSet.of(TEST_INGESTION_SOURCE_URN))),
+                Mockito.eq(ImmutableSet.of(Constants.INGESTION_INFO_ASPECT_NAME))))
+        .thenReturn(
+            ImmutableMap.of(
+                TEST_INGESTION_SOURCE_URN,
+                new EntityResponse()
+                    .setEntityName(Constants.INGESTION_SOURCE_ENTITY_NAME)
+                    .setUrn(TEST_INGESTION_SOURCE_URN)
+                    .setAspects(
+                        new EnvelopedAspectMap(
+                            ImmutableMap.of(
+                                Constants.INGESTION_INFO_ASPECT_NAME,
+                                new EnvelopedAspect().setValue(new Aspect(sourceInfo.data())))))));
+
+    IngestionConfiguration ingestionConfiguration = new IngestionConfiguration();
+    ingestionConfiguration.setDefaultCliVersion(DEFAULT_CLI_VERSION);
+    CreateIngestionExecutionRequestResolver resolver =
+        new CreateIngestionExecutionRequestResolver(mockClient, ingestionConfiguration);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    ArgumentCaptor<MetadataChangeProposal> mcpCaptor =
+        ArgumentCaptor.forClass(MetadataChangeProposal.class);
+    Mockito.verify(mockClient).ingestProposal(any(), mcpCaptor.capture(), Mockito.eq(false));
+
+    ExecutionRequestInput execInput =
+        GenericRecordUtils.deserializeAspect(
+            mcpCaptor.getValue().getAspect().getValue(),
+            mcpCaptor.getValue().getAspect().getContentType(),
+            ExecutionRequestInput.class);
+    return execInput.getArgs().get("version");
   }
 }


### PR DESCRIPTION
…ual run

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->

```
the version field is set to "" (not null), hasVersion() returns true. 
so the second block overwrites the default with the empty string — resulting in acryl-datahub[datahub-documents]==.
```

This impacts manual runs of system sources. https://linear.app/acryl-data/issue/AI-464/datahub-documents-system-source-fails-on-manual-run