### PR TITLE
fix(ingest/powerbi): apply lowercase normalization to all upstream lineage URN code paths

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -49,6 +49,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 ### Other Notable Changes
 
 - #16619 **(Operations / Helm)** Added a `Cleanup` upgrade that tears down all DataHub-owned infrastructure resources (Elasticsearch indices, Kafka topics, SQL database and users). It is designed to run as a Helm **pre-delete hook** so that `helm uninstall` leaves no DataHub-specific state on shared infrastructure. Each component (ES, Kafka, SQL) can be disabled independently via environment variables (`CLEANUP_ELASTICSEARCH_ENABLED`, `CLEANUP_KAFKA_ENABLED`, `CLEANUP_SQL_ENABLED`; all default to `true`). Elasticsearch cleanup uses scoped `IndexConvention` patterns to enumerate only DataHub-owned indices — it does **not** issue a wildcard `DELETE /*` that would be dangerous on shared clusters without an index prefix configured.
+- #16879 (Ingestion) PowerBI: When `convert_lineage_urns_to_lowercase` is enabled, column-level lineage and upstream dataset URNs are now consistently lowercased. Previously, only parts of the URN were lowercased, which could cause lineage mismatches. After upgrading, re-running ingestion will emit corrected URNs.
 
 ## v1.5.0
 

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
@@ -203,7 +203,6 @@ class Mapper:
                     else column_ref.column,
                 )
                 for column_ref in cll_info.upstreams
-                if column_ref.column
             ]
 
             fine_grained_lineages.append(


### PR DESCRIPTION
### Summary

- Fix inconsistent URN casing for PowerBI upstream lineage to BigQuery (and other platforms) when convert_lineage_urns_to_lowercase=True (the default)
- The standard M-Query accessor path correctly lowercased URNs via make_urn(), but the native SQL query path (Value.NativeQuery(...)) bypassed lowercasing because the shared SQL parser returns original-casing URNs for BigQuery (marked as case-sensitive in PLATFORMS_WITH_CASE_SENSITIVE_TABLES)
- Apply lineage_urn_to_lowercase() at the consumption point in extract_lineage() and make_fine_grained_lineage_class(), catching URNs from all code paths in one place

