### PR TITLE
fix(azure-ad): apply groups_pattern filter before URN construction

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
@@ -476,9 +476,21 @@ class AzureADSource(StatefulIngestionSourceBase):
                 self.report.report_failure("azure_ad_group", str(e))
 
     def _map_azure_ad_group(self, azure_ad_group):
-        # Extract group name first so we can apply the pattern filter before
-        # attempting URN construction. Groups excluded by the filter should be
-        # silently skipped, not reported as failures.
+        # Resolve group name and apply filters before building the URN.
+        # This avoids false report_failure entries for groups that are
+        # intentionally excluded by the user's configuration.
+        #
+        # Pre-check for missing attribute so we can distinguish misconfiguration
+        # from intentional regex filtering without changing the shared helper's
+        # exception contract (which other callers rely on).
+        raw_name = azure_ad_group.get(self.config.azure_ad_response_to_groupname_attr)
+        if raw_name is None:
+            self.report.report_failure(
+                "azure_ad_group_mapping",
+                f"Attribute '{self.config.azure_ad_response_to_groupname_attr}' not found in group response. "
+                f"Check azure_ad_response_to_groupname_attr in your config.",
+            )
+            return
         try:
             group_name = self._extract_regex_match_from_dict_value(
                 azure_ad_group,
@@ -486,25 +498,15 @@ class AzureADSource(StatefulIngestionSourceBase):
                 self.config.azure_ad_response_to_groupname_regex,
             )
         except ValueError:
-            # The group's displayName doesn't match the configured regex, which
-            # means it's intentionally excluded by the user's config — treat as
-            # filtered, not as an error.
-            raw_name = azure_ad_group.get(
-                self.config.azure_ad_response_to_groupname_attr, "unknown"
-            )
+            # Attribute exists but regex didn't match — group is intentionally
+            # excluded by azure_ad_response_to_groupname_regex, not an error.
             self.report.report_filtered(f"group:{raw_name}")
             return
         if not self.config.groups_pattern.allowed(group_name):
             self.report.report_filtered(f"group:{group_name}")
             return
-        corp_group_urn, error_str = self._map_identity_to_urn(
-            self._map_azure_ad_group_to_urn,
-            azure_ad_group,
-            "azure_ad_group_mapping",
-            "group",
-        )
-        if error_str is not None:
-            return
+        # URN construction is safe here: group_name is already validated above.
+        corp_group_urn = make_group_urn(urllib.parse.quote(group_name))
         self.selected_azure_ad_groups.append(azure_ad_group)
         corp_group_snapshot = CorpGroupSnapshot(
             urn=corp_group_urn,

--- a/metadata-ingestion/tests/integration/azure_ad/test_azure_ad.py
+++ b/metadata-ingestion/tests/integration/azure_ad/test_azure_ad.py
@@ -51,6 +51,7 @@ def run_ingest(
     mock_datahub_graph,
     mocked_functions_reference,
     recipe,
+    raise_from_status=True,
 ):
     test_resources_dir: pathlib.Path = (
         pytestconfig.rootpath / "tests/integration/azure_ad"
@@ -83,7 +84,8 @@ def run_ingest(
         # Run an azure usage ingestion run.
         pipeline = Pipeline.create(recipe)
         pipeline.run()
-        pipeline.raise_from_status()
+        if raise_from_status:
+            pipeline.raise_from_status()
         return pipeline
 
 
@@ -363,6 +365,30 @@ def test_azure_ad_group_regex_mismatch_is_filtered_not_failed(
     # Non-matching groups must be counted as filtered, not as failures.
     assert len(report.failures) == 0, f"Expected no failures but got: {report.failures}"
     assert len(report.filtered) > 0, "Expected some groups to be filtered by regex"
+
+
+@freeze_time(FROZEN_TIME)
+def test_azure_ad_group_missing_attr_is_failure(
+    pytestconfig, mock_datahub_graph, tmp_path
+):
+    """A missing azure_ad_response_to_groupname_attr key is a misconfiguration and
+    must surface as a failure, not be silently filtered."""
+    output_file_name = "azure_ad_mces_missing_attr.json"
+    new_recipe = default_recipe(tmp_path, output_file_name)
+    new_recipe["source"]["config"]["azure_ad_response_to_groupname_attr"] = (
+        "nonExistentAttr"
+    )
+
+    pipeline = run_ingest(
+        pytestconfig=pytestconfig,
+        mock_datahub_graph=mock_datahub_graph,
+        recipe=new_recipe,
+        mocked_functions_reference=mocked_functions,
+        raise_from_status=False,
+    )
+
+    report = pipeline.source.get_report()
+    assert len(report.failures) > 0, "Expected failures for missing attribute"
 
 
 @freeze_time(FROZEN_TIME)


### PR DESCRIPTION
## 📋 Summary
Fix Azure AD group sync failures caused by two bugs in group filtering: incorrect order of operations and wrong failure severity when groups don't match the configured name regex.

## 🎯 Motivation
Azure AD syncs were failing with spurious errors for groups that should have been silently filtered out. Two related bugs combined to mark the overall ingestion run as **failed** in the UI even though no real error occurred:

1. **Wrong order:** Groups excluded by `groups_pattern` were still being processed through URN construction — which uses the same regex extraction. If those groups didn't match the configured `azure_ad_response_to_groupname_regex`, they would fail during URN construction instead of being filtered.

2. **Wrong severity:** Even after fixing the order, regex mismatches were still reported via `report_failure` instead of `report_filtered`. Since `report_failure` marks the ingestion run as failed in DataHub's UI, the run would show as failed even though every non-matching group was intentionally excluded by the user's config (e.g. a customer using `^.*_(OWNER|MEMBER)$` to only ingest role groups would see hundreds of false failures for every other Azure AD group).

## 🔧 Changes Overview

**Bug Fix 1 — Order of operations:**
- In `AzureADSource._map_azure_ad_group`, the `groups_pattern` filter check now happens **before** URN construction instead of after
- Eliminates a redundant double-call to `_extract_regex_match_from_dict_value` — the group name was previously extracted twice (once inside `_map_identity_to_urn`, once again for the pattern check)

**Bug Fix 2 — Failure severity:**
- When a group's `displayName` doesn't match `azure_ad_response_to_groupname_regex`, it is now reported via `report_filtered` instead of `report_failure`
- A non-matching regex means the group is intentionally excluded by the user's config — not an error condition

## 🏗️ Architecture/Design Notes
The fix mirrors the existing pattern already used for **user** filtering in `_map_azure_ad_users`, where the pattern check gates further processing before any extraction work is done.

Order before this fix:
1. Extract URN (regex extraction — can raise `ValueError`) ← groups reported as **failures** here
2. Check `groups_pattern` ← never reached for non-matching groups

Order after this fix:
1. Extract group name (regex) — if no match, report **filtered** and skip
2. Check `groups_pattern` — if excluded, report filtered and skip
3. Build URN (succeeds, since name was already extracted successfully)

## 🧪 Testing
- All 7 Azure AD integration tests pass (6 existing + 1 new regression test)
- New test `test_azure_ad_group_regex_mismatch_is_filtered_not_failed` uses the customer's exact regex pattern (`^.*_(OWNER|MEMBER)$`) and asserts zero failures with non-zero filtered count
- Lint clean

## 📊 Impact Assessment
- **Affected Components:** Azure AD ingestion source only
- **Breaking Changes:** None — regex-unmatched and pattern-filtered groups were previously miscategorized as failures; they are now correctly categorized as filtered
- **Risk Level:** Low — single method change, covered by existing and new tests