### PR TITLE
fix(ui): preserve percent-encoding in URL params during sort option change

### DIFF
--- a/datahub-web-react/src/app/shared/__tests__/updateUrlParam.test.ts
+++ b/datahub-web-react/src/app/shared/__tests__/updateUrlParam.test.ts
@@ -2,21 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { updateUrlParam } from '@app/shared/updateUrlParam';
 
-// Mock the window.location
-const mockWindowLocation = {
-    href: 'http://localhost:3000/test?param1=value1',
-};
-
-// Mock window object
-Object.defineProperty(window, 'location', {
-    value: mockWindowLocation,
-    writable: true,
-});
-
-// Mock URL and URLSearchParams
-const originalURL = global.URL;
-const originalURLSearchParams = global.URLSearchParams;
-
 describe('updateUrlParam', () => {
     const mockHistory = {
         replace: vi.fn(),
@@ -26,61 +11,68 @@ describe('updateUrlParam', () => {
         vi.clearAllMocks();
     });
 
-    afterAll(() => {
-        // Restore original URL and URLSearchParams
-        global.URL = originalURL;
-        global.URLSearchParams = originalURLSearchParams;
-    });
-
     it('should replace history with new URL containing the parameter', () => {
-        // Mock URL constructor
-        const mockURLConstructor = vi.fn(function (this: any, url: string) {
-            this.href = url;
-            this.search = '?param1=value1&newParam=test';
-            this.searchParams = {
-                set: vi.fn(),
-            };
+        Object.defineProperty(window, 'location', {
+            value: { search: '?param1=value1' },
+            writable: true,
         });
-        global.URL = mockURLConstructor as any;
 
         updateUrlParam(mockHistory as any, 'newParam', 'test');
 
-        expect(mockURLConstructor).toHaveBeenCalledWith('http://localhost:3000/test?param1=value1');
-        expect(mockHistory.replace).toHaveBeenCalledWith('?param1=value1&newParam=test', undefined);
+        expect(mockHistory.replace).toHaveBeenCalledWith('?newParam=test&param1=value1', undefined);
     });
 
     it('should replace history with new URL containing the parameter and state', () => {
-        // Mock URL constructor
-        const mockURLConstructor = vi.fn(function (this: any, url: string) {
-            this.href = url;
-            this.search = '?param1=value1&newParam=test';
-            this.searchParams = {
-                set: vi.fn(),
-            };
+        Object.defineProperty(window, 'location', {
+            value: { search: '?param1=value1' },
+            writable: true,
         });
-        global.URL = mockURLConstructor as any;
 
         const mockState = { some: 'state' };
         updateUrlParam(mockHistory as any, 'newParam', 'test', mockState);
 
-        expect(mockURLConstructor).toHaveBeenCalledWith('http://localhost:3000/test?param1=value1');
-        expect(mockHistory.replace).toHaveBeenCalledWith('?param1=value1&newParam=test', mockState);
+        expect(mockHistory.replace).toHaveBeenCalledWith('?newParam=test&param1=value1', mockState);
     });
 
     it('should update existing parameter value', () => {
-        // Mock URL constructor
-        const mockURLConstructor = vi.fn(function (this: any, url: string) {
-            this.href = url;
-            this.search = '?param1=updated&existingParam=newValue';
-            this.searchParams = {
-                set: vi.fn(),
-            };
+        Object.defineProperty(window, 'location', {
+            value: { search: '?param1=value1&existingParam=oldValue' },
+            writable: true,
         });
-        global.URL = mockURLConstructor as any;
 
         updateUrlParam(mockHistory as any, 'existingParam', 'newValue');
 
-        expect(mockURLConstructor).toHaveBeenCalledWith('http://localhost:3000/test?param1=value1');
-        expect(mockHistory.replace).toHaveBeenCalledWith('?param1=updated&existingParam=newValue', undefined);
+        expect(mockHistory.replace).toHaveBeenCalledWith('?existingParam=newValue&param1=value1', undefined);
+    });
+
+    it('should preserve 3%2B encoding in existing params when adding a new param (regression: degree filter bug)', () => {
+        // Simulates the Impact Analysis URL after user selects 3+ dependency levels.
+        // Previously, the native URL.searchParams API would decode 3%2B → 3+ and re-encode as 3%20,
+        // causing GMS to reject with "3  is not a valid filter value for degree filters".
+        Object.defineProperty(window, 'location', {
+            value: { search: '?filter_degree___false___EQUAL___0=3%2B%2C2%2C1' },
+            writable: true,
+        });
+
+        updateUrlParam(mockHistory as any, 'sortOption', 'relevance');
+
+        const call = mockHistory.replace.mock.calls[0][0] as string;
+        expect(call).toContain('3%2B');
+        expect(call).not.toContain('3%20');
+        expect(call).not.toContain('3 ');
+        expect(call).toContain('sortOption=relevance');
+    });
+
+    it('should encode special characters in the new value being set', () => {
+        Object.defineProperty(window, 'location', {
+            value: { search: '' },
+            writable: true,
+        });
+
+        updateUrlParam(mockHistory as any, 'query', 'hello world');
+
+        const call = mockHistory.replace.mock.calls[0][0] as string;
+        expect(call).toContain('query=hello%20world');
+        expect(call).not.toContain('hello world');
     });
 });

--- a/datahub-web-react/src/app/shared/updateUrlParam.ts
+++ b/datahub-web-react/src/app/shared/updateUrlParam.ts
@@ -1,8 +1,12 @@
+import * as QueryString from 'query-string';
 import { RouteComponentProps } from 'react-router';
 
 export function updateUrlParam(history: RouteComponentProps['history'], key: string, value: string, state?: any) {
-    const url = new URL(window.location.href);
-    const { searchParams } = url;
-    searchParams.set(key, value);
-    history.replace(url.search, state);
+    // Parse existing params without decoding so percent-encoded values (e.g. filter_degree=3%2B) are
+    // preserved byte-for-byte. The native URL.searchParams API would decode %2B → + and re-encode it
+    // as %20 (space), which breaks the GMS degree filter validation.
+    const parsedParams = QueryString.parse(window.location.search, { arrayFormat: 'comma', decode: false });
+    const updatedParams = { ...parsedParams, [key]: encodeURIComponent(value) };
+    const newSearch = QueryString.stringify(updatedParams, { arrayFormat: 'comma', encode: false });
+    history.replace(`?${newSearch}`, state);
 }


### PR DESCRIPTION

### Summary

* Fixes a crash in the Impact Analysis (lineage) view when selecting 3+ dependency levels and then changing the sort option
* Root cause: `updateUrlParam` used the native `URL.searchParams` API which decodes 3%2B → 3+ then re-encodes it as 3%20 (space), causing GMS to reject the degree filter with IllegalArgumentException: 3 is not a valid filter value for degree filters

### Fix
* replace native `URL.searchParams` with `QueryString.parse/stringify` using `decode: false / encode: false` to preserve existing params byte-for-byte, while using `encodeURIComponent` on the new value being set

### Demo
| BEFORE | AFTER |
|--------|-------|
| <img width="748" height="517" alt="impact-before" src="https://github.com/user-attachments/assets/8934de0b-41b0-4686-b012-43fd434517a6" /> | <img width="1067" height="736" alt="Screenshot 2026-04-01 at 4 45 36 PM" src="https://github.com/user-attachments/assets/8be6b9ea-fd9b-4ea6-a611-cbc15b1412a3" /> |

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
