### PR TITLE
fix(graph): map deprecated dataProcess entity type to DATA_PROCESS_INSTANCE in GraphQL

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -136,6 +136,9 @@ def entity_type_to_graphql(entity_type: str) -> str:
         MlFeatureTableUrn.ENTITY_TYPE: "MLFEATURE_TABLE",
         MlFeatureUrn.ENTITY_TYPE: "MLFEATURE",
         MlPrimaryKeyUrn.ENTITY_TYPE: "MLPRIMARY_KEY",
+        # "dataProcess" (legacy entity) was never added to the GraphQL EntityType
+        # enum. Redirect to its searchable successor DATA_PROCESS_INSTANCE.
+        "dataProcess": "DATA_PROCESS_INSTANCE",
     }
     if entity_type in special_cases:
         return special_cases[entity_type]

--- a/metadata-ingestion/tests/unit/sdk/test_client.py
+++ b/metadata-ingestion/tests/unit/sdk/test_client.py
@@ -124,9 +124,22 @@ def test_get_urns_by_filter_rejects_draft_when_server_does_not_support_flag() ->
 
 
 def test_data_process_maps_to_data_process_instance() -> None:
-    # "dataProcess" (legacy Azkaban entity) has never been a valid GraphQL
-    # EntityType enum value. The searchable successor is DATA_PROCESS_INSTANCE.
-    # mcp-server-datahub triggers this path when an LLM asks it to search for
-    # pipeline/trace entities, producing a GraphQL ValidationError:
-    #   "No value found for name 'DATA_PROCESS'"
+    # "dataProcess" is a deprecated entity type (the PDL model is annotated
+    # @deprecated = "Use DataJob instead."). It was never added to the GraphQL
+    # EntityType enum in entity.graphql -- DATA_PROCESS does not exist as an
+    # enum value, only DATA_PROCESS_INSTANCE does.
+    #
+    # entity_type_to_graphql() converts camelCase mechanically, producing
+    # "DATA_PROCESS" for "dataProcess". Passing that to searchAcrossEntities
+    # causes GMS to return a GraphQL ValidationError:
+    #
+    #   Variable 'types' has an invalid value: Invalid input for enum
+    #   'EntityType'. No value found for name 'DATA_PROCESS'
+    #
+    # This is triggered in practice when mcp-server-datahub's search tool
+    # receives a filter like entity_type=dataProcess from an LLM agent
+    # querying for pipeline run entities. The mapping to DATA_PROCESS_INSTANCE
+    # is intentional: LLM agents using the deprecated name are almost certainly
+    # looking for run instances (traces/spans), not workflow definitions
+    # (DataJob). See entity.graphql enum EntityType for the authoritative list.
     assert entity_type_to_graphql("dataProcess") == "DATA_PROCESS_INSTANCE"

--- a/metadata-ingestion/tests/unit/sdk/test_client.py
+++ b/metadata-ingestion/tests/unit/sdk/test_client.py
@@ -121,3 +121,12 @@ def test_get_urns_by_filter_rejects_draft_when_server_does_not_support_flag() ->
             )
 
     assert mock_execute_graphql.call_count == 1
+
+
+def test_data_process_maps_to_data_process_instance() -> None:
+    # "dataProcess" (legacy Azkaban entity) has never been a valid GraphQL
+    # EntityType enum value. The searchable successor is DATA_PROCESS_INSTANCE.
+    # mcp-server-datahub triggers this path when an LLM asks it to search for
+    # pipeline/trace entities, producing a GraphQL ValidationError:
+    #   "No value found for name 'DATA_PROCESS'"
+    assert entity_type_to_graphql("dataProcess") == "DATA_PROCESS_INSTANCE"

--- a/metadata-ingestion/tests/unit/sdk/test_client.py
+++ b/metadata-ingestion/tests/unit/sdk/test_client.py
@@ -1,3 +1,5 @@
+import re
+from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -121,6 +123,81 @@ def test_get_urns_by_filter_rejects_draft_when_server_does_not_support_flag() ->
             )
 
     assert mock_execute_graphql.call_count == 1
+
+
+def _parse_entity_type_enum() -> set:
+    """Parse the valid EntityType enum values from the GraphQL schema file.
+
+    Returns an empty set if entity.graphql is not present (e.g. when only the
+    Python package is installed without the full repo checkout).
+    """
+    entity_graphql = (
+        Path(__file__).parents[4]
+        / "datahub-graphql-core/src/main/resources/entity.graphql"
+    )
+    if not entity_graphql.exists():
+        return set()
+    schema = entity_graphql.read_text()
+    m = re.search(r"enum EntityType \{([^}]+)\}", schema, re.DOTALL)
+    if not m:
+        return set()
+    return {
+        line.strip()
+        for line in m.group(1).splitlines()
+        if re.match(r"^\s+[A-Z][A-Z0-9_]+\s*$", line)
+    }
+
+
+def test_entity_type_to_graphql_produces_valid_enum_values() -> None:
+    """Every camelCase entity type name the Python client may pass through
+    entity_type_to_graphql() must produce a value that exists in the GraphQL
+    EntityType enum defined in entity.graphql.
+
+    This is a regression test for the class of bug where the mechanical
+    camelCase -> UPPER_SNAKE_CASE conversion produces a string that was never
+    added to the enum (e.g. 'dataProcess' -> 'DATA_PROCESS', which does not
+    exist; only 'DATA_PROCESS_INSTANCE' does).
+    """
+    valid_values = _parse_entity_type_enum()
+    if not valid_values:
+        pytest.skip("entity.graphql not found - skipping schema validation")
+
+    # Comprehensive list of camelCase entity type names the Python client may
+    # encounter, covering both active and deprecated types in the URN registry.
+    entity_types = [
+        "dataset",
+        "dashboard",
+        "chart",
+        "domain",
+        "container",
+        "corpuser",
+        "corpGroup",
+        "dataFlow",
+        "dataJob",
+        "glossaryNode",
+        "glossaryTerm",
+        "dataProduct",
+        "dataHubExecutionRequest",
+        "document",
+        "mlModel",
+        "mlModelGroup",
+        "mlFeatureTable",
+        "mlFeature",
+        "mlPrimaryKey",
+        "dataProcessInstance",
+        # Deprecated (PDL: @deprecated = "Use DataJob instead.") but still
+        # present in the URN registry.  Must produce a valid enum value rather
+        # than the non-existent DATA_PROCESS.
+        "dataProcess",
+    ]
+    for entity_type in entity_types:
+        result = entity_type_to_graphql(entity_type)
+        assert result in valid_values, (
+            f"entity_type_to_graphql({entity_type!r}) returned {result!r}, "
+            f"which is not a valid GraphQL EntityType enum value. "
+            f"Add it to the special_cases dict in entity_type_to_graphql() "
+            f"or add {result!r} to the EntityType enum in entity.graphql."
+        )
 
 
 def test_data_process_maps_to_data_process_instance() -> None:


### PR DESCRIPTION
## Summary

- `entity_type_to_graphql("dataProcess")` previously returned `"DATA_PROCESS"` via mechanical camelCase conversion, but `DATA_PROCESS` has never existed in the GraphQL `EntityType` enum (`entity.graphql`). Passing it to `searchAcrossEntities` causes GMS to return a `ValidationError`: _No value found for name 'DATA_PROCESS'_.
- Adds `"dataProcess"` to the `special_cases` dict, mapping it to `"DATA_PROCESS_INSTANCE"` — the correct searchable entity for pipeline run instances. (`dataProcess` is `@deprecated = "Use DataJob instead."` in the PDL, but the deprecation note refers to workflow *definitions*; agents querying for run traces are looking for `dataProcessInstance`.)
- Adds a schema-validating test that parses `entity.graphql` and asserts every camelCase entity type name the Python client may pass through `entity_type_to_graphql()` produces a real `EntityType` enum value. This test would have caught this bug at PR review time, and will catch the same class of bug for any future entity type additions.

## How it was discovered

`mcp-server-datahub`'s search tool passes LLM-generated `entity_type` filter values through `flexible_entity_type_to_graphql()` → `entity_type_to_graphql()`. When an LLM agent filters for pipeline run entities using the deprecated name `dataProcess`, the broken conversion reaches GMS and fails with a GraphQL `ValidationError`.

Redacted stack-trace:

```
ToolException('Error calling tool \'search\': Error executing graphql query: [{\'message\': "Variable \'types\' has an invalid value: Invalid input for enum \'EntityType\'. No value found for name \'DATA_PROCESS\'", \'locations\': [{\'line\': 80, \'column\': 3}], \'extensions\': {\'classification\': \'ValidationError\'}}]')
Traceback (most recent call last):

  File ".venv/lib/python3.13/site-packages/pregel/main.py", line 3111, in astream
    async for _ in runner.atick(
    ...<16 lines>...
            yield o

  File ".venv/lib/python3.13/site-packages/pregel/_runner.py", line 410, in atick
    _panic_or_proceed(
    ~~~~~~~~~~~~~~~~~^
        futures.done.union(f for f, t in futures.items() if t is not None),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        timeout_exc_cls=asyncio.TimeoutError,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        panic=reraise,
        ^^^^^^^^^^^^^^
    )
    ^

  File ".venv/lib/python3.13/site-packages/pregel/_runner.py", line 520, in _panic_or_proceed
    raise exc

  File ".venv/lib/python3.13/site-packages/pregel/_retry.py", line 211, in arun_with_retry
    return await task.proc.ainvoke(task.input, config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File ".venv/lib/python3.13/site-packages/agent/_runnable.py", line 705, in ainvoke
    input = await asyncio.create_task(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
        step.ainvoke(input, config, **kwargs), context=context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^

  File ".venv/lib/python3.13/site-packages/agent/_runnable.py", line 473, in ainvoke
    ret = await self.afunc(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File ".venv/lib/python3.13/site-packages/prebuilt/tool_node.py", line 846, in _afunc
    outputs = await asyncio.gather(*coros)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File ".venv/lib/python3.13/site-packages/prebuilt/tool_node.py", line 1177, in _arun_one
    return await self._execute_tool_async(tool_request, input_type, config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File ".venv/lib/python3.13/site-packages/prebuilt/tool_node.py", line 1126, in _execute_tool_async
    content = _handle_tool_error(e, flag=self._handle_tool_errors)

  File ".venv/lib/python3.13/site-packages/prebuilt/tool_node.py", line 430, in _handle_tool_error
    content = flag(e)  # type: ignore [assignment, call-arg]

  File ".venv/lib/python3.13/site-packages/prebuilt/tool_node.py", line 387, in _default_handle_tool_errors
    raise e

  File ".venv/lib/python3.13/site-packages/prebuilt/tool_node.py", line 1083, in _execute_tool_async
    response = await tool.ainvoke(call_args, config)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File ".venv/lib/python3.13/site-packages/core/tools/structured.py", line 70, in ainvoke
    return await super().ainvoke(input, config, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File ".venv/lib/python3.13/site-packages/core/tools/base.py", line 652, in ainvoke
    return await self.arun(tool_input, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File ".venv/lib/python3.13/site-packages/core/tools/base.py", line 1131, in arun
    raise error_to_raise

  File ".venv/lib/python3.13/site-packages/core/tools/base.py", line 1097, in arun
    response = await coro_with_context(coro, context)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File ".venv/lib/python3.13/site-packages/core/tools/structured.py", line 124, in _arun
    return await self.coroutine(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File ".venv/lib/python3.13/site-packages/mcp_adapters/tools.py", line 414, in call_tool
    return _convert_call_tool_result(call_tool_result)

  File ".venv/lib/python3.13/site-packages/mcp_adapters/tools.py", line 189, in _convert_call_tool_result
    raise ToolException(error_msg)

ToolException: Error calling tool 'search': Error executing graphql query: [{'message': "Variable 'types' has an invalid value: Invalid input for enum 'EntityType'. No value found for name 'DATA_PROCESS'", 'locations': [{'line': 80, 'column': 3}], 'extensions': {'classification': 'ValidationError'}}]

During task with name 'tools' and id '570ddcaa-35b8-f983-1ca2-f511daae988b'
```

## Test plan

- [x] `test_data_process_maps_to_data_process_instance` — targeted regression: failing before fix, passing after
- [x] `test_entity_type_to_graphql_produces_valid_enum_values` — schema-validating: parses `entity.graphql` and asserts all conversions produce real enum values; would have failed pre-fix with a descriptive message pointing to `special_cases` or `entity.graphql`
- [x] `test_graphql_entity_types` — existing mapping coverage, still passes
