### PR TITLE
fix(ingest/dbt): preserve manually added owners during PATCH mode ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -3164,10 +3164,8 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                 ),
             )
 
-    # This method attempts to read-modify and return the owners of a dataset.
-    # From the existing owners it will remove the owners that are of the source_type_filter and
-    # then add all the new owners to that list. Owners without a source (e.g. added via API/UI)
-    # are always preserved. New owners take precedence over existing ones with the same URN.
+    # Merges new owners with existing ones from the graph. Existing owners matching
+    # source_type_filter are replaced; owners without a source are always preserved.
     def get_transformed_owners_by_source_type(
         self, owners: List[OwnerClass], entity_urn: str, source_type_filter: str
     ) -> List[OwnerClass]:

--- a/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/dbt/test_dbt_source.py
@@ -156,8 +156,6 @@ def test_dbt_source_patching_with_conflict():
 
 
 def test_dbt_source_patching_with_null_source_type_in_existing_owner_preserves_them():
-    # Existing owners with null source_type (e.g. added via API/UI) should be
-    # preserved when new owners are added by ingestion.
     source = create_mocked_dbt_source()
     graph = mock.MagicMock()
     graph.get_ownership.return_value = mce_builder.make_ownership_aspect_from_urn_list(
@@ -177,14 +175,6 @@ def test_dbt_source_patching_with_null_source_type_in_existing_owner_preserves_t
 
 
 def test_dbt_source_patching_preserves_manually_added_owners_without_source():
-    """Owners added via API/UI (with no source type) must be preserved
-    during dbt ingestion PATCH mode.
-
-    Scenario (from Zendesk #5248):
-    1. dbt ingestion emits owner cakubilo@figma.com (with SOURCE_CONTROL source)
-    2. Customer adds urn:li:corpGroup:team_data_infra via API (no source type)
-    3. Next dbt ingestion run should PRESERVE the API-added owner
-    """
     source = create_mocked_dbt_source()
     graph = mock.MagicMock()
 


### PR DESCRIPTION
## Summary
- Fixes a bug where owners added via API/UI (with no `source` type) were silently dropped
  during dbt ingestion with `write_semantics=PATCH` (the default). The filter in
  `get_transformed_owners_by_source_type` short-circuited on `source=None`, discarding
  owners that should have been preserved.
- Adds dedup logic so existing owners with the same URN as a new owner are skipped,
  preventing duplicate accumulation across repeated PATCH runs.

## Details

The root cause was in `get_transformed_owners_by_source_type` in `dbt_common.py`:

## Before (buggy): drops owners with source=None
if existing_owner.source and existing_owner.source.type != source_type_filter:

## After (fixed): preserves owners with source=None
if not existing_owner.source or existing_owner.source.type != source_type_filter:
