### PR TITLE
feat(stateful-ingestion): add per-entity-type deletion summary to ingestion report

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
@@ -357,6 +357,9 @@ stateful_ingestion:\
                 self.add_entity_to_state("", urn)
             return
 
+        report = self.source.get_report()
+        assert isinstance(report, StaleEntityRemovalSourceReport)
+
         # Everything looks good, emit the soft-deletion workunits
         for urn in last_checkpoint_state.get_urns_not_in(
             type="*", other_checkpoint_state=cur_checkpoint_state

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
@@ -1,4 +1,5 @@
 import logging
+from collections import Counter
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Dict, Iterable, Optional, Set, Type, cast
@@ -49,9 +50,19 @@ class StatefulStaleMetadataRemovalConfig(StatefulIngestionConfig):
 
 
 @dataclass
+class EntityTypeDeletionSummary:
+    previous_checkpoint_count: int = 0
+    current_checkpoint_count: int = 0
+    soft_deleted_count: int = 0
+
+
+@dataclass
 class StaleEntityRemovalSourceReport(StatefulIngestionReport):
     soft_deleted_stale_entities: LossyList[str] = field(default_factory=LossyList)
     last_state_non_deletable_entities: LossyList[str] = field(default_factory=LossyList)
+    entity_type_deletion_summary: Dict[str, EntityTypeDeletionSummary] = field(
+        default_factory=dict
+    )
 
     def report_stale_entity_soft_deleted(self, urn: str) -> None:
         self.soft_deleted_stale_entities.append(urn)
@@ -237,6 +248,32 @@ class StaleEntityRemovalHandler(
 
         self._urns_to_skip.add(urn)
 
+    @staticmethod
+    def _build_checkpoint_comparison(
+        last_checkpoint_state: GenericCheckpointState,
+        cur_checkpoint_state: GenericCheckpointState,
+    ) -> Dict[str, "EntityTypeDeletionSummary"]:
+        previous_counts = Counter(
+            entity_type
+            for urn in last_checkpoint_state._urns_set
+            if (entity_type := guess_entity_type(urn))
+        )
+        current_counts = Counter(
+            entity_type
+            for urn in cur_checkpoint_state._urns_set
+            if (entity_type := guess_entity_type(urn))
+        )
+
+        return {
+            entity_type: EntityTypeDeletionSummary(
+                previous_checkpoint_count=previous_counts[entity_type],
+                current_checkpoint_count=current_counts[entity_type],
+            )
+            for entity_type in sorted(
+                set(previous_counts.keys()) | set(current_counts.keys())
+            )
+        }
+
     def gen_removed_entity_workunits(self) -> Iterable[MetadataWorkUnit]:
         if not self.is_checkpointing_enabled() or self._ignore_old_state():
             return
@@ -254,6 +291,13 @@ class StaleEntityRemovalHandler(
 
         assert self.stateful_ingestion_config
 
+        # Compute per-entity-type summary before any early-exit checks
+        # so the summary is always available in the report.
+        report = self.source.get_report()
+        assert isinstance(report, StaleEntityRemovalSourceReport)
+        report.entity_type_deletion_summary = self._build_checkpoint_comparison(
+            last_checkpoint_state, cur_checkpoint_state
+        )
         copy_previous_state_and_exit = False
 
         # If the source already had a failure, skip soft-deletion.
@@ -313,9 +357,6 @@ stateful_ingestion:\
                 self.add_entity_to_state("", urn)
             return
 
-        report = self.source.get_report()
-        assert isinstance(report, StaleEntityRemovalSourceReport)
-
         # Everything looks good, emit the soft-deletion workunits
         for urn in last_checkpoint_state.get_urns_not_in(
             type="*", other_checkpoint_state=cur_checkpoint_state
@@ -334,6 +375,9 @@ stateful_ingestion:\
                     f"Not soft-deleting entity {urn} since it is in urns_to_skip"
                 )
                 continue
+            # Track actual soft-deletion per entity type
+            if entity_type in report.entity_type_deletion_summary:
+                report.entity_type_deletion_summary[entity_type].soft_deleted_count += 1
             yield self._create_soft_delete_workunit(urn)
 
     def add_entity_to_state(self, type: str, urn: str) -> None:

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
@@ -254,14 +254,10 @@ class StaleEntityRemovalHandler(
         cur_checkpoint_state: GenericCheckpointState,
     ) -> Dict[str, "EntityTypeDeletionSummary"]:
         previous_counts = Counter(
-            entity_type
-            for urn in last_checkpoint_state._urns_set
-            if (entity_type := guess_entity_type(urn))
+            guess_entity_type(urn) for urn in last_checkpoint_state.urns
         )
         current_counts = Counter(
-            entity_type
-            for urn in cur_checkpoint_state._urns_set
-            if (entity_type := guess_entity_type(urn))
+            guess_entity_type(urn) for urn in cur_checkpoint_state.urns
         )
 
         return {
@@ -357,9 +353,6 @@ stateful_ingestion:\
                 self.add_entity_to_state("", urn)
             return
 
-        report = self.source.get_report()
-        assert isinstance(report, StaleEntityRemovalSourceReport)
-
         # Everything looks good, emit the soft-deletion workunits
         for urn in last_checkpoint_state.get_urns_not_in(
             type="*", other_checkpoint_state=cur_checkpoint_state
@@ -378,9 +371,7 @@ stateful_ingestion:\
                     f"Not soft-deleting entity {urn} since it is in urns_to_skip"
                 )
                 continue
-            # Track actual soft-deletion per entity type
-            if entity_type in report.entity_type_deletion_summary:
-                report.entity_type_deletion_summary[entity_type].soft_deleted_count += 1
+            report.entity_type_deletion_summary[entity_type].soft_deleted_count += 1
             yield self._create_soft_delete_workunit(urn)
 
     def add_entity_to_state(self, type: str, urn: str) -> None:

--- a/metadata-ingestion/tests/unit/stateful_ingestion/state/test_stateful_ingestion.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/state/test_stateful_ingestion.py
@@ -323,6 +323,17 @@ def test_stateful_ingestion(pytestconfig, tmp_path, mock_time):
             report.last_state_non_deletable_entities
         )
 
+        # Verify per-entity-type deletion summary
+        summary = report.entity_type_deletion_summary
+        # dataset: 3 in previous (run 1), 2 in current (run 2), 1 actually soft-deleted
+        assert summary["dataset"].previous_checkpoint_count == 3
+        assert summary["dataset"].current_checkpoint_count == 2
+        assert summary["dataset"].soft_deleted_count == 1
+        # DPI and query were in previous state (run 1 mocked ignored types)
+        # but are non-deletable, so soft_deleted_count should be 0
+        assert summary["dataProcessInstance"].soft_deleted_count == 0
+        assert summary["query"].soft_deleted_count == 0
+
 
 @freeze_time(FROZEN_TIME)
 def test_stateful_ingestion_failure(pytestconfig, tmp_path, mock_time):
@@ -445,3 +456,46 @@ def test_stateful_ingestion_failure(pytestconfig, tmp_path, mock_time):
         state1 = cast(GenericCheckpointState, checkpoint1.state)
         state2 = cast(GenericCheckpointState, checkpoint2.state)
         assert state1 == state2
+
+        # Summary should still be computed even when deletions are skipped
+        report2 = pipeline_run2.source.get_report()
+        assert isinstance(report2, StaleEntityRemovalSourceReport)
+        failure_summary = report2.entity_type_deletion_summary
+        assert failure_summary["dataset"].previous_checkpoint_count == 3
+        assert failure_summary["dataset"].current_checkpoint_count == 2
+        # No actual deletions because source reported failure
+        assert failure_summary["dataset"].soft_deleted_count == 0
+
+
+def test_build_checkpoint_comparison() -> None:
+    """Verify checkpoint comparison groups counts by entity type correctly."""
+    last_state = GenericCheckpointState(serde="utf-8")
+    last_state.add_checkpoint_urn(
+        type="", urn="urn:li:dataset:(urn:li:dataPlatform:postgres,t1,PROD)"
+    )
+    last_state.add_checkpoint_urn(
+        type="", urn="urn:li:dataset:(urn:li:dataPlatform:postgres,t2,PROD)"
+    )
+    last_state.add_checkpoint_urn(type="", urn="urn:li:corpuser:user1")
+
+    cur_state = GenericCheckpointState(serde="utf-8")
+    cur_state.add_checkpoint_urn(
+        type="", urn="urn:li:dataset:(urn:li:dataPlatform:postgres,t1,PROD)"
+    )
+    cur_state.add_checkpoint_urn(type="", urn="urn:li:container:c1")
+
+    summary = StaleEntityRemovalHandler._build_checkpoint_comparison(
+        last_state, cur_state
+    )
+
+    # dataset: 2 previous, 1 current (t2 disappeared)
+    assert summary["dataset"].previous_checkpoint_count == 2
+    assert summary["dataset"].current_checkpoint_count == 1
+    # corpuser: only in previous
+    assert summary["corpuser"].previous_checkpoint_count == 1
+    assert summary["corpuser"].current_checkpoint_count == 0
+    # container: only in current
+    assert summary["container"].previous_checkpoint_count == 0
+    assert summary["container"].current_checkpoint_count == 1
+    # soft_deleted_count is 0 everywhere — only set during actual deletion loop
+    assert all(s.soft_deleted_count == 0 for s in summary.values())


### PR DESCRIPTION
## Summary

- Adds entity_type_deletion_summary to StaleEntityRemovalSourceReport — a per-entity-type breakdown showing checkpoint counts and actual soft-deletion counts
- Introduces EntityTypeDeletionSummary dataclass with previous_checkpoint_count, current_checkpoint_count, and soft_deleted_count
- soft_deleted_count only tracks URNs that were actually soft-deleted (passed all checks), not the raw checkpoint diff — non-deletable entities are excluded
- Summary is always computed when both checkpoints exist, including when deletions are skipped.