### PR TITLE
docs: fix renamed/outdated privilege names in change proposals docs

### DIFF
--- a/docs/authorization/roles.md
+++ b/docs/authorization/roles.md
@@ -164,24 +164,24 @@ These privileges are only relevant to DataHub Cloud.
 
 ##### Metadata Privileges
 
-| Privilege                             | Admin              | Editor             | Reader             | Description                                                                                    |
-| ------------------------------------- | ------------------ | ------------------ | ------------------ | ---------------------------------------------------------------------------------------------- |
-| View Entity                           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to view the entity in search results.                                              |
-| Propose Tags                          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose adding a tag to an asset.                                               |
-| Propose Glossary Terms                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose adding a glossary term to an asset.                                     |
-| Propose Documentation                 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose updates to an asset's documentation.                                    |
-| Propose Dataset Column Glossary Terms | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose column (field) glossary terms associated with a dataset schema.         |
-| Propose Dataset Column Tags           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose new column (field) tags associated with a dataset schema.               |
-| Manage Tag Proposals                  | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage a proposal to add a tag to an asset.                                     |
-| Manage Glossary Term Proposals        | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage a proposal to add a glossary term to an asset.                           |
-| Manage Dataset Column Glossary Terms  | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage column (field) glossary term proposals associated with a dataset schema. |
-| Manage Dataset Column Tag Proposals   | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage column (field) tag proposals associated with a dataset schema.           |
-| Manage Documentation Proposals        | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage a proposal update an asset's documentation                               |
-| Manage Group Notification Settings    | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage notification settings for a group.                                       |
-| Manage Group Subscriptions            | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage subscriptions for a group.                                               |
-| Manage User Subscriptions             | :heavy_check_mark: | :x:                | :x:                | The ability to manage subscriptions for another user.                                          |
-| Manage Data Contract Proposals        | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage a proposal for a Data Contract                                           |
-| Share Entity                          | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to share an entity with another DataHub Cloud instance.                            |
+| Privilege                                     | Admin              | Editor             | Reader             | Description                                                                                    |
+| --------------------------------------------- | ------------------ | ------------------ | ------------------ | ---------------------------------------------------------------------------------------------- |
+| View Entity                                   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to view the entity in search results.                                              |
+| Propose Tags                                  | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose adding a tag to an asset.                                               |
+| Propose Glossary Terms                        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose adding a glossary term to an asset.                                     |
+| Propose Description                           | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose updates to an asset's description.                                      |
+| Propose Dataset Column Glossary Terms         | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose column (field) glossary terms associated with a dataset schema.         |
+| Propose Dataset Column Tags                   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | The ability to propose new column (field) tags associated with a dataset schema.               |
+| Manage Tag Proposals                          | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage a proposal to add a tag to an asset.                                     |
+| Manage Glossary Term Proposals                | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage a proposal to add a glossary term to an asset.                           |
+| Manage Dataset Column Glossary Term Proposals | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage column (field) glossary term proposals associated with a dataset schema. |
+| Manage Dataset Column Tag Proposals           | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage column (field) tag proposals associated with a dataset schema.           |
+| Manage Description Proposals                  | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage a proposal to update an asset's description                              |
+| Manage Group Notification Settings            | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage notification settings for a group.                                       |
+| Manage Group Subscriptions                    | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage subscriptions for a group.                                               |
+| Manage User Subscriptions                     | :heavy_check_mark: | :x:                | :x:                | The ability to manage subscriptions for another user.                                          |
+| Manage Data Contract Proposals                | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to manage a proposal for a Data Contract                                           |
+| Share Entity                                  | :heavy_check_mark: | :heavy_check_mark: | :x:                | The ability to share an entity with another DataHub Cloud instance.                            |
 
 ## Additional Resources
 

--- a/docs/managed-datahub/change-proposals.md
+++ b/docs/managed-datahub/change-proposals.md
@@ -17,8 +17,8 @@ To create proposals on assets, users need to have the following resource privile
 - `Propose Tags`
 - `Propose Glossary Terms`
 - `Propose Owners`
-- `Propose Domain`
-- `Propose Properties`
+- `Propose Domains`
+- `Propose Structured Properties`
 - `Propose Description`
 - `Propose Dataset Column Tags`
 - `Propose Dataset Column Glossary Terms`
@@ -28,7 +28,7 @@ To create proposals on assets, users need to have the following resource privile
 To create proposals to change the Business Glossary, users need to have the following platform privileges:
 
 - `Propose Create Glossary Term`
-- `Propose Create Glossary Node (Term Group)`
+- `Propose Create Glossary Node`
 
 Which are granted by default using the **Reader**, **Editor**, and **Admin** roles by default.
 
@@ -38,7 +38,7 @@ To review proposals for an asset, users need to have the following resource priv
 
 - `Manage Tag Proposals`
 - `Manage Glossary Term Proposals`
-- `Manage Property Proposals`
+- `Manage Structured Property Proposals`
 - `Manage Domain Proposals`
 - `Manage Owner Proposals`
 - `Manage Description Proposals`


### PR DESCRIPTION
## Summary

Corrects 7 stale privilege names across two docs files that no longer match the display names defined in `PoliciesConfig.java`:

**`docs/managed-datahub/change-proposals.md`**
- `Propose Domain` -> `Propose Domains`
- `Propose Properties` -> `Propose Structured Properties`
- `Propose Create Glossary Node (Term Group)` -> `Propose Create Glossary Node`
- `Manage Property Proposals` -> `Manage Structured Property Proposals`

**`docs/authorization/roles.md`**
- `Propose Documentation` -> `Propose Description`
- `Manage Dataset Column Glossary Terms` -> `Manage Dataset Column Glossary Term Proposals`
- `Manage Documentation Proposals` -> `Manage Description Proposals`

These names were renamed in the codebase (e.g. commit 587b320e1f) but the docs were not updated at the time.

## Test plan

- [ ] Docs-only change, no code logic affected
- [ ] Privilege names verified against `PoliciesConfig.java` in datahub-fork

🤖 Generated with [Claude Code](https://claude.com/claude-code)