### PR TITLE
fix(dataplex): include dataplex-emitted URNs in source report metrics

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/report.py
@@ -372,11 +372,20 @@ class ExamplesReport(Report, Closeable):
         #
         # See: https://github.com/datahub-project/datahub/issues/XXXXX
         platform_agnostic_entity_types = {"document"}
+        source_platform = self.get_platform()
 
         if entityType not in platform_agnostic_entity_types:
             platform_name = guess_platform_name(urn)
-            if platform_name != self.get_platform():
-                return
+            if platform_name != source_platform:
+                # Dataplex source reports itself as "dataplex" but intentionally emits
+                # entities on source-native platforms (bigquery/spanner/pubsub/etc.).
+                # Keep those entities in report metrics and also retain Dataplex
+                # project/container entities that do not encode a platform in URN.
+                if source_platform == "dataplex":
+                    if platform_name is None and entityType != "container":
+                        return
+                else:
+                    return
         if is_lineage_aspect(entityType, aspectName):
             self._lineage_aspects_seen.add(aspectName)
         has_fine_grained_lineage = self._has_fine_grained_lineage(mcp)

--- a/metadata-ingestion/tests/unit/test_source.py
+++ b/metadata-ingestion/tests/unit/test_source.py
@@ -437,3 +437,88 @@ def test_stale_entity_removal_excludes_all_aspects():
     assert source.source_report.aspects_by_subtypes == {
         "dataset": {"Table": {"status": 1, "subTypes": 1, "datasetProfile": 1}}
     }
+
+
+def test_dataplex_report_accepts_multi_platform_entities() -> None:
+    report = SourceReport()
+    report.set_platform("dataplex")
+
+    dataplex_dataset_urn = str(
+        DatasetUrn.create_from_ids(
+            platform_id="bigquery",
+            table_name="dataplex.table",
+            env="PROD",
+        )
+    )
+    report.report_workunit(
+        MetadataChangeProposalWrapper(
+            entityUrn=dataplex_dataset_urn,
+            aspect=DatasetProfileClass(
+                timestampMillis=0,
+                rowCount=100,
+                columnCount=10,
+                sizeInBytes=1000,
+            ),
+        ).as_workunit()
+    )
+
+    report.compute_stats()
+    assert report.get_aspects_dict() == {"dataset": {"datasetProfile": 1}}
+    assert report.aspects_by_subtypes_full_count == {
+        "dataset": {"unknown": {"datasetProfile": 1}}
+    }
+    assert report.samples == {"profiling": {"unknown": [dataplex_dataset_urn]}}
+
+
+def test_dataplex_report_accepts_platformless_containers_only() -> None:
+    report = SourceReport()
+    report.set_platform("dataplex")
+
+    container_urn = "urn:li:container:dataplex-container"
+    report.report_workunit(
+        MetadataChangeProposalWrapper(
+            entityUrn=container_urn,
+            aspect=StatusClass(removed=False),
+        ).as_workunit()
+    )
+    report.report_workunit(
+        MetadataChangeProposalWrapper(
+            entityUrn="urn:li:corpuser:jdoe",
+            aspect=StatusClass(removed=False),
+        ).as_workunit()
+    )
+
+    report.compute_stats()
+    assert report.get_aspects_dict() == {"container": {"status": 1}}
+    assert report.aspects_by_subtypes_full_count == {
+        "container": {"unknown": {"status": 1}}
+    }
+
+
+def test_non_dataplex_report_still_filters_mismatched_platforms() -> None:
+    report = SourceReport()
+    report.set_platform("fake")
+
+    non_matching_dataset_urn = str(
+        DatasetUrn.create_from_ids(
+            platform_id="bigquery",
+            table_name="external.table",
+            env="PROD",
+        )
+    )
+    report.report_workunit(
+        MetadataChangeProposalWrapper(
+            entityUrn=non_matching_dataset_urn,
+            aspect=DatasetProfileClass(
+                timestampMillis=0,
+                rowCount=100,
+                columnCount=10,
+                sizeInBytes=1000,
+            ),
+        ).as_workunit()
+    )
+
+    report.compute_stats()
+    assert report.get_aspects_dict() == {}
+    assert report.aspects_by_subtypes_full_count == {}
+    assert report.samples == {}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Dataplex ingestion can successfully emit entities, but report metrics (`aspects`, `aspects_by_subtypes_full_count`, `samples`) were coming back empty because report filtering assumed emitted URNs must match the source platform ID (`dataplex`).

## Problem and context
Dataplex intentionally emits multi-platform entities (for example BigQuery/Spanner/PubSub/Bigtable/Vertex AI) while the source report platform remains `dataplex`.

In `ExamplesReport._update_file_based_dict`, workunits were filtered by `guess_platform_name(urn) == report.platform`, which dropped valid Dataplex-emitted entities before they could contribute to report aggregates.

## Why this change
The report filter now preserves Dataplex-emitted entities while keeping the existing filtering behavior for other sources intact:
- For `report.platform == "dataplex"`, allow cross-platform URNs that encode their platform.
- Continue allowing Dataplex container URNs that do not encode platform in the URN.
- Still exclude unrelated platform-agnostic non-container URNs.
- Keep existing strict platform matching for non-Dataplex sources.

## Impact
Dataplex report metrics now reflect actual emitted workunits instead of appearing empty, improving UI/report observability without changing ingestion output semantics.

## Testing
- Added regression tests in `metadata-ingestion/tests/unit/test_source.py`:
  - `test_dataplex_report_accepts_multi_platform_entities`
  - `test_dataplex_report_accepts_platformless_containers_only`
  - `test_non_dataplex_report_still_filters_mismatched_platforms`
- Executed targeted tests:
  - `PYTHONPATH=/workspace/metadata-ingestion/src /workspace/metadata-ingestion/venv/bin/python -m pytest /workspace/metadata-ingestion/tests/unit/test_source.py -k "dataplex_report or non_dataplex_report" -q`

## Checklist
- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated
- [ ] Docs related to the changes have been added/updated (not applicable)
- [ ] Breaking changes entry in Updating DataHub (not applicable)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48819314-1a57-4c9e-8180-7593f77835c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48819314-1a57-4c9e-8180-7593f77835c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

