### PR TITLE
feat(redshift): add diagnostic logging for datashare lineage debugging

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/datashares.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/datashares.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, Iterable, List, Optional, Union
 
 from pydantic import BaseModel
@@ -22,6 +23,8 @@ from datahub.ingestion.source.redshift.redshift_schema import (
 from datahub.ingestion.source.redshift.report import RedshiftReport
 from datahub.sql_parsing.sql_parsing_aggregator import KnownLineageMapping
 from datahub.utilities.search_utils import LogicalOperator
+
+logger = logging.getLogger(__name__)
 
 
 class OutboundSharePlatformResource(BaseModel):
@@ -144,7 +147,17 @@ class RedshiftDatasharesHelper:
                 "set the top-level datahub_api config in the recipe",
             )
         else:
+            lookup_key = (
+                share.get_key()
+                if isinstance(share, InboundDatashare)
+                else f"{share.producer_namespace_prefix}* (partial)"
+            )
+            logger.info(
+                f"Looking up PlatformResource for inbound share: {share.get_description()}, "
+                f"lookup_key={lookup_key}"
+            )
             resources = self.get_platform_resources(self.graph, share)
+            logger.info(f"PlatformResource search returned {len(resources)} result(s)")
 
             if len(resources) == 0 or (
                 not any(
@@ -172,9 +185,15 @@ class RedshiftDatasharesHelper:
                             resource.resource_info is not None
                             and resource.resource_info.value is not None
                         )
-                        return resource.resource_info.value.as_pydantic_object(
+                        upstream = resource.resource_info.value.as_pydantic_object(
                             OutboundSharePlatformResource, True
                         )
+                        logger.info(
+                            f"Matched upstream share: platform_instance={upstream.platform_instance}, "
+                            f"env={upstream.env}, source_database={upstream.source_database}, "
+                            f"share_name={upstream.share_name}, namespace={upstream.namespace}"
+                        )
+                        return upstream
                     except Exception as e:
                         self.report.warning(
                             title="Upstream lineage of inbound datashare will be missing",

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -385,25 +385,12 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
         database = self.config.database
         logger.info(f"Processing db {database}")
 
-        if self.config.include_share_lineage:
-            try:
-                all_dbs = self.data_dictionary.get_all_databases(connection)
-                logger.info(
-                    "All databases visible on this cluster: %s",
-                    [
-                        f"{db.name} (type={db.type}, options={db.options})"
-                        for db in all_dbs
-                    ],
-                )
-            except Exception:
-                logger.info(
-                    "Could not list all databases (may lack permissions on svv_redshift_databases)"
-                )
-
         self.db = self.data_dictionary.get_database_details(connection, database)
         self.report.is_shared_database = (
             self.db is not None and self.db.is_shared_database()
         )
+        if self.db:
+            self.report.target_database_options = self.db.options
         with self.report.new_stage(METADATA_EXTRACTION):
             self.db_tables[database] = defaultdict()
             self.db_views[database] = defaultdict()
@@ -983,6 +970,34 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
         lineage_extractor: RedshiftSqlLineage,
     ) -> Iterable[MetadataWorkUnit]:
         if self.config.include_share_lineage:
+            try:
+                all_dbs = self.data_dictionary.get_all_databases(connection)
+                db_summary = {db.name: db.type for db in all_dbs}
+                self.report.all_databases_on_cluster = db_summary
+                logger.info(
+                    "All databases visible on this cluster: %s",
+                    [
+                        f"{db.name} (type={db.type}, options={db.options})"
+                        for db in all_dbs
+                    ],
+                )
+                shared_dbs = [db for db in all_dbs if db.is_shared_database()]
+                if shared_dbs:
+                    logger.info(
+                        "Shared databases available for bridge lineage: %s",
+                        [f"{db.name} (options={db.options})" for db in shared_dbs],
+                    )
+                else:
+                    logger.info(
+                        "No shared databases found on this cluster. "
+                        "Bridge lineage requires a shared database created from an inbound datashare."
+                    )
+            except Exception:
+                logger.warning(
+                    "Could not list all databases — may lack permissions on svv_redshift_databases",
+                    exc_info=True,
+                )
+
             outbound_shares = self.data_dictionary.get_outbound_datashares(connection)
             yield from auto_workunit(
                 self.datashares_helper.to_platform_resource(list(outbound_shares))
@@ -990,7 +1005,8 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
 
             if self.db and self.db.is_shared_database():
                 logger.info(
-                    f"Database '{database}' is shared — will attempt bridge lineage"
+                    f"Database '{database}' is shared (options={self.db.options}) "
+                    f"— will attempt bridge lineage"
                 )
                 inbound_share = self.db.get_inbound_share()
                 if inbound_share is None:
@@ -1020,7 +1036,7 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
                 logger.info(
                     f"Database '{database}' is local (type={self.db.type if self.db else 'N/A'}) "
                     f"— skipping bridge lineage. To generate bridge lineage, "
-                    f"create a recipe targeting the shared database."
+                    f"create a recipe targeting a shared database instead."
                 )
 
         # TODO: distinguish between definition level lineage and audit log based lineage.

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -385,6 +385,21 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
         database = self.config.database
         logger.info(f"Processing db {database}")
 
+        if self.config.include_share_lineage:
+            try:
+                all_dbs = self.data_dictionary.get_all_databases(connection)
+                logger.info(
+                    "All databases visible on this cluster: %s",
+                    [
+                        f"{db.name} (type={db.type}, options={db.options})"
+                        for db in all_dbs
+                    ],
+                )
+            except Exception:
+                logger.info(
+                    "Could not list all databases (may lack permissions on svv_redshift_databases)"
+                )
+
         self.db = self.data_dictionary.get_database_details(connection, database)
         self.report.is_shared_database = (
             self.db is not None and self.db.is_shared_database()
@@ -974,6 +989,9 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
             )
 
             if self.db and self.db.is_shared_database():
+                logger.info(
+                    f"Database '{database}' is shared — will attempt bridge lineage"
+                )
                 inbound_share = self.db.get_inbound_share()
                 if inbound_share is None:
                     self.report.warning(
@@ -982,10 +1000,28 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
                         context=f"Database: {database}, Options {self.db.options}",
                     )
                 else:
+                    logger.info(
+                        f"Inbound share resolved: type={type(inbound_share).__name__}, "
+                        f"share_name={inbound_share.share_name}, "
+                        f"consumer_database={inbound_share.consumer_database}, "
+                        f"description={inbound_share.get_description()}"
+                    )
+                    lineage_count = 0
                     for known_lineage in self.datashares_helper.generate_lineage(
                         inbound_share, self.get_all_tables()[database]
                     ):
                         lineage_extractor.aggregator.add(known_lineage)
+                        lineage_count += 1
+                    logger.info(
+                        f"Generated {lineage_count} bridge lineage mappings "
+                        f"from datashare '{inbound_share.share_name}'"
+                    )
+            else:
+                logger.info(
+                    f"Database '{database}' is local (type={self.db.type if self.db else 'N/A'}) "
+                    f"— skipping bridge lineage. To generate bridge lineage, "
+                    f"create a recipe targeting the shared database."
+                )
 
         # TODO: distinguish between definition level lineage and audit log based lineage.
         # Definition level lineage should never be skipped

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift_schema.py
@@ -294,12 +294,33 @@ class RedshiftDataDictionary:
 
         row = cursor.fetchone()
         if row is None:
+            logger.info(f"Database '{database}' not found in svv_redshift_databases")
             return None
-        return RedshiftDatabase(
+        db = RedshiftDatabase(
             name=database,
             type=row[1],
             options=row[2],
         )
+        logger.info(
+            f"Database details: name={db.name}, type={db.type}, "
+            f"is_shared={db.is_shared_database()}, options={db.options}"
+        )
+        return db
+
+    @staticmethod
+    def get_all_databases(
+        conn: redshift_connector.Connection,
+    ) -> List["RedshiftDatabase"]:
+        """Fetch all databases visible to the current user for diagnostic logging."""
+        cursor = RedshiftDataDictionary.get_query_result(
+            conn,
+            "SELECT database_name, database_type, database_options "
+            "FROM svv_redshift_databases ORDER BY database_type",
+        )
+        results = []
+        for row in cursor.fetchall():
+            results.append(RedshiftDatabase(name=row[0], type=row[1], options=row[2]))
+        return results
 
     @staticmethod
     def get_schemas(
@@ -686,12 +707,20 @@ class RedshiftDataDictionary:
         cursor = RedshiftDataDictionary.get_query_result(
             conn=conn, query=RedshiftCommonQuery.list_outbound_datashares()
         )
-        for item in cursor.fetchall():
-            yield OutboundDatashare(
+        rows = cursor.fetchall()
+        logger.info(f"Found {len(rows)} outbound datashares")
+        for item in rows:
+            share = OutboundDatashare(
                 share_name=item[1],
                 producer_namespace=item[2],
                 source_database=item[3],
             )
+            logger.info(
+                f"Outbound datashare: share_name={share.share_name}, "
+                f"producer_namespace={share.producer_namespace}, "
+                f"source_database={share.source_database}"
+            )
+            yield share
 
     # NOTE: this is not used right now as it requires superuser privilege
     # We can use this in future if the permissions are lowered.

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/report.py
@@ -60,6 +60,8 @@ class RedshiftReport(
 
     is_shared_database: bool = False
     outbound_shares_count: Optional[int] = None
+    all_databases_on_cluster: Optional[Dict[str, str]] = None
+    target_database_options: Optional[str] = None
 
     def report_dropped(self, key: str) -> None:
         self.filtered.append(key)


### PR DESCRIPTION
Adds info-level logging across the datashare lineage flow to enable debugging directly from ingestion logs without needing customer DB access:

- Log all databases visible on the cluster (svv_redshift_databases)
- Log target database type/options and is_shared determination
- Log each outbound datashare with namespace and source_database
- Log bridge lineage skip/run decision with clear reason
- Log inbound share details and PlatformResource lookup results
- Log matched upstream share and bridge lineage mapping count

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
