### PR TITLE
docs(managed-datahub): add v0.3.15.6 and v0.3.16.6 release notes

### DIFF
--- a/docs/managed-datahub/release-notes/v_0_3_15.md
+++ b/docs/managed-datahub/release-notes/v_0_3_15.md
@@ -21,6 +21,24 @@ This contains detailed release notes, but there's also an [announcement blog pos
 
 ## Release Changelog
 
+### v0.3.15.6-acryl
+
+#### Release Availability Date
+
+7-Apr-2026
+
+#### Security
+
+- OIDC: Stop exposing the client secret via GraphQL (use `hasClientSecret` only) and fix SSO save errors by omitting read-only fields from the update mutation.
+
+#### Platform
+
+- **Gzip / frontend proxy**: The frontend HTTP filter chain now includes Play’s enabled filters (including `GzipFilter`) in addition to the base-path redirect filter, so proxied responses can be compressed again. Non-streaming proxied traffic (for example GraphQL) uses a buffered body path so gzip applies; paths configured as streaming (for example SSE for AI chat) stay streamed. Upstream `Content-Encoding` and `Transfer-Encoding` are stripped on buffered responses so the gzip filter can run; streaming responses set `Content-Encoding: identity` so they are not double-compressed. Streaming path prefixes are configurable via `proxy.streamingPathPrefixes` / `PROXY_STREAMING_PATH_PREFIXES`.
+
+#### Gen AI
+
+- **Daily LLM token limit**: Integrations service enforces a per-day token budget for LLM calls (tracked in UTC, resets at midnight UTC). Default limit is 20 million tokens; configure with `GENAI_DAILY_TOKEN_LIMIT` (use `0` to disable). Calls check the limit before invoking the model and record usage after each response; when the limit is exceeded, new calls fail fast with a clear error.
+
 ### v0.3.15.5-acryl
 
 - Fix for automations stability

--- a/docs/managed-datahub/release-notes/v_0_3_16.md
+++ b/docs/managed-datahub/release-notes/v_0_3_16.md
@@ -21,6 +21,27 @@ This contains detailed release notes. Read the highlights in this [blog post](ht
 
 ## Release Changelog
 
+### v0.3.16.6-acryl
+
+#### Release Availability Date
+
+7-Apr-2026
+
+#### Security
+
+- OIDC: Stop exposing the client secret via GraphQL (use `hasClientSecret` only) and fix SSO save errors by omitting read-only fields from the update mutation (#8887).
+
+#### Product
+
+- **Structured property proposals** (#8103): Clearer structured-property flows on assets and on dataset schema columns—direct edit/upsert where you have full write access, versus proposal flows that require approval. Separate actions for proposing new structured property values vs proposing updates to existing values (update proposals cannot add new properties). Same pattern at the column level for schema fields.
+- **Ingestion UI**: Fixed a cache bug when creating a new ingestion source (#8533).
+- **Bulk editing**: Fixed alignment for selected items in bulk edit.
+- **Entity profile**: Other (non-editable) fields now use display names consistently with editable structured properties (#8352).
+
+#### Platform
+
+- **CI / images**: Fixed `copy_re` workflow variant lists so publish jobs match variants present on this branch; partial sync and version bumps aligned with acyl-main (#8844).
+
 ### v0.3.16.5-acryl
 
 - **On-Prem Versions**:


### PR DESCRIPTION
- v0.3.15.6: OIDC GraphQL security, gzip/proxy fix, daily LLM token limit
- v0.3.16.6: OIDC fix, structured property proposals, UI fixes, CI sync

Made-with: Cursor

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
