### PR TITLE
fix(ingest/glue): emit datajob aspect for no transform case

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1115,6 +1115,46 @@ class GlueSource(StatefulIngestionSourceBase):
 
         return MetadataWorkUnit(id=f"{job_name}-{node['Id']}", mce=mce)
 
+    def get_datajob_wu_for_dataflow(
+        self,
+        flow_urn: str,
+        job: Dict[str, Any],
+        input_datasets: Optional[List[str]] = None,
+        output_datasets: Optional[List[str]] = None,
+    ) -> Iterable[MetadataWorkUnit]:
+        """
+        Generate DataJob workunits for a Glue job that has no transform nodes.
+
+        This handles cases where a job has no script, the script could not be
+        parsed, or the DAG contains only sources and sinks with no transforms.
+        We emit one DataJob representing the entire job so it still appears in
+        the lineage graph and bridges source-to-sink lineage.
+        """
+
+        region = self.source_config.aws_region
+        job_name = job["Name"]
+        job_id = "job"
+
+        datajob_urn = mce_builder.make_data_job_urn_with_flow(flow_urn, job_id=job_id)
+
+        yield MetadataChangeProposalWrapper(
+            entityUrn=datajob_urn,
+            aspect=DataJobInfoClass(
+                name=job_name,
+                type="GLUE",
+                externalUrl=f"https://{region}.console.aws.amazon.com/gluestudio/home?region={region}#/editor/job/{job_name}/graph",
+            ),
+        ).as_workunit()
+
+        yield MetadataChangeProposalWrapper(
+            entityUrn=datajob_urn,
+            aspect=DataJobInputOutputClass(
+                inputDatasets=input_datasets or [],
+                outputDatasets=output_datasets or [],
+                inputDatajobs=[],
+            ),
+        ).as_workunit()
+
     def get_all_databases(self) -> Iterable[Mapping[str, Any]]:
         logger.debug("Getting all databases")
         # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue/paginator/GetDatabases.html
@@ -1641,6 +1681,7 @@ class GlueSource(StatefulIngestionSourceBase):
     def _transform_extraction(self) -> Iterable[MetadataWorkUnit]:
         dags: Dict[str, Optional[Dict[str, Any]]] = {}
         flow_names: Dict[str, str] = {}
+        flow_jobs: Dict[str, Dict[str, Any]] = {}
         for job in self.get_all_jobs():
             flow_urn = mce_builder.make_data_flow_urn(
                 self.platform, job["Name"], self.env
@@ -1659,6 +1700,7 @@ class GlueSource(StatefulIngestionSourceBase):
 
             dags[flow_urn] = dag
             flow_names[flow_urn] = job["Name"]
+            flow_jobs[flow_urn] = job
         # run a first pass to pick up s3 bucket names and formats
         # in Glue, it's possible for two buckets to have files of different extensions
         # if this happens, we append the extension in the URN so the sources can be distinguished
@@ -1671,14 +1713,41 @@ class GlueSource(StatefulIngestionSourceBase):
         # run second pass to generate node workunits
         for flow_urn, dag in dags.items():
             if dag is None:
+                yield from self.get_datajob_wu_for_dataflow(
+                    flow_urn, flow_jobs[flow_urn]
+                )
                 continue
 
             nodes, new_dataset_ids, new_dataset_mces = self.process_dataflow_graph(
                 dag, flow_urn, s3_formats
             )
 
+            has_transform_nodes = any(
+                node["NodeType"] not in ["DataSource", "DataSink"]
+                for node in nodes.values()
+            )
+
             if not nodes:
                 self.report.num_job_without_nodes += 1
+                yield from self.get_datajob_wu_for_dataflow(
+                    flow_urn, flow_jobs[flow_urn]
+                )
+            elif not has_transform_nodes:
+                # Job has sources/sinks but no transforms — emit a fallback
+                # DataJob that bridges source-to-sink lineage.
+                input_datasets: List[str] = []
+                output_datasets: List[str] = []
+                for node in nodes.values():
+                    if node["NodeType"] == "DataSource":
+                        input_datasets.extend(node.get("dataset_urns", [node["urn"]]))
+                    elif node["NodeType"] == "DataSink":
+                        output_datasets.append(node["urn"])
+                yield from self.get_datajob_wu_for_dataflow(
+                    flow_urn,
+                    flow_jobs[flow_urn],
+                    input_datasets=input_datasets,
+                    output_datasets=output_datasets,
+                )
 
             for node in nodes.values():
                 if node["NodeType"] not in ["DataSource", "DataSink"]:

--- a/metadata-ingestion/tests/unit/glue/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source.py
@@ -1,3 +1,5 @@
+import datetime
+import io
 import json
 from collections import defaultdict
 from pathlib import Path
@@ -6,10 +8,12 @@ from unittest.mock import patch
 
 import pydantic
 import pytest
+from botocore.response import StreamingBody
 from botocore.stub import Stubber
 from freezegun import freeze_time
 
 import datahub.metadata.schema_classes as models
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.extractor.schema_util import avro_schema_to_mce_fields
 from datahub.ingestion.graph.client import DataHubGraph
@@ -1435,3 +1439,180 @@ def test_process_dataflow_node_jdbc_query_fallback() -> None:
 )
 def test_sanitize_jdbc_url(raw_url: str, expected_safe: str) -> None:
     assert _sanitize_jdbc_url(raw_url) == expected_safe
+
+
+@freeze_time(FROZEN_TIME)
+def test_glue_ingest_job_without_script_location() -> None:
+    """Jobs with no ScriptLocation should still emit a fallback DataJob."""
+    source = glue_source(extract_transforms=True)
+
+    job_without_script = {
+        "Name": "no-script-job",
+        "Description": "A job with no script",
+        "Role": "arn:aws:iam::123412341234:role/service-role/AWSGlueServiceRole",
+        "CreatedOn": datetime.datetime(2021, 6, 10, 16, 51, 25, 690000),
+        "LastModifiedOn": datetime.datetime(2021, 6, 10, 16, 55, 35, 307000),
+        "ExecutionProperty": {"MaxConcurrentRuns": 1},
+        "Command": {
+            "Name": "glueetl",
+            "PythonVersion": "3",
+            # No ScriptLocation
+        },
+        "DefaultArguments": {},
+        "MaxRetries": 0,
+        "GlueVersion": "2.0",
+    }
+
+    jobs_response = {"Jobs": [job_without_script]}
+
+    with Stubber(source.glue_client) as glue_stubber:
+        glue_stubber.add_response("get_databases", {"DatabaseList": []}, {})
+        glue_stubber.add_response("get_jobs", jobs_response, {})
+
+        workunits = list(source.get_workunits())
+
+    # Find DataJob MCP workunits (MCP-based, not MCE snapshots)
+    datajob_info_wus = [
+        wu
+        for wu in workunits
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        and isinstance(wu.metadata.aspect, models.DataJobInfoClass)
+    ]
+    datajob_io_wus = [
+        wu
+        for wu in workunits
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        and isinstance(wu.metadata.aspect, models.DataJobInputOutputClass)
+    ]
+
+    assert len(datajob_info_wus) == 1
+    assert len(datajob_io_wus) == 1
+
+    # Verify the fallback DataJob has expected properties
+    info_mcp = datajob_info_wus[0].metadata
+    datajob_info = info_mcp.aspect
+    assert isinstance(datajob_info, models.DataJobInfoClass)
+    assert datajob_info.name == "no-script-job"
+    assert datajob_info.type == "GLUE"
+    assert "no-script-job" in (datajob_info.externalUrl or "")
+
+    # Verify the URN uses the "job" job_id
+    assert info_mcp.entityUrn is not None
+    assert info_mcp.entityUrn.endswith(",job)")
+
+    # Verify the report counted the missing script
+    assert source.report.num_job_script_location_missing == 1
+
+
+@freeze_time(FROZEN_TIME)
+def test_glue_ingest_job_with_no_transforms() -> None:
+    """Jobs with only DataSource/DataSink nodes (no transforms) should emit
+    a fallback DataJob that bridges source-to-sink lineage."""
+    source = glue_source(extract_transforms=True)
+
+    job_with_script = {
+        "Name": "source-sink-only-job",
+        "Description": "A job with only source and sink, no transforms",
+        "Role": "arn:aws:iam::123412341234:role/service-role/AWSGlueServiceRole",
+        "CreatedOn": datetime.datetime(2021, 6, 10, 16, 51, 25, 690000),
+        "LastModifiedOn": datetime.datetime(2021, 6, 10, 16, 55, 35, 307000),
+        "ExecutionProperty": {"MaxConcurrentRuns": 1},
+        "Command": {
+            "Name": "glueetl",
+            "ScriptLocation": "s3://aws-glue-assets-123412341234-us-west-2/scripts/source-sink-job.py",
+            "PythonVersion": "3",
+        },
+        "DefaultArguments": {},
+        "MaxRetries": 0,
+        "GlueVersion": "2.0",
+    }
+
+    jobs_response = {"Jobs": [job_with_script]}
+
+    # DAG with only a DataSource and a DataSink, no transform nodes
+    source_sink_only_dag = {
+        "DagNodes": [
+            {
+                "Id": "DataSource0",
+                "NodeType": "DataSource",
+                "Args": [
+                    {"Name": "database", "Value": '"flights-database"', "Param": False},
+                    {"Name": "table_name", "Value": '"avro"', "Param": False},
+                    {
+                        "Name": "transformation_ctx",
+                        "Value": '"DataSource0"',
+                        "Param": False,
+                    },
+                ],
+                "LineNumber": 10,
+            },
+            {
+                "Id": "DataSink0",
+                "NodeType": "DataSink",
+                "Args": [
+                    {"Name": "database", "Value": '"test-database"', "Param": False},
+                    {
+                        "Name": "table_name",
+                        "Value": '"test_jsons_markers"',
+                        "Param": False,
+                    },
+                    {
+                        "Name": "transformation_ctx",
+                        "Value": '"DataSink0"',
+                        "Param": False,
+                    },
+                ],
+                "LineNumber": 20,
+            },
+        ],
+        "DagEdges": [
+            {
+                "Source": "DataSource0",
+                "Target": "DataSink0",
+                "TargetParameter": "frame",
+            },
+        ],
+    }
+
+    script_body = b"# dummy script"
+
+    with Stubber(source.glue_client) as glue_stubber:
+        glue_stubber.add_response("get_databases", {"DatabaseList": []}, {})
+        glue_stubber.add_response("get_jobs", jobs_response, {})
+        glue_stubber.add_response(
+            "get_dataflow_graph",
+            source_sink_only_dag,
+            {"PythonScript": script_body.decode()},
+        )
+
+        with Stubber(source.s3_client) as s3_stubber:
+            s3_stubber.add_response(
+                "get_object",
+                {
+                    "Body": StreamingBody(io.BytesIO(script_body), len(script_body)),
+                },
+                {
+                    "Bucket": "aws-glue-assets-123412341234-us-west-2",
+                    "Key": "scripts/source-sink-job.py",
+                },
+            )
+
+            workunits = list(source.get_workunits())
+
+    # Should have a fallback DataJob with lineage
+    datajob_io_wus = [
+        wu
+        for wu in workunits
+        if isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        and isinstance(wu.metadata.aspect, models.DataJobInputOutputClass)
+    ]
+
+    assert len(datajob_io_wus) == 1
+    io_aspect = datajob_io_wus[0].metadata.aspect
+    assert isinstance(io_aspect, models.DataJobInputOutputClass)
+
+    # The fallback DataJob should carry lineage from source to sink
+    assert len(io_aspect.inputDatasets) == 1
+    assert len(io_aspect.outputDatasets) == 1
+    assert "flights-database.avro" in io_aspect.inputDatasets[0]
+    assert "test-database.test_jsons_markers" in io_aspect.outputDatasets[0]

--- a/metadata-ingestion/tests/unit/glue/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/glue/test_glue_source.py
@@ -1490,6 +1490,7 @@ def test_glue_ingest_job_without_script_location() -> None:
 
     # Verify the fallback DataJob has expected properties
     info_mcp = datajob_info_wus[0].metadata
+    assert isinstance(info_mcp, MetadataChangeProposalWrapper)
     datajob_info = info_mcp.aspect
     assert isinstance(datajob_info, models.DataJobInfoClass)
     assert datajob_info.name == "no-script-job"
@@ -1608,7 +1609,9 @@ def test_glue_ingest_job_with_no_transforms() -> None:
     ]
 
     assert len(datajob_io_wus) == 1
-    io_aspect = datajob_io_wus[0].metadata.aspect
+    io_mcp = datajob_io_wus[0].metadata
+    assert isinstance(io_mcp, MetadataChangeProposalWrapper)
+    io_aspect = io_mcp.aspect
     assert isinstance(io_aspect, models.DataJobInputOutputClass)
 
     # The fallback DataJob should carry lineage from source to sink


### PR DESCRIPTION
# Summary                                                                                                    
                  
  - Glue jobs without transform nodes (only DataSource/DataSink) previously emitted no DataJob, silently     
  dropping source-to-sink lineage                                                                            
  - Added `get_datajob_wu_for_dataflow()` that emits a fallback DataJob to represent the
  entire job when no transform nodes exist                                                                   
  - The fallback DataJob carries inputDatasets/outputDatasets extracted from the DAG's source and sink nodes,
   preserving lineage                                                                                        
  - Also handles jobs with no script location or failed script parsing by emitting a DataJob with empty
  lineage (so the job is at least visible in DataHub)   

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)