### PR TITLE
fix(auth): remove deprecated corpUserInfo.active check from session eligibility

### DIFF
--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/session/UserSessionEligibilityChecker.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/session/UserSessionEligibilityChecker.java
@@ -12,7 +12,6 @@ import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.RecordTemplate;
-import com.linkedin.identity.CorpUserInfo;
 import com.linkedin.identity.CorpUserStatus;
 import com.linkedin.metadata.entity.EntityService;
 import io.datahubproject.metadata.context.OperationContext;
@@ -23,8 +22,8 @@ import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Evaluates whether a corp user may receive a UI session token (aligned with ActorContext.isActive
- * plus corpUserInfo.active).
+ * Evaluates whether a corp user may receive a UI session token (aligned with
+ * ActorContext.isActive).
  */
 @RequiredArgsConstructor
 public class UserSessionEligibilityChecker {
@@ -79,12 +78,6 @@ public class UserSessionEligibilityChecker {
       return Optional.of(LoginDenialReason.NOT_PROVISIONED);
     }
 
-    if (corpUserInfoAspect != null) {
-      final CorpUserInfo info = new CorpUserInfo(corpUserInfoAspect.data());
-      if (info.hasActive() && !info.isActive()) {
-        return Optional.of(LoginDenialReason.INACTIVE);
-      }
-    }
 
     return Optional.empty();
   }

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/session/UserSessionEligibilityCheckerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/session/UserSessionEligibilityCheckerTest.java
@@ -107,7 +107,8 @@ public class UserSessionEligibilityCheckerTest {
   }
 
   @Test
-  public void testInactiveCorpUserInfo() {
+  public void testInactiveCorpUserInfoIsIgnored() {
+    // corpUserInfo.active is deprecated since 2021 — should NOT block login
     CorpUserKey key = new CorpUserKey().setUsername("eligibilitytest");
     EntityService<?> entityService = Mockito.mock(EntityService.class);
     Map<String, RecordTemplate> aspects = new HashMap<>();
@@ -116,8 +117,7 @@ public class UserSessionEligibilityCheckerTest {
     stubLatestAspectsForUrn(entityService, UrnUtils.getUrn(USER), aspects);
 
     UserSessionEligibilityChecker checker = new UserSessionEligibilityChecker(entityService);
-    assertEquals(
-        checker.checkEligibility(opContext, USER, true), Optional.of(LoginDenialReason.INACTIVE));
+    assertTrue(checker.checkEligibility(opContext, USER, true).isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- `UserSessionEligibilityChecker` was checking the deprecated `corpUserInfo.active` field (deprecated since 2021), causing login failures when stale `active=false` values conflicted with `corpUserStatus=ACTIVE`
- Remove the check — `CorpUserStatus` is the canonical field
