### PR TITLE
feat(actions): Expose event source on PipelineContext

### DIFF
--- a/datahub-actions/src/datahub_actions/pipeline/pipeline.py
+++ b/datahub-actions/src/datahub_actions/pipeline/pipeline.py
@@ -124,6 +124,7 @@ class Pipeline:
 
         # Create Event Source
         event_source = create_event_source(config.source, ctx)
+        ctx.event_source = event_source
 
         # Create Transforms
         transforms = []

--- a/datahub-actions/src/datahub_actions/pipeline/pipeline_context.py
+++ b/datahub-actions/src/datahub_actions/pipeline/pipeline_context.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from datahub_actions.api.action_graph import AcrylDataHubGraph
+
+if TYPE_CHECKING:
+    from datahub_actions.source.event_source import EventSource
 
 
 @dataclass
@@ -29,3 +34,6 @@ class PipelineContext:
 
     # An instance of a DataHub client.
     graph: Optional[AcrylDataHubGraph]
+
+    # Provided so that actions can manually acknowledge events, e.g. for bulk processing
+    event_source: Optional[EventSource] = None


### PR DESCRIPTION
Expose event source on ctx so that actions can manually ack if it needs to. This does complicate the handoff between the action pipeline and the action itself, but I don't see an alternative for async / batch processing actions that aren't processing one event at a time in serial

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
