### PR TITLE
fix(docs): Dataplex docs update including permissions fix

### DIFF
--- a/metadata-ingestion/docs/sources/dataplex/dataplex_post.md
+++ b/metadata-ingestion/docs/sources/dataplex/dataplex_post.md
@@ -18,10 +18,18 @@ Datasets discovered by Dataplex use the same URNs as native connectors (e.g., `b
 
 The connector adds the following custom properties to datasets:
 
-- `dataplex_entry_id`: The entry identifier in Dataplex
-- `dataplex_entry_group`: The entry group containing this entry
-- `dataplex_fully_qualified_name`: The fully qualified name of the entry
-- `dataplex_ingested`: Marker indicating the dataset was ingested via Dataplex
+| Property                        | Always Present | Description                                                                |
+| ------------------------------- | -------------- | -------------------------------------------------------------------------- |
+| `dataplex_ingested`             | Yes            | Marker indicating the dataset was ingested via Dataplex                    |
+| `dataplex_entry_id`             | Yes            | The entry identifier in Dataplex                                           |
+| `dataplex_entry_group`          | Yes            | The entry group containing this entry                                      |
+| `dataplex_fully_qualified_name` | Yes            | The fully qualified name of the entry                                      |
+| `dataplex_entry_type`           | No             | The Dataplex entry type (e.g. `bigquery-table`)                            |
+| `dataplex_parent_entry`         | No             | The parent entry name, if set                                              |
+| `dataplex_source_resource`      | No             | The source resource identifier from the entry source                       |
+| `dataplex_source_system`        | No             | The source system from the entry source                                    |
+| `dataplex_source_platform`      | No             | The source platform from the entry source                                  |
+| `dataplex_aspect_<aspect_type>` | No             | One property per aspect attached to the entry, named after the aspect type |
 
 #### Filtering Configuration
 
@@ -103,7 +111,7 @@ source:
     project_ids:
       - "my-gcp-project"
 
-    # Location for entries (Universal Catalog) - defaults to "us"
+    # Location for entries (Universal Catalog) - defaults to ["us", "eu", "asia", "global"]
     # Must be multi-region (us, eu, asia) for system entry groups like @bigquery
     entries_locations:
       - "us"

--- a/metadata-ingestion/docs/sources/dataplex/dataplex_pre.md
+++ b/metadata-ingestion/docs/sources/dataplex/dataplex_pre.md
@@ -64,25 +64,15 @@ For service account authentication, follow these instructions:
 
 #### Permissions
 
-Grant the following permissions to the service account on all target projects.
+Grant the following roles to the service account on all target projects.
 
-**Universal Catalog Entries API:**
+| Feature                                        | Required Role                                                                                             |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Universal Catalog Entries API (core ingestion) | [`roles/dataplex.catalogViewer`](https://cloud.google.com/dataplex/docs/iam-roles#dataplex.catalogViewer) |
+| Lineage extraction (`include_lineage: true`)   | [`roles/datalineage.viewer`](https://cloud.google.com/dataplex/docs/iam-roles#datalineage.viewer)         |
 
-**Default GCP Role:** [roles/dataplex.catalogViewer](https://cloud.google.com/dataplex/docs/iam-roles#dataplex.catalogViewer)
-
-| Permission                  | Description                           |
-| --------------------------- | ------------------------------------- |
-| `dataplex.entryGroups.get`  | Retrieve specific entry group details |
-| `dataplex.entryGroups.list` | View all entry groups in a location   |
-| `dataplex.entries.get`      | Access entry metadata and details     |
-| `dataplex.entries.getData`  | View data aspects within entries      |
-| `dataplex.entries.list`     | Enumerate entries within groups       |
-
-**Lineage extraction** (optional, `include_lineage: true`):
-
-**Default GCP Role:** [roles/datalineage.viewer](https://docs.cloud.google.com/iam/docs/roles-permissions/datalineage#datalineage.viewer)
-
-| Permission                 | Description                               |
-| -------------------------- | ----------------------------------------- |
-| `datalineage.links.get`    | Allows a user to view lineage links       |
-| `datalineage.links.search` | Allows a user to search for lineage links |
+> **Lineage requires the role on multiple projects.** Grant `roles/datalineage.viewer` on both the
+> _active project_ (the project from which API calls are made) and every _compute project_ where
+> lineage is recorded. Lineage is stored in the project where the corresponding process executed,
+> which may differ from the project containing the asset. If lineage appears missing, a missing
+> grant on a compute project is the most likely cause.

--- a/metadata-ingestion/docs/sources/dataplex/dataplex_pre.md
+++ b/metadata-ingestion/docs/sources/dataplex/dataplex_pre.md
@@ -71,8 +71,8 @@ Grant the following roles to the service account on all target projects.
 | Universal Catalog Entries API (core ingestion) | [`roles/dataplex.catalogViewer`](https://cloud.google.com/dataplex/docs/iam-roles#dataplex.catalogViewer) |
 | Lineage extraction (`include_lineage: true`)   | [`roles/datalineage.viewer`](https://cloud.google.com/dataplex/docs/iam-roles#datalineage.viewer)         |
 
-> **Lineage requires the role on multiple projects.** Grant `roles/datalineage.viewer` on both the
-> _active project_ (the project from which API calls are made) and every _compute project_ where
-> lineage is recorded. Lineage is stored in the project where the corresponding process executed,
-> which may differ from the project containing the asset. If lineage appears missing, a missing
-> grant on a compute project is the most likely cause.
+:::tip "Lineage requires the role on multiple projects"
+
+Grant `roles/datalineage.viewer` on all projects where the corresponding process is actually executed. Note it may differ from the project containing the asset.
+:::
+

--- a/metadata-ingestion/docs/sources/dataplex/dataplex_pre.md
+++ b/metadata-ingestion/docs/sources/dataplex/dataplex_pre.md
@@ -75,4 +75,3 @@ Grant the following roles to the service account on all target projects.
 
 Grant `roles/datalineage.viewer` on all projects where the corresponding process is actually executed. Note it may differ from the project containing the asset.
 :::
-

--- a/metadata-ingestion/docs/sources/dataplex/dataplex_recipe.yml
+++ b/metadata-ingestion/docs/sources/dataplex/dataplex_recipe.yml
@@ -7,7 +7,7 @@ source:
 
     # Optional: GCP location(s) for entries (Universal Catalog)
     # Use multi-region locations (us, eu, asia) to access system entry groups like @bigquery
-    # Default: "us"
+    # Default: ["us", "eu", "asia", "global"]
     entries_locations:
       - "us"
 


### PR DESCRIPTION
- Corrected IAM permissions section to reference predefined GCP roles (roles/dataplex.catalogViewer, roles/datalineage.viewer) rather than listing individual permissions, with links to Google's official IAM docs
- Removed invalid permissions (dataplex.entries.getData, datalineage.links.get, datalineage.links.search) that don't exist in the referenced roles
- Added note that roles/datalineage.viewer must be granted on both the active project and all compute projects where lineage is recorded
- Fixed entries_locations default value in recipe and example config (was "us", actual default is ["us", "eu", "asia", "global"])
- Expanded custom properties table to document all extracted properties, including conditional fields and dynamic dataplex_aspect_* entries