### PR TITLE
fix(ui/glossary): fix copy name on glossary term returns uuid instead of term name

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntityDropdown/EntityDropdown.tsx
@@ -405,7 +405,7 @@ const EntityDropdown = (props: Props) => {
 
         // Copy Name
         if (navigator.clipboard) {
-            const displayName = entityData?.name || urn;
+            const displayName = entityData ? entityRegistryV2.getDisplayName(entityType, entityData) : urn;
             shareChildren.push({
                 type: 'item' as const,
                 key: 'copy-name',
@@ -429,7 +429,7 @@ const EntityDropdown = (props: Props) => {
             title: 'Email',
             icon: Envelope,
             onClick: () => {
-                const displayName = entityData?.name || urn;
+                const displayName = entityData ? entityRegistryV2.getDisplayName(entityType, entityData) : urn;
                 const displayType =
                     getFirstSubType(entityData) || entityRegistryV2.getEntityName(entityType) || entityType;
                 const linkText = window.location.href;


### PR DESCRIPTION
**Linear ticket:**
https://linear.app/acryl-data/issue/CAT-1706/copy-name-on-glossary-term-returns-uuid-instead-of-term-name

**Description:**

This fixes the bug where Copy Name on a glossary term was returning UUID instead of the term name.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
