### PR TITLE
"fix(bigquery): reverts replace deprecated __TABLES__ with INFORMATION_SCHEMA.TABLE_STORAGE"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,4 +172,3 @@ test-models/bin/
 
 # Git Worktree management (wtp)
 .wtp.yml
-.worktrees/

--- a/metadata-ingestion/docs/sources/bigquery/bigquery_post.md
+++ b/metadata-ingestion/docs/sources/bigquery/bigquery_post.md
@@ -125,7 +125,7 @@ source:
 
 :::note Profiling Permission Requirement
 
-When profiling is enabled, the `bigquery.tables.getData` permission is **required**. This is needed to read actual table data for computing statistics such as row counts, null counts, and value distributions. See the permissions section above for details.
+When profiling is enabled, the `bigquery.tables.getData` permission is **required**. This is needed to access detailed table metadata including partition information. See the permissions section above for details.
 
 :::
 

--- a/metadata-ingestion/docs/sources/bigquery/bigquery_pre.md
+++ b/metadata-ingestion/docs/sources/bigquery/bigquery_pre.md
@@ -51,14 +51,17 @@ These permissions must be granted on **every project** you want to extract metad
 | `bigquery.jobs.listAll` | List all jobs (queries) submitted by any user. Needs for Lineage extraction. | Lineage Extraction/Usage Extraction | [roles/bigquery.resourceViewer](https://cloud.google.com/bigquery/docs/access-control#bigquery.resourceViewer) |
 | `logging.logEntries.list` | Fetch log entries for lineage/usage data. Not required if `use_exported_bigquery_audit_metadata` is enabled. | Lineage Extraction/Usage Extraction | [roles/logging.privateLogViewer](https://cloud.google.com/logging/docs/access-control#logging.privateLogViewer) |
 | `logging.privateLogEntries.list` | Fetch log entries for lineage/usage data. Not required if `use_exported_bigquery_audit_metadata` is enabled. | Lineage Extraction/Usage Extraction | [roles/logging.privateLogViewer](https://cloud.google.com/logging/docs/access-control#logging.privateLogViewer) |
-| `bigquery.tables.getData` | Access table data for data profiling. **Required only when profiling is enabled.** | Profiling | |
+| `bigquery.tables.getData` | Access table data to extract storage size, last updated at, partition information, data profiles etc. **Required when profiling is enabled or when `use_tables_list_query_v2` is enabled.** This permission is needed to query BigQuery's `__TABLES__` pseudo-table. | Profiling/Enhanced Table Metadata | |
 | `datacatalog.taxonomies.get` | _Optional_ Get policy tags for columns with associated policy tags. This permission is required only if `extract_policy_tags_from_catalog` is enabled. | Policy Tag Extraction | [roles/datacatalog.viewer](https://cloud.google.com/iam/docs/roles-permissions/datacatalog#datacatalog.viewer) |
 
 :::warning Important: bigquery.tables.getData Permission
 
-The `bigquery.tables.getData` permission is **required** only when profiling is enabled (`profiling.enabled: true`).
+The `bigquery.tables.getData` permission is **required** in the following scenarios:
 
-Without this permission, profiling will fail when the connector tries to read actual table data for statistics such as row counts, null counts, and value distributions.
+- When **profiling is enabled** (`profiling.enabled: true`)
+- When **`use_tables_list_query_v2` is enabled** (for enhanced table metadata extraction)
+
+Without this permission, you'll encounter errors when the connector tries to access BigQuery's `__TABLES__` pseudo-table for detailed table information including partition data, row counts, and storage metrics.
 
 :::
 

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -27,6 +27,7 @@ from google.cloud.bigquery.table import (
     TimePartitioningType,
 )
 
+from datahub.emitter.mce_builder import parse_ts_millis
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.source.bigquery_v2.bigquery_audit import BigqueryTableIdentifier
 from datahub.ingestion.source.bigquery_v2.bigquery_helper import parse_labels
@@ -439,13 +440,6 @@ class BigQuerySchemaApi:
             self.report.num_list_tables_api_requests += 1
             self.report.list_tables_sec += current_timer.elapsed_seconds()
 
-    @staticmethod
-    def _bq_location_to_region(location: str) -> str:
-        # BigQuery INFORMATION_SCHEMA.TABLE_STORAGE is scoped to a region, not a dataset.
-        # The region identifier uses the format "region-<location>" (case-insensitive).
-        # E.g. "US" -> "region-us", "us-central1" -> "region-us-central1".
-        return f"region-{location.lower()}"
-
     def get_tables_for_dataset(
         self,
         project_id: str,
@@ -453,34 +447,28 @@ class BigQuerySchemaApi:
         tables: Dict[str, TableListItem],
         report: BigQueryV2Report,
         with_partitions: bool = False,
-        location: Optional[str] = None,
     ) -> Iterator[BigqueryTable]:
         with PerfTimer() as current_timer:
             filter_clause: str = ", ".join(f"'{table}'" for table in tables)
 
-            if with_partitions and location:
+            if with_partitions:
                 query_template = BigqueryQuery.tables_for_dataset
             else:
-                if with_partitions and not location:
-                    logger.warning(
-                        f"Dataset location not available for {project_id}.{dataset_name}, "
-                        "falling back to query without storage statistics."
-                    )
                 query_template = BigqueryQuery.tables_for_dataset_without_partition_data
-
-            query_args: Dict[str, str] = dict(
-                project_id=project_id,
-                dataset_name=dataset_name,
-                table_filter=(
-                    f" and t.table_name in ({filter_clause})" if filter_clause else ""
-                ),
-            )
-            if location:
-                query_args["region"] = self._bq_location_to_region(location)
 
             # Tables are ordered by name and table suffix to make sure we always process the latest sharded table
             # and skip the others. Sharded tables are tables with suffix _20220102
-            cur = self.get_query_result(query_template.format(**query_args))
+            cur = self.get_query_result(
+                query_template.format(
+                    project_id=project_id,
+                    dataset_name=dataset_name,
+                    table_filter=(
+                        f" and t.table_name in ({filter_clause})"
+                        if filter_clause
+                        else ""
+                    ),
+                ),
+            )
 
             for table in cur:
                 try:
@@ -522,7 +510,7 @@ class BigQuerySchemaApi:
             name=table.table_name,
             created=table.created,
             table_type=table.table_type,
-            last_altered=table.get("last_altered"),
+            last_altered=parse_ts_millis(table.get("last_altered")),
             size_in_bytes=table.get("bytes"),
             rows_count=table.get("row_count"),
             comment=table.comment,
@@ -551,23 +539,16 @@ class BigQuerySchemaApi:
         dataset_name: str,
         has_data_read: bool,
         report: BigQueryV2Report,
-        location: Optional[str] = None,
     ) -> Iterator[BigqueryView]:
         with PerfTimer() as current_timer:
-            if has_data_read and location:
+            if has_data_read:
+                # If profiling is enabled
                 cur = self.get_query_result(
                     BigqueryQuery.views_for_dataset.format(
-                        project_id=project_id,
-                        dataset_name=dataset_name,
-                        region=self._bq_location_to_region(location),
+                        project_id=project_id, dataset_name=dataset_name
                     ),
                 )
             else:
-                if has_data_read and not location:
-                    logger.warning(
-                        f"Dataset location not available for {project_id}.{dataset_name}, "
-                        "falling back to query without storage statistics."
-                    )
                 cur = self.get_query_result(
                     BigqueryQuery.views_for_dataset_without_data_read.format(
                         project_id=project_id, dataset_name=dataset_name
@@ -594,7 +575,7 @@ class BigQuerySchemaApi:
         return BigqueryView(
             name=view.table_name,
             created=view.created,
-            last_altered=view.get("last_altered"),
+            last_altered=(parse_ts_millis(view.get("last_altered"))),
             comment=view.comment,
             view_definition=view.view_definition,
             materialized=view.table_type == BigqueryTableType.MATERIALIZED_VIEW,
@@ -799,23 +780,16 @@ class BigQuerySchemaApi:
         dataset_name: str,
         has_data_read: bool,
         report: BigQueryV2Report,
-        location: Optional[str] = None,
     ) -> Iterator[BigqueryTableSnapshot]:
         with PerfTimer() as current_timer:
-            if has_data_read and location:
+            if has_data_read:
+                # If profiling is enabled
                 cur = self.get_query_result(
                     BigqueryQuery.snapshots_for_dataset.format(
-                        project_id=project_id,
-                        dataset_name=dataset_name,
-                        region=self._bq_location_to_region(location),
+                        project_id=project_id, dataset_name=dataset_name
                     ),
                 )
             else:
-                if has_data_read and not location:
-                    logger.warning(
-                        f"Dataset location not available for {project_id}.{dataset_name}, "
-                        "falling back to query without storage statistics."
-                    )
                 cur = self.get_query_result(
                     BigqueryQuery.snapshots_for_dataset_without_data_read.format(
                         project_id=project_id, dataset_name=dataset_name
@@ -842,7 +816,7 @@ class BigQuerySchemaApi:
         return BigqueryTableSnapshot(
             name=snapshot.table_name,
             created=snapshot.created,
-            last_altered=snapshot.get("last_altered"),
+            last_altered=parse_ts_millis(snapshot.get("last_altered")),
             comment=snapshot.comment,
             ddl=snapshot.ddl,
             snapshot_time=snapshot.snapshot_time,

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
@@ -697,7 +697,6 @@ class BigQuerySchemaGenerator:
                     dataset_name,
                     self.config.is_profiling_enabled(),
                     self.report,
-                    location=bigquery_dataset.location,
                 )
             )
 
@@ -717,7 +716,6 @@ class BigQuerySchemaGenerator:
                     dataset_name,
                     self.config.is_profiling_enabled(),
                     self.report,
-                    location=bigquery_dataset.location,
                 )
             )
 
@@ -1375,7 +1373,6 @@ class BigQuerySchemaGenerator:
                         items_to_get,
                         with_partitions=with_partitions,
                         report=self.report,
-                        location=dataset.location,
                     )
                     items_to_get.clear()
 
@@ -1386,7 +1383,6 @@ class BigQuerySchemaGenerator:
                     items_to_get,
                     with_partitions=with_partitions,
                     report=self.report,
-                    location=dataset.location,
                 )
 
         self.report.metadata_extraction_sec[f"{project_id}.{dataset.name}"] = (

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/queries.py
@@ -41,12 +41,12 @@ SELECT
   t.table_name as table_name,
   t.table_type as table_type,
   t.creation_time as created,
-  ts.storage_last_modified_time as last_altered,
+  ts.last_modified_time as last_altered,
   tos.OPTION_VALUE as comment,
   t.is_insertable_into,
   t.ddl,
-  ts.total_rows as row_count,
-  ts.total_logical_bytes as bytes,
+  ts.row_count as row_count,
+  ts.size_bytes as bytes,
   p.num_partitions,
   p.max_partition_id,
   p.active_billable_bytes as active_billable_bytes,
@@ -56,8 +56,7 @@ SELECT
 
 FROM
   `{{project_id}}`.`{{dataset_name}}`.INFORMATION_SCHEMA.TABLES t
-  left join `{{project_id}}`.`{{region}}`.INFORMATION_SCHEMA.TABLE_STORAGE as ts
-    on ts.table_schema = '{{dataset_name}}' and ts.table_name = t.TABLE_NAME and ts.deleted = false
+  join `{{project_id}}`.`{{dataset_name}}`.__TABLES__ as ts on ts.table_id = t.TABLE_NAME
   left join `{{project_id}}`.`{{dataset_name}}`.INFORMATION_SCHEMA.TABLE_OPTIONS as tos on t.table_schema = tos.table_schema
   and t.TABLE_NAME = tos.TABLE_NAME
   and tos.OPTION_NAME = "description"
@@ -75,7 +74,7 @@ FROM
         table_name) as p on
     t.table_name = p.table_name
 WHERE
-  t.table_type in ('{BigqueryTableType.BASE_TABLE}', '{BigqueryTableType.EXTERNAL}', '{BigqueryTableType.CLONE}')
+  table_type in ('{BigqueryTableType.BASE_TABLE}', '{BigqueryTableType.EXTERNAL}', '{BigqueryTableType.CLONE}')
 {{table_filter}}
 order by
   table_schema ASC,
@@ -117,17 +116,16 @@ SELECT
   t.table_name as table_name,
   t.table_type as table_type,
   t.creation_time as created,
-  ts.storage_last_modified_time as last_altered,
+  ts.last_modified_time as last_altered,
   tos_description.OPTION_VALUE as comment,
   tos_labels.OPTION_VALUE as labels,
   t.is_insertable_into,
   t.ddl as view_definition,
-  ts.total_rows as row_count,
-  ts.total_logical_bytes as size_bytes
+  ts.row_count,
+  ts.size_bytes
 FROM
   `{{project_id}}`.`{{dataset_name}}`.INFORMATION_SCHEMA.TABLES t
-  left join `{{project_id}}`.`{{region}}`.INFORMATION_SCHEMA.TABLE_STORAGE as ts
-    on ts.table_schema = '{{dataset_name}}' and ts.table_name = t.TABLE_NAME and ts.deleted = false
+  join `{{project_id}}`.`{{dataset_name}}`.__TABLES__ as ts on ts.table_id = t.TABLE_NAME
   left join `{{project_id}}`.`{{dataset_name}}`.INFORMATION_SCHEMA.TABLE_OPTIONS as tos_description on t.table_schema = tos_description.table_schema
   and t.TABLE_NAME = tos_description.TABLE_NAME
   and tos_description.OPTION_NAME = "description"
@@ -135,7 +133,7 @@ FROM
   and t.TABLE_NAME = tos_labels.TABLE_NAME
   and tos_labels.OPTION_NAME = "labels"
 WHERE
-  t.table_type in ('{BigqueryTableType.VIEW}', '{BigqueryTableType.MATERIALIZED_VIEW}')
+  table_type in ('{BigqueryTableType.VIEW}', '{BigqueryTableType.MATERIALIZED_VIEW}')
 order by
   table_schema ASC,
   table_name ASC
@@ -180,19 +178,18 @@ SELECT
   t.base_table_catalog,
   t.base_table_schema,
   t.base_table_name,
-  ts.storage_last_modified_time as last_altered,
+  ts.last_modified_time as last_altered,
   tos.OPTION_VALUE as comment,
-  ts.total_rows as row_count,
-  ts.total_logical_bytes as size_bytes
+  ts.row_count,
+  ts.size_bytes
 FROM
   `{{project_id}}`.`{{dataset_name}}`.INFORMATION_SCHEMA.TABLES t
-  left join `{{project_id}}`.`{{region}}`.INFORMATION_SCHEMA.TABLE_STORAGE as ts
-    on ts.table_schema = '{{dataset_name}}' and ts.table_name = t.TABLE_NAME and ts.deleted = false
+  join `{{project_id}}`.`{{dataset_name}}`.__TABLES__ as ts on ts.table_id = t.TABLE_NAME
   left join `{{project_id}}`.`{{dataset_name}}`.INFORMATION_SCHEMA.TABLE_OPTIONS as tos on t.table_schema = tos.table_schema
   and t.TABLE_NAME = tos.TABLE_NAME
   and tos.OPTION_NAME = "description"
 WHERE
-  t.table_type = '{BigqueryTableType.SNAPSHOT}'
+  table_type = '{BigqueryTableType.SNAPSHOT}'
 order by
   table_schema ASC,
   table_name ASC

--- a/metadata-ingestion/tests/unit/bigquery/test_bigquery_source.py
+++ b/metadata-ingestion/tests/unit/bigquery/test_bigquery_source.py
@@ -1111,7 +1111,7 @@ def test_get_views_for_dataset(
         dict(
             table_name=bigquery_view_1.name,
             created=bigquery_view_1.created,
-            last_altered=bigquery_view_1.last_altered,
+            last_altered=bigquery_view_1.last_altered.timestamp() * 1000,
             comment=bigquery_view_1.comment,
             view_definition=bigquery_view_1.view_definition,
             table_type="VIEW",
@@ -1220,7 +1220,7 @@ def test_get_snapshots_for_dataset(
         dict(
             table_name=bigquery_snapshot.name,
             created=bigquery_snapshot.created,
-            last_altered=bigquery_snapshot.last_altered,
+            last_altered=bigquery_snapshot.last_altered.timestamp() * 1000,
             comment=bigquery_snapshot.comment,
             ddl=bigquery_snapshot.ddl,
             snapshot_time=bigquery_snapshot.snapshot_time,


### PR DESCRIPTION
## Problem

Using `TABLE_STORAGE` has been causing unexpected cost increases due to a significant rise in bytes scanned in BigQuery.

## Details

Each query against `TABLE_STORAGE` is scoped to the entire region and then filtered down to a specific dataset. This means that if a project has many datasets in a region and they're ingested one by one, every per-dataset query pays the full scan cost across all datasets — just to return rows for one.

## Fix

Reverting the use of `TABLE_STORAGE` until a dataset-scoped view becomes available.
Reverts datahub-project/datahub#16726