### PR TITLE
feat(incidents): add IncidentExternalLinks and IncidentNotes aspects

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentExternalLink.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentExternalLink.pdl
@@ -1,0 +1,58 @@
+namespace com.linkedin.incident
+
+import com.linkedin.common.AuditStamp
+import com.linkedin.common.Url
+
+/**
+ * A link to an external system (e.g., Jira, ServiceNow, PagerDuty) associated with an incident.
+ */
+record IncidentExternalLink {
+  /**
+   * Unique connection identifier for this integration. Allows linking to multiple instances
+   * of the same system (e.g., 'primary-jira', 'ops-servicenow', 'critical-pagerduty').
+   */
+  @Searchable = {
+    "fieldType": "KEYWORD"
+  }
+  connectionId: string
+
+  /**
+   * The external system name (e.g., 'jira', 'servicenow', 'pagerduty').
+   */
+  @Searchable = {
+    "fieldType": "KEYWORD",
+    "addToFilters": true,
+    "filterNameOverride": "External System",
+    "fieldName": "externalSystem"
+  }
+  system: string
+
+  /**
+   * The identifier in the external system (e.g., 'PROJ-123' for Jira).
+   */
+  @Searchable = {
+    "fieldType": "KEYWORD",
+    "fieldName": "externalLinkId"
+  }
+  externalId: string
+
+  /**
+   * The direct URL to the external issue/ticket.
+   */
+  url: Url
+
+  /**
+   * When this link was created.
+   */
+  created: AuditStamp
+
+  /**
+   * Whether bidirectional sync is enabled for this link.
+   */
+  syncEnabled: boolean = true
+
+  /**
+   * Epoch milliseconds of the last successful synchronization.
+   */
+  lastSyncTimeMillis: optional long
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentExternalLinks.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentExternalLinks.pdl
@@ -1,0 +1,15 @@
+namespace com.linkedin.incident
+
+/**
+ * Links to external systems for this incident (e.g., Jira, ServiceNow, PagerDuty)
+ */
+@Aspect = {
+  "name": "incidentExternalLinks"
+}
+record IncidentExternalLinks {
+  /**
+   * List of links to external systems
+   */
+  links: array[IncidentExternalLink] = []
+}
+

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNote.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNote.pdl
@@ -1,0 +1,28 @@
+namespace com.linkedin.incident
+
+import com.linkedin.common.AuditStamp
+
+/**
+ * A note or update added to an incident, either by a user in DataHub or synced from an
+ * external incident management system.
+ */
+record IncidentNote {
+
+  /**
+   * The content of the note. Rendered as markdown in the UI.
+   */
+  @Searchable = {
+    "fieldType": "TEXT"
+  }
+  message: string
+
+  /**
+   * When the note was created, and the actor who created it.
+   */
+  created: AuditStamp
+
+  /**
+   * The source of this note. Absent if the note was created natively in DataHub.
+   */
+  source: optional IncidentNoteSource
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNote.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNote.pdl
@@ -25,11 +25,4 @@ record IncidentNote {
    * The source of this note. Absent if the note was created natively in DataHub.
    */
   source: optional IncidentNoteSource
-
-  /**
-   * Optional reference to a parent note's external ID, enabling threaded replies.
-   * Set when this note is a reply to another note (e.g., a Jira comment reply or
-   * a Linear thread response).
-   */
-  parentNoteId: optional string
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNote.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNote.pdl
@@ -25,4 +25,11 @@ record IncidentNote {
    * The source of this note. Absent if the note was created natively in DataHub.
    */
   source: optional IncidentNoteSource
+
+  /**
+   * Optional reference to a parent note's external ID, enabling threaded replies.
+   * Set when this note is a reply to another note (e.g., a Jira comment reply or
+   * a Linear thread response).
+   */
+  parentNoteId: optional string
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNoteSource.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNoteSource.pdl
@@ -1,0 +1,33 @@
+namespace com.linkedin.incident
+
+/**
+ * The source of an incident note, indicating whether it was created natively in DataHub
+ * or synced from an external system (e.g., Jira, ServiceNow).
+ */
+record IncidentNoteSource {
+
+  /**
+   * The type of system this note originated from. Optional — inferred from externalId presence
+   * when absent, but useful for explicit filtering and future third-party source types.
+   */
+  sourceType: optional IncidentNoteSourceType
+
+  /**
+   * URL to the note in the external system (e.g., a Jira comment permalink).
+   */
+  @Searchable = {
+    "fieldType": "KEYWORD",
+    "queryByDefault": false
+  }
+  externalUrl: optional string
+
+  /**
+   * Unique identifier for the note in the external system, used for deduplication.
+   * For example, a Jira comment ID.
+   */
+  @Searchable = {
+    "fieldType": "KEYWORD",
+    "queryByDefault": false
+  }
+  externalId: optional string
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNoteSourceType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNoteSourceType.pdl
@@ -1,0 +1,18 @@
+namespace com.linkedin.incident
+
+/**
+ * The source type of an incident note, indicating whether it was created natively
+ * in DataHub or synced from an external system.
+ */
+enum IncidentNoteSourceType {
+
+  /**
+   * Created via the DataHub UI or API.
+   */
+  NATIVE
+
+  /**
+   * Synced from an external incident management or ticketing system.
+   */
+  EXTERNAL
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNotes.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentNotes.pdl
@@ -1,0 +1,17 @@
+namespace com.linkedin.incident
+
+/**
+ * A collection of notes and updates added to an incident over its lifetime, by users
+ * in DataHub or synced from external systems. Stored as a separate aspect so that
+ * ingestion sources that UPSERT IncidentInfo do not accidentally overwrite user-authored notes.
+ */
+@Aspect = {
+  "name": "incidentNotes"
+}
+record IncidentNotes {
+
+  /**
+   * The list of notes associated with this incident, ordered by creation time ascending.
+   */
+  notes: array[IncidentNote] = []
+}

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -601,6 +601,8 @@ entities:
     keyAspect: incidentKey
     aspects:
       - incidentInfo
+      - incidentExternalLinks
+      - incidentNotes
       - globalTags
   - name: dataHubRole
     category: core


### PR DESCRIPTION
Extends the incident metadata model with two new aspects to support structured tracking of external ticket links and incident discussion notes:

- **IncidentExternalLink** / **IncidentExternalLinks**: links a DataHub incident to one or more external tickets (Jira, ServiceNow, PagerDuty, etc.) with `connectionId`, `system`, `externalId`, `url`, `syncEnabled`, and `lastSyncTimeMillis` fields. Searchable on `system` and `externalId`.

- **IncidentNote** / **IncidentNotes**: append-only log of notes on an incident, either authored in DataHub or synced from an external system. Each note has a `message`, `created` AuditStamp, and optional `source` (IncidentNoteSource with optional `sourceType`, `externalUrl`, `externalId` for deduplication).

Both aspects are registered on the `incident` entity in entity-registry.yml.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
