### PR TITLE
fix(upgrade): fix document count logic for zdu

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/IncrementalReindex.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/IncrementalReindex.java
@@ -6,6 +6,7 @@ import com.linkedin.datahub.upgrade.shared.ElasticSearchUpgradeUtils;
 import com.linkedin.datahub.upgrade.system.NonBlockingSystemUpgrade;
 import com.linkedin.datahub.upgrade.system.elasticsearch.steps.IncrementalReindexCatchUpStep;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.search.BuildIndicesConfiguration;
 import com.linkedin.metadata.entity.AspectDao;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphService;
@@ -49,12 +50,8 @@ public class IncrementalReindex implements NonBlockingSystemUpgrade {
       structuredProperties = Set.of();
     }
 
-    boolean rollbackDualWriteEnabled =
-        configurationProvider.getElasticSearch().getBuildIndices() != null
-            && configurationProvider
-                .getElasticSearch()
-                .getBuildIndices()
-                .isRollbackDualWriteEnabled();
+    BuildIndicesConfiguration buildIndicesConfig =
+        configurationProvider.getElasticSearch().getBuildIndices();
 
     List<ElasticSearchIndexed> indexedServices =
         ElasticSearchUpgradeUtils.createElasticSearchIndexedServices(
@@ -69,7 +66,7 @@ public class IncrementalReindex implements NonBlockingSystemUpgrade {
             indexedServices,
             structuredProperties,
             upgradeVersion,
-            rollbackDualWriteEnabled));
+            buildIndicesConfig));
   }
 
   @Override

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStep.java
@@ -129,11 +129,25 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
               && !existingNextIndex.get().isEmpty()) {
             log.info("Resuming polling for index {} -> {}", config.name(), existingNextIndex.get());
             int targetShards = ESIndexBuilder.extractTargetShards(config);
+            long persistedSourceDocCount =
+                IncrementalReindexState.get(
+                        upgradeState, config.name(), IncrementalReindexState.SOURCE_DOC_COUNT)
+                    .map(Long::parseLong)
+                    .orElse(0L);
+            String persistedTaskId =
+                IncrementalReindexState.get(
+                        upgradeState, config.name(), IncrementalReindexState.TASK_ID)
+                    .orElse("");
             // On resume, reindexInfo from the original submission is not available — use empty map.
             // Stall-retry will re-submit with fresh optimal settings if needed.
             ESIndexBuilder.PollReindexResult pollResult =
                 indexBuilder.pollReindexCompletion(
-                    config.name(), existingNextIndex.get(), targetShards, new HashMap<>(), "");
+                    config.name(),
+                    existingNextIndex.get(),
+                    () -> persistedSourceDocCount,
+                    targetShards,
+                    new HashMap<>(),
+                    persistedTaskId);
             upgradeState =
                 handlePollResult(
                     context,
@@ -181,6 +195,8 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
                   result.nextIndexName(),
                   oldBackingIndexName,
                   result.reindexStartTime(),
+                  result.sourceDocCount(),
+                  result.taskId(),
                   requiresDataBackfill,
                   IncrementalReindexState.Status.IN_PROGRESS);
           checkpoint(context, upgradeState, DataHubUpgradeState.IN_PROGRESS);
@@ -207,10 +223,12 @@ public class BuildIndicesIncrementalStep implements UpgradeStep {
             continue;
           }
 
+          final long sourceDocCount = result.sourceDocCount();
           ESIndexBuilder.PollReindexResult pollResult =
               indexBuilder.pollReindexCompletion(
                   config.name(),
                   result.nextIndexName(),
+                  () -> sourceDocCount,
                   result.targetShards(),
                   result.reindexInfo(),
                   result.taskId());

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/IncrementalReindexCatchUpStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/IncrementalReindexCatchUpStep.java
@@ -8,6 +8,7 @@ import com.linkedin.datahub.upgrade.impl.DefaultUpgradeStepResult;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.aspect.SystemAspect;
 import com.linkedin.metadata.boot.BootstrapStep;
+import com.linkedin.metadata.config.search.BuildIndicesConfiguration;
 import com.linkedin.metadata.entity.AspectDao;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.EntityUtils;
@@ -41,6 +42,7 @@ import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.tasks.TaskInfo;
 
 /**
  * Phase 2 non-blocking upgrade step that closes the T0 gap created during Phase 1. Queries aspects
@@ -69,7 +71,7 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
   private final List<ElasticSearchIndexed> indexedServices;
   private final Set<Pair<Urn, StructuredPropertyDefinition>> structuredProperties;
   private final String upgradeVersion;
-  private final boolean rollbackDualWriteEnabled;
+  private final BuildIndicesConfiguration buildIndicesConfig;
   private final Urn upgradeIdUrn;
   private final Urn phase1UpgradeIdUrn;
   private final int batchSize;
@@ -81,7 +83,7 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
       List<ElasticSearchIndexed> indexedServices,
       Set<Pair<Urn, StructuredPropertyDefinition>> structuredProperties,
       String upgradeVersion,
-      boolean rollbackDualWriteEnabled,
+      BuildIndicesConfiguration buildIndicesConfig,
       int batchSize) {
     this.opContext = opContext;
     this.entityService = entityService;
@@ -89,7 +91,7 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
     this.indexedServices = indexedServices;
     this.structuredProperties = structuredProperties;
     this.upgradeVersion = upgradeVersion;
-    this.rollbackDualWriteEnabled = rollbackDualWriteEnabled;
+    this.buildIndicesConfig = buildIndicesConfig;
     this.upgradeIdUrn = BootstrapStep.getUpgradeUrn(UPGRADE_ID_PREFIX + "_" + upgradeVersion);
     this.phase1UpgradeIdUrn =
         BootstrapStep.getUpgradeUrn(
@@ -104,7 +106,7 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
       List<ElasticSearchIndexed> indexedServices,
       Set<Pair<Urn, StructuredPropertyDefinition>> structuredProperties,
       String upgradeVersion,
-      boolean rollbackDualWriteEnabled) {
+      @Nullable BuildIndicesConfiguration buildIndicesConfig) {
     this(
         opContext,
         entityService,
@@ -112,7 +114,7 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
         indexedServices,
         structuredProperties,
         upgradeVersion,
-        rollbackDualWriteEnabled,
+        buildIndicesConfig,
         DEFAULT_BATCH_SIZE);
   }
 
@@ -189,13 +191,28 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
                 dualWriteStartTime);
           } else if (indexConvention.getEntityAndAspectName(indexName).isPresent()
               && nextIndexName != null) {
-            // Timeseries index — filtered _reindex from current to next for the gap window
+            // Timeseries index — filtered _reindex from OLD backing index to next for the gap
+            // window. The old backing index continued receiving writes during Phase 1; after alias
+            // swap the alias points to next, so we must use the physical old index name.
+            String oldBackingIndexName =
+                indexState.get(IncrementalReindexState.OLD_BACKING_INDEX_NAME);
+            if (oldBackingIndexName == null || oldBackingIndexName.isEmpty()) {
+              log.warn(
+                  "Timeseries index {} has no oldBackingIndexName, skipping catch-up", indexName);
+              continue;
+            }
             log.info(
-                "Catch-up for timeseries index {}: _reindex window [{}, {}]",
+                "Catch-up for timeseries index {} (old: {}): _reindex window [{}, {}]",
                 indexName,
+                oldBackingIndexName,
                 reindexStartTime,
                 dualWriteStartTime);
-            reindexTimeseriesGap(indexName, nextIndexName, reindexStartTime, dualWriteStartTime);
+            reindexTimeseriesGap(
+                indexName,
+                oldBackingIndexName,
+                nextIndexName,
+                reindexStartTime,
+                dualWriteStartTime);
           } else if (isGlobalIndex(indexName)) {
             // Graph or system metadata index — emit MCLs for ALL entities in the gap window.
             // These indices are not entity-scoped, so we need to cover all entity types.
@@ -217,7 +234,7 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
         // If rollback dual-write is not enabled, mark all completed indices as
         // DUAL_WRITE_DISABLED to prevent a later enable of the flag from writing to stale or
         // deleted old indices.
-        if (!rollbackDualWriteEnabled) {
+        if (!buildIndicesConfig.isRollbackDualWriteEnabled()) {
           for (Map.Entry<String, Map<String, String>> entry : allIndexStates.entrySet()) {
             String indexName = entry.getKey();
             String status = entry.getValue().get(IncrementalReindexState.STATUS);
@@ -358,15 +375,20 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
   }
 
   /**
-   * Copies timeseries documents from the current index to the next index for the T0 gap window
+   * Copies timeseries documents from the old backing index to the next index for the T0 gap window
    * using a filtered ES _reindex. Timeseries data is not in SQL so MCL-based catch-up doesn't work.
    * Polls until the reindex completes and throws on failure.
+   *
+   * @param aliasName the index alias name (for looking up the index builder and config)
+   * @param oldBackingIndex the physical old backing index that received writes during Phase 1
+   * @param nextIndex the physical next index created by Phase 1
    */
   private void reindexTimeseriesGap(
-      String currentIndex, String nextIndex, long fromEpochMs, long toEpochMs) throws Throwable {
-    Pair<ESIndexBuilder, ReindexConfig> builderAndConfig = findIndexBuilderAndConfig(currentIndex);
+      String aliasName, String oldBackingIndex, String nextIndex, long fromEpochMs, long toEpochMs)
+      throws Throwable {
+    Pair<ESIndexBuilder, ReindexConfig> builderAndConfig = findIndexBuilderAndConfig(aliasName);
     if (builderAndConfig == null) {
-      log.warn("No index builder found for timeseries index {}, skipping catch-up", currentIndex);
+      log.warn("No index builder found for timeseries index {}, skipping catch-up", aliasName);
       return;
     }
 
@@ -378,22 +400,34 @@ public class IncrementalReindexCatchUpStep implements UpgradeStep {
         QueryBuilders.rangeQuery(TIMESERIES_TIMESTAMP_FIELD).gte(fromEpochMs).lt(toEpochMs);
 
     String taskId =
-        indexBuilder.submitFilteredReindex(currentIndex, nextIndex, timeRangeFilter, targetShards);
+        indexBuilder.submitFilteredReindex(
+            oldBackingIndex, nextIndex, timeRangeFilter, targetShards);
     log.info(
         "Submitted timeseries catch-up _reindex for {} -> {} (task {}, shards {})",
-        currentIndex,
+        oldBackingIndex,
         nextIndex,
         taskId,
         targetShards);
 
-    ESIndexBuilder.PollReindexResult pollResult =
-        indexBuilder.pollReindexCompletion(
-            currentIndex, nextIndex, targetShards, new HashMap<>(), taskId);
-    if (!pollResult.completed()) {
-      throw new RuntimeException(
-          "Timeseries catch-up _reindex did not complete for " + currentIndex + " -> " + nextIndex);
+    // Poll using listTasks until the reindex task is no longer running. Once the task drops off
+    // the active task list, it has completed. Doc count comparison is not used here because the
+    // next index is also receiving live writes via the alias.
+    long timeoutAt = indexBuilder.computeTimeoutAt();
+    long pollIntervalMs = buildIndicesConfig.getTaskPollIntervalSeconds() * 1000;
+
+    while (System.currentTimeMillis() < timeoutAt) {
+      Optional<TaskInfo> runningTask = indexBuilder.getTaskInfoByHeader(oldBackingIndex);
+      if (runningTask.isEmpty()) {
+        log.info("Timeseries catch-up _reindex completed for {} -> {}", oldBackingIndex, nextIndex);
+        return;
+      }
+      log.info(
+          "Timeseries catch-up _reindex still running for {} -> {}", oldBackingIndex, nextIndex);
+      Thread.sleep(pollIntervalMs);
     }
-    log.info("Timeseries catch-up _reindex completed for {} -> {}", currentIndex, nextIndex);
+
+    throw new RuntimeException(
+        "Timeseries catch-up _reindex timed out for " + oldBackingIndex + " -> " + nextIndex);
   }
 
   /**

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/IncrementalReindexFlowTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/IncrementalReindexFlowTest.java
@@ -20,6 +20,7 @@ import com.linkedin.datahub.upgrade.UpgradeStepResult;
 import com.linkedin.datahub.upgrade.system.elasticsearch.steps.IncrementalReindexCatchUpStep;
 import com.linkedin.metadata.aspect.SystemAspect;
 import com.linkedin.metadata.boot.BootstrapStep;
+import com.linkedin.metadata.config.search.BuildIndicesConfiguration;
 import com.linkedin.metadata.entity.AspectDao;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.EntityUtils;
@@ -147,6 +148,8 @@ public class IncrementalReindexFlowTest {
             NEXT_INDEX_NAME,
             null,
             1000L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.COMPLETED);
     phase1State = IncrementalReindexState.setReindexCompleteTime(phase1State, INDEX_NAME, 2000L);
@@ -155,7 +158,13 @@ public class IncrementalReindexFlowTest {
 
     IncrementalReindexCatchUpStep catchUpStep =
         new IncrementalReindexCatchUpStep(
-            opContext, entityService, aspectDao, List.of(), Set.of(), UPGRADE_VERSION, false);
+            opContext,
+            entityService,
+            aspectDao,
+            List.of(),
+            Set.of(),
+            UPGRADE_VERSION,
+            new BuildIndicesConfiguration());
 
     UpgradeStepResult catchUpResult = catchUpStep.executable().apply(upgradeContext);
     assertEquals(catchUpResult.result(), DataHubUpgradeState.SUCCEEDED);
@@ -180,6 +189,8 @@ public class IncrementalReindexFlowTest {
             NEXT_INDEX_NAME,
             null,
             1000L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.COMPLETED);
     phase1State = IncrementalReindexState.setDualWriteStartTime(phase1State, INDEX_NAME, 2000L);
@@ -190,6 +201,8 @@ public class IncrementalReindexFlowTest {
             "chartindex_v2_0_14_0-0_100",
             null,
             1000L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.COMPLETED);
     phase1State = IncrementalReindexState.setDualWriteStartTime(phase1State, index2, 2000L);
@@ -235,7 +248,13 @@ public class IncrementalReindexFlowTest {
 
     IncrementalReindexCatchUpStep catchUpStep =
         new IncrementalReindexCatchUpStep(
-            opContext, entityService, aspectDao, List.of(), Set.of(), UPGRADE_VERSION, false);
+            opContext,
+            entityService,
+            aspectDao,
+            List.of(),
+            Set.of(),
+            UPGRADE_VERSION,
+            new BuildIndicesConfiguration());
 
     UpgradeStepResult result = catchUpStep.executable().apply(upgradeContext);
     assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/IncrementalReindexStateTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/IncrementalReindexStateTest.java
@@ -47,6 +47,8 @@ public class IncrementalReindexStateTest {
             NEXT_INDEX,
             null,
             1679000000000L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.IN_PROGRESS);
 
@@ -66,6 +68,72 @@ public class IncrementalReindexStateTest {
   }
 
   @Test
+  public void testSetPhase1StatePersistsSourceDocCountAndTaskId() {
+    Map<String, String> state =
+        IncrementalReindexState.setPhase1State(
+            null,
+            INDEX_NAME,
+            NEXT_INDEX,
+            "datasetindex_v2_old",
+            1679000000000L,
+            42000L,
+            "node1:12345",
+            true,
+            IncrementalReindexState.Status.IN_PROGRESS);
+
+    assertEquals(
+        IncrementalReindexState.get(state, INDEX_NAME, IncrementalReindexState.SOURCE_DOC_COUNT),
+        Optional.of("42000"));
+    assertEquals(
+        IncrementalReindexState.get(state, INDEX_NAME, IncrementalReindexState.TASK_ID),
+        Optional.of("node1:12345"));
+    assertEquals(
+        IncrementalReindexState.get(
+            state, INDEX_NAME, IncrementalReindexState.OLD_BACKING_INDEX_NAME),
+        Optional.of("datasetindex_v2_old"));
+  }
+
+  @Test
+  public void testGetAllIndexStatesIncludesSourceDocCountAndTaskId() {
+    Map<String, String> state =
+        IncrementalReindexState.setPhase1State(
+            null,
+            INDEX_NAME,
+            NEXT_INDEX,
+            null,
+            100L,
+            5000L,
+            "node1:99",
+            true,
+            IncrementalReindexState.Status.COMPLETED);
+
+    Map<String, Map<String, String>> allStates = IncrementalReindexState.getAllIndexStates(state);
+    assertEquals(allStates.size(), 1);
+    Map<String, String> indexState = allStates.get(INDEX_NAME);
+    assertEquals(indexState.get(IncrementalReindexState.SOURCE_DOC_COUNT), "5000");
+    assertEquals(indexState.get(IncrementalReindexState.TASK_ID), "node1:99");
+  }
+
+  @Test
+  public void testSetPhase1StateOmitsNullTaskId() {
+    Map<String, String> state =
+        IncrementalReindexState.setPhase1State(
+            null,
+            INDEX_NAME,
+            NEXT_INDEX,
+            null,
+            100L,
+            0L,
+            null,
+            false,
+            IncrementalReindexState.Status.IN_PROGRESS);
+
+    assertEquals(
+        IncrementalReindexState.get(state, INDEX_NAME, IncrementalReindexState.TASK_ID),
+        Optional.empty());
+  }
+
+  @Test
   public void testSetPhase1StatePreservesExisting() {
     Map<String, String> existing = new HashMap<>();
     existing.put("someOtherKey", "someValue");
@@ -77,6 +145,8 @@ public class IncrementalReindexStateTest {
             NEXT_INDEX,
             null,
             100L,
+            0L,
+            null,
             false,
             IncrementalReindexState.Status.PENDING);
 
@@ -95,6 +165,8 @@ public class IncrementalReindexStateTest {
             NEXT_INDEX,
             null,
             100L,
+            0L,
+            null,
             false,
             IncrementalReindexState.Status.IN_PROGRESS);
 
@@ -118,6 +190,8 @@ public class IncrementalReindexStateTest {
             NEXT_INDEX,
             null,
             100L,
+            0L,
+            null,
             false,
             IncrementalReindexState.Status.COMPLETED);
 
@@ -142,6 +216,8 @@ public class IncrementalReindexStateTest {
             NEXT_INDEX,
             null,
             100L,
+            0L,
+            null,
             false,
             IncrementalReindexState.Status.COMPLETED);
 
@@ -170,6 +246,8 @@ public class IncrementalReindexStateTest {
             "dataset_next_1",
             null,
             100L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.COMPLETED);
     state =
@@ -179,6 +257,8 @@ public class IncrementalReindexStateTest {
             "chart_next_1",
             null,
             200L,
+            0L,
+            null,
             false,
             IncrementalReindexState.Status.IN_PROGRESS);
 

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesIncrementalStepTest.java
@@ -99,20 +99,22 @@ public class BuildIndicesIncrementalStepTest {
   @Test
   public void testFreshStartSuccessful() throws Throwable {
     IncrementalReindexResult incrementalResult =
-        new IncrementalReindexResult(NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, Map.of());
+        new IncrementalReindexResult(
+            NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, 0L, Map.of());
     when(indexBuilder.buildIndexIncremental(any(), eq(UPGRADE_VERSION)))
         .thenReturn(incrementalResult);
 
     PollReindexResult pollResult = new PollReindexResult(true, Map.of(), Pair.of(100L, 100L));
     when(indexBuilder.pollReindexCompletion(
-            eq(INDEX_NAME), eq(NEXT_INDEX_NAME), eq(2), anyMap(), eq("task1")))
+            eq(INDEX_NAME), eq(NEXT_INDEX_NAME), any(), anyInt(), anyMap(), eq("task1")))
         .thenReturn(pollResult);
 
     UpgradeStepResult result = step.executable().apply(upgradeContext);
 
     assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
     verify(indexBuilder).buildIndexIncremental(any(), eq(UPGRADE_VERSION));
-    verify(indexBuilder).pollReindexCompletion(any(), any(), anyInt(), anyMap(), anyString());
+    verify(indexBuilder)
+        .pollReindexCompletion(any(), any(), any(), anyInt(), anyMap(), anyString());
     verify(indexBuilder).undoReindexOptimalSettings(eq(NEXT_INDEX_NAME), any(), anyMap());
     verify(indexBuilder).validateAndSwapAlias(eq(INDEX_NAME), eq(NEXT_INDEX_NAME));
   }
@@ -120,7 +122,7 @@ public class BuildIndicesIncrementalStepTest {
   @Test
   public void testSkippedEmptyIndex() throws Throwable {
     IncrementalReindexResult emptyResult =
-        new IncrementalReindexResult(NEXT_INDEX_NAME, 1679000000000L, null, true, 2, Map.of());
+        new IncrementalReindexResult(NEXT_INDEX_NAME, 1679000000000L, null, true, 2, 0L, Map.of());
     when(indexBuilder.buildIndexIncremental(any(), eq(UPGRADE_VERSION))).thenReturn(emptyResult);
 
     UpgradeStepResult result = step.executable().apply(upgradeContext);
@@ -128,19 +130,20 @@ public class BuildIndicesIncrementalStepTest {
     assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
     // Should not poll or undo settings for empty index
     verify(indexBuilder, never())
-        .pollReindexCompletion(any(), any(), anyInt(), anyMap(), anyString());
+        .pollReindexCompletion(any(), any(), any(), anyInt(), anyMap(), anyString());
     verify(indexBuilder, never()).undoReindexOptimalSettings(any(), any(), anyMap());
   }
 
   @Test
   public void testPollTimeoutReturnsFailed() throws Throwable {
     IncrementalReindexResult incrementalResult =
-        new IncrementalReindexResult(NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, Map.of());
+        new IncrementalReindexResult(
+            NEXT_INDEX_NAME, 1679000000000L, "task1", false, 2, 0L, Map.of());
     when(indexBuilder.buildIndexIncremental(any(), eq(UPGRADE_VERSION)))
         .thenReturn(incrementalResult);
 
     PollReindexResult timedOut = new PollReindexResult(false, Map.of(), Pair.of(100L, 50L));
-    when(indexBuilder.pollReindexCompletion(any(), any(), anyInt(), anyMap(), anyString()))
+    when(indexBuilder.pollReindexCompletion(any(), any(), any(), anyInt(), anyMap(), anyString()))
         .thenReturn(timedOut);
 
     UpgradeStepResult result = step.executable().apply(upgradeContext);
@@ -159,6 +162,8 @@ public class BuildIndicesIncrementalStepTest {
             NEXT_INDEX_NAME,
             null,
             1679000000000L,
+            0L,
+            null,
             false,
             IncrementalReindexState.Status.IN_PROGRESS);
 
@@ -168,7 +173,7 @@ public class BuildIndicesIncrementalStepTest {
 
     PollReindexResult pollResult = new PollReindexResult(true, Map.of(), Pair.of(100L, 100L));
     when(indexBuilder.pollReindexCompletion(
-            eq(INDEX_NAME), eq(NEXT_INDEX_NAME), anyInt(), anyMap(), eq("")))
+            eq(INDEX_NAME), eq(NEXT_INDEX_NAME), any(), anyInt(), anyMap(), eq("")))
         .thenReturn(pollResult);
 
     UpgradeStepResult result = step.executable().apply(upgradeContext);
@@ -176,7 +181,8 @@ public class BuildIndicesIncrementalStepTest {
     assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
     // Should NOT call buildIndexIncremental — just resume polling
     verify(indexBuilder, never()).buildIndexIncremental(any(), anyString());
-    verify(indexBuilder).pollReindexCompletion(any(), any(), anyInt(), anyMap(), anyString());
+    verify(indexBuilder)
+        .pollReindexCompletion(any(), any(), any(), anyInt(), anyMap(), anyString());
     verify(indexBuilder).undoReindexOptimalSettings(eq(NEXT_INDEX_NAME), any(), anyMap());
     verify(indexBuilder).validateAndSwapAlias(eq(INDEX_NAME), eq(NEXT_INDEX_NAME));
   }
@@ -191,6 +197,8 @@ public class BuildIndicesIncrementalStepTest {
             NEXT_INDEX_NAME,
             null,
             1679000000000L,
+            0L,
+            null,
             false,
             IncrementalReindexState.Status.COMPLETED);
 
@@ -204,7 +212,7 @@ public class BuildIndicesIncrementalStepTest {
     // Should not build or poll — index was already done
     verify(indexBuilder, never()).buildIndexIncremental(any(), anyString());
     verify(indexBuilder, never())
-        .pollReindexCompletion(any(), any(), anyInt(), anyMap(), anyString());
+        .pollReindexCompletion(any(), any(), any(), anyInt(), anyMap(), anyString());
   }
 
   @Test

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/IncrementalReindexCatchUpStepTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/IncrementalReindexCatchUpStepTest.java
@@ -1,6 +1,9 @@
 package com.linkedin.datahub.upgrade.system.elasticsearch.steps;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -12,12 +15,16 @@ import com.linkedin.data.template.StringMap;
 import com.linkedin.datahub.upgrade.Upgrade;
 import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeStepResult;
+import com.linkedin.metadata.config.search.BuildIndicesConfiguration;
 import com.linkedin.metadata.entity.AspectDao;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.IngestResult;
 import com.linkedin.metadata.entity.ebean.EbeanAspectV2;
 import com.linkedin.metadata.entity.ebean.PartitionedStream;
 import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
+import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.IncrementalReindexState;
+import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.upgrade.DataHubUpgradeResult;
 import com.linkedin.upgrade.DataHubUpgradeState;
 import io.datahubproject.metadata.context.OperationContext;
@@ -48,17 +55,26 @@ public class IncrementalReindexCatchUpStepTest {
   private IncrementalReindexCatchUpStep step;
 
   @BeforeMethod
-  public void setup() {
+  public void setup() throws Exception {
     MockitoAnnotations.openMocks(this);
     opContext = TestOperationContexts.systemContextNoValidate();
 
     when(upgradeContext.opContext()).thenReturn(opContext);
     when(upgradeContext.upgrade()).thenReturn(upgrade);
     when(upgrade.getUpgradeResult(any(), any(), any())).thenReturn(Optional.empty());
+    when(entityService.getLatestEnvelopedAspect(any(), any(), any(), any())).thenReturn(null);
+    when(entityService.ingestProposal(any(), any(), any(), anyBoolean()))
+        .thenReturn(mock(IngestResult.class));
 
     step =
         new IncrementalReindexCatchUpStep(
-            opContext, entityService, aspectDao, List.of(), Set.of(), UPGRADE_VERSION, false);
+            opContext,
+            entityService,
+            aspectDao,
+            List.of(),
+            Set.of(),
+            UPGRADE_VERSION,
+            new BuildIndicesConfiguration());
   }
 
   @Test
@@ -82,6 +98,8 @@ public class IncrementalReindexCatchUpStepTest {
             "datasetindex_v2_0_14_0-0_100",
             null,
             1000L,
+            0L,
+            null,
             false, // requiresDataBackfill = false
             IncrementalReindexState.Status.COMPLETED);
     phase1State = IncrementalReindexState.setDualWriteStartTime(phase1State, INDEX_NAME, 2000L);
@@ -114,6 +132,8 @@ public class IncrementalReindexCatchUpStepTest {
             "datasetindex_v2_0_14_0-0_100",
             null,
             100L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.COMPLETED);
     // Set dual write start time equal to reindex start time (empty window)
@@ -181,6 +201,8 @@ public class IncrementalReindexCatchUpStepTest {
             "datasetindex_v2_0_14_0-0_100",
             null,
             1000L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.COMPLETED);
     phase1State = IncrementalReindexState.setDualWriteStartTime(phase1State, INDEX_NAME, 2000L);
@@ -217,6 +239,8 @@ public class IncrementalReindexCatchUpStepTest {
             "datasetindex_v2_0_14_0-0_100",
             null,
             1000L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.COMPLETED);
     phase1State = IncrementalReindexState.setDualWriteStartTime(phase1State, INDEX_NAME, 2000L);
@@ -227,6 +251,8 @@ public class IncrementalReindexCatchUpStepTest {
             "chartindex_v2_0_14_0-0_100",
             null,
             1000L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.COMPLETED);
     phase1State = IncrementalReindexState.setDualWriteStartTime(phase1State, index2, 2000L);
@@ -252,6 +278,84 @@ public class IncrementalReindexCatchUpStepTest {
         allArgs.stream().map(args -> args.urnLike).collect(java.util.stream.Collectors.toSet());
     assertTrue(urnLikes.contains("urn:li:dataset:%"));
     assertTrue(urnLikes.contains("urn:li:chart:%"));
+  }
+
+  @Test
+  public void testGlobalIndexCatchUpUsesUnscopedUrnLike() {
+    // Graph index is a "global" index — catch-up should emit MCLs for ALL entities (urnLike = "%")
+    IndexConvention indexConvention = opContext.getSearchContext().getIndexConvention();
+    String graphIndexName = indexConvention.getIndexName(ElasticSearchGraphService.INDEX_NAME);
+
+    Map<String, String> phase1State =
+        IncrementalReindexState.setPhase1State(
+            null,
+            graphIndexName,
+            graphIndexName + "_next",
+            graphIndexName + "_old",
+            1000L,
+            0L,
+            null,
+            true,
+            IncrementalReindexState.Status.COMPLETED);
+    phase1State = IncrementalReindexState.setDualWriteStartTime(phase1State, graphIndexName, 2000L);
+
+    setupPhase1Result(phase1State);
+
+    when(aspectDao.streamAspectBatches(any()))
+        .thenReturn(
+            PartitionedStream.<EbeanAspectV2>builder().delegateStream(Stream.empty()).build());
+
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+
+    ArgumentCaptor<RestoreIndicesArgs> argsCaptor =
+        ArgumentCaptor.forClass(RestoreIndicesArgs.class);
+    verify(aspectDao).streamAspectBatches(argsCaptor.capture());
+    RestoreIndicesArgs capturedArgs = argsCaptor.getValue();
+    assertEquals(capturedArgs.urnLike, "%");
+  }
+
+  @Test
+  public void testMarksDualWriteDisabledWhenRollbackNotEnabled() {
+    // When rollbackDualWriteEnabled=false, catch-up should mark completed indices as
+    // DUAL_WRITE_DISABLED
+    Map<String, String> phase1State =
+        IncrementalReindexState.setPhase1State(
+            null,
+            INDEX_NAME,
+            "datasetindex_v2_0_14_0-0_100",
+            null,
+            1000L,
+            0L,
+            null,
+            true,
+            IncrementalReindexState.Status.COMPLETED);
+    phase1State = IncrementalReindexState.setDualWriteStartTime(phase1State, INDEX_NAME, 2000L);
+
+    DataHubUpgradeResult phase1Result = mock(DataHubUpgradeResult.class);
+    when(phase1Result.getResult()).thenReturn(new StringMap(phase1State));
+    when(phase1Result.getState()).thenReturn(DataHubUpgradeState.SUCCEEDED);
+
+    when(upgrade.getUpgradeResult(any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Object urnArg = invocation.getArgument(1);
+              if (urnArg.toString().contains("BuildIndicesIncremental")) {
+                return Optional.of(phase1Result);
+              }
+              return Optional.empty();
+            });
+
+    when(aspectDao.streamAspectBatches(any()))
+        .thenReturn(
+            PartitionedStream.<EbeanAspectV2>builder().delegateStream(Stream.empty()).build());
+
+    // rollbackDualWriteEnabled defaults to false in BuildIndicesConfiguration
+    UpgradeStepResult result = step.executable().apply(upgradeContext);
+    assertEquals(result.result(), DataHubUpgradeState.SUCCEEDED);
+
+    // Should have called ingestProposal to persist DUAL_WRITE_DISABLED on the Phase 1 URN
+    verify(entityService, atLeastOnce()).ingestProposal(eq(opContext), any(), any(), eq(false));
   }
 
   private void setupPhase1Result(Map<String, String> phase1State) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -752,6 +752,7 @@ public class ESIndexBuilder {
       String taskId,
       boolean skippedEmpty,
       int targetShards,
+      long sourceDocCount,
       Map<String, Object> reindexInfo) {}
 
   /**
@@ -776,14 +777,14 @@ public class ESIndexBuilder {
 
     createIndex(nextIndexName, indexState);
 
-    long curDocCount = getSourceDocCount(indexState.name());
-    if (curDocCount == 0) {
+    long sourceDocCount = getSourceDocCount(indexState.name());
+    if (sourceDocCount == 0) {
       log.info(
           "Incremental reindex: skipping _reindex for {} -> {} (0 docs in source)",
           indexState.name(),
           nextIndexName);
       return new IncrementalReindexResult(
-          nextIndexName, startTime, null, true, targetShards, Map.of());
+          nextIndexName, startTime, null, true, targetShards, 0, Map.of());
     }
 
     Map<String, Object> reindexInfo =
@@ -801,10 +802,10 @@ public class ESIndexBuilder {
         taskId,
         indexState.name(),
         nextIndexName,
-        curDocCount);
+        sourceDocCount);
 
     return new IncrementalReindexResult(
-        nextIndexName, startTime, taskId, false, targetShards, reindexInfo);
+        nextIndexName, startTime, taskId, false, targetShards, sourceDocCount, reindexInfo);
   }
 
   /**
@@ -828,11 +829,17 @@ public class ESIndexBuilder {
       Pair<Long, Long> finalDocumentCounts) {}
 
   /**
-   * Polls an in-progress reindex until document counts match or timeout. Includes stall detection
-   * with automatic reindex re-submission and progress estimation.
+   * Polls an in-progress reindex until document counts converge or timeout. Includes stall
+   * detection with automatic reindex re-submission and progress estimation.
    *
-   * @param sourceIndex the source index name
+   * <p>The {@code expectedCountSupplier} controls how the expected document count is resolved each
+   * poll iteration. For the legacy blocked-writes path, pass {@code () -> getCount(sourceIndex)} to
+   * re-query the live source (stable since writes are blocked). For incremental reindex where
+   * writes continue to the source, pass a fixed snapshot: {@code () -> snapshotCount}.
+   *
+   * @param sourceIndex the source index name (for logging and stall-retry resubmission)
    * @param destIndex the destination index name
+   * @param expectedCountSupplier supplies the expected doc count; called each poll iteration
    * @param targetShards target shard count (needed if re-submitting reindex on stall)
    * @param reindexInfo mutable reindex info map from {@code submitReindex}; updated on stall-retry
    * @param taskId ES task ID for log correlation (may be empty if resuming a previous task)
@@ -841,6 +848,7 @@ public class ESIndexBuilder {
   public PollReindexResult pollReindexCompletion(
       String sourceIndex,
       String destIndex,
+      Callable<Long> expectedCountSupplier,
       int targetShards,
       Map<String, Object> reindexInfo,
       String taskId)
@@ -852,7 +860,7 @@ public class ESIndexBuilder {
     Map<String, Object> latestReindexInfo = new HashMap<>(reindexInfo);
     int reindexCount = 1;
     int count = 0;
-    Pair<Long, Long> documentCounts = getDocumentCounts(sourceIndex, destIndex);
+    Pair<Long, Long> documentCounts = getDocumentCounts(expectedCountSupplier, destIndex);
     long documentCountsLastUpdated = System.currentTimeMillis();
     long previousDocCount = documentCounts.getSecond();
     long estimatedMinutesRemaining = 0;
@@ -861,7 +869,7 @@ public class ESIndexBuilder {
       log.info(
           "Task: {} - Reindexing from {} to {} in progress...", taskId, sourceIndex, destIndex);
 
-      Pair<Long, Long> latestCounts = getDocumentCounts(sourceIndex, destIndex);
+      Pair<Long, Long> latestCounts = getDocumentCounts(expectedCountSupplier, destIndex);
 
       if (!latestCounts.equals(documentCounts)) {
         long currentTime = System.currentTimeMillis();
@@ -986,14 +994,14 @@ public class ESIndexBuilder {
   }
 
   /** Get doc count for a source index with retry. */
-  private long getSourceDocCount(String indexName) throws Throwable {
+  public long getSourceDocCount(String indexName) throws Throwable {
     return retryRegistry
         .retry("retryCurDocCount", "countRetry")
         .executeCheckedSupplier(() -> getCount(indexName));
   }
 
   /** Compute the timeout timestamp based on maxReindexHours config. */
-  private long computeTimeoutAt() {
+  public long computeTimeoutAt() {
     return indexConfig.getMaxReindexHours() > 0
         ? System.currentTimeMillis() + (1000L * 60 * 60 * indexConfig.getMaxReindexHours())
         : Long.MAX_VALUE;
@@ -1047,7 +1055,12 @@ public class ESIndexBuilder {
       if (!reindexTaskCompleted) {
         PollReindexResult pollResult =
             pollReindexCompletion(
-                indexState.name(), tempIndexName, targetShards, reinfo, parentTaskId);
+                indexState.name(),
+                tempIndexName,
+                () -> getCount(indexState.name()),
+                targetShards,
+                reinfo,
+                parentTaskId);
         reindexTaskCompleted = pollResult.completed();
         reinfo = pollResult.latestReindexInfo();
         Pair<Long, Long> documentCounts = pollResult.finalDocumentCounts();
@@ -1447,24 +1460,24 @@ public class ESIndexBuilder {
     return reindexInfo;
   }
 
-  private Pair<Long, Long> getDocumentCounts(String sourceIndex, String destinationIndex)
-      throws Throwable {
+  private Pair<Long, Long> getDocumentCounts(
+      Callable<Long> expectedCountSupplier, String destinationIndex) throws Throwable {
     // Check whether reindex succeeded by comparing document count
     // There can be some delay between the reindex finishing and count being fully up to date, so
     // try multiple times
-    long originalCount = 0;
+    long expectedCount = 0;
     long reindexedCount = 0;
     for (int i = 0; i <= indexConfig.getNumRetries(); i++) {
       // Check if reindex succeeded by comparing document counts
-      originalCount =
+      expectedCount =
           retryRegistry
               .retry("retrySourceIndexCount", "countRetry")
-              .executeCheckedSupplier(() -> getCount(sourceIndex));
+              .executeCheckedSupplier(expectedCountSupplier::call);
       reindexedCount =
           retryRegistry
               .retry("retryDestinationIndexCount", "countRetry")
               .executeCheckedSupplier(() -> getCount(destinationIndex));
-      if (originalCount == reindexedCount) {
+      if (expectedCount == reindexedCount) {
         break;
       }
       try {
@@ -1479,10 +1492,10 @@ public class ESIndexBuilder {
       }
     }
 
-    return Pair.of(originalCount, reindexedCount);
+    return Pair.of(expectedCount, reindexedCount);
   }
 
-  private Optional<TaskInfo> getTaskInfoByHeader(String indexName) throws Throwable {
+  public Optional<TaskInfo> getTaskInfoByHeader(String indexName) throws Throwable {
     Retry retryWithDefaultConfig = retryRegistry.retry("getTaskInfoByHeader");
 
     return retryWithDefaultConfig.executeCheckedSupplier(

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IncrementalReindexState.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IncrementalReindexState.java
@@ -48,6 +48,12 @@ public final class IncrementalReindexState {
   /** Whether this index requires a data backfill (new @Searchable fields, not just settings). */
   public static final String REQUIRES_DATA_BACKFILL = "requiresDataBackfill";
 
+  /** Source index document count snapshotted at _reindex submission time. */
+  public static final String SOURCE_DOC_COUNT = "sourceDocCount";
+
+  /** ES task ID for the _reindex task submitted during Phase 1. */
+  public static final String TASK_ID = "taskId";
+
   public enum Status {
     PENDING,
     IN_PROGRESS,
@@ -85,6 +91,8 @@ public final class IncrementalReindexState {
       @Nonnull String nextIndexName,
       @Nullable String oldBackingIndexName,
       long reindexStartTime,
+      long sourceDocCount,
+      @Nullable String taskId,
       boolean requiresDataBackfill,
       @Nonnull Status status) {
 
@@ -94,6 +102,10 @@ public final class IncrementalReindexState {
       result.put(key(indexName, OLD_BACKING_INDEX_NAME), oldBackingIndexName);
     }
     result.put(key(indexName, REINDEX_START_TIME), String.valueOf(reindexStartTime));
+    result.put(key(indexName, SOURCE_DOC_COUNT), String.valueOf(sourceDocCount));
+    if (taskId != null) {
+      result.put(key(indexName, TASK_ID), taskId);
+    }
     result.put(key(indexName, REQUIRES_DATA_BACKFILL), String.valueOf(requiresDataBackfill));
     result.put(key(indexName, STATUS), status.name());
     return result;
@@ -163,7 +175,9 @@ public final class IncrementalReindexState {
               REINDEX_COMPLETE_TIME,
               STATUS,
               DUAL_WRITE_START_TIME,
-              REQUIRES_DATA_BACKFILL
+              REQUIRES_DATA_BACKFILL,
+              SOURCE_DOC_COUNT,
+              TASK_ID
             }) {
           String val = resultMap.get(key(indexName, prop));
           if (val != null) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/IndexBuilderTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/indexbuilder/IndexBuilderTestBase.java
@@ -1322,6 +1322,7 @@ public abstract class IndexBuilderTestBase extends AbstractTestNGSpringContextTe
         changedShardBuilder.pollReindexCompletion(
             TEST_INDEX_NAME,
             incrementalResult.nextIndexName(),
+            () -> (long) incrementalResult.sourceDocCount(),
             incrementalResult.targetShards(),
             incrementalResult.reindexInfo(),
             incrementalResult.taskId());

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesUpgradeStrategyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/UpdateIndicesUpgradeStrategyTest.java
@@ -316,6 +316,8 @@ public class UpdateIndicesUpgradeStrategyTest {
             "datasetindex_v2_next_123",
             null,
             100L,
+            0L,
+            null,
             true,
             IncrementalReindexState.Status.DUAL_WRITE_DISABLED);
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -564,6 +564,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "elasticsearch.buildIndices.retentionUnit",
           "elasticsearch.buildIndices.retentionValue",
           "elasticsearch.buildIndices.slowOperationTimeoutSeconds",
+          "elasticsearch.buildIndices.taskPollIntervalSeconds",
           "elasticsearch.buildIndices.countRetryMaxAttempts",
           "elasticsearch.buildIndices.countRetryWaitSeconds",
           "elasticsearch.buildIndices.createIndexRetryEnabled",

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/BuildIndicesConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/search/BuildIndicesConfiguration.java
@@ -70,6 +70,12 @@ public class BuildIndicesConfiguration {
   private boolean incrementalReindexEnabled;
 
   /**
+   * Seconds between polls when checking if a timeseries catch-up reindex task is still running via
+   * the listTasks API. Default 5 seconds.
+   */
+  private long taskPollIntervalSeconds = 5;
+
+  /**
    * When true (and incrementalReindexEnabled is also true), the MAE consumer dual-writes to the old
    * backing index for rollback safety. When false, Phase 2 marks all completed indices as
    * DUAL_WRITE_DISABLED to prevent a later enable from writing to stale or deleted old indices.

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -512,6 +512,7 @@ elasticsearch:
     countRetryMaxAttempts: ${ELASTICSEARCH_BUILD_INDICES_COUNT_RETRY_MAX_ATTEMPTS:2} # getCount retries on timeout/OpenSearchException
     countRetryWaitSeconds: ${ELASTICSEARCH_BUILD_INDICES_COUNT_RETRY_WAIT_SECONDS:5} # wait between getCount retries
     createIndexRetryEnabled: ${ELASTICSEARCH_BUILD_INDICES_CREATE_INDEX_RETRY_ENABLED:true} # retry createIndex once on IOException if index does not exist
+    taskPollIntervalSeconds: ${ELASTICSEARCH_BUILD_INDICES_TASK_POLL_INTERVAL_SECONDS:5} # seconds between listTasks polls for timeseries catch-up reindex
     incrementalReindexEnabled: ${ELASTICSEARCH_BUILD_INDICES_INCREMENTAL_REINDEX_ENABLED:${ZDU_STAGE_20:false}} # non-blocking incremental reindex with dual-write
     rollbackDualWriteEnabled: ${ELASTICSEARCH_BUILD_INDICES_ROLLBACK_DUAL_WRITE_ENABLED:${ZDU_STAGE_20:false}} # dual-write to old backing index for rollback safety during incremental reindex
   search:

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/elastic/ElasticsearchControllerTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/operations/elastic/ElasticsearchControllerTest.java
@@ -825,6 +825,8 @@ public class ElasticsearchControllerTest extends AbstractTestNGSpringContextTest
             "datasetindex_v2_next_123",
             "datasetindex_v2_current_123",
             1L,
+            0L,
+            null,
             true,
             status);
     DataHubUpgradeResult dur = new DataHubUpgradeResult();


### PR DESCRIPTION
Removes document count equivalence check for both entity and timeseries indices for ZDU pathway. This is because writes can continue to go into indices during ZDU so it causes a tight race condition with any inserts or deletes, relaxing this condition for this pathway since we don't need to guarantee no writes while it occurs.
