### PR TITLE
fix(ingestion): stream JSON schema inference to prevent OOM on large files

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/schema_inference/json.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/schema_inference/json.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 from typing import IO, Dict, List, Type, Union
 
+import ijson
 import jsonlines as jsl
 import ujson
 
@@ -50,12 +51,26 @@ class JsonInferrer(SchemaInferenceBase):
             ]
         else:
             try:
-                datastore = ujson.load(file)
-            except ujson.JSONDecodeError as e:
-                logger.info(f"Got ValueError: {e}. Retry with jsonlines")
+                # Stream-parse to avoid loading the entire file into memory.
+                # ijson.items(file, 'item') lazily yields elements of a top-level JSON array.
+                file.seek(0)
+                datastore = list(
+                    itertools.islice(ijson.items(file, "item"), self.max_rows)
+                )
+                if not datastore:
+                    # Not a top-level array — likely a single JSON object.
+                    file.seek(0)
+                    datastore = [ujson.load(file)]
+            except (ijson.common.JSONError, UnicodeDecodeError) as e:
+                logger.info(f"Failed to parse as JSON: {e}. Retry with jsonlines")
                 file.seek(0)
                 reader = jsl.Reader(file)
-                datastore = [obj for obj in reader.iter(type=dict, skip_invalid=True)]
+                datastore = [
+                    obj
+                    for obj in itertools.islice(
+                        reader.iter(type=dict, skip_invalid=True), self.max_rows
+                    )
+                ]
 
         if not isinstance(datastore, list):
             datastore = [datastore]

--- a/metadata-ingestion/src/datahub/ingestion/source/schema_inference/json.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/schema_inference/json.py
@@ -61,7 +61,7 @@ class JsonInferrer(SchemaInferenceBase):
                     # Not a top-level array — likely a single JSON object.
                     file.seek(0)
                     datastore = [ujson.load(file)]
-            except (ijson.common.JSONError, UnicodeDecodeError) as e:
+            except (ujson.JSONDecodeError, ijson.common.JSONError, UnicodeDecodeError) as e:
                 logger.info(f"Failed to parse as JSON: {e}. Retry with jsonlines")
                 file.seek(0)
                 reader = jsl.Reader(file)

--- a/metadata-ingestion/src/datahub/ingestion/source/schema_inference/json.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/schema_inference/json.py
@@ -61,7 +61,11 @@ class JsonInferrer(SchemaInferenceBase):
                     # Not a top-level array — likely a single JSON object.
                     file.seek(0)
                     datastore = [ujson.load(file)]
-            except (ujson.JSONDecodeError, ijson.common.JSONError, UnicodeDecodeError) as e:
+            except (
+                ujson.JSONDecodeError,
+                ijson.common.JSONError,
+                UnicodeDecodeError,
+            ) as e:
                 logger.info(f"Failed to parse as JSON: {e}. Retry with jsonlines")
                 file.seek(0)
                 reader = jsl.Reader(file)

--- a/metadata-ingestion/tests/unit/data_lake/test_schema_inference.py
+++ b/metadata-ingestion/tests/unit/data_lake/test_schema_inference.py
@@ -98,6 +98,53 @@ def test_infer_schema_json():
         assert_field_types_match(fields, expected_field_types)
 
 
+def test_infer_schema_json_large_array_capped():
+    """Verify that JsonInferrer only reads max_rows records from a large JSON array."""
+    records = [
+        {"integer_field": i, "boolean_field": i % 2 == 0, "string_field": f"val_{i}"}
+        for i in range(1000)
+    ]
+    with tempfile.TemporaryFile(mode="w+b") as file:
+        file.write(ujson.dumps(records).encode("utf-8"))
+        file.seek(0)
+
+        fields = json.JsonInferrer(max_rows=10).infer_schema(file)
+
+        assert_field_paths_match(fields, expected_field_paths)
+        assert_field_types_match(fields, expected_field_types)
+
+
+def test_infer_schema_json_single_object():
+    """Verify that a single JSON object (not array) is handled correctly."""
+    with tempfile.TemporaryFile(mode="w+b") as file:
+        file.write(
+            ujson.dumps(
+                {"integer_field": 1, "boolean_field": True, "string_field": "a"}
+            ).encode("utf-8")
+        )
+        file.seek(0)
+
+        fields = json.JsonInferrer().infer_schema(file)
+
+        assert_field_paths_match(fields, expected_field_paths)
+        assert_field_types_match(fields, expected_field_types)
+
+
+def test_infer_schema_json_fallback_to_jsonlines():
+    """Verify that JSONL content with .json extension falls back correctly."""
+    with tempfile.TemporaryFile(mode="w+b") as file:
+        file.write(
+            bytes(test_table.to_json(orient="records", lines=True), encoding="utf-8")
+        )
+        file.seek(0)
+
+        # format="json" (not "jsonl") but content is actually JSONL
+        fields = json.JsonInferrer(max_rows=100, format="json").infer_schema(file)
+
+        assert_field_paths_match(fields, expected_field_paths)
+        assert_field_types_match(fields, expected_field_types)
+
+
 def test_infer_schema_parquet():
     with tempfile.TemporaryFile(mode="w+b") as file:
         test_table.to_parquet(file)


### PR DESCRIPTION
Replace ujson.load() with ijson streaming parser capped at max_rows.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
