### PR TITLE
fix(upgrade): wait for full deployment rollout during K8s scale-down

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesApiAccessor.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesApiAccessor.java
@@ -7,6 +7,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.ListOptionsBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
@@ -29,6 +30,9 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class KubernetesApiAccessor {
+
+  /** Default minimum time between INFO logs while polling rollout (when config omits interval). */
+  private static final long DEFAULT_ROLLOUT_PROGRESS_LOG_INTERVAL_MS = 60_000L;
 
   private final KubernetesClient client;
   @Nullable private final KubernetesScaleDownConfiguration configuration;
@@ -126,6 +130,13 @@ public class KubernetesApiAccessor {
           "Rollout max wait seconds required: set systemUpdate.kubernetesScaleDown.rolloutMaxWaitSeconds in application.yaml");
     }
     return configuration.getRolloutMaxWaitSeconds();
+  }
+
+  private long rolloutProgressLogIntervalMs() {
+    if (configuration == null || configuration.getRolloutProgressLogIntervalSeconds() <= 0) {
+      return DEFAULT_ROLLOUT_PROGRESS_LOG_INTERVAL_MS;
+    }
+    return TimeUnit.SECONDS.toMillis((long) configuration.getRolloutProgressLogIntervalSeconds());
   }
 
   /**
@@ -310,29 +321,127 @@ public class KubernetesApiAccessor {
   }
 
   public void waitForRollout(String deploymentName, String namespace) {
-    long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(rolloutMaxWaitSeconds());
+    int maxWaitSec = rolloutMaxWaitSeconds();
+    int pollSec = rolloutPollSeconds();
+    long progressLogIntervalMs = rolloutProgressLogIntervalMs();
+    long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(maxWaitSec);
+    long lastProgressLogMs = System.currentTimeMillis();
+
+    log.info(
+        "Waiting for Deployment {}/{} to reach rollout target: spec must be observed (generation), "
+            + "unavailableReplicas must be 0, and replica counts (replicas/updated/available/ready) "
+            + "must match desired. pollInterval={}s timeout={}s",
+        namespace,
+        deploymentName,
+        pollSec,
+        maxWaitSec);
+
     while (System.currentTimeMillis() < deadline) {
       Deployment d =
           client.apps().deployments().inNamespace(namespace).withName(deploymentName).get();
       if (d == null || d.getSpec() == null) {
+        log.info(
+            "Deployment {}/{} missing or has no spec; treating as done waiting.",
+            namespace,
+            deploymentName);
         return;
       }
-      Integer desired = d.getSpec().getReplicas();
-      Integer updated =
-          d.getStatus() != null && d.getStatus().getUpdatedReplicas() != null
-              ? d.getStatus().getUpdatedReplicas()
-              : 0;
-      if (desired != null && desired.equals(updated)) {
+      if (isDeploymentRolloutComplete(d)) {
+        log.info("Deployment {}/{} rollout complete.", namespace, deploymentName);
         return;
+      }
+      long now = System.currentTimeMillis();
+      if (now - lastProgressLogMs >= progressLogIntervalMs) {
+        log.info(
+            "Still waiting for Deployment {}/{}: {}",
+            namespace,
+            deploymentName,
+            formatRolloutProgressSnapshot(d));
+        lastProgressLogMs = now;
       }
       try {
-        Thread.sleep(TimeUnit.SECONDS.toMillis(rolloutPollSeconds()));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(pollSec));
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new RuntimeException("Interrupted while waiting for rollout", e);
       }
     }
+    log.warn(
+        "Timed out waiting for Deployment {}/{} rollout after {}s (last status not logged here)",
+        namespace,
+        deploymentName,
+        maxWaitSec);
     throw new RuntimeException("Timeout waiting for deployment " + deploymentName + " rollout");
+  }
+
+  /**
+   * One-line snapshot of Deployment status fields relevant to {@link #isDeploymentRolloutComplete}.
+   * Package-private for unit tests (same package).
+   */
+  static String formatRolloutProgressSnapshot(Deployment deployment) {
+    Integer desired = deployment.getSpec() != null ? deployment.getSpec().getReplicas() : null;
+    Long gen = deployment.getMetadata() != null ? deployment.getMetadata().getGeneration() : null;
+    DeploymentStatus st = deployment.getStatus();
+    if (st == null) {
+      return "desired=%s generation=%s status=null"
+          .formatted(desired != null ? desired : "null", gen != null ? gen : "null");
+    }
+    return ("desired=%s generation=%s observedGeneration=%s unavailable=%s "
+            + "replicas=%s updated=%s available=%s ready=%s")
+        .formatted(
+            desired != null ? desired : "null",
+            gen != null ? gen : "null",
+            st.getObservedGeneration() != null ? st.getObservedGeneration() : "null",
+            st.getUnavailableReplicas() != null ? st.getUnavailableReplicas() : "null",
+            st.getReplicas() != null ? st.getReplicas() : "null",
+            st.getUpdatedReplicas() != null ? st.getUpdatedReplicas() : "null",
+            st.getAvailableReplicas() != null ? st.getAvailableReplicas() : "null",
+            st.getReadyReplicas() != null ? st.getReadyReplicas() : "null");
+  }
+
+  /**
+   * Returns true when the Deployment controller has applied the latest spec and there are no stale
+   * pods for this workload.
+   *
+   * <p><strong>Environment variable updates (desired &gt; 0):</strong> requires {@code
+   * observedGeneration} to match the spec (so the new pod template is reconciled), {@code
+   * unavailableReplicas == 0}, and {@code replicas == updated == available == ready == desired}.
+   * That implies no extra pods from a rolling update (e.g. maxSurge) and no old revision pods still
+   * counted toward {@code replicas}.
+   *
+   * <p><strong>Scale to zero:</strong> requires the same generation check and all replica counters
+   * at zero so no workload pods remain in Running/terminating states tracked by this Deployment.
+   */
+  static boolean isDeploymentRolloutComplete(Deployment deployment) {
+    if (deployment == null || deployment.getSpec() == null) {
+      return false;
+    }
+    int desired = Optional.ofNullable(deployment.getSpec().getReplicas()).orElse(0);
+    DeploymentStatus status = deployment.getStatus();
+    if (status == null) {
+      return false;
+    }
+    Long generation =
+        deployment.getMetadata() != null ? deployment.getMetadata().getGeneration() : null;
+    Long observedGeneration = status.getObservedGeneration();
+    if (generation != null) {
+      if (observedGeneration == null || generation > observedGeneration) {
+        return false;
+      }
+    }
+    int unavailable = Optional.ofNullable(status.getUnavailableReplicas()).orElse(0);
+    if (unavailable > 0) {
+      return false;
+    }
+    int updated = Optional.ofNullable(status.getUpdatedReplicas()).orElse(0);
+    int current = Optional.ofNullable(status.getReplicas()).orElse(0);
+    int available = Optional.ofNullable(status.getAvailableReplicas()).orElse(0);
+    int ready = Optional.ofNullable(status.getReadyReplicas()).orElse(0);
+
+    if (desired == 0) {
+      return current == 0 && updated == 0 && available == 0 && ready == 0;
+    }
+    return desired == current && desired == updated && desired == available && desired == ready;
   }
 
   /**

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesApiAccessorTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/kubernetes/KubernetesApiAccessorTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.upgrade.kubernetes;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -10,6 +11,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,6 +19,7 @@ import com.linkedin.metadata.config.kubernetes.KubernetesScaleDownConfiguration;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentList;
@@ -27,6 +30,7 @@ import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
 import io.fabric8.kubernetes.client.dsl.ScalableResource;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -955,12 +959,18 @@ public class KubernetesApiAccessorTest {
             .withNewMetadata()
             .withName("gms")
             .withNamespace(NAMESPACE)
+            .withGeneration(3L)
             .endMetadata()
             .withNewSpec()
             .withReplicas(2)
             .endSpec()
             .withNewStatus()
+            .withObservedGeneration(3L)
+            .withReplicas(2)
             .withUpdatedReplicas(2)
+            .withAvailableReplicas(2)
+            .withReadyReplicas(2)
+            .withUnavailableReplicas(0)
             .endStatus()
             .build();
     KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
@@ -979,6 +989,593 @@ public class KubernetesApiAccessorTest {
     when(resource.get()).thenReturn(deployment);
     KubernetesApiAccessor accessor = new KubernetesApiAccessor(client, config);
     accessor.waitForRollout("gms", NAMESPACE);
+  }
+
+  @Test
+  public void testFormatRolloutProgressSnapshotWhenStatusNull() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("gms")
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .build();
+    deployment.setStatus(null);
+    String s = KubernetesApiAccessor.formatRolloutProgressSnapshot(deployment);
+    assertTrue(s.contains("desired=2"));
+    assertTrue(s.contains("generation=1"));
+    assertTrue(s.contains("status=null"));
+  }
+
+  @Test
+  public void testFormatRolloutProgressSnapshotWhenDesiredReplicasUnset() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("gms")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(1)
+            .endStatus()
+            .build();
+    deployment.getSpec().setReplicas(null);
+    String s = KubernetesApiAccessor.formatRolloutProgressSnapshot(deployment);
+    assertTrue(s.contains("desired=null"));
+    assertTrue(s.contains("observedGeneration=1"));
+  }
+
+  @Test
+  public void testFormatRolloutProgressSnapshotUsesNullPlaceholdersForUnsetStatusInts() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(2L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(1)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(2L)
+            .endStatus()
+            .build();
+    String s = KubernetesApiAccessor.formatRolloutProgressSnapshot(deployment);
+    assertTrue(s.contains("desired=1"));
+    assertTrue(s.contains("generation=2"));
+    assertTrue(s.contains("observedGeneration=2"));
+    assertTrue(s.contains("unavailable=null"));
+    assertTrue(s.contains("replicas=null"));
+    assertTrue(s.contains("updated=null"));
+    assertTrue(s.contains("available=null"));
+    assertTrue(s.contains("ready=null"));
+  }
+
+  @Test
+  public void testWaitForRolloutHitsProgressLogPathWhenIntervalElapses() {
+    Deployment stuck =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(2L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(2)
+            .withUpdatedReplicas(2)
+            .endStatus()
+            .build();
+    Deployment complete =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(2L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(2L)
+            .withReplicas(2)
+            .withUpdatedReplicas(2)
+            .withAvailableReplicas(2)
+            .withReadyReplicas(2)
+            .withUnavailableReplicas(0)
+            .endStatus()
+            .build();
+    KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
+    config.setRolloutPollSeconds(1);
+    config.setRolloutMaxWaitSeconds(30);
+    config.setRolloutProgressLogIntervalSeconds(1);
+    KubernetesClient client = mock(KubernetesClient.class);
+    io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL apps =
+        mock(io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL.class);
+    MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentsOp =
+        mock(MixedOperation.class);
+    RollableScalableResource<Deployment> resource = mock(RollableScalableResource.class);
+    when(client.apps()).thenReturn(apps);
+    when(apps.deployments()).thenReturn(deploymentsOp);
+    when(deploymentsOp.inNamespace(anyString())).thenReturn(deploymentsOp);
+    when(deploymentsOp.withName("gms")).thenReturn(resource);
+    when(resource.get()).thenReturn(stuck, stuck, complete);
+    KubernetesApiAccessor accessor = new KubernetesApiAccessor(client, config);
+    accessor.waitForRollout("gms", NAMESPACE);
+    verify(resource, atLeast(3)).get();
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenObservedGenerationBehind() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(5L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(4L)
+            .withReplicas(2)
+            .withUpdatedReplicas(2)
+            .withAvailableReplicas(2)
+            .withReadyReplicas(2)
+            .endStatus()
+            .build();
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenUpdatedButNotAvailable() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(2)
+            .withUpdatedReplicas(2)
+            .withAvailableReplicas(1)
+            .withReadyReplicas(1)
+            .endStatus()
+            .build();
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteTrueForZeroReplicasAfterReconcile() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(2L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(0)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(2L)
+            .withReplicas(0)
+            .withUpdatedReplicas(0)
+            .withAvailableReplicas(0)
+            .withReadyReplicas(0)
+            .withUnavailableReplicas(0)
+            .endStatus()
+            .build();
+    assertTrue(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteTrueViaReplicaCountsWhenNoConditions() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(2)
+            .withUpdatedReplicas(2)
+            .withAvailableReplicas(2)
+            .withReadyReplicas(2)
+            .withUnavailableReplicas(0)
+            .endStatus()
+            .build();
+    assertTrue(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenScaleToZeroStillHasPods() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(0)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(1)
+            .withUpdatedReplicas(0)
+            .withAvailableReplicas(0)
+            .withReadyReplicas(0)
+            .endStatus()
+            .build();
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenUnavailableReplicasPositive() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(2)
+            .withUpdatedReplicas(2)
+            .withAvailableReplicas(2)
+            .withReadyReplicas(2)
+            .withUnavailableReplicas(1)
+            .endStatus()
+            .build();
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenExtraReplicaDuringRollout() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(3)
+            .withUpdatedReplicas(2)
+            .withAvailableReplicas(2)
+            .withReadyReplicas(2)
+            .withUnavailableReplicas(0)
+            .endStatus()
+            .build();
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testWaitForRolloutTimesOutWhenObservedGenerationNeverAdvances() {
+    Deployment stuck =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(2L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(2)
+            .withUpdatedReplicas(2)
+            .endStatus()
+            .build();
+    KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
+    config.setRolloutPollSeconds(1);
+    config.setRolloutMaxWaitSeconds(2);
+    KubernetesClient client = mock(KubernetesClient.class);
+    io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL apps =
+        mock(io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL.class);
+    MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentsOp =
+        mock(MixedOperation.class);
+    RollableScalableResource<Deployment> resource = mock(RollableScalableResource.class);
+    when(client.apps()).thenReturn(apps);
+    when(apps.deployments()).thenReturn(deploymentsOp);
+    when(deploymentsOp.inNamespace(anyString())).thenReturn(deploymentsOp);
+    when(deploymentsOp.withName("gms")).thenReturn(resource);
+    when(resource.get()).thenReturn(stuck);
+    KubernetesApiAccessor accessor = new KubernetesApiAccessor(client, config);
+    assertThrows(RuntimeException.class, () -> accessor.waitForRollout("gms", NAMESPACE));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenDeploymentNull() {
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(null));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenSpecNull() {
+    Deployment deployment = new Deployment();
+    deployment.setMetadata(
+        new ObjectMetaBuilder().withName("gms").withNamespace(NAMESPACE).build());
+    deployment.setSpec(null);
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenStatusNull() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("gms")
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .build();
+    deployment.setStatus(null);
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenObservedGenerationNullButGenerationSet() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withReplicas(2)
+            .withUpdatedReplicas(2)
+            .withAvailableReplicas(2)
+            .withReadyReplicas(2)
+            .endStatus()
+            .build();
+    deployment.getStatus().setObservedGeneration(null);
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteTrueWhenMetadataGenerationUnset() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("gms")
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(1)
+            .endSpec()
+            .withNewStatus()
+            .withReplicas(1)
+            .withUpdatedReplicas(1)
+            .withAvailableReplicas(1)
+            .withReadyReplicas(1)
+            .withUnavailableReplicas(0)
+            .endStatus()
+            .build();
+    assertTrue(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testIsDeploymentRolloutCompleteFalseWhenScaleToZeroButReadyNonZero() {
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(0)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(0)
+            .withUpdatedReplicas(0)
+            .withAvailableReplicas(0)
+            .withReadyReplicas(1)
+            .endStatus()
+            .build();
+    assertFalse(KubernetesApiAccessor.isDeploymentRolloutComplete(deployment));
+  }
+
+  @Test
+  public void testWaitForRolloutReturnsWhenDeploymentGetReturnsNull() {
+    KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
+    config.setRolloutPollSeconds(1);
+    config.setRolloutMaxWaitSeconds(10);
+    KubernetesClient client = mock(KubernetesClient.class);
+    io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL apps =
+        mock(io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL.class);
+    MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentsOp =
+        mock(MixedOperation.class);
+    RollableScalableResource<Deployment> resource = mock(RollableScalableResource.class);
+    when(client.apps()).thenReturn(apps);
+    when(apps.deployments()).thenReturn(deploymentsOp);
+    when(deploymentsOp.inNamespace(anyString())).thenReturn(deploymentsOp);
+    when(deploymentsOp.withName("missing")).thenReturn(resource);
+    when(resource.get()).thenReturn(null);
+    KubernetesApiAccessor accessor = new KubernetesApiAccessor(client, config);
+    accessor.waitForRollout("missing", NAMESPACE);
+    verify(resource).get();
+  }
+
+  @Test
+  public void testWaitForRolloutReturnsWhenDeploymentSpecNull() {
+    KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
+    config.setRolloutPollSeconds(1);
+    config.setRolloutMaxWaitSeconds(10);
+    Deployment noSpec = new Deployment();
+    noSpec.setMetadata(new ObjectMetaBuilder().withName("gms").build());
+    noSpec.setSpec(null);
+    KubernetesClient client = mock(KubernetesClient.class);
+    io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL apps =
+        mock(io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL.class);
+    MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentsOp =
+        mock(MixedOperation.class);
+    RollableScalableResource<Deployment> resource = mock(RollableScalableResource.class);
+    when(client.apps()).thenReturn(apps);
+    when(apps.deployments()).thenReturn(deploymentsOp);
+    when(deploymentsOp.inNamespace(anyString())).thenReturn(deploymentsOp);
+    when(deploymentsOp.withName("gms")).thenReturn(resource);
+    when(resource.get()).thenReturn(noSpec);
+    KubernetesApiAccessor accessor = new KubernetesApiAccessor(client, config);
+    accessor.waitForRollout("gms", NAMESPACE);
+  }
+
+  @Test
+  public void testWaitForRolloutPollsUntilRolloutComplete() {
+    Deployment incomplete =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(2)
+            .withUpdatedReplicas(1)
+            .withAvailableReplicas(2)
+            .withReadyReplicas(2)
+            .withUnavailableReplicas(0)
+            .endStatus()
+            .build();
+    Deployment complete =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(1L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .withReplicas(2)
+            .withUpdatedReplicas(2)
+            .withAvailableReplicas(2)
+            .withReadyReplicas(2)
+            .withUnavailableReplicas(0)
+            .endStatus()
+            .build();
+    KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
+    config.setRolloutPollSeconds(1);
+    config.setRolloutMaxWaitSeconds(30);
+    KubernetesClient client = mock(KubernetesClient.class);
+    io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL apps =
+        mock(io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL.class);
+    MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentsOp =
+        mock(MixedOperation.class);
+    RollableScalableResource<Deployment> resource = mock(RollableScalableResource.class);
+    when(client.apps()).thenReturn(apps);
+    when(apps.deployments()).thenReturn(deploymentsOp);
+    when(deploymentsOp.inNamespace(anyString())).thenReturn(deploymentsOp);
+    when(deploymentsOp.withName("gms")).thenReturn(resource);
+    when(resource.get()).thenReturn(incomplete, complete);
+    KubernetesApiAccessor accessor = new KubernetesApiAccessor(client, config);
+    accessor.waitForRollout("gms", NAMESPACE);
+    verify(resource, atLeast(2)).get();
+  }
+
+  @Test
+  public void testWaitForRolloutThrowsWhenInterruptedDuringSleep() throws Exception {
+    Deployment stuck =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withGeneration(2L)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(2)
+            .endSpec()
+            .withNewStatus()
+            .withObservedGeneration(1L)
+            .endStatus()
+            .build();
+    KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
+    config.setRolloutPollSeconds(10);
+    config.setRolloutMaxWaitSeconds(120);
+    KubernetesClient client = mock(KubernetesClient.class);
+    io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL apps =
+        mock(io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL.class);
+    MixedOperation<Deployment, DeploymentList, RollableScalableResource<Deployment>> deploymentsOp =
+        mock(MixedOperation.class);
+    RollableScalableResource<Deployment> resource = mock(RollableScalableResource.class);
+    when(client.apps()).thenReturn(apps);
+    when(apps.deployments()).thenReturn(deploymentsOp);
+    when(deploymentsOp.inNamespace(anyString())).thenReturn(deploymentsOp);
+    when(deploymentsOp.withName("gms")).thenReturn(resource);
+    when(resource.get()).thenReturn(stuck);
+    KubernetesApiAccessor accessor = new KubernetesApiAccessor(client, config);
+    AtomicReference<Throwable> caught = new AtomicReference<>();
+    Thread worker =
+        new Thread(
+            () -> {
+              try {
+                accessor.waitForRollout("gms", NAMESPACE);
+              } catch (Throwable t) {
+                caught.set(t);
+              }
+            });
+    worker.start();
+    Thread.sleep(300);
+    worker.interrupt();
+    worker.join(15000);
+    assertNotNull(caught.get());
+    assertTrue(caught.get() instanceof RuntimeException);
+    assertTrue(caught.get().getMessage().contains("Interrupted"));
+  }
+
+  @Test
+  public void testDeleteScaledObjectSwallowsGenericDeleteException() {
+    KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
+    config.setKedaGroup("keda.sh");
+    config.setKedaVersion("v1alpha1");
+    config.setKedaScaledObjectsPlural("scaledobjects");
+    config.setRolloutPollSeconds(1);
+    config.setRolloutMaxWaitSeconds(60);
+    KubernetesClient client = mock(KubernetesClient.class);
+    io.fabric8.kubernetes.client.dsl.MixedOperation genericOp =
+        mock(io.fabric8.kubernetes.client.dsl.MixedOperation.class);
+    io.fabric8.kubernetes.client.dsl.NonNamespaceOperation nsOp =
+        mock(io.fabric8.kubernetes.client.dsl.NonNamespaceOperation.class);
+    Resource genericResource = mock(Resource.class);
+    when(client.genericKubernetesResources(any())).thenReturn(genericOp);
+    when(genericOp.inNamespace(anyString())).thenReturn(nsOp);
+    when(nsOp.withName("so")).thenReturn(genericResource);
+    when(genericResource.delete()).thenThrow(new RuntimeException("forbidden: user cannot delete"));
+    KubernetesApiAccessor accessor = new KubernetesApiAccessor(client, config);
+    accessor.deleteScaledObject("so", NAMESPACE);
+    verify(genericResource).delete();
+  }
+
+  @Test
+  public void testDeleteScaledObjectSwallowsNoMatchesForKindException() {
+    KubernetesScaleDownConfiguration config = new KubernetesScaleDownConfiguration();
+    config.setKedaGroup("keda.sh");
+    config.setKedaVersion("v1alpha1");
+    config.setKedaScaledObjectsPlural("scaledobjects");
+    config.setRolloutPollSeconds(1);
+    config.setRolloutMaxWaitSeconds(60);
+    KubernetesClient client = mock(KubernetesClient.class);
+    io.fabric8.kubernetes.client.dsl.MixedOperation genericOp =
+        mock(io.fabric8.kubernetes.client.dsl.MixedOperation.class);
+    io.fabric8.kubernetes.client.dsl.NonNamespaceOperation nsOp =
+        mock(io.fabric8.kubernetes.client.dsl.NonNamespaceOperation.class);
+    Resource genericResource = mock(Resource.class);
+    when(client.genericKubernetesResources(any())).thenReturn(genericOp);
+    when(genericOp.inNamespace(anyString())).thenReturn(nsOp);
+    when(nsOp.withName("so")).thenReturn(genericResource);
+    when(genericResource.delete())
+        .thenThrow(new RuntimeException("no matches for kind \"ScaledObject\" in version"));
+    KubernetesApiAccessor accessor = new KubernetesApiAccessor(client, config);
+    accessor.deleteScaledObject("so", NAMESPACE);
   }
 
   @Test

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kubernetes/KubernetesScaleDownConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/kubernetes/KubernetesScaleDownConfiguration.java
@@ -79,4 +79,11 @@ public class KubernetesScaleDownConfiguration {
    * out. Default 1800 (30 min); increase for many pods or slow rollout strategies.
    */
   private int rolloutMaxWaitSeconds;
+
+  /**
+   * Minimum seconds between INFO logs while polling rollout status (avoids log spam). Defaults to
+   * 60 when unset or non-positive. Use a small value in tests to exercise progress logging without
+   * long waits.
+   */
+  private int rolloutProgressLogIntervalSeconds;
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1015,6 +1015,8 @@ systemUpdate:
     rolloutPollSeconds: ${DATAHUB_UPGRADE_K8_ROLLOUT_POLL_SECONDS:5}
     # Max wait for each deployment rollout (scale down or rolling restart). Default 30m; increase for many pods or slow strategies.
     rolloutMaxWaitSeconds: ${DATAHUB_UPGRADE_K8_ROLLOUT_MAX_WAIT_SECONDS:1800}
+    # Minimum interval between rollout progress INFO logs while waiting. Default 60s; unset or 0 uses default.
+    rolloutProgressLogIntervalSeconds: ${DATAHUB_UPGRADE_K8_ROLLOUT_PROGRESS_LOG_INTERVAL_SECONDS:60}
 
 structuredProperties:
   enabled: ${ENABLE_STRUCTURED_PROPERTIES_HOOK:true} # applies structured properties mappings


### PR DESCRIPTION
System update scales workloads and patches Deployments (e.g. GMS env to gate consumers). The previous rollout check only compared `updatedReplicas` to desired, which could return too early (env not fully reconciled when scaled to zero, or pods not ready / old revision still draining).
#### Changes
- **`KubernetesApiAccessor.waitForRollout`** now delegates to **`isDeploymentRolloutComplete`**: require `metadata.generation` to be observed when present, `unavailableReplicas == 0`, and alignment of `replicas` / `updated` / `available` / `ready` with desired (all zeros when scaling to zero).
- **Logging**: INFO once at start (targets + poll interval + timeout), INFO on completion or missing deployment / no spec, at most **one INFO progress line per minute** with a compact status snapshot while waiting, **WARN** on timeout.
- **Tests**: expanded **`KubernetesApiAccessorTest`** for rollout completion, `waitForRollout` (timeout, polling, interrupt, early exits), and related edge cases.
