### PR TITLE
feat(models): add searchTier annotations to glossary and document definitions

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/glossary/GlossaryNodeInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/glossary/GlossaryNodeInfo.pdl
@@ -14,7 +14,10 @@ record GlossaryNodeInfo includes CustomProperties {
   /**
    * Definition of business node
    */
-  @Searchable = {}
+  @Searchable = {
+    "fieldType": "TEXT",
+    "searchTier": 2
+  }
   definition: string
 
   /**

--- a/metadata-models/src/main/pegasus/com/linkedin/glossary/GlossaryTermInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/glossary/GlossaryTermInfo.pdl
@@ -36,7 +36,10 @@ record GlossaryTermInfo includes CustomProperties {
   /**
    * Definition of business term.
    */
-  @Searchable = {}
+  @Searchable = {
+    "fieldType": "TEXT",
+    "searchTier": 2
+  }
   definition: string
 
   /**

--- a/metadata-models/src/main/pegasus/com/linkedin/knowledge/DocumentContents.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/knowledge/DocumentContents.pdl
@@ -9,7 +9,8 @@ record DocumentContents {
      * This needs to be added to semantic search! 
      */
     @Searchable = {
-        "fieldType": "TEXT"
+        "fieldType": "TEXT",
+        "searchTier": 2
     }
     text: string
 }


### PR DESCRIPTION
## Summary

The `definition` field on `GlossaryNodeInfo` and `GlossaryTermInfo`, and the `text` field on `DocumentContents`, are annotated with `@Searchable` but lack a `searchTier` assignment. In the V3 tiered search architecture, fields without a `searchTier` are not copied into the `_search.tier_N` consolidated fields and therefore don't participate in tiered relevance scoring.

This PR assigns `searchTier: 2` (description/definition tier) to these fields, consistent with similar fields across the model:

| Tier | Purpose | Examples |
|------|---------|----------|
| 1 | Names, titles | `DatasetProperties.name`, `ChartInfo.title`, `GlossaryTermInfo.name` |
| 2 | Descriptions, definitions | `DatasetProperties.description`, `ChartInfo.description` |
| 3 | Secondary text | `DatasetProperties.qualifiedName` |
| 4 | Low-priority metadata | Tags, custom properties |

## Changes

| File | Change |
|------|--------|
| `metadata-models/.../GlossaryNodeInfo.pdl` | Add `"fieldType": "TEXT", "searchTier": 2` to `definition` |
| `metadata-models/.../GlossaryTermInfo.pdl` | Add `"fieldType": "TEXT", "searchTier": 2` to `definition` |
| `metadata-models/.../DocumentContents.pdl` | Add `"searchTier": 2` to `text` (already had `fieldType: TEXT`) |

### Notes

- `GlossaryNodeInfo.definition` and `GlossaryTermInfo.definition` previously had `@Searchable = {}` (empty annotation). This explicitly sets `fieldType: TEXT` which was previously the implicit default. No behavioral change for V2 search.
- Requires V3 index rebuild to take effect (the `copy_to` directives are generated at index creation time based on `searchTier` values).

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://datahubproject.io/docs/contributing)
- [x] Links to related issue: N/A