### PR TITLE
fix(gms): forward ssl.keystore.type/truststore.type to schema registr…

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/schemaregistry/KafkaSchemaRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/schemaregistry/KafkaSchemaRegistryFactory.java
@@ -57,10 +57,18 @@ public class KafkaSchemaRegistryFactory {
     props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, kafkaSchemaRegistryUrl);
     props.put(withNamespace(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG), sslTruststoreLocation);
     props.put(withNamespace(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG), sslTruststorePassword);
-    props.put(withNamespace(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG), sslTruststoreType);
+    // Confluent SslFactory only null-checks the type field, not empty — an empty string
+    // is handed straight to KeyStore.getInstance("") and throws. Only forward type when
+    // the operator actually set it, so existing JKS deployments that rely on the default
+    // keep working.
+    if (!sslTruststoreType.isEmpty()) {
+      props.put(withNamespace(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG), sslTruststoreType);
+    }
     props.put(withNamespace(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG), sslKeystoreLocation);
     props.put(withNamespace(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), sslKeystorePassword);
-    props.put(withNamespace(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG), sslKeystoreType);
+    if (!sslKeystoreType.isEmpty()) {
+      props.put(withNamespace(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG), sslKeystoreType);
+    }
     props.put(withNamespace(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG), securityProtocol);
 
     if (sslKeystoreLocation.isEmpty()) {

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/schemaregistry/KafkaSchemaRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/schemaregistry/KafkaSchemaRegistryFactory.java
@@ -31,11 +31,17 @@ public class KafkaSchemaRegistryFactory {
   @Value("${kafka.schema.registry.ssl.truststore.password:}")
   private String sslTruststorePassword;
 
+  @Value("${kafka.schema.registry.ssl.truststore.type:}")
+  private String sslTruststoreType;
+
   @Value("${kafka.schema.registry.ssl.keystore.location:}")
   private String sslKeystoreLocation;
 
   @Value("${kafka.schema.registry.ssl.keystore.password:}")
   private String sslKeystorePassword;
+
+  @Value("${kafka.schema.registry.ssl.keystore.type:}")
+  private String sslKeystoreType;
 
   @Value("${kafka.schema.registry.security.protocol:}")
   private String securityProtocol;
@@ -51,8 +57,10 @@ public class KafkaSchemaRegistryFactory {
     props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, kafkaSchemaRegistryUrl);
     props.put(withNamespace(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG), sslTruststoreLocation);
     props.put(withNamespace(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG), sslTruststorePassword);
+    props.put(withNamespace(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG), sslTruststoreType);
     props.put(withNamespace(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG), sslKeystoreLocation);
     props.put(withNamespace(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), sslKeystorePassword);
+    props.put(withNamespace(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG), sslKeystoreType);
     props.put(withNamespace(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG), securityProtocol);
 
     if (sslKeystoreLocation.isEmpty()) {


### PR DESCRIPTION
Adds `ssl.keystore.type` / `ssl.truststore.type` to the `@Value` allowlist in `KafkaSchemaRegistryFactory`. Without this, the factory silently drops those two keys from the schema-registry props map, and the consumer/producer factories then `putAll()` the factory's output **after** Spring Boot's auto-binding, so any `SPRING_KAFKA_PROPERTIES_SCHEMA_REGISTRY_SSL_KEYSTORE_TYPE=PEM` the operator set
gets overwritten. This blocks PEM TLS for the Confluent schema-registry REST hop from GMS/MAE/MCE consumers, even though the client itself fully supports PEM via its own `SslFactory` (https://github.com/confluentinc/schema-registry/blob/v8.0.0/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/SslFactory.java).

The two new fields default to empty string and are **only forwarded to the props map when actually set** — existing JKS deployments that rely on the client's default `type` behavior are unaffected.

This is one of the code fixes from RFC [datahub-project/datahub#16975](https://github.com/datahub-project/datahub/pull/16975) (PEM-first TLS for DataHub outbound connections). Adjacent to [datahub-project/datahub#14354](datahub-project/datahub/#14354) (MAE/MCE consumers can't reach Schema Registry with TLS) and [acryldata/datahub-helm#601](https://github.com/acryldata/datahub-helm/issues/601) (chart has no unified SSL story)
