### PR TITLE
fix(ui): fix duplication of owners in applications

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/application/CreateApplicationResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/application/CreateApplicationResolver.java
@@ -56,8 +56,11 @@ public class CreateApplicationResolver implements DataFetcher<CompletableFuture<
                   applicationUrn,
                   UrnUtils.getUrn(input.getDomainUrn()));
             }
-            OwnerUtils.addCreatorAsOwner(
-                context, applicationUrn.toString(), OwnerEntityType.CORP_USER, entityService);
+            Boolean shouldAddCreatorAsOwner = input.getShouldAddCreatorAsOwner();
+            if (shouldAddCreatorAsOwner == null || shouldAddCreatorAsOwner) {
+              OwnerUtils.addCreatorAsOwner(
+                  context, applicationUrn.toString(), OwnerEntityType.CORP_USER, entityService);
+            }
             EntityResponse response =
                 applicationService.getApplicationEntityResponse(
                     context.getOperationContext(), applicationUrn);

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -13674,6 +13674,11 @@ input CreateApplicationInput {
   An optional id for the new application
   """
   id: String
+
+  """
+  Whether to add the creator as an owner of the application. Defaults to true if not specified.
+  """
+  shouldAddCreatorAsOwner: Boolean
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/CreateApplicationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/application/CreateApplicationResolverTest.java
@@ -2,8 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.application;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.testng.Assert.*;
 
 import com.linkedin.common.urn.Urn;
@@ -11,11 +10,13 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.CreateApplicationInput;
 import com.linkedin.datahub.graphql.generated.CreateApplicationPropertiesInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.service.ApplicationService;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -148,5 +149,99 @@ public class CreateApplicationResolverTest {
     // Verify the application was created
     Mockito.verify(mockApplicationService, Mockito.times(1))
         .createApplication(any(), eq(TEST_APP_ID), eq(TEST_APP_NAME), eq(TEST_APP_DESCRIPTION));
+  }
+
+  @Test
+  public void testGetWithShouldAddCreatorAsOwnerTrue() throws Exception {
+    CreateApplicationPropertiesInput propertiesInput =
+        CreateApplicationPropertiesInput.builder()
+            .setName(TEST_APP_NAME)
+            .setDescription(TEST_APP_DESCRIPTION)
+            .build();
+    CreateApplicationInput input =
+        CreateApplicationInput.builder()
+            .setId(TEST_APP_ID)
+            .setProperties(propertiesInput)
+            .setShouldAddCreatorAsOwner(true)
+            .build();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+
+    Mockito.when(
+            mockApplicationService.createApplication(
+                any(), eq(TEST_APP_ID), eq(TEST_APP_NAME), eq(TEST_APP_DESCRIPTION)))
+        .thenReturn(TEST_APP_URN);
+
+    Mockito.when(mockApplicationService.getApplicationEntityResponse(any(), eq(TEST_APP_URN)))
+        .thenReturn(null);
+
+    // Mock entityService.exists to prevent OwnerUtils from failing
+    Mockito.doReturn(true).when(mockEntityService).exists(any(), any(Urn.class), anyBoolean());
+
+    resolver.get(mockEnv).get();
+
+    Mockito.verify(mockApplicationService, Mockito.times(1))
+        .createApplication(any(), eq(TEST_APP_ID), eq(TEST_APP_NAME), eq(TEST_APP_DESCRIPTION));
+  }
+
+  @Test
+  public void testGetWithShouldAddCreatorAsOwnerNull() throws Exception {
+    CreateApplicationPropertiesInput propertiesInput =
+        CreateApplicationPropertiesInput.builder()
+            .setName(TEST_APP_NAME)
+            .setDescription(TEST_APP_DESCRIPTION)
+            .build();
+    CreateApplicationInput input =
+        CreateApplicationInput.builder()
+            .setId(TEST_APP_ID)
+            .setProperties(propertiesInput)
+            .setShouldAddCreatorAsOwner(null)
+            .build();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+
+    Mockito.when(
+            mockApplicationService.createApplication(
+                any(), eq(TEST_APP_ID), eq(TEST_APP_NAME), eq(TEST_APP_DESCRIPTION)))
+        .thenReturn(TEST_APP_URN);
+
+    Mockito.when(mockApplicationService.getApplicationEntityResponse(any(), eq(TEST_APP_URN)))
+        .thenReturn(null);
+
+    // Mock entityService.exists to prevent OwnerUtils from failing
+    Mockito.doReturn(true).when(mockEntityService).exists(any(), any(Urn.class), anyBoolean());
+
+    resolver.get(mockEnv).get();
+
+    Mockito.verify(mockApplicationService, Mockito.times(1))
+        .createApplication(any(), eq(TEST_APP_ID), eq(TEST_APP_NAME), eq(TEST_APP_DESCRIPTION));
+  }
+
+  @Test
+  public void testGetWithShouldAddCreatorAsOwnerFalse() throws Exception {
+    CreateApplicationPropertiesInput propertiesInput =
+        CreateApplicationPropertiesInput.builder()
+            .setName(TEST_APP_NAME)
+            .setDescription(TEST_APP_DESCRIPTION)
+            .build();
+    CreateApplicationInput input =
+        CreateApplicationInput.builder()
+            .setId(TEST_APP_ID)
+            .setProperties(propertiesInput)
+            .setShouldAddCreatorAsOwner(false)
+            .build();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+
+    Mockito.when(
+            mockApplicationService.createApplication(
+                any(), eq(TEST_APP_ID), eq(TEST_APP_NAME), eq(TEST_APP_DESCRIPTION)))
+        .thenReturn(TEST_APP_URN);
+
+    Mockito.when(mockApplicationService.getApplicationEntityResponse(any(), eq(TEST_APP_URN)))
+        .thenReturn(null);
+
+    try (MockedStatic<OwnerUtils> mockedOwnerUtils = Mockito.mockStatic(OwnerUtils.class)) {
+      resolver.get(mockEnv).get();
+
+      mockedOwnerUtils.verifyNoInteractions();
+    }
   }
 }

--- a/datahub-web-react/src/app/applications/CreateNewApplicationModal/CreateNewApplicationModal.tsx
+++ b/datahub-web-react/src/app/applications/CreateNewApplicationModal/CreateNewApplicationModal.tsx
@@ -1,10 +1,11 @@
 import { Modal } from '@components';
 import { message } from 'antd';
-import React, { useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { ModalButton } from '@components/components/Modal/Modal';
 
 import ApplicationDetailsSection from '@app/applications/CreateNewApplicationModal/ApplicationDetailsSection';
+import { useUserContext } from '@app/context/useUserContext';
 import OwnersSection from '@app/domainV2/OwnersSection';
 import { createOwnerInputs } from '@app/entityV2/shared/utils/selectorUtils';
 
@@ -13,10 +14,14 @@ import { useBatchAddOwnersMutation } from '@graphql/mutations.generated';
 
 type CreateNewApplicationModalProps = {
     open: boolean;
-    onClose: () => void;
+    onCreate: () => void;
+    onClose?: () => void;
 };
 
-const CreateNewApplicationModal: React.FC<CreateNewApplicationModalProps> = ({ onClose, open }) => {
+const CreateNewApplicationModal: React.FC<CreateNewApplicationModalProps> = ({ onCreate, onClose, open }) => {
+    const { user } = useUserContext();
+    const initialOwners = useMemo(() => (user ? [user] : []), [user]);
+    const initialOwnerUrns = useMemo(() => initialOwners.map((owner) => owner.urn), [initialOwners]);
     const [applicationName, setApplicationName] = useState('');
     const [applicationDescription, setApplicationDescription] = useState('');
     const [selectedOwnerUrns, setSelectedOwnerUrns] = useState<string[]>([]);
@@ -24,6 +29,12 @@ const CreateNewApplicationModal: React.FC<CreateNewApplicationModalProps> = ({ o
 
     const [createApplicationMutation] = useCreateApplicationMutation();
     const [batchAddOwnersMutation] = useBatchAddOwnersMutation();
+
+    const clearFields = useCallback(() => {
+        setApplicationName('');
+        setApplicationDescription('');
+        setSelectedOwnerUrns(initialOwnerUrns);
+    }, [initialOwnerUrns]);
 
     const onOk = async () => {
         if (!applicationName) {
@@ -41,6 +52,7 @@ const CreateNewApplicationModal: React.FC<CreateNewApplicationModalProps> = ({ o
                             name: applicationName.trim(),
                             description: applicationDescription,
                         },
+                        shouldAddCreatorAsOwner: false,
                     },
                 },
             });
@@ -66,10 +78,8 @@ const CreateNewApplicationModal: React.FC<CreateNewApplicationModalProps> = ({ o
             }
 
             message.success(`Application "${applicationName}" successfully created`);
-            setApplicationName('');
-            setApplicationDescription('');
-            setSelectedOwnerUrns([]);
-            onClose();
+            clearFields();
+            onCreate();
         } catch (e: any) {
             message.destroy();
             message.error(`Failed to create application. An unexpected error occurred: ${e.message}`);
@@ -78,12 +88,17 @@ const CreateNewApplicationModal: React.FC<CreateNewApplicationModalProps> = ({ o
         }
     };
 
+    const onModalClose = useCallback(() => {
+        clearFields();
+        onClose?.();
+    }, [onClose, clearFields]);
+
     const buttons: ModalButton[] = [
         {
             text: 'Cancel',
             color: 'violet',
             variant: 'text',
-            onClick: onClose,
+            onClick: onModalClose,
         },
         {
             text: 'Create',
@@ -97,14 +112,25 @@ const CreateNewApplicationModal: React.FC<CreateNewApplicationModalProps> = ({ o
     ];
 
     return (
-        <Modal title="Create New Application" onCancel={onClose} buttons={buttons} open={open} centered width={500}>
+        <Modal
+            title="Create New Application"
+            onCancel={onModalClose}
+            buttons={buttons}
+            open={open}
+            centered
+            width={500}
+        >
             <ApplicationDetailsSection
                 applicationName={applicationName}
                 setApplicationName={setApplicationName}
                 applicationDescription={applicationDescription}
                 setApplicationDescription={setApplicationDescription}
             />
-            <OwnersSection selectedOwnerUrns={selectedOwnerUrns} setSelectedOwnerUrns={setSelectedOwnerUrns} />
+            <OwnersSection
+                selectedOwnerUrns={selectedOwnerUrns}
+                setSelectedOwnerUrns={setSelectedOwnerUrns}
+                defaultOwners={user ? [user] : []}
+            />
         </Modal>
     );
 };

--- a/datahub-web-react/src/app/applications/ManageApplications.tsx
+++ b/datahub-web-react/src/app/applications/ManageApplications.tsx
@@ -165,10 +165,11 @@ const ManageApplications = () => {
 
             <CreateNewApplicationModal
                 open={showCreateApplicationModal}
-                onClose={() => {
+                onCreate={() => {
                     setShowCreateApplicationModal(false);
                     setTimeout(() => refetch(), 3000);
                 }}
+                onClose={() => setShowCreateApplicationModal(false)}
             />
         </PageContainer>
     );


### PR DESCRIPTION
Linear: https://linear.app/acryl-data/issue/CAT-1708/duplicate-owner-added-when-creating-application-due-to-default-owners

This PR fixes duplication of owners when you're adding yourself as owner too:
- added new optional field to the graphql endpoint to add creator as owner (it's true by default)
- added skipping of adding creator as owner (that optional field is false) when we create an application in UI
- the input is filled with the current user by default
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
