### PR TITLE
fix(ui): Make updating data products on asset profile page consistent with other metadata

### DIFF
--- a/datahub-web-react/src/app/entity/shared/EntityContext.ts
+++ b/datahub-web-react/src/app/entity/shared/EntityContext.ts
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 
 import { shouldEntityBeTreatedAsPrimary, useIsSeparateSiblingsMode } from '@app/entity/shared/siblingUtils';
-import { EntityContextType, UpdateEntityType } from '@app/entity/shared/types';
+import { EntityContextType, GenericEntityProperties, UpdateEntityType } from '@app/entity/shared/types';
 
 import { EntityType } from '@types';
 
@@ -33,6 +33,11 @@ export const useBaseEntity = <T>(): T => {
 export const useDataNotCombinedWithSiblings = <T>(): T => {
     const { dataNotCombinedWithSiblings } = useContext(EntityContext);
     return dataNotCombinedWithSiblings as T;
+};
+
+export const useRootEntityData = (): GenericEntityProperties | null | undefined => {
+    const { rootEntityData } = useContext(EntityContext);
+    return rootEntityData;
 };
 
 export const useEntityUpdate = <U>(): UpdateEntityType<U> | null | undefined => {

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -173,6 +173,7 @@ export type EntityContextType = {
     entityType: EntityType;
     dataNotCombinedWithSiblings: any;
     entityData: GenericEntityProperties | null;
+    rootEntityData?: GenericEntityProperties | null;
     loading: boolean;
     baseEntity: any;
     updateEntity?: UpdateEntityType<any> | null;

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/EntityProfile.tsx
@@ -246,8 +246,15 @@ export const EntityProfile = <T, U>({
         skip: !entityRegistry.getSupportedEntityCapabilities(entityType).has(EntityCapabilityType.FORMS),
     });
 
-    const { entityData, dataPossiblyCombinedWithSiblings, dataNotCombinedWithSiblings, loading, error, refetch } =
-        useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties, formsData });
+    const {
+        entityData,
+        rootEntityData,
+        dataPossiblyCombinedWithSiblings,
+        dataNotCombinedWithSiblings,
+        loading,
+        error,
+        refetch,
+    } = useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties, formsData });
 
     useUpdateGlossaryEntityDataOnChange(entityData, entityType);
     useUpdateDomainEntityDataOnChangeV2(entityData, entityType);
@@ -317,6 +324,7 @@ export const EntityProfile = <T, U>({
                     urn,
                     entityType,
                     entityData,
+                    rootEntityData,
                     loading,
                     baseEntity: dataPossiblyCombinedWithSiblings,
                     dataNotCombinedWithSiblings,
@@ -355,6 +363,7 @@ export const EntityProfile = <T, U>({
                 urn,
                 entityType,
                 entityData,
+                rootEntityData,
                 loading,
                 baseEntity: dataPossiblyCombinedWithSiblings,
                 dataNotCombinedWithSiblings,

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/DataProduct/DataProductSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/DataProduct/DataProductSection.tsx
@@ -1,15 +1,16 @@
 import { toast } from '@components';
-import { PencilSimple } from '@phosphor-icons/react/dist/csr/PencilSimple';
 import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { useEntityData } from '@app/entity/shared/EntityContext';
+import { useDataNotCombinedWithSiblings, useEntityData, useMutationUrn } from '@app/entity/shared/EntityContext';
 import { EMPTY_MESSAGES } from '@app/entityV2/shared/constants';
 import SetDataProductModal from '@app/entityV2/shared/containers/profile/sidebar/DataProduct/SetDataProductModal';
 import EmptySectionText from '@app/entityV2/shared/containers/profile/sidebar/EmptySectionText';
 import SectionActionButton from '@app/entityV2/shared/containers/profile/sidebar/SectionActionButton';
 import { SidebarSection } from '@app/entityV2/shared/containers/profile/sidebar/SidebarSection';
+import { useIsSeparateSiblingsMode } from '@app/entityV2/shared/useIsSeparateSiblingsMode';
+import handleGraphQLError from '@app/shared/handleGraphQLError';
 import { useIsMultipleDataProductsEnabled } from '@app/shared/hooks/useIsMultipleDataProductsEnabled';
 import { ConfirmationModal } from '@app/sharedV2/modals/ConfirmationModal';
 import { useReloadableContext } from '@app/sharedV2/reloadableContext/hooks/useReloadableContext';
@@ -38,15 +39,21 @@ export default function DataProductSection({ readOnly }: Props) {
     const [showRemoveModal, setShowRemoveModal] = useState(false);
     const [dataProductToRemove, setDataProductToRemove] = useState<string | null>(null);
     const { entityData, urn } = useEntityData();
+    const mutationUrn = useMutationUrn();
+    const isSeparateSiblingsMode = useIsSeparateSiblingsMode();
+    const dataNotCombined = useDataNotCombinedWithSiblings<any>();
     const isMultipleDataProductsEnabled = useIsMultipleDataProductsEnabled();
     const [batchSetDataProductMutation] = useBatchSetDataProductMutation();
     const [batchRemoveFromDataProductsMutation] = useBatchRemoveFromDataProductsMutation();
     const [dataProducts, setDataProducts] = useState<DataProduct[]>([]);
     const dataProductRelationships = entityData?.dataProduct?.relationships;
-    const siblingUrns: string[] =
-        entityData?.siblingsSearch?.searchResults?.map((sibling) => sibling.entity.urn || '') || [];
-
     const canEditDataProducts = !!entityData?.privileges?.canEditDataProducts;
+
+    // Use a stable string key instead of the array reference as the effect dependency.
+    const dataProductUrnKey = (dataProductRelationships || [])
+        .map((r) => r.entity?.urn)
+        .sort()
+        .join(',');
 
     useEffect(() => {
         if (dataProductRelationships && dataProductRelationships.length > 0) {
@@ -55,16 +62,48 @@ export default function DataProductSection({ readOnly }: Props) {
         } else {
             setDataProducts([]);
         }
-    }, [dataProductRelationships]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [dataProductUrnKey]);
+
+    // Returns the URNs (root and/or siblings) that a given data product is associated with,
+    // so that remove mutations target only the entities that actually have the relationship.
+    function getAssociatedUrns(dataProductUrn: string): string[] {
+        if (isSeparateSiblingsMode) {
+            return [urn];
+        }
+
+        const assocUrns: string[] = [];
+
+        // Check the root entity using the non-combined query data so we don't pick up
+        // relationships that were contributed only by a sibling.
+        const entityKey = dataNotCombined ? Object.keys(dataNotCombined)[0] : null;
+        const rootRelationships: any[] =
+            (entityKey && (dataNotCombined as any)[entityKey]?.dataProduct?.relationships) || [];
+        if (rootRelationships.some((r: any) => r.entity?.urn === dataProductUrn)) {
+            assocUrns.push(urn);
+        }
+
+        // Check each sibling's individual (non-merged) data product relationships.
+        entityData?.siblingsSearch?.searchResults?.forEach((result) => {
+            const siblingRelationships: any[] = (result.entity as any)?.dataProduct?.relationships || [];
+            if (siblingRelationships.some((r: any) => r.entity?.urn === dataProductUrn)) {
+                assocUrns.push(result.entity.urn);
+            }
+        });
+
+        return assocUrns.length > 0 ? assocUrns : [mutationUrn];
+    }
 
     function removeDataProduct() {
         if (!dataProductToRemove) return;
+
+        const associatedUrns = getAssociatedUrns(dataProductToRemove);
 
         if (isMultipleDataProductsEnabled) {
             batchRemoveFromDataProductsMutation({
                 variables: {
                     input: {
-                        resourceUrns: [urn, ...siblingUrns],
+                        resourceUrns: associatedUrns,
                         dataProductUrns: [dataProductToRemove],
                     },
                 },
@@ -81,21 +120,18 @@ export default function DataProductSection({ readOnly }: Props) {
                         ],
                         3000,
                     );
-                    // Mark these URNs to bypass cache on next fetch
-                    [urn, ...siblingUrns].forEach((entityUrn) => {
-                        bypassCacheForUrn(entityUrn);
-                    });
+                    associatedUrns.forEach((entityUrn) => bypassCacheForUrn(entityUrn));
                 })
-                .catch((e: unknown) => {
-                    toast.destroy();
-                    if (e instanceof Error) {
-                        toast.error('Failed to remove from data product. An unknown error occurred.', {
-                            duration: 3,
-                        });
-                    }
-                });
+                .catch((error) =>
+                    handleGraphQLError({
+                        error,
+                        defaultMessage: 'Failed to remove from data product. An unexpected error occurred',
+                        permissionMessage:
+                            'Unauthorized to remove from data product. Please contact your DataHub administrator.',
+                    }),
+                );
         } else {
-            batchSetDataProductMutation({ variables: { input: { resourceUrns: [urn, ...siblingUrns] } } })
+            batchSetDataProductMutation({ variables: { input: { resourceUrns: associatedUrns } } })
                 .then(() => {
                     toast.success('Removed Data Product.', { duration: 2 });
                     setDataProducts([]);
@@ -108,19 +144,16 @@ export default function DataProductSection({ readOnly }: Props) {
                         ],
                         3000,
                     );
-                    // Mark these URNs to bypass cache on next fetch
-                    [urn, ...siblingUrns].forEach((entityUrn) => {
-                        bypassCacheForUrn(entityUrn);
-                    });
+                    associatedUrns.forEach((entityUrn) => bypassCacheForUrn(entityUrn));
                 })
-                .catch((e: unknown) => {
-                    toast.destroy();
-                    if (e instanceof Error) {
-                        toast.error('Failed to remove data product. An unknown error occurred.', {
-                            duration: 3,
-                        });
-                    }
-                });
+                .catch((error) =>
+                    handleGraphQLError({
+                        error,
+                        defaultMessage: 'Failed to remove from data product. An unexpected error occurred',
+                        permissionMessage:
+                            'Unauthorized to remove from data product. Please contact your DataHub administrator.',
+                    }),
+                );
         }
     }
 
@@ -152,7 +185,7 @@ export default function DataProductSection({ readOnly }: Props) {
                 }
                 extra={
                     <SectionActionButton
-                        icon={dataProducts.length > 0 ? PencilSimple : Plus}
+                        icon={Plus}
                         onClick={(event) => {
                             setIsModalVisible(true);
                             event.stopPropagation();
@@ -163,10 +196,19 @@ export default function DataProductSection({ readOnly }: Props) {
             />
             {isModalVisible && (
                 <SetDataProductModal
-                    urns={[urn, ...siblingUrns]}
-                    currentDataProducts={dataProducts}
+                    urns={[mutationUrn]}
+                    currentDataProducts={[]}
                     onModalClose={() => setIsModalVisible(false)}
-                    setDataProducts={setDataProducts}
+                    setDataProducts={(newProducts) => {
+                        if (isMultipleDataProductsEnabled) {
+                            setDataProducts((prev) => [
+                                ...prev,
+                                ...newProducts.filter((np) => !prev.some((p) => p.urn === np.urn)),
+                            ]);
+                        } else {
+                            setDataProducts(newProducts);
+                        }
+                    }}
                 />
             )}
             <ConfirmationModal

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/DataProduct/DataProductSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/DataProduct/DataProductSection.tsx
@@ -3,7 +3,7 @@ import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { useDataNotCombinedWithSiblings, useEntityData, useMutationUrn } from '@app/entity/shared/EntityContext';
+import { useEntityData, useMutationUrn, useRootEntityData } from '@app/entity/shared/EntityContext';
 import { EMPTY_MESSAGES } from '@app/entityV2/shared/constants';
 import SetDataProductModal from '@app/entityV2/shared/containers/profile/sidebar/DataProduct/SetDataProductModal';
 import EmptySectionText from '@app/entityV2/shared/containers/profile/sidebar/EmptySectionText';
@@ -41,7 +41,7 @@ export default function DataProductSection({ readOnly }: Props) {
     const { entityData, urn } = useEntityData();
     const mutationUrn = useMutationUrn();
     const isSeparateSiblingsMode = useIsSeparateSiblingsMode();
-    const dataNotCombined = useDataNotCombinedWithSiblings<any>();
+    const rootEntityData = useRootEntityData();
     const isMultipleDataProductsEnabled = useIsMultipleDataProductsEnabled();
     const [batchSetDataProductMutation] = useBatchSetDataProductMutation();
     const [batchRemoveFromDataProductsMutation] = useBatchRemoveFromDataProductsMutation();
@@ -74,12 +74,10 @@ export default function DataProductSection({ readOnly }: Props) {
 
         const assocUrns: string[] = [];
 
-        // Check the root entity using the non-combined query data so we don't pick up
+        // Check the root entity using the non-combined data so we don't pick up
         // relationships that were contributed only by a sibling.
-        const entityKey = dataNotCombined ? Object.keys(dataNotCombined)[0] : null;
-        const rootRelationships: any[] =
-            (entityKey && (dataNotCombined as any)[entityKey]?.dataProduct?.relationships) || [];
-        if (rootRelationships.some((r: any) => r.entity?.urn === dataProductUrn)) {
+        const rootRelationships = rootEntityData?.dataProduct?.relationships || [];
+        if (rootRelationships.some((r) => r.entity?.urn === dataProductUrn)) {
             assocUrns.push(urn);
         }
 

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/useGetDataForProfile.ts
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/useGetDataForProfile.ts
@@ -91,5 +91,25 @@ export default function useGetDataForProfile<T>({
             })) ||
         null;
 
-    return { entityData, dataPossiblyCombinedWithSiblings, dataNotCombinedWithSiblings, loading, error, refetch };
+    const rootEntityData =
+        (dataNotCombinedWithSiblings &&
+            Object.keys(dataNotCombinedWithSiblings).length > 0 &&
+            getDataForEntityType({
+                data: dataNotCombinedWithSiblings[Object.keys(dataNotCombinedWithSiblings)[0]],
+                entityType,
+                getOverrideProperties,
+                isHideSiblingMode,
+                flags,
+            })) ||
+        null;
+
+    return {
+        entityData,
+        rootEntityData,
+        dataPossiblyCombinedWithSiblings,
+        dataNotCombinedWithSiblings,
+        loading,
+        error,
+        refetch,
+    };
 }

--- a/datahub-web-react/src/app/entityV2/shared/embed/EmbeddedProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/embed/EmbeddedProfile.tsx
@@ -49,8 +49,14 @@ interface Props<T> {
 
 export default function EmbeddedProfile<T>({ urn, entityType, getOverrideProperties, useEntityQuery }: Props<T>) {
     const entityRegistry = useEntityRegistryV2();
-    const { entityData, dataPossiblyCombinedWithSiblings, dataNotCombinedWithSiblings, loading, refetch } =
-        useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties });
+    const {
+        entityData,
+        rootEntityData,
+        dataPossiblyCombinedWithSiblings,
+        dataNotCombinedWithSiblings,
+        loading,
+        refetch,
+    } = useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties });
 
     // Only compute sidebar tabs when entityData.type is available to avoid unnecessary work during loading.
     const sidebarTabs = entityData?.type ? entityRegistry.getSidebarTabs(entityData.type) : [];
@@ -70,6 +76,7 @@ export default function EmbeddedProfile<T>({ urn, entityType, getOverridePropert
                 urn,
                 entityType,
                 entityData,
+                rootEntityData,
                 loading,
                 baseEntity: dataPossiblyCombinedWithSiblings,
                 dataNotCombinedWithSiblings,

--- a/datahub-web-react/src/app/shared/handleGraphQLError.ts
+++ b/datahub-web-react/src/app/shared/handleGraphQLError.ts
@@ -1,5 +1,5 @@
 import { ErrorResponse } from '@apollo/client/link/error';
-import { message } from 'antd';
+import { toast } from '@components';
 
 import { ErrorCodes } from '@app/shared/constants';
 
@@ -19,23 +19,23 @@ export default function handleGraphQLError({
     serverErrorMessage,
 }: Props) {
     // destroy the default error message from errorLink in App.tsx
-    message.destroy();
+    toast.destroy();
     const { graphQLErrors } = error;
     if (graphQLErrors && graphQLErrors.length) {
         const { extensions } = graphQLErrors[0];
         const errorCode = extensions && (extensions.code as number);
         if (errorCode === ErrorCodes.Forbidden) {
-            message.error(permissionMessage);
+            toast.error(permissionMessage);
             return;
         }
         if (errorCode === ErrorCodes.BadRequest && badRequestMessage) {
-            message.error(badRequestMessage);
+            toast.error(badRequestMessage);
             return;
         }
         if (errorCode === ErrorCodes.ServerError && serverErrorMessage) {
-            message.error(serverErrorMessage);
+            toast.error(serverErrorMessage);
             return;
         }
     }
-    message.error(defaultMessage);
+    toast.error(defaultMessage);
 }


### PR DESCRIPTION
We were experiencing some issues and confusion where a user had permission to edit the data product of one sibling but not the other, but no matter what "page" they were on, when they were on a combined siblings page, they got an error.

This is because on siblings pages wee were always trying to add a sibling urns when adding to a data product. Now, I make adding data products consistent with other ways we add tags, terms, owners, domains etc. - when you are on a combined siblings page we get the urn of the "primary" sibling (using `useMutationUrn`) so the user needs permission on that entity. And then if we are on an individual sibling page we use that urn as expected (in the past we were still adding it to all siblings mistakenly).

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
