### PR TITLE
fix(ingestion): fix parse_obj_allow_extras failing on models with deep inheritance

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -1,7 +1,6 @@
 import contextvars
 import dataclasses
 import re
-import unittest.mock
 from abc import ABC, abstractmethod
 from enum import auto
 from functools import cached_property as functools_cached_property
@@ -277,22 +276,23 @@ class ConfigModel(BaseModel):
 
     @classmethod
     def parse_obj_allow_extras(cls, obj: Any) -> Self:
-        """Parse an object while allowing extra fields.
+        """Parse an object, silently ignoring any fields not defined on the model.
 
-        This method temporarily modifies the model's configuration to allow extra fields.
-
-        TODO: Do we really need to support this behaviour? Consider removing this method in future.
+        This is useful when parsing a config dict that may contain fields for a
+        broader config class (e.g. a full ingestion recipe) into a narrower one.
         """
-        try:
-            with unittest.mock.patch.dict(
-                cls.model_config,  # type: ignore
-                {"extra": "allow"},
-                clear=False,
-            ):
-                cls.model_rebuild(force=True)  # type: ignore
-                return cls.model_validate(obj)
-        finally:
-            cls.model_rebuild(force=True)  # type: ignore
+        if isinstance(obj, dict):
+            known_keys: set = set()
+            for field_name, field_info in cls.model_fields.items():
+                known_keys.add(field_name)
+                if field_info.alias and isinstance(field_info.alias, str):
+                    known_keys.add(field_info.alias)
+                if field_info.validation_alias and isinstance(
+                    field_info.validation_alias, str
+                ):
+                    known_keys.add(field_info.validation_alias)
+            obj = {k: v for k, v in obj.items() if k in known_keys}
+        return cls.model_validate(obj)
 
 
 class PermissiveConfigModel(ConfigModel):

--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -281,18 +281,12 @@ class ConfigModel(BaseModel):
         This is useful when parsing a config dict that may contain fields for a
         broader config class (e.g. a full ingestion recipe) into a narrower one.
         """
-        if isinstance(obj, dict):
-            known_keys: set = set()
-            for field_name, field_info in cls.model_fields.items():
-                known_keys.add(field_name)
-                if field_info.alias and isinstance(field_info.alias, str):
-                    known_keys.add(field_info.alias)
-                if field_info.validation_alias and isinstance(
-                    field_info.validation_alias, str
-                ):
-                    known_keys.add(field_info.validation_alias)
-            obj = {k: v for k, v in obj.items() if k in known_keys}
-        return cls.model_validate(obj)
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+        relaxed_cls = type(
+            cls.__name__, (cls,), {"model_config": ConfigDict(extra="ignore")}
+        )
+        return relaxed_cls.model_validate(obj)  # type: ignore[return-value]
 
 
 class PermissiveConfigModel(ConfigModel):

--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -16,7 +16,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
     runtime_checkable,
 )
 
@@ -284,11 +283,10 @@ class ConfigModel(BaseModel):
         """
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
-        relaxed_cls = cast(
-            Type[Self],
-            type(cls.__name__, (cls,), {"model_config": ConfigDict(extra="ignore")}),
+        relaxed_cls = type(
+            cls.__name__, (cls,), {"model_config": ConfigDict(extra="ignore")}
         )
-        return relaxed_cls.model_validate(obj)
+        return relaxed_cls.model_validate(obj)  # type: ignore[attr-defined,return-value]
 
 
 class PermissiveConfigModel(ConfigModel):

--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -16,6 +16,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
     runtime_checkable,
 )
 
@@ -283,10 +284,11 @@ class ConfigModel(BaseModel):
         """
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
-        relaxed_cls = type(
-            cls.__name__, (cls,), {"model_config": ConfigDict(extra="ignore")}
+        relaxed_cls = cast(
+            Type[Self],
+            type(cls.__name__, (cls,), {"model_config": ConfigDict(extra="ignore")}),
         )
-        return relaxed_cls.model_validate(obj)  # type: ignore[return-value]
+        return relaxed_cls.model_validate(obj)
 
 
 class PermissiveConfigModel(ConfigModel):

--- a/metadata-ingestion/tests/unit/config/test_config_model.py
+++ b/metadata-ingestion/tests/unit/config/test_config_model.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pydantic
 import pytest
+from pydantic import Field
 
 from datahub.configuration.common import (
     AllowDenyPattern,
@@ -30,6 +31,133 @@ def test_extras_allowed():
     MyConfig.parse_obj_allow_extras({"required": "foo"})
     MyConfig.parse_obj_allow_extras({"required": "foo", "optional": "baz"})
     MyConfig.parse_obj_allow_extras({"required": "foo", "extra": "extra"})
+
+
+def test_parse_obj_allow_extras_strips_unknown_fields():
+    """Extras should be silently dropped, not stored on the model."""
+
+    class MyConfig(ConfigModel):
+        required: str
+
+    config = MyConfig.parse_obj_allow_extras(
+        {"required": "foo", "unknown1": "a", "unknown2": 42}
+    )
+    assert config.required == "foo"
+    assert not hasattr(config, "unknown1")
+    assert not hasattr(config, "unknown2")
+
+
+def test_parse_obj_allow_extras_with_non_dict():
+    """Non-dict input should be passed through to model_validate as-is."""
+
+    class MyConfig(ConfigModel):
+        required: str
+
+    config = MyConfig.parse_obj_allow_extras(MyConfig(required="foo"))
+    assert config.required == "foo"
+
+
+def test_parse_obj_allow_extras_multi_inheritance():
+    """parse_obj_allow_extras must work with deep multi-inheritance.
+
+    This is the scenario that caused SourceConnectionErrorException in
+    datahub-executor: parent classes like GcsDatasetLineageProviderConfigBase
+    have extra="forbid" and only define a subset of the child's fields.
+    The method must recognize fields from ALL parents in the MRO.
+    """
+
+    class ParentA(ConfigModel):
+        field_a: str = "a"
+
+    class ParentB(ConfigModel):
+        field_b: str = "b"
+
+    class ParentC(ConfigModel):
+        field_c: str = "c"
+
+    class Child(ParentA, ParentB, ParentC):
+        field_child: str = "child"
+
+    # All parent fields should be recognized; extras should be stripped
+    config = Child.parse_obj_allow_extras(
+        {
+            "field_a": "A",
+            "field_b": "B",
+            "field_c": "C",
+            "field_child": "CHILD",
+            "extra_field": "should_be_stripped",
+        }
+    )
+    assert config.field_a == "A"
+    assert config.field_b == "B"
+    assert config.field_c == "C"
+    assert config.field_child == "CHILD"
+    assert not hasattr(config, "extra_field")
+
+
+def test_parse_obj_allow_extras_diamond_inheritance():
+    """Diamond inheritance: multiple parents share a common ancestor."""
+
+    class Base(ConfigModel):
+        base_field: str = "base"
+
+    class Left(Base):
+        left_field: str = "left"
+
+    class Right(Base):
+        right_field: str = "right"
+
+    class Diamond(Left, Right):
+        diamond_field: str = "diamond"
+
+    config = Diamond.parse_obj_allow_extras(
+        {
+            "base_field": "BASE",
+            "left_field": "LEFT",
+            "right_field": "RIGHT",
+            "diamond_field": "DIAMOND",
+            "unknown": "stripped",
+        }
+    )
+    assert config.base_field == "BASE"
+    assert config.left_field == "LEFT"
+    assert config.right_field == "RIGHT"
+    assert config.diamond_field == "DIAMOND"
+
+
+def test_parse_obj_allow_extras_with_aliases():
+    """Fields with alias or validation_alias should be recognized by their alias names."""
+
+    class AliasConfig(ConfigModel):
+        normal_field: str
+        aliased: str = Field(default="x", alias="aliasName")
+        val_aliased: str = Field(default="y", validation_alias="valAliasName")
+
+    # Alias names should be kept; extras should be stripped
+    config = AliasConfig.parse_obj_allow_extras(
+        {"normal_field": "n", "aliasName": "A", "valAliasName": "V", "extra": "gone"}
+    )
+    assert config.normal_field == "n"
+    assert config.aliased == "A"
+    assert config.val_aliased == "V"
+
+
+def test_parse_obj_allow_extras_does_not_corrupt_class():
+    """Calling parse_obj_allow_extras must not affect subsequent normal validation.
+
+    The old model_rebuild approach could corrupt shared class state. Verify that
+    normal validation still rejects extras after parse_obj_allow_extras is called.
+    """
+
+    class MyConfig(ConfigModel):
+        field: str
+
+    # First call with extras
+    MyConfig.parse_obj_allow_extras({"field": "ok", "extra": "stripped"})
+
+    # Normal validation must still reject extras
+    with pytest.raises(pydantic.ValidationError, match="extra"):
+        MyConfig.model_validate({"field": "ok", "extra": "should_fail"})
 
 
 def test_default_object_copy():

--- a/metadata-ingestion/tests/unit/config/test_config_model.py
+++ b/metadata-ingestion/tests/unit/config/test_config_model.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pydantic
 import pytest
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from datahub.configuration.common import (
     AllowDenyPattern,
@@ -140,6 +140,32 @@ def test_parse_obj_allow_extras_with_aliases():
     assert config.normal_field == "n"
     assert config.aliased == "A"
     assert config.val_aliased == "V"
+
+
+def test_parse_obj_allow_extras_with_alias_choices():
+    """AliasChoices validation aliases must be handled correctly.
+
+    The key-stripping approach failed here because isinstance(AliasChoices, str)
+    is False, so alternate alias names were incorrectly stripped from the dict.
+    """
+
+    class ChoicesConfig(ConfigModel):
+        pattern: str = Field(
+            default="default",
+            validation_alias=AliasChoices("pattern", "dataset_pattern"),
+        )
+
+    # Primary alias
+    config = ChoicesConfig.parse_obj_allow_extras(
+        {"pattern": "primary", "extra": "gone"}
+    )
+    assert config.pattern == "primary"
+
+    # Alternate alias
+    config2 = ChoicesConfig.parse_obj_allow_extras(
+        {"dataset_pattern": "alternate", "extra": "gone"}
+    )
+    assert config2.pattern == "alternate"
 
 
 def test_parse_obj_allow_extras_does_not_corrupt_class():


### PR DESCRIPTION
## Summary

Fixes `SourceConnectionErrorException` in datahub-executor when parsing `BigQueryV2Config` (and similar deeply-inherited config models) from ingestion recipes via `parse_obj_allow_extras`.

The old implementation used `unittest.mock.patch.dict` + `model_rebuild(force=True)` to temporarily allow extra fields. This had two problems:
1. **Race condition** — `model_rebuild` mutates shared class state, so concurrent Celery tasks could corrupt each other's validation
2. **MRO cascade** — `model_rebuild(force=True)` cascades to parent classes, which retain `extra="forbid"` and reject fields from sibling parents

Replaced with a dynamic subclass approach: `type(cls.__name__, (cls,), {"model_config": ConfigDict(extra="ignore")})`. Pydantic's metaclass compiles a fresh validator with `extra="ignore"` baked in, merging the full MRO into one flat schema. This:
- Has no shared state mutation (inherently thread-safe)
- Handles all alias types natively (`AliasChoices`, `AliasPath`, string aliases) — the intermediate key-stripping approach silently dropped `AliasChoices` fields
- Requires no `unittest.mock` import

Cherry-picked from acryldata/datahub-fork#9005 and then improved.

## Test plan
- [x] New unit tests for multi-inheritance, diamond inheritance, aliases, `AliasChoices`, no class corruption
- [x] Existing `test_extras_allowed`, `test_extras_not_allowed`, `test_state_provider_configs` pass
- [x] Empirically verified with `BigQueryV2Config` (11 parent classes, 82 fields)
- [x] Ruff lint passes