### PR TITLE
fix(agent): return message instead of raising ItemNotFoundError in get_lineage_paths_between

### DIFF
--- a/datahub-agent-context/src/datahub_agent_context/mcp_tools/lineage.py
+++ b/datahub-agent-context/src/datahub_agent_context/mcp_tools/lineage.py
@@ -564,6 +564,46 @@ def _find_lineage_path(
         )
 
 
+def _build_no_path_found_message(
+    source_urn: str,
+    target_urn: str,
+    source_column: Optional[str] = None,
+    target_column: Optional[str] = None,
+) -> dict:
+    """Build a friendly response when no lineage path is found.
+
+    Returns a dict instead of raising an exception so that agent/ADK
+    consumers get a usable message rather than an unhandled error.
+
+    Args:
+        source_urn: Source entity URN
+        target_urn: Target entity URN
+        source_column: Optional source column name
+        target_column: Optional target column name
+
+    Returns:
+        Dictionary with a message and metadata about the failed lookup
+    """
+    source_display = source_urn + (f".{source_column}" if source_column else "")
+    target_display = target_urn + (f".{target_column}" if target_column else "")
+    return {
+        "message": (
+            f"No lineage path found between {source_display} and {target_display} "
+            f"in either upstream or downstream direction."
+        ),
+        "source": {
+            "urn": source_urn,
+            **({"column": source_column} if source_column else {}),
+        },
+        "target": {
+            "urn": target_urn,
+            **({"column": target_column} if target_column else {}),
+        },
+        "pathCount": 0,
+        "paths": [],
+    }
+
+
 def get_lineage_paths_between(
     source_urn: str,
     target_urn: str,
@@ -595,6 +635,11 @@ def get_lineage_paths_between(
         - paths: Array of path objects from GraphQL (with QUERY URNs)
         - pathCount: Number of paths found
         - metadata: Query metadata including direction and path type
+        OR when no path is found:
+        - message: Human-readable explanation
+        - source/target: Entity info
+        - pathCount: 0
+        - paths: []
 
     Examples:
         # Column-level paths
@@ -633,7 +678,6 @@ def get_lineage_paths_between(
 
     Raises:
         ValueError: If column parameters are mismatched or invalid
-        ItemNotFoundError: If no lineage path found
     """
     # Normalize column parameters
     if source_column == "null" or source_column == "":
@@ -688,22 +732,24 @@ def get_lineage_paths_between(
                 )
                 return result
             except ItemNotFoundError:
-                # Not found in either direction
-                raise ItemNotFoundError(
-                    f"No lineage path found between {source_urn}"
-                    + (f".{source_column}" if source_column else "")
-                    + f" and {target_urn}"
-                    + (f".{target_column}" if target_column else "")
-                    + " in either upstream or downstream direction"
-                ) from None
+                # Not found in either direction: return a message
+                # instead of raising (see #16882)
+                return _build_no_path_found_message(
+                    source_urn, target_urn, source_column, target_column
+                )
     else:
         # User specified direction explicitly
-        return _find_lineage_path(
-            query_urn=query_urn,
-            target_full_urn=target_full_urn,
-            source_urn=source_urn,
-            target_urn=target_urn,
-            source_column=source_column,
-            target_column=target_column,
-            direction=direction,
-        )
+        try:
+            return _find_lineage_path(
+                query_urn=query_urn,
+                target_full_urn=target_full_urn,
+                source_urn=source_urn,
+                target_urn=target_urn,
+                source_column=source_column,
+                target_column=target_column,
+                direction=direction,
+            )
+        except ItemNotFoundError:
+            return _build_no_path_found_message(
+                source_urn, target_urn, source_column, target_column
+            )

--- a/datahub-agent-context/tests/unit/mcp_tools/test_lineage.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_lineage.py
@@ -358,19 +358,49 @@ class TestGetLineagePathsBetween:
         assert "direction" in result["metadata"]
         assert "auto-discovered" in result["metadata"]["direction"]
 
-    def test_path_not_found_raises_error(self, mock_client):
-        """Test that no path found raises ItemNotFoundError."""
+    def test_path_not_found_returns_message(self, mock_client):
+        """Test that no path found returns a message dict instead of raising.
+
+        Regression test for #16882: get_lineage_paths_between should return a
+        friendly message when no lineage path exists, not raise ItemNotFoundError.
+        """
         mock_client._graph.execute_graphql.return_value = {
             "searchAcrossLineage": {"searchResults": []}
         }
 
-        with pytest.raises(ItemNotFoundError, match="No lineage"):
-            with DataHubContext(mock_client):
-                get_lineage_paths_between(
-                    source_urn="urn:li:dataset:source",
-                    target_urn="urn:li:dataset:target",
-                    direction="downstream",
-                )
+        with DataHubContext(mock_client):
+            result = get_lineage_paths_between(
+                source_urn="urn:li:dataset:source",
+                target_urn="urn:li:dataset:target",
+                direction="downstream",
+            )
+
+        assert "message" in result
+        assert "No lineage path found" in result["message"]
+        assert result["pathCount"] == 0
+        assert result["paths"] == []
+        assert result["source"]["urn"] == "urn:li:dataset:source"
+        assert result["target"]["urn"] == "urn:li:dataset:target"
+
+    def test_path_not_found_auto_discover_returns_message(self, mock_client):
+        """Test that auto-discover with no path in either direction returns a message.
+
+        Regression test for #16882.
+        """
+        mock_client._graph.execute_graphql.return_value = {
+            "searchAcrossLineage": {"searchResults": []}
+        }
+
+        with DataHubContext(mock_client):
+            result = get_lineage_paths_between(
+                source_urn="urn:li:dataset:source",
+                target_urn="urn:li:dataset:target",
+                direction=None,  # Auto-discover
+            )
+
+        assert "message" in result
+        assert "No lineage path found" in result["message"]
+        assert result["pathCount"] == 0
 
     def test_column_mismatch_raises_error(self, mock_client):
         """Test that mismatched column parameters raise ValueError."""

--- a/datahub-agent-context/tests/unit/mcp_tools/test_lineage.py
+++ b/datahub-agent-context/tests/unit/mcp_tools/test_lineage.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from datahub.errors import ItemNotFoundError
 from datahub_agent_context.context import DataHubContext
 from datahub_agent_context.mcp_tools.lineage import (
     AssetLineageAPI,


### PR DESCRIPTION
## Summary

When no lineage path exists between two assets, `get_lineage_paths_between` raises `ItemNotFoundError`. In an agent/ADK context this surfaces as an unhandled exception instead of a useful response.

Closes #16882

## What Changed

### `datahub-agent-context/src/datahub_agent_context/mcp_tools/lineage.py`
- `get_lineage_paths_between()` now catches `ItemNotFoundError` and returns a friendly message dict instead of raising
- Added `_build_no_path_found_message()` helper that returns a consistent response with `message`, `source`, `target`, `pathCount=0`, and empty `paths`
- Both code paths are covered: auto-discover (tries downstream then upstream) and explicit direction
- Updated docstring to document the new return shape for the no-path case
- Removed `ItemNotFoundError` from the `Raises` section of the docstring

### `datahub-agent-context/tests/unit/mcp_tools/test_lineage.py`
- Replaced `test_path_not_found_raises_error` (which expected `ItemNotFoundError`) with `test_path_not_found_returns_message` that checks the message dict
- Added `test_path_not_found_auto_discover_returns_message` for the auto-discover code path

## Before vs After

**Before (raises, agent sees unhandled error):**
```
ItemNotFoundError: No lineage path found between urn:li:dataset:A and urn:li:dataset:B
in either upstream or downstream direction
```

**After (returns dict, agent gets a usable response):**
```json
{
  "message": "No lineage path found between urn:li:dataset:A and urn:li:dataset:B in either upstream or downstream direction.",
  "source": {"urn": "urn:li:dataset:A"},
  "target": {"urn": "urn:li:dataset:B"},
  "pathCount": 0,
  "paths": []
}
```

## Notes
- Internal helpers (`_find_upstream_lineage_path`, `_find_lineage_path`) still raise `ItemNotFoundError` for control flow. Only the public-facing `get_lineage_paths_between` catches and converts them.
- No changes to `get_lineage()` which has different behavior and is not affected by this issue.