### PR TITLE
fix(openlineage): accept custom producer URIs instead of returning 500

### DIFF
--- a/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
+++ b/metadata-integration/java/openlineage-converter/src/main/java/io/datahubproject/openlineage/converter/OpenLineageToDataHub.java
@@ -1292,12 +1292,48 @@ public class OpenLineageToDataHub {
         orchestrator = "airflow";
       } else if (producer.startsWith("https://github.com/trinodb/trino/")) {
         orchestrator = "trino";
+      } else {
+        // Fallback for custom producers: extract the last non-empty path segment
+        // from the producer URI. Per the OpenLineage spec, the producer field is
+        // a URI that can be any value, so we should not reject unknown producers.
+        // See: https://github.com/datahub-project/datahub/issues/16961
+        orchestrator = extractOrchestratorFromProducerUri(producer);
       }
     }
     if (orchestrator == null) {
       throw new RuntimeException("Unable to determine orchestrator");
     }
     return orchestrator;
+  }
+
+  /**
+   * Extract an orchestrator name from a custom producer URI by using the last non-empty path
+   * segment. For example, "https://github.com/myorg/myproducer/blob/v1/client" returns "client".
+   *
+   * @param producer the producer URI string
+   * @return the last path segment, or null if no usable segment is found
+   */
+  private static String extractOrchestratorFromProducerUri(String producer) {
+    try {
+      URI uri = new URI(producer);
+      String path = uri.getPath();
+      if (path != null && !path.isEmpty()) {
+        // Remove trailing slashes and split
+        String trimmedPath = path.replaceAll("/+$", "");
+        if (!trimmedPath.isEmpty()) {
+          String[] segments = trimmedPath.split("/");
+          // Return the last non-empty segment
+          for (int i = segments.length - 1; i >= 0; i--) {
+            if (!segments[i].isEmpty()) {
+              return segments[i].toLowerCase();
+            }
+          }
+        }
+      }
+    } catch (URISyntaxException e) {
+      log.warn("Unable to parse producer URI '{}': {}", producer, e.getMessage());
+    }
+    return null;
   }
 
   public static SchemaFieldDataType.Type convertOlFieldTypeToDHFieldType(

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageOrchestratorTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageOrchestratorTest.java
@@ -1,105 +1,105 @@
-package io.datahubproject.openlineage.converter;
+package io.datahubproject.openlineage;
 
 import static org.testng.Assert.assertEquals;
 
+import com.linkedin.common.FabricType;
+import com.linkedin.common.urn.DataFlowUrn;
 import io.datahubproject.openlineage.config.DatahubOpenlineageConfig;
+import io.datahubproject.openlineage.converter.OpenLineageToDataHub;
+import java.net.URI;
 import org.testng.annotations.Test;
 
+/**
+ * Tests for custom OpenLineage producer support.
+ *
+ * <p>Regression tests for https://github.com/datahub-project/datahub/issues/16961
+ */
 public class OpenLineageOrchestratorTest {
 
   private static DatahubOpenlineageConfig defaultConfig() {
-    return DatahubOpenlineageConfig.builder().build();
+    return DatahubOpenlineageConfig.builder().fabricType(FabricType.PROD).build();
   }
 
-  /**
-   * Tests that the getFlowUrn method (which calls getOrchestrator internally) works with custom
-   * producer URIs that don't match the hardcoded OpenLineage/Airflow/Trino patterns.
-   *
-   * <p>Regression test for https://github.com/datahub-project/datahub/issues/16961
-   */
   @Test
   public void testCustomProducerExtractsOrchestratorFromPath() {
-    var flowUrn =
+    DataFlowUrn flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             null,
-            java.net.URI.create(
-                "https://github.com/myorganization/myproducer/blob/v1-0-0/client"),
+            URI.create("https://github.com/myorganization/myproducer/blob/v1-0-0/client"),
             defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "client");
   }
 
   @Test
   public void testCustomProducerWithSimplePath() {
-    var flowUrn =
+    DataFlowUrn flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             null,
-            java.net.URI.create("https://example.com/my-custom-producer"),
+            URI.create("https://example.com/my-custom-producer"),
             defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "my-custom-producer");
   }
 
   @Test
   public void testCustomProducerWithTrailingSlash() {
-    var flowUrn =
+    DataFlowUrn flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             null,
-            java.net.URI.create("https://example.com/my-producer/"),
+            URI.create("https://example.com/my-producer/"),
             defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "my-producer");
   }
 
   @Test
   public void testKnownOpenLineageProducerStillWorks() {
-    var flowUrn =
+    DataFlowUrn flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             null,
-            java.net.URI.create(
-                "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"),
+            URI.create("https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"),
             defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "client");
   }
 
   @Test
   public void testAirflowProducerStillWorks() {
-    var flowUrn =
+    DataFlowUrn flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             null,
-            java.net.URI.create(
-                "https://github.com/apache/airflow/tree/providers-openlineage/1.0.0"),
+            URI.create("https://github.com/apache/airflow/tree/providers-openlineage/1.0.0"),
             defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "airflow");
   }
 
   @Test
   public void testTrinoProducerStillWorks() {
-    var flowUrn =
+    DataFlowUrn flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             null,
-            java.net.URI.create("https://github.com/trinodb/trino/blob/v435/core"),
+            URI.create("https://github.com/trinodb/trino/blob/v435/core"),
             defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "trino");
   }
 
   @Test
   public void testProcessingEngineOverridesProducer() {
-    var flowUrn =
+    DataFlowUrn flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             "spark",
-            java.net.URI.create("https://example.com/whatever"),
+            URI.create("https://example.com/whatever"),
             defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "spark");
   }

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageOrchestratorTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageOrchestratorTest.java
@@ -1,0 +1,106 @@
+package io.datahubproject.openlineage.converter;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class OpenLineageOrchestratorTest {
+
+  /**
+   * Tests that the getFlowUrn method (which calls getOrchestrator internally) works with custom
+   * producer URIs that don't match the hardcoded OpenLineage/Airflow/Trino patterns.
+   *
+   * <p>Regression test for https://github.com/datahub-project/datahub/issues/16961
+   */
+  @Test
+  public void testCustomProducerExtractsOrchestratorFromPath() {
+    // Custom producer URI should extract "client" from the path
+    var flowUrn =
+        OpenLineageToDataHub.getFlowUrn(
+            "my_namespace",
+            "my_job",
+            null,
+            java.net.URI.create(
+                "https://github.com/myorganization/myproducer/blob/v1-0-0/client"),
+            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+    assertEquals(flowUrn.getOrchestratorEntity(), "client");
+  }
+
+  @Test
+  public void testCustomProducerWithSimplePath() {
+    // A producer URI with a simple path should use the last segment
+    var flowUrn =
+        OpenLineageToDataHub.getFlowUrn(
+            "my_namespace",
+            "my_job",
+            null,
+            java.net.URI.create("https://example.com/my-custom-producer"),
+            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+    assertEquals(flowUrn.getOrchestratorEntity(), "my-custom-producer");
+  }
+
+  @Test
+  public void testCustomProducerWithTrailingSlash() {
+    // Trailing slash should be handled gracefully
+    var flowUrn =
+        OpenLineageToDataHub.getFlowUrn(
+            "my_namespace",
+            "my_job",
+            null,
+            java.net.URI.create("https://example.com/my-producer/"),
+            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+    assertEquals(flowUrn.getOrchestratorEntity(), "my-producer");
+  }
+
+  @Test
+  public void testKnownOpenLineageProducerStillWorks() {
+    // Standard OpenLineage producer should still work
+    var flowUrn =
+        OpenLineageToDataHub.getFlowUrn(
+            "my_namespace",
+            "my_job",
+            null,
+            java.net.URI.create(
+                "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"),
+            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+    assertEquals(flowUrn.getOrchestratorEntity(), "client");
+  }
+
+  @Test
+  public void testAirflowProducerStillWorks() {
+    var flowUrn =
+        OpenLineageToDataHub.getFlowUrn(
+            "my_namespace",
+            "my_job",
+            null,
+            java.net.URI.create(
+                "https://github.com/apache/airflow/tree/providers-openlineage/1.0.0"),
+            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+    assertEquals(flowUrn.getOrchestratorEntity(), "airflow");
+  }
+
+  @Test
+  public void testTrinoProducerStillWorks() {
+    var flowUrn =
+        OpenLineageToDataHub.getFlowUrn(
+            "my_namespace",
+            "my_job",
+            null,
+            java.net.URI.create("https://github.com/trinodb/trino/blob/v435/core"),
+            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+    assertEquals(flowUrn.getOrchestratorEntity(), "trino");
+  }
+
+  @Test
+  public void testProcessingEngineOverridesProducer() {
+    // When processingEngine is provided, it should take precedence
+    var flowUrn =
+        OpenLineageToDataHub.getFlowUrn(
+            "my_namespace",
+            "my_job",
+            "spark",
+            java.net.URI.create("https://example.com/whatever"),
+            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+    assertEquals(flowUrn.getOrchestratorEntity(), "spark");
+  }
+}

--- a/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageOrchestratorTest.java
+++ b/metadata-integration/java/openlineage-converter/src/test/java/io/datahubproject/openlineage/OpenLineageOrchestratorTest.java
@@ -2,9 +2,14 @@ package io.datahubproject.openlineage.converter;
 
 import static org.testng.Assert.assertEquals;
 
+import io.datahubproject.openlineage.config.DatahubOpenlineageConfig;
 import org.testng.annotations.Test;
 
 public class OpenLineageOrchestratorTest {
+
+  private static DatahubOpenlineageConfig defaultConfig() {
+    return DatahubOpenlineageConfig.builder().build();
+  }
 
   /**
    * Tests that the getFlowUrn method (which calls getOrchestrator internally) works with custom
@@ -14,7 +19,6 @@ public class OpenLineageOrchestratorTest {
    */
   @Test
   public void testCustomProducerExtractsOrchestratorFromPath() {
-    // Custom producer URI should extract "client" from the path
     var flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
@@ -22,39 +26,36 @@ public class OpenLineageOrchestratorTest {
             null,
             java.net.URI.create(
                 "https://github.com/myorganization/myproducer/blob/v1-0-0/client"),
-            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+            defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "client");
   }
 
   @Test
   public void testCustomProducerWithSimplePath() {
-    // A producer URI with a simple path should use the last segment
     var flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             null,
             java.net.URI.create("https://example.com/my-custom-producer"),
-            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+            defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "my-custom-producer");
   }
 
   @Test
   public void testCustomProducerWithTrailingSlash() {
-    // Trailing slash should be handled gracefully
     var flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             null,
             java.net.URI.create("https://example.com/my-producer/"),
-            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+            defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "my-producer");
   }
 
   @Test
   public void testKnownOpenLineageProducerStillWorks() {
-    // Standard OpenLineage producer should still work
     var flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
@@ -62,7 +63,7 @@ public class OpenLineageOrchestratorTest {
             null,
             java.net.URI.create(
                 "https://github.com/OpenLineage/OpenLineage/blob/v1-0-0/client"),
-            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+            defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "client");
   }
 
@@ -75,7 +76,7 @@ public class OpenLineageOrchestratorTest {
             null,
             java.net.URI.create(
                 "https://github.com/apache/airflow/tree/providers-openlineage/1.0.0"),
-            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+            defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "airflow");
   }
 
@@ -87,20 +88,19 @@ public class OpenLineageOrchestratorTest {
             "my_job",
             null,
             java.net.URI.create("https://github.com/trinodb/trino/blob/v435/core"),
-            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+            defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "trino");
   }
 
   @Test
   public void testProcessingEngineOverridesProducer() {
-    // When processingEngine is provided, it should take precedence
     var flowUrn =
         OpenLineageToDataHub.getFlowUrn(
             "my_namespace",
             "my_job",
             "spark",
             java.net.URI.create("https://example.com/whatever"),
-            new io.datahubproject.openlineage.config.DatahubOpenlineageConfig());
+            defaultConfig());
     assertEquals(flowUrn.getOrchestratorEntity(), "spark");
   }
 }


### PR DESCRIPTION
## Summary

The OpenLineage converter rejects events with custom producer URIs that don't match the hardcoded OpenLineage, Airflow, or Trino patterns, returning a 500 error. According to the OpenLineage spec, the producer field is a URI that can be any value.

Closes #16961

## What Changed

### `OpenLineageToDataHub.java`
- Added `extractOrchestratorFromProducerUri()` helper that extracts the last non-empty path segment from a producer URI to use as the orchestrator name
- In `getOrchestrator()`, added an `else` branch for unknown producers that calls the new helper instead of falling through to the `RuntimeException`
- Existing behavior for OpenLineage, Airflow, and Trino producers is unchanged

### `OpenLineageOrchestratorTest.java` (new)
- 7 tests covering:
  - Custom producer URIs (the bug scenario from the issue)
  - Simple paths, trailing slashes
  - Known producers still work (OpenLineage, Airflow, Trino)
  - processingEngine takes precedence over producer

## Before vs After

**Before:**
```
POST /openapi/openlineage/api/v1/lineage
{"producer": "https://github.com/myorg/myproducer/blob/v1/client", ...}

=> 500 Internal Server Error (RuntimeException: Unable to determine orchestrator)
```

**After:**
```
POST /openapi/openlineage/api/v1/lineage
{"producer": "https://github.com/myorg/myproducer/blob/v1/client", ...}

=> 200 OK (orchestrator = "client", extracted from last path segment)
```