### PR TITLE
fix(ingest): split statement support end/END and IF not exists

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/split_statements.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/split_statements.py
@@ -228,19 +228,24 @@ class _StatementSplitter:
         )
         if (
             is_control_keyword
-            and keyword == END_KEYWORD
+            and keyword.upper() == END_KEYWORD
             and self.current_case_statements > 0
         ):
             # If we're closing a CASE statement with END, we can just decrement the counter and continue.
             self.current_case_statements -= 1
         elif is_control_keyword:
-            # Yield current statement if any
-            yield from self._yield_if_complete()
-            # Yield keyword as its own statement
-            yield keyword
-            self.i += keyword_len
-            self.does_select_mean_new_statement = True
-            raise _AlreadyIncremented()
+            if keyword.upper() == "IF" and re.match(
+                r"IF\s+(NOT\s+)?EXISTS\b", self.sql[self.i :], re.IGNORECASE
+            ):
+                pass  # IF EXISTS / IF NOT EXISTS is DDL syntax, not control flow
+            else:
+                # Yield current statement if any
+                yield from self._yield_if_complete()
+                # Yield keyword as its own statement
+                yield keyword
+                self.i += keyword_len
+                self.does_select_mean_new_statement = True
+                raise _AlreadyIncremented()
 
         (
             is_strict_new_statement_keyword,

--- a/metadata-ingestion/tests/unit/sql_parsing/test_split_statements.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_split_statements.py
@@ -451,3 +451,73 @@ END;"""
         "END" in statements and "LOOP" in statements
     )
     assert "RETURN" in statements
+
+
+def test_split_insert_select_with_case_expression():
+    """
+    Regression test: INSERT...SELECT containing a CASE expression should not be
+    split at the END keyword closing the CASE block, regardless of case.
+    The END keyword comparison must be case-insensitive.
+    """
+    test_sql = """\
+delete from raw.eventhub.events_datamill_all_regions
+where date = '2026-03-31';
+
+insert into raw.eventhub.events_datamill_all_regions
+select
+    date_part as date,
+    case
+        when person is not null
+        then initiator_id
+    end as user_id,
+    user_or_anonymous_id
+from raw.eventhub.events_datamill_eu
+where date_part = '2026-03-31'"""
+
+    statements = [statement.strip() for statement in split_statements(test_sql)]
+    assert len(statements) == 2
+    assert statements[0].startswith("delete from")
+    assert statements[1].startswith("insert into")
+    assert "end as user_id" in statements[1]
+    assert "from raw.eventhub.events_datamill_eu" in statements[1]
+
+
+def test_split_snowflake_materialize_native_table():
+    """
+    Regression test for customer bug: Snowflake SQLExecuteQueryOperator task with
+    a CASE expression inside an INSERT...SELECT was causing DataHub to hang due to
+    incorrect statement splitting at the END keyword closing the CASE block.
+    """
+    test_sql = """\
+create table if not exists my_schema.my_table cluster by (date, event) (
+    date date,
+    event varchar
+);
+
+delete from my_schema.my_table
+where date = '2026-03-31'
+    and dc_id = 'eu';
+
+insert into my_schema.my_table
+select
+    date_part as date,
+    event as event,
+    case
+        when person is not null
+        then initiator_id
+    end as user_id,
+    user_or_anonymous_id as user_or_anonymous_id,
+    is_valid as is_valid,
+    'eu' as dc_id
+from my_schema.my_source_table
+where date_part = '2026-03-31'
+    and greatest(skip_validation, is_valid)
+order by date, event"""
+
+    statements = [statement.strip() for statement in split_statements(test_sql)]
+    assert len(statements) == 3
+    assert statements[0].startswith("create table if not exists")
+    assert statements[1].startswith("delete from")
+    assert statements[2].startswith("insert into")
+    assert "end as user_id" in statements[2]
+    assert "from my_schema.my_source_table" in statements[2]


### PR DESCRIPTION
The sql statement splitter contains two bugs: 
1. it incorrectly treats the END keyword closing a CASE expression as a statement boundary due to a case-sensitive string comparison
2. it incorrectly treats IF in CREATE TABLE IF NOT EXISTS / DROP TABLE IF EXISTS DDL syntax as a control flow keyword. 

Both of these cause multi-statement SQL blocks containing these keywords to be split into broken fragments, resulting in failed lineage extraction parsing issues in the airflow plugin.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
