### PR TITLE
feat(ece): Add documentation change event generator

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/DatasetPropertiesChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/DatasetPropertiesChangeEventGenerator.java
@@ -1,7 +1,7 @@
 package com.linkedin.metadata.timeline.eventgenerator;
 
 import static com.linkedin.metadata.Constants.*;
-import static com.linkedin.metadata.timeline.eventgenerator.EditableDatasetPropertiesChangeEventGenerator.*;
+import static com.linkedin.metadata.timeline.eventgenerator.DocumentationChangeEventGenerator.*;
 
 import com.datahub.util.RecordUtils;
 import com.google.common.collect.ImmutableMap;

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/DocumentationChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/DocumentationChangeEventGenerator.java
@@ -1,0 +1,198 @@
+package com.linkedin.metadata.timeline.eventgenerator;
+
+import static com.linkedin.metadata.Constants.*;
+
+import com.datahub.util.RecordUtils;
+import com.google.common.collect.ImmutableMap;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Documentation;
+import com.linkedin.common.DocumentationAssociation;
+import com.linkedin.common.MetadataAttribution;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.aspect.EntityAspect;
+import com.linkedin.metadata.timeline.data.ChangeCategory;
+import com.linkedin.metadata.timeline.data.ChangeEvent;
+import com.linkedin.metadata.timeline.data.ChangeOperation;
+import com.linkedin.metadata.timeline.data.ChangeTransaction;
+import com.linkedin.metadata.timeline.data.SemanticChangeType;
+import jakarta.json.JsonPatch;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class DocumentationChangeEventGenerator extends EntityChangeEventGenerator<Documentation> {
+
+  public static final String DESCRIPTION_ADDED = "Documentation for '%s' has been added: '%s'.";
+  public static final String DESCRIPTION_REMOVED = "Documentation for '%s' has been removed: '%s'.";
+  public static final String DESCRIPTION_CHANGED =
+      "Documentation of '%s' has been changed from '%s' to '%s'.";
+
+  private static List<ChangeEvent> computeDiffs(
+      Documentation baseDocumentation,
+      Documentation targetDocumentation,
+      String entityUrn,
+      AuditStamp auditStamp) {
+    List<ChangeEvent> changeEvents = new ArrayList<>();
+
+    Map<String, DocumentationAssociation> oldDocMap = buildDocumentationMap(baseDocumentation);
+    Map<String, DocumentationAssociation> newDocMap = buildDocumentationMap(targetDocumentation);
+
+    Set<String> allKeys = new HashSet<>();
+    allKeys.addAll(oldDocMap.keySet());
+    allKeys.addAll(newDocMap.keySet());
+
+    for (String key : allKeys) {
+      DocumentationAssociation oldAssoc = oldDocMap.get(key);
+      DocumentationAssociation newAssoc = newDocMap.get(key);
+
+      if (oldAssoc == null) {
+        changeEvents.add(makeAddChangeEvent(newAssoc, key, entityUrn, auditStamp));
+      } else if (newAssoc == null) {
+        changeEvents.add(makeRemoveChangeEvent(oldAssoc, key, entityUrn, auditStamp));
+      } else if (!oldAssoc.getDocumentation().equals(newAssoc.getDocumentation())) {
+        changeEvents.add(makeModifyChangeEvent(oldAssoc, newAssoc, key, entityUrn, auditStamp));
+      }
+    }
+
+    return changeEvents;
+  }
+
+  /**
+   * Returns the attribution source URN string as the stable key, or null for unattributed entries
+   * (at most one such entry is expected per the aspect semantics).
+   */
+  @Nullable
+  static String getKey(DocumentationAssociation association) {
+    MetadataAttribution attribution = association.getAttribution();
+    if (attribution != null && attribution.hasSource() && attribution.getSource() != null) {
+      return attribution.getSource().toString();
+    }
+    return null;
+  }
+
+  private static Map<String, DocumentationAssociation> buildDocumentationMap(
+      Documentation documentation) {
+    Map<String, DocumentationAssociation> map = new HashMap<>();
+    if (documentation != null) {
+      documentation.getDocumentations().forEach(assoc -> map.put(getKey(assoc), assoc));
+    }
+    return map;
+  }
+
+  private static ChangeEvent makeAddChangeEvent(
+      DocumentationAssociation assoc, String key, String entityUrn, AuditStamp auditStamp) {
+    return ChangeEvent.builder()
+        .modifier(key)
+        .entityUrn(entityUrn)
+        .category(ChangeCategory.DOCUMENTATION)
+        .operation(ChangeOperation.ADD)
+        .semVerChange(SemanticChangeType.MINOR)
+        .description(String.format(DESCRIPTION_ADDED, entityUrn, assoc.getDocumentation()))
+        .parameters(ImmutableMap.of("documentation", assoc.getDocumentation()))
+        .auditStamp(auditStamp)
+        .build();
+  }
+
+  private static ChangeEvent makeRemoveChangeEvent(
+      DocumentationAssociation assoc, String key, String entityUrn, AuditStamp auditStamp) {
+    return ChangeEvent.builder()
+        .modifier(key)
+        .entityUrn(entityUrn)
+        .category(ChangeCategory.DOCUMENTATION)
+        .operation(ChangeOperation.REMOVE)
+        .semVerChange(SemanticChangeType.MINOR)
+        .description(String.format(DESCRIPTION_REMOVED, entityUrn, assoc.getDocumentation()))
+        .parameters(ImmutableMap.of("documentation", assoc.getDocumentation()))
+        .auditStamp(auditStamp)
+        .build();
+  }
+
+  private static ChangeEvent makeModifyChangeEvent(
+      DocumentationAssociation oldAssoc,
+      DocumentationAssociation newAssoc,
+      String key,
+      String entityUrn,
+      AuditStamp auditStamp) {
+    return ChangeEvent.builder()
+        .modifier(key)
+        .entityUrn(entityUrn)
+        .category(ChangeCategory.DOCUMENTATION)
+        .operation(ChangeOperation.MODIFY)
+        .semVerChange(SemanticChangeType.PATCH)
+        .description(
+            String.format(
+                DESCRIPTION_CHANGED,
+                entityUrn,
+                oldAssoc.getDocumentation(),
+                newAssoc.getDocumentation()))
+        .parameters(ImmutableMap.of("documentation", newAssoc.getDocumentation()))
+        .auditStamp(auditStamp)
+        .build();
+  }
+
+  @Nullable
+  private static Documentation getDocumentationFromAspect(EntityAspect entityAspect) {
+    if (entityAspect != null && entityAspect.getMetadata() != null) {
+      return RecordUtils.toRecordTemplate(Documentation.class, entityAspect.getMetadata());
+    }
+    return null;
+  }
+
+  @Override
+  public ChangeTransaction getSemanticDiff(
+      EntityAspect previousValue,
+      EntityAspect currentValue,
+      ChangeCategory element,
+      JsonPatch rawDiff,
+      boolean rawDiffsRequested) {
+
+    if (currentValue == null) {
+      throw new IllegalArgumentException("EntityAspect currentValue should not be null");
+    }
+
+    if (!previousValue.getAspect().equals(DOCUMENTATION_ASPECT_NAME)
+        || !currentValue.getAspect().equals(DOCUMENTATION_ASPECT_NAME)) {
+      throw new IllegalArgumentException("Aspect is not " + DOCUMENTATION_ASPECT_NAME);
+    }
+
+    List<ChangeEvent> changeEvents = new ArrayList<>();
+    if (element == ChangeCategory.DOCUMENTATION) {
+      Documentation baseDocumentation = getDocumentationFromAspect(previousValue);
+      Documentation targetDocumentation = getDocumentationFromAspect(currentValue);
+      changeEvents.addAll(
+          computeDiffs(baseDocumentation, targetDocumentation, currentValue.getUrn(), null));
+    }
+
+    SemanticChangeType highestSemanticChange = SemanticChangeType.NONE;
+    ChangeEvent highestChangeEvent =
+        changeEvents.stream().max(Comparator.comparing(ChangeEvent::getSemVerChange)).orElse(null);
+    if (highestChangeEvent != null) {
+      highestSemanticChange = highestChangeEvent.getSemVerChange();
+    }
+
+    return ChangeTransaction.builder()
+        .semVerChange(highestSemanticChange)
+        .changeEvents(changeEvents)
+        .timestamp(currentValue.getCreatedOn().getTime())
+        .rawDiff(rawDiffsRequested ? rawDiff : null)
+        .actor(currentValue.getCreatedBy())
+        .build();
+  }
+
+  @Override
+  public List<ChangeEvent> getChangeEvents(
+      @Nonnull Urn urn,
+      @Nonnull String entity,
+      @Nonnull String aspect,
+      @Nonnull Aspect<Documentation> from,
+      @Nonnull Aspect<Documentation> to,
+      @Nonnull AuditStamp auditStamp) {
+    return computeDiffs(from.getValue(), to.getValue(), urn.toString(), auditStamp);
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableDatasetPropertiesChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableDatasetPropertiesChangeEventGenerator.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.timeline.eventgenerator;
 
 import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.timeline.eventgenerator.DocumentationChangeEventGenerator.*;
 
 import com.datahub.util.RecordUtils;
 import com.google.common.collect.ImmutableMap;
@@ -21,11 +22,6 @@ import javax.annotation.Nonnull;
 
 public class EditableDatasetPropertiesChangeEventGenerator
     extends EntityChangeEventGenerator<EditableDatasetProperties> {
-
-  public static final String DESCRIPTION_ADDED = "Documentation for '%s' has been added: '%s'.";
-  public static final String DESCRIPTION_REMOVED = "Documentation for '%s' has been removed: '%s'.";
-  public static final String DESCRIPTION_CHANGED =
-      "Documentation of '%s' has been changed from '%s' to '%s'.";
 
   private static List<ChangeEvent> computeDiffs(
       EditableDatasetProperties baseDatasetProperties,

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
@@ -293,8 +293,9 @@ public class EditableSchemaMetadataChangeEventGenerator
       throw new IllegalArgumentException("EntityAspect currentValue should not be null");
     }
 
-    if (!previousValue.getAspect().equals(EDITABLE_SCHEMA_METADATA_ASPECT_NAME)
-        || !currentValue.getAspect().equals(EDITABLE_SCHEMA_METADATA_ASPECT_NAME)) {
+    if (!currentValue.getAspect().equals(EDITABLE_SCHEMA_METADATA_ASPECT_NAME)
+        || (previousValue != null
+            && !previousValue.getAspect().equals(EDITABLE_SCHEMA_METADATA_ASPECT_NAME))) {
       throw new IllegalArgumentException("Aspect is not " + EDITABLE_SCHEMA_METADATA_ASPECT_NAME);
     }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/GlossaryTermInfoChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/GlossaryTermInfoChangeEventGenerator.java
@@ -1,7 +1,7 @@
 package com.linkedin.metadata.timeline.eventgenerator;
 
 import static com.linkedin.metadata.Constants.*;
-import static com.linkedin.metadata.timeline.eventgenerator.EditableDatasetPropertiesChangeEventGenerator.*;
+import static com.linkedin.metadata.timeline.eventgenerator.DocumentationChangeEventGenerator.*;
 
 import com.datahub.util.RecordUtils;
 import com.linkedin.common.AuditStamp;

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
@@ -582,8 +582,9 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       ChangeCategory changeCategory,
       JsonPatch rawDiff,
       boolean rawDiffRequested) {
-    if (!previousValue.getAspect().equals(SCHEMA_METADATA_ASPECT_NAME)
-        || !currentValue.getAspect().equals(SCHEMA_METADATA_ASPECT_NAME)) {
+    if (!currentValue.getAspect().equals(SCHEMA_METADATA_ASPECT_NAME)
+        || (previousValue != null
+            && !previousValue.getAspect().equals(SCHEMA_METADATA_ASPECT_NAME))) {
       throw new IllegalArgumentException("Aspect is not " + SCHEMA_METADATA_ASPECT_NAME);
     }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/DocumentationChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/DocumentationChangeEventGeneratorTest.java
@@ -1,0 +1,411 @@
+package com.linkedin.metadata.timeline.eventgenerator;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Documentation;
+import com.linkedin.common.DocumentationAssociation;
+import com.linkedin.common.DocumentationAssociationArray;
+import com.linkedin.common.MetadataAttribution;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.timeline.data.ChangeCategory;
+import com.linkedin.metadata.timeline.data.ChangeEvent;
+import com.linkedin.metadata.timeline.data.ChangeOperation;
+import com.linkedin.mxe.SystemMetadata;
+import java.net.URISyntaxException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.Test;
+
+public class DocumentationChangeEventGeneratorTest extends AbstractTestNGSpringContextTests {
+
+  private static final String TEST_ENTITY_URN =
+      "urn:li:dataset:(urn:li:dataPlatform:hive,SampleTable,PROD)";
+  private static final String TEST_ACTOR_URN_1 = "urn:li:corpuser:user1";
+  private static final String TEST_ACTOR_URN_2 = "urn:li:corpuser:user2";
+  private static final String TEST_SOURCE_URN_1 = "urn:li:dataHubAction:action1";
+  private static final String TEST_SOURCE_URN_2 = "urn:li:dataHubAction:action2";
+
+  private static Urn getTestUrn() throws URISyntaxException {
+    return Urn.createFromString(TEST_ENTITY_URN);
+  }
+
+  private static AuditStamp getTestAuditStamp() throws URISyntaxException {
+    return new AuditStamp()
+        .setActor(Urn.createFromString("urn:li:corpuser:__datahub_system"))
+        .setTime(1683829509553L);
+  }
+
+  private static Aspect<Documentation> createDocumentationAspect(
+      List<DocumentationAssociation> associations) {
+    Documentation documentation = new Documentation();
+    documentation.setDocumentations(new DocumentationAssociationArray(associations));
+    return new Aspect<>(documentation, new SystemMetadata());
+  }
+
+  private static DocumentationAssociation createAssociationWithSource(
+      String docText, String actorUrn, String sourceUrn) throws URISyntaxException {
+    DocumentationAssociation association = new DocumentationAssociation();
+    association.setDocumentation(docText);
+    MetadataAttribution attribution = new MetadataAttribution();
+    attribution.setActor(Urn.createFromString(actorUrn));
+    attribution.setTime(1683829509553L);
+    if (sourceUrn != null) {
+      attribution.setSource(Urn.createFromString(sourceUrn));
+    }
+    association.setAttribution(attribution);
+    return association;
+  }
+
+  private static DocumentationAssociation createAssociationNoAttribution(String docText) {
+    DocumentationAssociation association = new DocumentationAssociation();
+    association.setDocumentation(docText);
+    return association;
+  }
+
+  private static void validateChangeEvent(
+      ChangeEvent changeEvent,
+      ChangeOperation expectedOperation,
+      String expectedDoc,
+      String expectedModifier) {
+    assertNotNull(changeEvent);
+    assertEquals(changeEvent.getOperation(), expectedOperation);
+    assertEquals(changeEvent.getCategory(), ChangeCategory.DOCUMENTATION);
+    assertEquals(changeEvent.getEntityUrn(), TEST_ENTITY_URN);
+    assertEquals(changeEvent.getModifier(), expectedModifier);
+    assertNotNull(changeEvent.getParameters());
+    assertEquals(changeEvent.getParameters().get("documentation"), expectedDoc);
+  }
+
+  @Test
+  public void testAddDocumentationWithSource() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from = createDocumentationAspect(List.of());
+    Aspect<Documentation> to =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource(
+                    "Some documentation text", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(
+        actual.get(0), ChangeOperation.ADD, "Some documentation text", TEST_SOURCE_URN_1);
+  }
+
+  @Test
+  public void testRemoveDocumentationWithSource() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource(
+                    "Some documentation text", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+    Aspect<Documentation> to = createDocumentationAspect(List.of());
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(
+        actual.get(0), ChangeOperation.REMOVE, "Some documentation text", TEST_SOURCE_URN_1);
+  }
+
+  @Test
+  public void testModifyDocumentationWithSource() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from =
+        createDocumentationAspect(
+            List.of(createAssociationWithSource("Old text", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+    Aspect<Documentation> to =
+        createDocumentationAspect(
+            List.of(createAssociationWithSource("New text", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.MODIFY, "New text", TEST_SOURCE_URN_1);
+  }
+
+  @Test
+  public void testNoChanges() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from =
+        createDocumentationAspect(
+            List.of(createAssociationWithSource("Same text", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+    Aspect<Documentation> to =
+        createDocumentationAspect(
+            List.of(createAssociationWithSource("Same text", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 0);
+  }
+
+  @Test
+  public void testMultipleSourcesAddAndRemove() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource(
+                    "Doc from source1", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1),
+                createAssociationWithSource(
+                    "Doc from source2", TEST_ACTOR_URN_2, TEST_SOURCE_URN_2)));
+    Aspect<Documentation> to =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource(
+                    "Doc from source1", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(
+        actual.get(0), ChangeOperation.REMOVE, "Doc from source2", TEST_SOURCE_URN_2);
+  }
+
+  @Test
+  public void testAddSecondSource() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource(
+                    "Doc from source1", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+    Aspect<Documentation> to =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource(
+                    "Doc from source1", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1),
+                createAssociationWithSource(
+                    "Doc from source2", TEST_ACTOR_URN_2, TEST_SOURCE_URN_2)));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.ADD, "Doc from source2", TEST_SOURCE_URN_2);
+  }
+
+  @Test
+  public void testUnattributedDocUsesUnattributedKey() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from = createDocumentationAspect(List.of());
+    Aspect<Documentation> to =
+        createDocumentationAspect(List.of(createAssociationNoAttribution("Plain doc text")));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.ADD, "Plain doc text", null);
+  }
+
+  @Test
+  public void testUnattributedDocModified() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from =
+        createDocumentationAspect(List.of(createAssociationNoAttribution("Old unattributed")));
+    Aspect<Documentation> to =
+        createDocumentationAspect(List.of(createAssociationNoAttribution("New unattributed")));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.MODIFY, "New unattributed", null);
+  }
+
+  @Test
+  public void testFromEmptyToMultiple() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from = createDocumentationAspect(List.of());
+    Aspect<Documentation> to =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource("Doc 1", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1),
+                createAssociationWithSource("Doc 2", TEST_ACTOR_URN_2, TEST_SOURCE_URN_2)));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 2);
+    Set<ChangeOperation> operations =
+        actual.stream().map(ChangeEvent::getOperation).collect(Collectors.toSet());
+    assertEquals(operations, Set.of(ChangeOperation.ADD));
+    Set<String> docs =
+        actual.stream()
+            .map(e -> (String) e.getParameters().get("documentation"))
+            .collect(Collectors.toSet());
+    assertEquals(docs, Set.of("Doc 1", "Doc 2"));
+  }
+
+  @Test
+  public void testFromMultipleToEmpty() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource("Doc 1", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1),
+                createAssociationWithSource("Doc 2", TEST_ACTOR_URN_2, TEST_SOURCE_URN_2)));
+    Aspect<Documentation> to = createDocumentationAspect(List.of());
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 2);
+    Set<ChangeOperation> operations =
+        actual.stream().map(ChangeEvent::getOperation).collect(Collectors.toSet());
+    assertEquals(operations, Set.of(ChangeOperation.REMOVE));
+  }
+
+  @Test
+  public void testSwapSourcesWithDifferentDocs() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    // source1 removed, source2 added; both different text
+    Aspect<Documentation> from =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource(
+                    "Doc from source1", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+    Aspect<Documentation> to =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource(
+                    "Doc from source2", TEST_ACTOR_URN_2, TEST_SOURCE_URN_2)));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 2);
+
+    List<ChangeEvent> sorted =
+        actual.stream()
+            .sorted(Comparator.comparing(ChangeEvent::getOperation))
+            .collect(Collectors.toList());
+
+    validateChangeEvent(sorted.get(0), ChangeOperation.ADD, "Doc from source2", TEST_SOURCE_URN_2);
+    validateChangeEvent(
+        sorted.get(1), ChangeOperation.REMOVE, "Doc from source1", TEST_SOURCE_URN_1);
+  }
+
+  @Test
+  public void testAddUnattributedDocAlongsideAttributed() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource(
+                    "Attributed doc", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+    Aspect<Documentation> to =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource("Attributed doc", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1),
+                createAssociationNoAttribution("Unattributed doc")));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.ADD, "Unattributed doc", null);
+  }
+
+  @Test
+  public void testRemoveUnattributedDoc() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from =
+        createDocumentationAspect(List.of(createAssociationNoAttribution("Unattributed doc")));
+    Aspect<Documentation> to = createDocumentationAspect(List.of());
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    validateChangeEvent(actual.get(0), ChangeOperation.REMOVE, "Unattributed doc", null);
+  }
+
+  @Test
+  public void testDescriptionFormat() throws Exception {
+    DocumentationChangeEventGenerator generator = new DocumentationChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<Documentation> from = createDocumentationAspect(List.of());
+    Aspect<Documentation> to =
+        createDocumentationAspect(
+            List.of(
+                createAssociationWithSource("My doc text", TEST_ACTOR_URN_1, TEST_SOURCE_URN_1)));
+
+    List<ChangeEvent> actual =
+        generator.getChangeEvents(urn, "dataset", "documentation", from, to, auditStamp);
+
+    assertEquals(actual.size(), 1);
+    assertNotNull(actual.get(0).getDescription());
+    assertEquals(
+        actual.get(0).getDescription(),
+        String.format("Documentation for '%s' has been added: 'My doc text'.", TEST_ENTITY_URN));
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/timeline/eventgenerator/EntityChangeEventGeneratorRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/timeline/eventgenerator/EntityChangeEventGeneratorRegistryFactory.java
@@ -10,6 +10,7 @@ import com.linkedin.metadata.timeline.eventgenerator.BusinessAttributesChangeEve
 import com.linkedin.metadata.timeline.eventgenerator.DataProcessInstanceRunEventChangeEventGenerator;
 import com.linkedin.metadata.timeline.eventgenerator.DatasetPropertiesChangeEventGenerator;
 import com.linkedin.metadata.timeline.eventgenerator.DeprecationChangeEventGenerator;
+import com.linkedin.metadata.timeline.eventgenerator.DocumentationChangeEventGenerator;
 import com.linkedin.metadata.timeline.eventgenerator.EditableDatasetPropertiesChangeEventGenerator;
 import com.linkedin.metadata.timeline.eventgenerator.EditableSchemaMetadataChangeEventGenerator;
 import com.linkedin.metadata.timeline.eventgenerator.EntityChangeEventGeneratorRegistry;
@@ -50,6 +51,7 @@ public class EntityChangeEventGeneratorRegistryFactory {
     registry.register(OWNERSHIP_ASPECT_NAME, new OwnershipChangeEventGenerator());
     registry.register(
         INSTITUTIONAL_MEMORY_ASPECT_NAME, new InstitutionalMemoryChangeEventGenerator());
+    registry.register(DOCUMENTATION_ASPECT_NAME, new DocumentationChangeEventGenerator());
     registry.register(GLOSSARY_TERM_INFO_ASPECT_NAME, new GlossaryTermInfoChangeEventGenerator());
     registry.register(DOMAINS_ASPECT_NAME, new SingleDomainChangeEventGenerator());
     registry.register(DATASET_PROPERTIES_ASPECT_NAME, new DatasetPropertiesChangeEventGenerator());


### PR DESCRIPTION
Also fixes NPE on schema metadata / editable schema metadata change event generators. And moves constants to DocumentationChangeEventGenerator because that feels more appropriate than EditableDatasetPropertiesChangeEventGenerator.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->
